### PR TITLE
Fixed duplicate tags

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -962,6 +962,8 @@ drawbar(Monitor *m)
 
 	resizebarwin(m);
 	for (c = m->clients; c; c = c->next) {
+		if(c->tags == ((1 << LENGTH(tags)) - 1))
+			continue;
 		occ |= c->tags == 255 ? 0 : c->tags;
 		if (c->isurgent)
 			urg |= c->tags;


### PR DESCRIPTION
Hey Cris, Its me [@DEDSHOT_vk](https://www.twitch.tv/dedshot_vk) from Twitch. 

Like I said, I've fixed the issue with duplicate tags appearing when windows created on workspace 0. :smile: 

![ss2](https://github.com/ChrisTitusTech/dwm-titus/assets/49726816/9660478c-b108-4076-8ca5-2edcc8bed7f8)
![](https://github.com/ChrisTitusTech/dwm-titus/assets/49726816/aca7cccc-468a-44a6-80a8-a2c4d9f19620)
Brave placed in workspace 0.

Hopefully it works this time. See you on stream today!! Missed previous stream coz of buggy twitch notification :cry:.
