### PR TITLE
[Bug Fix] Linutil Command URL Incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This guide assumes your system has the latest updates before going ahead with th
 
 1. Launch Linutil Project with the command:
     ```bash
-    curl -fsSL https://linutil.github.io/install | bash
+    curl -fsSL https://christitus.com/linux | bash
     ```
 <img width="1839" height="1000" alt="image" src="https://github.com/user-attachments/assets/314f9a40-4ccb-4c34-b3d2-dcfee63c278b" />
 


### PR DESCRIPTION
# Pull Request

## Title
[Bug Fix] Linutil Command URL Incorrect

## Type of Change
- [X] Bug fix

## Description
The URL `https://linutil.github.io/install` currently returns:
curl: (22) The requested URL returned error: 404


## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] My changes generate no errors/warnings/merge conflicts.
