### PR TITLE
Fix icon in drum ui caused by new nerd-font fonts

### DIFF
--- a/config/rofi/config.rasi
+++ b/config/rofi/config.rasi
@@ -3,7 +3,7 @@
 configuration {
   show-icons: true;
   icon-theme: "Papirus";
-  display-drun: "";
+  display-drun: "  ";
   display-window: "﩯 ";
   display-combi: "  ";
 }


### PR DESCRIPTION
Current config generated the following icon when nerd-fonts are installed:

![original-with-nerd-fonts](https://github.com/user-attachments/assets/0d740af6-d61a-4734-a541-b8e6784b74f8)

Patch fixes the icon:
![fix-with-nerd-fonts](https://github.com/user-attachments/assets/d31c3c73-6f89-4565-986c-ac5e4f2f8e43)


