### PR TITLE
Refactor Config.h and Add Noborder Patch

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1,7 +1,8 @@
 /* See LICENSE file for copyright and license details. */
 
 /* appearance */
-static const unsigned int refresh_rate = 60;    /* Matches dwm's mouse event processing to your monitor's refresh rate for smoother window interactions. */
+static const unsigned int refresh_rate = 60;    /* matches dwm's mouse event processing to your monitor's refresh rate for smoother window interactions */
+static const unsigned int enable_noborder = 1;  /* toggles noborder feature (0=disabled, 1=enabled) */
 static const unsigned int borderpx  = 1;        /* border pixel of windows */
 static const unsigned int snap      = 32;       /* snap pixel */
 static const int swallowfloating    = 0;        /* 1 means swallow floating windows by default */

--- a/config.h
+++ b/config.h
@@ -1,28 +1,31 @@
 /* See LICENSE file for copyright and license details. */
 
 /* appearance */
-static const unsigned int refresh_rate = 60;    /* Matches dwm's mouse event processing to your monitor's refresh rate for smoother window interactions. */
-static const unsigned int borderpx  = 0;        /* border pixel of windows */
-static const unsigned int snap      = 26;       /* snap pixel */
-static const int swallowfloating    = 1;        /* 1 means swallow floating windows by default */
-static const unsigned int systraypinning = 0;   /* 0: sloppy systray follows selected monitor, >0: pin systray to monitor X */
-static const unsigned int systrayonleft = 0;   	/* 0: systray in the right corner, >0: systray on left of status text */
-static const unsigned int systrayspacing = 1;   /* systray spacing */
-static const int systraypinningfailfirst = 1;   /* 1: if pinning fails, display systray on the first monitor, False: display systray on the last monitor*/
-static const int showsystray        = 1;        /* 0 means no systray */
-static const int showbar            = 1;        /* 0 means no bar */
-static const int topbar             = 1;        /* 0 means bottom bar */
-static const Bool viewontag         = True;     /* Switch view on tag switch */
-static const char *fonts[]          = { "MesloLGS Nerd Font Mono:size=14" };
-static const char col_gray1[]       = "#2E3440";
-static const char col_gray2[]       = "#3B4252";
-static const char col_gray3[]       = "#D8DEE9";
-static const char col_gray4[]       = "#ECEFF4";
-static const char col_cyan[]        = "#434C5E";
+static const unsigned int refresh_rate    = 60;     /* matches dwm's mouse event processing to your monitor's refresh rate for smoother window interactions */
+static const unsigned int enable_noborder = 1;      /* toggles noborder feature (0=disabled, 1=enabled) */
+static const unsigned int borderpx        = 1;      /* border pixel of windows */
+static const unsigned int snap            = 26;     /* snap pixel */
+static const int swallowfloating          = 1;      /* 1 means swallow floating windows by default */
+static const unsigned int systraypinning  = 0;      /* 0: sloppy systray follows selected monitor, >0: pin systray to monitor X */
+static const unsigned int systrayonleft   = 0;      /* 0: systray in the right corner, >0: systray on left of status text */
+static const unsigned int systrayspacing  = 1;      /* systray spacing */
+static const int systraypinningfailfirst  = 1;      /* 1: if pinning fails, display systray on the first monitor, False: display systray on the last monitor*/
+static const int showsystray              = 1;      /* 0 means no systray */
+static const int showbar                  = 1;      /* 0 means no bar */
+static const int topbar                   = 1;      /* 0 means bottom bar */
+static const Bool viewontag               = True;   /* Switch view on tag switch */
+static const char *fonts[]                = { "MesloLGS Nerd Font Mono:size=14", "NotoColorEmoji:pixelsize=10:antialias=true:autohint=true"  };
+static const char normbordercolor[]       = "#3B4252";
+static const char normbgcolor[]           = "#2E3440";
+static const char normfgcolor[]           = "#D8DEE9";
+static const char selbordercolor[]        = "#434C5E";
+static const char selbgcolor[]            = "#434C5E";
+static const char selfgcolor[]            = "#ECEFF4";
+
 static const char *colors[][3]      = {
-	/*               fg         bg         border   */
-	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
-	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
+	/*               fg           bg           border   */
+	[SchemeNorm] = { normfgcolor, normbgcolor, normbordercolor },
+	[SchemeSel] =  { selfgcolor,  selbgcolor,  selbordercolor },
 };
 
 static const char *const autostart[] = {
@@ -42,9 +45,9 @@ static const char *const autostart[] = {
 /* tagging */
 static const char *tags[] = { "", "", "", "", "" };
 
-static const char ptagf[] = "[%s %s]";	/* format of a tag label */
-static const char etagf[] = "[%s]";	/* format of an empty tag */
-static const int lcaselbl = 0;		/* 1 means make tag label lowercase */	
+static const char ptagf[] = "[%s %s]";  /* format of a tag label */
+static const char etagf[] = "[%s]";     /* format of an empty tag */
+static const int lcaselbl = 0;          /* 1 means make tag label lowercase */
 
 static const Rule rules[] = {
 	/* xprop(1):
@@ -86,52 +89,52 @@ static const char *launchercmd[] = { "rofi", "-show", "drun", NULL };
 static const char *termcmd[]  = { "kitty", NULL };
 
 static Key keys[] = {
-	/* modifier                     key        function        argument */
-	{ MODKEY,                       XK_r,      spawn,          {.v = launchercmd} },
-	{ MODKEY,                       XK_x,      spawn,          {.v = termcmd } },
-	{ MODKEY,                       XK_b,      spawn,          SHCMD ("thorium-browser")},
-	{ MODKEY,                       XK_p,      spawn,          SHCMD ("flameshot full -p /media/drive/Screenshots/")},
-	{ MODKEY|ShiftMask,             XK_p,      spawn,          SHCMD ("flameshot gui -p /media/drive/Screenshots/")},
-	{ MODKEY|ControlMask,           XK_p,      spawn,          SHCMD ("flameshot gui --clipboard")},
-	{ MODKEY,                       XK_e,      spawn,          SHCMD ("thunar")},
-	{ MODKEY,                       XK_w,      spawn,          SHCMD ("looking-glass-client -F")},
-	{ 0,                            0x1008ff02, spawn,         SHCMD ("xbacklight -inc 10")},
-	{ 0,                            0x1008ff03, spawn,         SHCMD ("xbacklight -dec 10")},
-	{ 0,                            0x1008ff11, spawn,         SHCMD ("amixer sset Master 5%- unmute")},
-	{ 0,                            0x1008ff12, spawn,         SHCMD ("amixer sset Master $(amixer get Master | grep -q '\\[on\\]' && echo 'mute' || echo 'unmute')")},
-	{ 0,                            0x1008ff13, spawn,         SHCMD ("amixer sset Master 5%+ unmute")},
-	{ MODKEY|ShiftMask,             XK_b,      togglebar,      {0} },
-	{ MODKEY,                       XK_j,      focusstack,     {.i = +1 } },
-	{ MODKEY,                       XK_k,      focusstack,     {.i = -1 } },
-	{ MODKEY,                       XK_i,      incnmaster,     {.i = +1 } },
-	{ MODKEY,                       XK_d,      incnmaster,     {.i = -1 } },
-	{ MODKEY,                       XK_h,      setmfact,       {.f = -0.05} },
-	{ MODKEY,                       XK_l,      setmfact,       {.f = +0.05} },
-	{ MODKEY|ShiftMask,             XK_h,      setcfact,       {.f = +0.25} },
-	{ MODKEY|ShiftMask,             XK_l,      setcfact,       {.f = -0.25} },
-	{ MODKEY|ShiftMask,             XK_o,      setcfact,       {.f =  0.00} },
-	{ MODKEY,                       XK_Return, zoom,           {0} },
-	{ MODKEY,                       XK_Tab,    view,           {0} },
-	{ MODKEY,                       XK_q,      killclient,     {0} },
-	{ MODKEY,                       XK_t,      setlayout,      {.v = &layouts[0]} },
-	{ MODKEY,                       XK_f,      setlayout,      {.v = &layouts[1]} },
-  	{ MODKEY,                       XK_m,      fullscreen,     {0} },
-	{ MODKEY,                       XK_space,  setlayout,      {0} },
-	{ MODKEY|ShiftMask,             XK_m,      togglefloating, {0} },
-	{ MODKEY,                       XK_0,      view,           {.ui = ~0 } },
-	{ MODKEY|ShiftMask,             XK_0,      tag,            {.ui = ~0 } },
-	{ MODKEY,                       XK_comma,  focusmon,       {.i = -1 } },
-	{ MODKEY,                       XK_period, focusmon,       {.i = +1 } },
-	{ MODKEY|ShiftMask,             XK_comma,  tagmon,         {.i = -1 } },
-	{ MODKEY|ShiftMask,             XK_period, tagmon,         {.i = +1 } },
-	TAGKEYS(                        XK_1,                      0)
-	TAGKEYS(                        XK_2,                      1)
-	TAGKEYS(                        XK_3,                      2)
-	TAGKEYS(                        XK_4,                      3)
-	TAGKEYS(                        XK_5,                      4)
-	{ MODKEY|ShiftMask,             XK_q,      quit,           {0} },
-	{ MODKEY|ControlMask|ShiftMask, XK_r,      spawn,          SHCMD("systemctl reboot")},
-	{ MODKEY|ControlMask|ShiftMask, XK_s,      spawn,          SHCMD("systemctl suspend")},
+	/* modifier                     key            function                argument */
+	{ MODKEY,                       XK_r,          spawn,                  {.v = launchercmd} },
+	{ MODKEY,                       XK_x,          spawn,                  {.v = termcmd } },
+	{ MODKEY,                       XK_b,          spawn,                  SHCMD ("thorium-browser")},
+	{ MODKEY,                       XK_p,          spawn,                  SHCMD ("flameshot full -p /media/drive/Screenshots/")},
+	{ MODKEY|ShiftMask,             XK_p,          spawn,                  SHCMD ("flameshot gui -p /media/drive/Screenshots/")},
+	{ MODKEY|ControlMask,           XK_p,          spawn,                  SHCMD ("flameshot gui --clipboard")},
+	{ MODKEY,                       XK_e,          spawn,                  SHCMD ("thunar")},
+	{ MODKEY,                       XK_w,          spawn,                  SHCMD ("looking-glass-client -F")},
+	{ 0,                            0x1008ff02,    spawn,                  SHCMD ("xbacklight -inc 10")},
+	{ 0,                            0x1008ff03,    spawn,                  SHCMD ("xbacklight -dec 10")},
+	{ 0,                            0x1008ff11,    spawn,                  SHCMD ("amixer sset Master 5%- unmute")},
+	{ 0,                            0x1008ff12,    spawn,                  SHCMD ("amixer sset Master $(amixer get Master | grep -q '\\[on\\]' && echo 'mute' || echo 'unmute')")},
+	{ 0,                            0x1008ff13,    spawn,                  SHCMD ("amixer sset Master 5%+ unmute")},
+	{ MODKEY|ShiftMask,             XK_b,          togglebar,              {0} },
+	{ MODKEY,                       XK_j,          focusstack,             {.i = +1 } },
+	{ MODKEY,                       XK_k,          focusstack,             {.i = -1 } },
+	{ MODKEY,                       XK_i,          incnmaster,             {.i = +1 } },
+	{ MODKEY,                       XK_d,          incnmaster,             {.i = -1 } },
+	{ MODKEY,                       XK_h,          setmfact,               {.f = -0.05} },
+	{ MODKEY,                       XK_l,          setmfact,               {.f = +0.05} },
+	{ MODKEY|ShiftMask,             XK_h,          setcfact,               {.f = +0.25} },
+	{ MODKEY|ShiftMask,             XK_l,          setcfact,               {.f = -0.25} },
+	{ MODKEY|ShiftMask,             XK_o,          setcfact,               {.f =  0.00} },
+	{ MODKEY,                       XK_Return,     zoom,                   {0} },
+	{ MODKEY,                       XK_Tab,        view,                   {0} },
+	{ MODKEY,                       XK_q,          killclient,             {0} },
+	{ MODKEY,                       XK_t,          setlayout,              {.v = &layouts[0]} },
+	{ MODKEY,                       XK_f,          setlayout,              {.v = &layouts[1]} },
+	{ MODKEY,                       XK_m,          fullscreen,             {0} },
+	{ MODKEY,                       XK_space,      setlayout,              {0} },
+	{ MODKEY|ShiftMask,             XK_m,          togglefloating,         {0} },
+	{ MODKEY,                       XK_0,          view,                   {.ui = ~0 } },
+	{ MODKEY|ShiftMask,             XK_0,          tag,                    {.ui = ~0 } },
+	{ MODKEY,                       XK_comma,      focusmon,               {.i = -1 } },
+	{ MODKEY,                       XK_period,     focusmon,               {.i = +1 } },
+	{ MODKEY|ShiftMask,             XK_comma,      tagmon,                 {.i = -1 } },
+	{ MODKEY|ShiftMask,             XK_period,     tagmon,                 {.i = +1 } },
+	TAGKEYS(                        XK_1,                                  0)
+	TAGKEYS(                        XK_2,                                  1)
+	TAGKEYS(                        XK_3,                                  2)
+	TAGKEYS(                        XK_4,                                  3)
+	TAGKEYS(                        XK_5,                                  4)
+	{ MODKEY|ShiftMask,             XK_q,          quit,                   {0} },
+	{ MODKEY|ControlMask|ShiftMask, XK_r,          spawn,                  SHCMD("systemctl reboot")},
+	{ MODKEY|ControlMask|ShiftMask, XK_s,          spawn,                  SHCMD("systemctl suspend")},
 };
 
 /* button definitions */
@@ -152,4 +155,3 @@ static Button buttons[] = {
 	{ ClkTagBar,            MODKEY,         Button1,        tag,            {0} },
 	{ ClkTagBar,            MODKEY,         Button3,        toggletag,      {0} },
 };
-

--- a/dwm.c
+++ b/dwm.c
@@ -229,6 +229,7 @@ static void motionnotify(XEvent *e);
 static void movemouse(const Arg *arg);
 static void moveorplace(const Arg *arg);
 static Client *nexttiled(Client *c);
+static int noborder(Client *c);
 static void placemouse(const Arg *arg);
 static void pop(Client *c);
 static void propertynotify(XEvent *e);
@@ -806,6 +807,13 @@ configure(Client *c)
 	ce.width = c->w;
 	ce.height = c->h;
 	ce.border_width = c->bw;
+
+	if (noborder(c) && enable_noborder) {
+		ce.width += c->bw * 2;
+		ce.height += c->bw * 2;
+		ce.border_width = 0;
+	}
+
 	ce.above = None;
 	ce.override_redirect = False;
 	XSendEvent(dpy, c->win, False, StructureNotifyMask, (XEvent *)&ce);
@@ -1588,6 +1596,23 @@ nexttiled(Client *c)
 	return c;
 }
 
+int
+noborder(Client *c)
+{
+	int monocle_layout = 0;
+
+	if (!monocle_layout && (nexttiled(c->mon->clients) != c || nexttiled(c->next)))
+		return 0;
+
+	if (c->isfloating)
+		return 0;
+
+	if (!c->mon->lt[c->mon->sellt]->arrange)
+		return 0;
+
+	return 1;
+}
+
 void
 placemouse(const Arg *arg)
 {
@@ -1865,6 +1890,11 @@ resizeclient(Client *c, int x, int y, int w, int h)
 		return;
 
 	wc.border_width = c->bw;
+	if (noborder(c) && enable_noborder) {
+		wc.width += c->bw * 2;
+		wc.height += c->bw * 2;
+		wc.border_width = 0;
+	}
 	XConfigureWindow(dpy, c->win, CWX|CWY|CWWidth|CWHeight|CWBorderWidth, &wc);
 	configure(c);
 	XSync(dpy, False);

--- a/dwm.desktop
+++ b/dwm.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Encoding=UTF-8
-Name=Dwm
+Name=dwm
 Comment=Dynamic window manager
 Exec=dwm
 Icon=dwm


### PR DESCRIPTION
This commit includes the following:
1- Config.h Refactor: Improve readability of config.h, resolving past formatting issues.
2- The "noborder" patch, which permits the concealment of the border when only one client is visible, represents a superior implementation compared to those in suckless patches, as it is less prone to causing bugs. With this implementation, I have yet to encounter a single bug. I have also added a static variable in config.def.h and config.h that allows enabling or disabling noborder for those who do not wish to have this feature at all and would prefer to disable the borders completely.

You should consider changing either the unfocused client colour or the focused client colour so that they can be different, enabling us to differentiate between them, thus making the borders usable.