### PR TITLE
Integrating Enhanced System Tray & Added Movestack and Winicon patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is my personal fork with following patches:
 + cool autostart
 + fakefullscreen client (with resize fix for chrome-based browsers + noborder fix)
 + multikeycode
++ movestack
 + noborder (floating + border flicker fix)
 + pertag
 + placemouse

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This is my personal fork with following patches:
 + true fullscreen
 + hide vacant tags
 + warp v2
++ winicon
 
 Some patches are rewritten or modified to work together.
 

--- a/config.def.h
+++ b/config.def.h
@@ -88,6 +88,8 @@ static Key keys[] = {
 	{ MODKEY,                       XK_b,      togglebar,      {0} },
 	{ MODKEY,                       XK_j,      focusstack,     {.i = +1 } },
 	{ MODKEY,                       XK_k,      focusstack,     {.i = -1 } },
+	{ MODKEY|ShiftMask,             XK_j,      movestack,      {.i = +1 } },
+	{ MODKEY|ShiftMask,             XK_k,      movestack,      {.i = -1 } },
 	{ MODKEY,                       XK_i,      incnmaster,     {.i = +1 } },
 	{ MODKEY,                       XK_d,      incnmaster,     {.i = -1 } },
 	{ MODKEY,                       XK_h,      setmfact,       {.f = -0.05} },

--- a/config.def.h
+++ b/config.def.h
@@ -7,12 +7,15 @@ static const unsigned int borderpx  = 1;        /* border pixel of windows */
 static const unsigned int snap      = 32;       /* snap pixel */
 static const int swallowfloating    = 0;        /* 1 means swallow floating windows by default */
 static const unsigned int systraypinning = 0;   /* 0: sloppy systray follows selected monitor, >0: pin systray to monitor X */
-static const unsigned int systrayonleft = 0;   	/* 0: systray in the right corner, >0: systray on left of status text */
+static const unsigned int systrayonleft = 0;    /* 0: systray in the right corner, >0: systray on left of status text */
 static const unsigned int systrayspacing = 2;   /* systray spacing */
 static const int systraypinningfailfirst = 1;   /* 1: if pinning fails, display systray on the first monitor, False: display systray on the last monitor*/
-static const int showsystray        = 1;     /* 0 means no systray */
-static const int showbar            = 1;     /* 0 means no bar */
-static const int topbar             = 1;     /* 0 means bottom bar */
+static const int showsystray        = 1;        /* 0 means no systray */
+static const int showbar            = 1;        /* 0 means no bar */
+static const int topbar             = 1;        /* 0 means bottom bar */
+#define ICONSIZE                      17        /* icon size */
+#define ICONSPACING                   5         /* space between icon and title */
+#define SHOWWINICON                   1         /* 0 means no winicon */
 static const char *fonts[]          = { "monospace:size=10" };
 static const char dmenufont[]       = "monospace:size=10";
 static const char col_gray1[]       = "#222222";

--- a/config.h
+++ b/config.h
@@ -109,6 +109,8 @@ static Key keys[] = {
 	{ MODKEY|ShiftMask,             XK_b,          togglebar,              {0} },
 	{ MODKEY,                       XK_j,          focusstack,             {.i = +1 } },
 	{ MODKEY,                       XK_k,          focusstack,             {.i = -1 } },
+	{ MODKEY|ShiftMask,             XK_j,          movestack,              {.i = +1 } },
+	{ MODKEY|ShiftMask,             XK_k,          movestack,              {.i = -1 } },
 	{ MODKEY,                       XK_i,          incnmaster,             {.i = +1 } },
 	{ MODKEY,                       XK_d,          incnmaster,             {.i = -1 } },
 	{ MODKEY,                       XK_h,          setmfact,               {.f = -0.05} },

--- a/config.h
+++ b/config.h
@@ -13,6 +13,9 @@ static const int systraypinningfailfirst  = 1;      /* 1: if pinning fails, disp
 static const int showsystray              = 1;      /* 0 means no systray */
 static const int showbar                  = 1;      /* 0 means no bar */
 static const int topbar                   = 1;      /* 0 means bottom bar */
+#define ICONSIZE                            17      /* icon size */
+#define ICONSPACING                         5       /* space between icon and title */
+#define SHOWWINICON                         1       /* 0 means no winicon */
 static const char *fonts[]                = { "MesloLGS Nerd Font Mono:size=16", "NotoColorEmoji:pixelsize=16:antialias=true:autohint=true"  };
 static const char normbordercolor[]       = "#3B4252";
 static const char normbgcolor[]           = "#2E3440";

--- a/config.mk
+++ b/config.mk
@@ -31,7 +31,6 @@ OPTIMISATIONS = -march=native -mtune=native -flto=auto -O3
 
 # flags
 CPPFLAGS = -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_XOPEN_SOURCE=700L -DVERSION=\"${VERSION}\" ${XINERAMAFLAGS}
-#CFLAGS   = -g -std=c99 -pedantic -Wall -O0 ${INCS} ${CPPFLAGS}
 CFLAGS   = ${OPTIMISATIONS} -std=c99 -pedantic -Wall -Wno-unused-function -Wno-deprecated-declarations ${INCS} ${CPPFLAGS}
 LDFLAGS  = ${LIBS}
 

--- a/config.mk
+++ b/config.mk
@@ -22,7 +22,7 @@ FREETYPEINC = /usr/include/freetype2
 
 # includes and libs
 INCS = -I${X11INC} -I${FREETYPEINC}
-LIBS = -L${X11LIB} -lX11 ${XINERAMALIBS} ${FREETYPELIBS} -lX11-xcb -lxcb -lxcb-res ${KVMLIB}
+LIBS = -L${X11LIB} -lX11 ${XINERAMALIBS} ${FREETYPELIBS} -lXrender -lImlib2 -lX11-xcb -lxcb -lxcb-res ${KVMLIB}
 
 # Optional compiler optimisations may create smaller binaries and
 # faster code, but increases compile time.

--- a/drw.c
+++ b/drw.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <X11/Xlib.h>
 #include <X11/Xft/Xft.h>
+#include <Imlib2.h>
 
 #include "drw.h"
 #include "util.h"
@@ -71,6 +72,7 @@ drw_create(Display *dpy, int screen, Window root, unsigned int w, unsigned int h
 	drw->w = w;
 	drw->h = h;
 	drw->drawable = XCreatePixmap(dpy, root, w, h, DefaultDepth(dpy, screen));
+	drw->picture = XRenderCreatePicture(dpy, drw->drawable, XRenderFindVisualFormat(dpy, DefaultVisual(dpy, screen)), 0, NULL);
 	drw->gc = XCreateGC(dpy, root, 0, NULL);
 	XSetLineAttributes(dpy, drw->gc, 1, LineSolid, CapButt, JoinMiter);
 
@@ -85,18 +87,83 @@ drw_resize(Drw *drw, unsigned int w, unsigned int h)
 
 	drw->w = w;
 	drw->h = h;
+	if (drw->picture)
+		XRenderFreePicture(drw->dpy, drw->picture);
 	if (drw->drawable)
 		XFreePixmap(drw->dpy, drw->drawable);
 	drw->drawable = XCreatePixmap(drw->dpy, drw->root, w, h, DefaultDepth(drw->dpy, drw->screen));
+	drw->picture = XRenderCreatePicture(drw->dpy, drw->drawable, XRenderFindVisualFormat(drw->dpy, DefaultVisual(drw->dpy, drw->screen)), 0, NULL);
 }
 
 void
 drw_free(Drw *drw)
 {
+	XRenderFreePicture(drw->dpy, drw->picture);
 	XFreePixmap(drw->dpy, drw->drawable);
 	XFreeGC(drw->dpy, drw->gc);
 	drw_fontset_free(drw->fonts);
 	free(drw);
+}
+
+Picture
+drw_picture_create_resized(Drw *drw, char *src, unsigned int srcw, unsigned int srch, unsigned int dstw, unsigned int dsth) {
+	Pixmap pm;
+	Picture pic;
+	GC gc;
+
+	if (srcw <= (dstw << 1u) && srch <= (dsth << 1u)) {
+		XImage img = {
+			srcw, srch, 0, ZPixmap, src,
+			ImageByteOrder(drw->dpy), BitmapUnit(drw->dpy), BitmapBitOrder(drw->dpy), 32,
+			32, 0, 32,
+			0, 0, 0
+		};
+		XInitImage(&img);
+
+		pm = XCreatePixmap(drw->dpy, drw->root, srcw, srch, 32);
+		gc = XCreateGC(drw->dpy, pm, 0, NULL);
+		XPutImage(drw->dpy, pm, gc, &img, 0, 0, 0, 0, srcw, srch);
+		XFreeGC(drw->dpy, gc);
+
+		pic = XRenderCreatePicture(drw->dpy, pm, XRenderFindStandardFormat(drw->dpy, PictStandardARGB32), 0, NULL);
+		XFreePixmap(drw->dpy, pm);
+
+		XRenderSetPictureFilter(drw->dpy, pic, FilterBilinear, NULL, 0);
+		XTransform xf;
+		xf.matrix[0][0] = (srcw << 16u) / dstw; xf.matrix[0][1] = 0; xf.matrix[0][2] = 0;
+		xf.matrix[1][0] = 0; xf.matrix[1][1] = (srch << 16u) / dsth; xf.matrix[1][2] = 0;
+		xf.matrix[2][0] = 0; xf.matrix[2][1] = 0; xf.matrix[2][2] = 65536;
+		XRenderSetPictureTransform(drw->dpy, pic, &xf);
+	} else {
+		Imlib_Image origin = imlib_create_image_using_data(srcw, srch, (DATA32 *)src);
+		if (!origin) return None;
+		imlib_context_set_image(origin);
+		imlib_image_set_has_alpha(1);
+		Imlib_Image scaled = imlib_create_cropped_scaled_image(0, 0, srcw, srch, dstw, dsth);
+		imlib_free_image_and_decache();
+		if (!scaled) return None;
+		imlib_context_set_image(scaled);
+		imlib_image_set_has_alpha(1);
+
+		XImage img = {
+		    dstw, dsth, 0, ZPixmap, (char *)imlib_image_get_data_for_reading_only(),
+		    ImageByteOrder(drw->dpy), BitmapUnit(drw->dpy), BitmapBitOrder(drw->dpy), 32,
+		    32, 0, 32,
+		    0, 0, 0
+		};
+		XInitImage(&img);
+
+		pm = XCreatePixmap(drw->dpy, drw->root, dstw, dsth, 32);
+		gc = XCreateGC(drw->dpy, pm, 0, NULL);
+		XPutImage(drw->dpy, pm, gc, &img, 0, 0, 0, 0, dstw, dsth);
+		imlib_free_image_and_decache();
+		XFreeGC(drw->dpy, gc);
+
+		pic = XRenderCreatePicture(drw->dpy, pm, XRenderFindStandardFormat(drw->dpy, PictStandardARGB32), 0, NULL);
+		XFreePixmap(drw->dpy, pm);
+	}
+
+	return pic;
 }
 
 /* This function is an implementation detail. Library users should use
@@ -382,6 +449,14 @@ no_match:
 		XftDrawDestroy(d);
 
 	return x + (render ? w : 0);
+}
+
+void
+drw_pic(Drw *drw, int x, int y, unsigned int w, unsigned int h, Picture pic)
+{
+	if (!drw)
+		return;
+	XRenderComposite(drw->dpy, PictOpOver, pic, None, drw->picture, 0, 0, 0, 0, x, y, w, h);
 }
 
 void

--- a/drw.h
+++ b/drw.h
@@ -21,6 +21,7 @@ typedef struct {
 	int screen;
 	Window root;
 	Drawable drawable;
+	Picture picture;
 	GC gc;
 	Clr *scheme;
 	Fnt *fonts;
@@ -50,9 +51,12 @@ void drw_cur_free(Drw *drw, Cur *cursor);
 void drw_setfontset(Drw *drw, Fnt *set);
 void drw_setscheme(Drw *drw, Clr *scm);
 
+Picture drw_picture_create_resized(Drw *drw, char *src, unsigned int src_w, unsigned int src_h, unsigned int dst_w, unsigned int dst_h);
+
 /* Drawing functions */
 void drw_rect(Drw *drw, int x, int y, unsigned int w, unsigned int h, int filled, int invert);
 int drw_text(Drw *drw, int x, int y, unsigned int w, unsigned int h, unsigned int lpad, const char *text, int invert);
+void drw_pic(Drw *drw, int x, int y, unsigned int w, unsigned int h, Picture pic);
 
 /* Map functions */
 void drw_map(Drw *drw, Window win, int x, int y, unsigned int w, unsigned int h);


### PR DESCRIPTION
I've refined the system tray functionality and seamlessly incorporated the MoveStack patch. This enhancement grants the flexibility to rearrange clients within the stack and interchange them with the master client. Additionally, I've integrated the Winicon patch, allowing users to toggle its presence via config.h and customise the icon size according to preference. The Winicon patch relies on Imlib2 for icon scaling, so ensure you install that package according to your distribution. Lastly, I've updated the Swallow patch to ensure optimal performance and usability.