### PR TITLE
Fix Swallow Patch

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -50,6 +50,7 @@ static const Rule rules[] = {
 	{ "Gimp",    NULL,     NULL,           0,         1,          0,           0,        -1 },
 	{ "Firefox", NULL,     NULL,           1 << 8,    0,          0,          -1,        -1 },
 	{ "St",      NULL,     NULL,           0,         0,          1,           0,        -1 },
+  { "Alacritty",NULL,    NULL,           0,         0,          1,           0,        -1 },
 	{ NULL,      NULL,     "Event Tester", 0,         0,          0,           1,        -1 }, /* xev */
 };
 


### PR DESCRIPTION
# you need to add window rules  examples

```c
static const Rule rules[] = {
    /* class            instance      title           tags mask  isfloating  isterminal  noswallow  monitor */
    { "Gimp",            NULL,        NULL,           0,         1,          0,          0,        -1 }, /* GIMP application */
    { "Firefox",         NULL,        NULL,           1 << 8,    0,          0,          -1,        -1 }, /* Firefox browser */
    { "St",                  NULL,        NULL,           0,         0,          1,          0,        -1 }, /* Simple terminal */
    { "Alacritty",       NULL,        NULL,           0,         0,          1,          0,        -1 }, /* Alacritty terminal */
    { NULL,               NULL,        "Event Tester", 0,         0,          0,          1,        -1 }, /* xev window */
    { "Volapplet",    NULL,        NULL,           0,         1,          0,          1,        -1 }, /* Volume applet */
    { "Blueman-manager",NULL,       NULL,           0,         1,          0,          1,        -1 }, /* Bluetooth manager */
};

```