### PR TITLE
Improve dwm experience on high-refresh monitors

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1,6 +1,7 @@
 /* See LICENSE file for copyright and license details. */
 
 /* appearance */
+static const unsigned int refresh_rate = 60;    /* Matches dwm's mouse event processing to your monitor's refresh rate for smoother window interactions. */
 static const unsigned int borderpx  = 1;        /* border pixel of windows */
 static const unsigned int snap      = 32;       /* snap pixel */
 static const int swallowfloating    = 0;        /* 1 means swallow floating windows by default */
@@ -138,4 +139,3 @@ static Button buttons[] = {
 	{ ClkTagBar,            MODKEY,         Button1,        tag,            {0} },
 	{ ClkTagBar,            MODKEY,         Button3,        toggletag,      {0} },
 };
-

--- a/config.h
+++ b/config.h
@@ -1,6 +1,7 @@
 /* See LICENSE file for copyright and license details. */
 
 /* appearance */
+static const unsigned int refresh_rate = 60;    /* Matches dwm's mouse event processing to your monitor's refresh rate for smoother window interactions. */
 static const unsigned int borderpx  = 0;        /* border pixel of windows */
 static const unsigned int snap      = 26;       /* snap pixel */
 static const int swallowfloating    = 1;        /* 1 means swallow floating windows by default */

--- a/dwm.c
+++ b/dwm.c
@@ -1551,7 +1551,7 @@ movemouse(const Arg *arg)
 			handler[ev.type](&ev);
 			break;
 		case MotionNotify:
-			if ((ev.xmotion.time - lasttime) <= (1000 / 60))
+			if ((ev.xmotion.time - lasttime) <= (1000 / refresh_rate))
 				continue;
 			lasttime = ev.xmotion.time;
 
@@ -1632,7 +1632,7 @@ placemouse(const Arg *arg)
 			handler[ev.type](&ev);
 			break;
 		case MotionNotify:
-			if ((ev.xmotion.time - lasttime) <= (1000 / 60))
+			if ((ev.xmotion.time - lasttime) <= (1000 / refresh_rate))
 				continue;
 			lasttime = ev.xmotion.time;
 
@@ -1912,7 +1912,7 @@ resizemouse(const Arg *arg)
 			handler[ev.type](&ev);
 			break;
 		case MotionNotify:
-			if ((ev.xmotion.time - lasttime) <= (1000 / 60))
+			if ((ev.xmotion.time - lasttime) <= (1000 / refresh_rate))
 				continue;
 			lasttime = ev.xmotion.time;
 


### PR DESCRIPTION
This commit is designed for users who may desire a more consistent experience when utilising dwm on monitors with refresh rates exceeding 60Hz. I am confident that I have addressed all areas where this enhancement would be noticeable. The new value, refresh_rate, can now be configured in either config.def.h or config.h. Additionally, should you wish to implement this commit, please ensure to adjust it in config.h to match your monitor's resolution post-application of this commit.