### PR TITLE
Phase4/main

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -268,7 +268,7 @@ complete from compile-only validation.
     and client-list changes.
   - Validation: `make check-xvfb-runtime`, `make check-monitor-tags`,
     `make check`.
-- [ ] Replace unchecked formatting and allocation edge cases in touched paths.
+- [x] Replace unchecked formatting and allocation edge cases in touched paths.
   - Scope: address issues encountered while touching maintainability paths,
     without broad unrelated rewrites.
   - Acceptance: touched paths check allocation and formatting boundaries.

--- a/TASKS.md
+++ b/TASKS.md
@@ -256,7 +256,7 @@ complete from compile-only validation.
   - Acceptance: related patched subsystems are easier to locate and no runtime
     behavior changes.
   - Validation: `make check`.
-- [ ] Extract runtime TOML loading/reload state behind a narrow interface.
+- [x] Extract runtime TOML loading/reload state behind a narrow interface.
   - Scope: isolate runtime TOML state transitions while preserving
     transactional reload behavior.
   - Acceptance: invalid reloads keep the last valid state and existing hotkey,

--- a/TASKS.md
+++ b/TASKS.md
@@ -273,3 +273,10 @@ complete from compile-only validation.
     without broad unrelated rewrites.
   - Acceptance: touched paths check allocation and formatting boundaries.
   - Validation: `make check`.
+- [x] Keep layout and event-loop code in `dwm.c` unless extraction measurably
+  improves clarity without increasing coupling.
+  - Scope: preserve layout functions and the X event loop in `dwm.c`; the Phase
+    4 extraction work added internal interfaces without moving those ownership
+    boundaries.
+  - Acceptance: layout and event-loop ownership remains local to `dwm.c`.
+  - Validation: `make check`, code review of Phase 4 diff.

--- a/TASKS.md
+++ b/TASKS.md
@@ -262,7 +262,7 @@ complete from compile-only validation.
   - Acceptance: invalid reloads keep the last valid state and existing hotkey,
     theme, and rule behavior remains covered.
   - Validation: `make check-xvfb-runtime`, `make check`.
-- [ ] Extract EWMH property updates behind a narrow interface.
+- [x] Extract EWMH property updates behind a narrow interface.
   - Scope: isolate root/client property updates from layout and monitor logic.
   - Acceptance: EWMH state remains synchronized with focus, tag, fullscreen,
     and client-list changes.

--- a/TASKS.md
+++ b/TASKS.md
@@ -250,7 +250,7 @@ complete from compile-only validation.
   - Acceptance: each named subsystem has documented invariants and validation
     notes, including explicit gaps where direct automated coverage is missing.
   - Validation: `make check`, `git diff --check`.
-- [ ] Group static declarations and implementation sections by subsystem.
+- [x] Group static declarations and implementation sections by subsystem.
   - Scope: regroup declarations and implementation blocks inside `dwm.c`
     without changing behavior.
   - Acceptance: related patched subsystems are easier to locate and no runtime

--- a/TASKS.md
+++ b/TASKS.md
@@ -188,7 +188,7 @@ This file tracks the next reviewable work. Product requirements live in
   - Validation: `make check-monitor-tags`, `make`, `make check-shell`,
     `make check-format`.
 
-## Current Phase: Minimal Feature-Complete Desktop
+## Completed Phase: Minimal Feature-Complete Desktop
 
 - [x] Select a usable installed terminal at runtime with an actionable fallback
   when none is available.
@@ -240,3 +240,36 @@ This file tracks the next reviewable work. Product requirements live in
 A task is complete only when its acceptance command passes or the exact skipped
 environment is recorded. Runtime and multi-monitor tasks cannot be marked
 complete from compile-only validation.
+
+## Current Phase: Core Maintainability
+
+- [x] Document patch ownership and invariants for EWMH, pertag, swallowing,
+  systray, fullscreen, icons, and runtime TOML.
+  - Scope: add a Phase 4 maintenance baseline that identifies the owning source
+    areas, invariants, and existing regression coverage before extraction work.
+  - Acceptance: each named subsystem has documented invariants and validation
+    notes, including explicit gaps where direct automated coverage is missing.
+  - Validation: `make check`, `git diff --check`.
+- [ ] Group static declarations and implementation sections by subsystem.
+  - Scope: regroup declarations and implementation blocks inside `dwm.c`
+    without changing behavior.
+  - Acceptance: related patched subsystems are easier to locate and no runtime
+    behavior changes.
+  - Validation: `make check`.
+- [ ] Extract runtime TOML loading/reload state behind a narrow interface.
+  - Scope: isolate runtime TOML state transitions while preserving
+    transactional reload behavior.
+  - Acceptance: invalid reloads keep the last valid state and existing hotkey,
+    theme, and rule behavior remains covered.
+  - Validation: `make check-xvfb-runtime`, `make check`.
+- [ ] Extract EWMH property updates behind a narrow interface.
+  - Scope: isolate root/client property updates from layout and monitor logic.
+  - Acceptance: EWMH state remains synchronized with focus, tag, fullscreen,
+    and client-list changes.
+  - Validation: `make check-xvfb-runtime`, `make check-monitor-tags`,
+    `make check`.
+- [ ] Replace unchecked formatting and allocation edge cases in touched paths.
+  - Scope: address issues encountered while touching maintainability paths,
+    without broad unrelated rewrites.
+  - Acceptance: touched paths check allocation and formatting boundaries.
+  - Validation: `make check`.

--- a/docs/PATCH-OWNERSHIP.md
+++ b/docs/PATCH-OWNERSHIP.md
@@ -1,0 +1,165 @@
+# dwm-titus Patch Ownership and Invariants
+
+This document records the major patched subsystems in `dwm.c` before Phase 4
+refactoring. "Owner" means the source area that owns the behavior and must stay
+authoritative when code is regrouped or extracted.
+
+## EWMH
+
+Owner: root-window and client property handling in `dwm.c`, including atom
+setup, desktop metadata, active-window state, client lists, and fullscreen
+messages.
+
+Invariants:
+
+- `_NET_SUPPORTED`, `_NET_CLIENT_LIST`, `_NET_NUMBER_OF_DESKTOPS`,
+  `_NET_CURRENT_DESKTOP`, `_NET_DESKTOP_NAMES`, `_NET_DESKTOP_VIEWPORT`, and
+  `_NET_ACTIVE_WINDOW` must reflect the current monitor/tag state after setup,
+  client management changes, focus changes, and tag switches.
+- Cross-monitor tag changes must update selected monitor state, focus, cursor
+  placement, and EWMH current desktop together.
+- Property updates must be synchronous with state changes and must not add
+  blocking work to the X event loop.
+- External bars must be able to reconstruct tag and client state from root
+  properties without relying on dwm internals.
+
+Regression coverage:
+
+- `make check-xvfb-runtime` validates startup EWMH state, focus, tag switching,
+  fullscreen requests, and client-list behavior.
+- `make check-monitor-tags` validates the cross-monitor source path for EWMH
+  tag handoff.
+
+## Pertag
+
+Owner: monitor state, tag selection, layout selection, and view/toggle-view
+paths in `dwm.c`.
+
+Invariants:
+
+- Each monitor owns independent per-tag layout, master count, master factor,
+  selected layout, and visibility state.
+- Switching tags must restore the target tag state before arranging windows.
+- The all-tags view must not corrupt the remembered current or previous tag.
+- Pertag state must stay attached to its monitor and must not be shared across
+  monitor instances.
+
+Regression coverage:
+
+- `make check-xvfb-runtime` validates tag switching in a live Xvfb session.
+- `make check-monitor-tags` validates the cross-monitor tag-switching source
+  path.
+
+## Swallowing
+
+Owner: client process tracking and swallow/unswallow paths in `dwm.c`.
+
+Invariants:
+
+- Only terminal clients with process ancestry to the launched client may swallow.
+- Rules with `noswallow` must prevent swallowing for matching clients.
+- Floating swallow behavior must respect the `swallowfloating` setting.
+- Unswallowing must restore the terminal client without losing monitor, tag,
+  layout, or focus consistency.
+- Missing process information must skip swallowing rather than guessing.
+
+Regression coverage:
+
+- No direct automated swallowing regression exists yet. Refactors that touch
+  this path need either a focused process-tree test or manual X11 validation.
+
+## Systray
+
+Owner: systray window management, tray icon reparenting, bar geometry, and
+Polybar-facing monitor behavior in `dwm.c` plus Polybar launch configuration.
+
+Invariants:
+
+- The tray belongs to the primary bar path and must not duplicate across
+  secondary monitors.
+- Missing tray-capable desktop components must not prevent dwm startup.
+- Tray icon mapping, unmapping, and geometry changes must keep bar layout
+  stable.
+- Systray code must stay optional and must not become a dependency for core dwm
+  behavior.
+
+Regression coverage:
+
+- `make check-session-guards` validates optional startup behavior.
+- Polybar capability checks cover missing desktop components, but live tray icon
+  behavior still requires runtime validation.
+
+## Fullscreen
+
+Owner: fullscreen state transitions in `dwm.c`, including EWMH fullscreen
+messages, fake fullscreen, layout interaction, and focus rules.
+
+Invariants:
+
+- EWMH fullscreen requests must update client state and X properties together.
+- Fake fullscreen must preserve tiling state while making the client appear
+  fullscreen according to the configured mode.
+- Focus locking for fullscreen clients must respect the configured
+  `lockfullscreen` behavior.
+- Fullscreen transitions must not strand border, geometry, monitor, or tag
+  state when toggled repeatedly.
+
+Regression coverage:
+
+- `make check-xvfb-runtime` validates EWMH fullscreen handling in a live Xvfb
+  session.
+
+## Icons
+
+Owner: `_NET_WM_ICON` parsing, client icon storage, and draw paths in `dwm.c`
+and `drw.c`.
+
+Invariants:
+
+- `_NET_WM_ICON` data must be bounds checked before reading width, height, or
+  pixel data.
+- Missing, empty, or truncated icon properties must leave the client managed and
+  must not terminate dwm.
+- Icon allocation failures must fall back to no icon without corrupting client
+  state.
+- Drawing code must tolerate clients without icons.
+
+Regression coverage:
+
+- `make check-xvfb-runtime` validates missing hints and malformed
+  `_NET_WM_ICON` data.
+
+## Runtime TOML
+
+Owner: runtime configuration loading, inotify reload, and applied hotkey, theme,
+and rule state in `dwm.c` plus `tomlparser.c`.
+
+Invariants:
+
+- User runtime files live under
+  `${XDG_CONFIG_HOME:-$HOME/.config}/dwm-titus/`.
+- `hotkeys.toml`, `themes.toml`, and `window-rules.toml` reload independently
+  when changed.
+- A failed reload must report the invalid file and keep the last valid runtime
+  state.
+- Defaults may seed missing files, but reloads must not overwrite user-owned
+  configuration.
+- Theme application may spawn helper work asynchronously; config parsing itself
+  must not block the event loop for long-running operations.
+
+Regression coverage:
+
+- `make check-xvfb-runtime` validates hotkey TOML reload and invalid reload
+  preservation.
+- `make check-install-preservation` validates user runtime TOML preservation
+  during repeated installs.
+
+## Phase 4 Refactor Rules
+
+- Preserve the existing test coverage before extracting code.
+- Add direct tests or Xvfb coverage for any subsystem whose invariants are
+  changed.
+- Keep X event-loop paths nonblocking.
+- Keep extracted interfaces narrow: the caller should request an EWMH update,
+  TOML reload, or client-state transition without exposing unrelated globals.
+- Do not increase the default runtime dependency footprint.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -155,7 +155,7 @@ Goal: reduce risk in the patched C core after behavior is covered by tests.
   systray, fullscreen, icons, and runtime TOML.
 - [x] Group static declarations and implementation sections by subsystem.
 - [x] Extract runtime TOML loading/reload state behind a narrow interface.
-- [ ] Extract EWMH property updates behind a narrow interface.
+- [x] Extract EWMH property updates behind a narrow interface.
 - [ ] Replace unchecked formatting and allocation edge cases in touched paths.
 - [ ] Keep layout and event-loop code in `dwm.c` unless extraction measurably
   improves clarity without increasing coupling.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -156,7 +156,7 @@ Goal: reduce risk in the patched C core after behavior is covered by tests.
 - [x] Group static declarations and implementation sections by subsystem.
 - [x] Extract runtime TOML loading/reload state behind a narrow interface.
 - [x] Extract EWMH property updates behind a narrow interface.
-- [ ] Replace unchecked formatting and allocation edge cases in touched paths.
+- [x] Replace unchecked formatting and allocation edge cases in touched paths.
 - [ ] Keep layout and event-loop code in `dwm.c` unless extraction measurably
   improves clarity without increasing coupling.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -154,7 +154,7 @@ Goal: reduce risk in the patched C core after behavior is covered by tests.
 - [x] Document patch ownership and invariants for EWMH, pertag, swallowing,
   systray, fullscreen, icons, and runtime TOML.
 - [x] Group static declarations and implementation sections by subsystem.
-- [ ] Extract runtime TOML loading/reload state behind a narrow interface.
+- [x] Extract runtime TOML loading/reload state behind a narrow interface.
 - [ ] Extract EWMH property updates behind a narrow interface.
 - [ ] Replace unchecked formatting and allocation edge cases in touched paths.
 - [ ] Keep layout and event-loop code in `dwm.c` unless extraction measurably

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -153,7 +153,7 @@ Goal: reduce risk in the patched C core after behavior is covered by tests.
 
 - [x] Document patch ownership and invariants for EWMH, pertag, swallowing,
   systray, fullscreen, icons, and runtime TOML.
-- [ ] Group static declarations and implementation sections by subsystem.
+- [x] Group static declarations and implementation sections by subsystem.
 - [ ] Extract runtime TOML loading/reload state behind a narrow interface.
 - [ ] Extract EWMH property updates behind a narrow interface.
 - [ ] Replace unchecked formatting and allocation edge cases in touched paths.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -157,7 +157,7 @@ Goal: reduce risk in the patched C core after behavior is covered by tests.
 - [x] Extract runtime TOML loading/reload state behind a narrow interface.
 - [x] Extract EWMH property updates behind a narrow interface.
 - [x] Replace unchecked formatting and allocation edge cases in touched paths.
-- [ ] Keep layout and event-loop code in `dwm.c` unless extraction measurably
+- [x] Keep layout and event-loop code in `dwm.c` unless extraction measurably
   improves clarity without increasing coupling.
 
 Exit criteria:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -151,7 +151,7 @@ Exit criteria:
 
 Goal: reduce risk in the patched C core after behavior is covered by tests.
 
-- [ ] Document patch ownership and invariants for EWMH, pertag, swallowing,
+- [x] Document patch ownership and invariants for EWMH, pertag, swallowing,
   systray, fullscreen, icons, and runtime TOML.
 - [ ] Group static declarations and implementation sections by subsystem.
 - [ ] Extract runtime TOML loading/reload state behind a narrow interface.
@@ -168,17 +168,24 @@ Exit criteria:
 
 ## Phase 5: Feature Expansion
 
-Goal: Replace rofi menus with vicinae menus, add a small GUI for hotkey and theme management. Treat this like a control center and making it accessible from Mod+F1. Make a settings cog that shows all the small GUI management options, and make them accessible from Mod+F2 through Mod+F7. Each GUI should be optional and not required for the core functionality of dwm-titus.
+Goal: Replace rofi menus with vicinae menus, add a small GUI for hotkey and
+theme management. Treat this like a control center and making it accessible
+from Mod+F1. Make a settings cog that shows all the small GUI management
+options, and make them accessible from Mod+F2 through Mod+F7. Each GUI should
+be optional and not required for the core functionality of dwm-titus.
 
 - [ ] Replace rofi menus with vicinae menus for power, app launcher, and
-	window switching. Keep rofi as an optional fallback with hotkey Mod+Shift+R.
+  window switching. Keep rofi as an optional fallback with hotkey Mod+Shift+R.
 - [ ] Add a small GUI for hotkey and theme management, accessible from Mod+F1.
 - [ ] Add a small GUI for display profile management, accessible from Mod+F2.
 - [ ] Add a small GUI for Polybar module management, accessible from Mod+F3.
 - [ ] Add a small GUI for optional service management, accessible from Mod+F4.
-- [ ] Add a small GUI for optional application management, accessible from Mod+F5.
-- [ ] Add a small GUI for optional configuration management, accessible from Mod+F6.
-- [ ] Add a small GUI for optional system information management, accessible from Mod+F7.
+- [ ] Add a small GUI for optional application management, accessible from
+  Mod+F5.
+- [ ] Add a small GUI for optional configuration management, accessible from
+  Mod+F6.
+- [ ] Add a small GUI for optional system information management, accessible
+  from Mod+F7.
 
 ## Phase 6: Release Qualification
 

--- a/dwm.c
+++ b/dwm.c
@@ -314,6 +314,12 @@ static void load_rules_toml(const char *user_path, const char *default_path);
 static void notify_bad_config(const char *filename, const char *reason);
 static int pathjoin(char *dst, size_t dstsz, const char *dir, const char *name);
 static void reload_config(void);
+static int runtime_config_fd(void);
+static void runtime_config_mark_reload_pending(void);
+static void runtime_config_poll_inotify(void);
+static void runtime_config_reload(void);
+static void runtime_config_reload_if_pending(void);
+static void runtime_config_setup(void);
 static void setup_inotify(void);
 static void *toml_alloc(size_t sz);
 
@@ -2241,6 +2247,7 @@ run(void)
 {
 	XEvent ev;
 	int x11_fd = ConnectionNumber(dpy);
+	int config_fd;
 	fd_set rfds;
 
 	XSync(dpy, False);
@@ -2253,18 +2260,16 @@ run(void)
 		}
 		if (!running) break;
 
-		/* Handle SIGUSR1-triggered reload */
-		if (sig_reload_pending) {
-			sig_reload_pending = 0;
-			reload_config();
-		}
+		runtime_config_reload_if_pending();
 
 		FD_ZERO(&rfds);
 		FD_SET(x11_fd, &rfds);
 		int maxfd = x11_fd;
-		if (inotify_fd >= 0) {
-			FD_SET(inotify_fd, &rfds);
-			if (inotify_fd > maxfd) maxfd = inotify_fd;
+		config_fd = runtime_config_fd();
+		if (config_fd >= 0) {
+			FD_SET(config_fd, &rfds);
+			if (config_fd > maxfd)
+				maxfd = config_fd;
 		}
 
 		if (select(maxfd + 1, &rfds, NULL, NULL, NULL) < 0) {
@@ -2272,25 +2277,8 @@ run(void)
 			break;
 		}
 
-		/* Handle inotify file-change events */
-		if (inotify_fd >= 0 && FD_ISSET(inotify_fd, &rfds)) {
-			char ibuf[4096];
-			ssize_t nr = read(inotify_fd, ibuf, sizeof(ibuf));
-			if (nr > 0) {
-				int need_reload = 0;
-				char *ptr = ibuf;
-				while (ptr < ibuf + nr) {
-					struct inotify_event *ie = (struct inotify_event *)ptr;
-					if (ie->len > 0 &&
-					    (strcmp(ie->name, "hotkeys.toml")      == 0 ||
-					     strcmp(ie->name, "themes.toml")       == 0 ||
-					     strcmp(ie->name, "window-rules.toml") == 0))
-						need_reload = 1;
-					ptr += sizeof(struct inotify_event) + ie->len;
-				}
-				if (need_reload) reload_config();
-			}
-		}
+		if (config_fd >= 0 && FD_ISSET(config_fd, &rfds))
+			runtime_config_poll_inotify();
 	}
 }
 
@@ -2695,7 +2683,7 @@ static void
 sigusr1_handler(int sig)
 {
 	(void)sig;
-	sig_reload_pending = 1;
+	runtime_config_mark_reload_pending();
 }
 
 static void *
@@ -3239,6 +3227,63 @@ reload_config(void)
 	}
 }
 
+static int
+runtime_config_fd(void)
+{
+	return inotify_fd;
+}
+
+static void
+runtime_config_mark_reload_pending(void)
+{
+	sig_reload_pending = 1;
+}
+
+static void
+runtime_config_poll_inotify(void)
+{
+	char ibuf[4096];
+	ssize_t nr = read(inotify_fd, ibuf, sizeof(ibuf));
+	int need_reload = 0;
+	char *ptr = ibuf;
+
+	if (nr <= 0)
+		return;
+
+	while (ptr < ibuf + nr) {
+		struct inotify_event *ie = (struct inotify_event *)ptr;
+		if (ie->len > 0 &&
+		    (strcmp(ie->name, "hotkeys.toml")      == 0 ||
+		     strcmp(ie->name, "themes.toml")       == 0 ||
+		     strcmp(ie->name, "window-rules.toml") == 0))
+			need_reload = 1;
+		ptr += sizeof(struct inotify_event) + ie->len;
+	}
+	if (need_reload)
+		runtime_config_reload();
+}
+
+static void
+runtime_config_reload(void)
+{
+	reload_config();
+}
+
+static void
+runtime_config_reload_if_pending(void)
+{
+	if (!sig_reload_pending)
+		return;
+	sig_reload_pending = 0;
+	runtime_config_reload();
+}
+
+static void
+runtime_config_setup(void)
+{
+	setup_inotify();
+}
+
 static void
 setup_inotify(void)
 {
@@ -3392,8 +3437,8 @@ setup(void)
 	XSelectInput(dpy, root, wa.event_mask);
 	/* Install SIGUSR1 handler and load TOML configs before grabbing keys */
 	signal(SIGUSR1, sigusr1_handler);
-	setup_inotify();
-	reload_config();
+	runtime_config_setup();
+	runtime_config_reload();
 	grabkeys();
 	focus(NULL);
 	spawnbar();

--- a/dwm.c
+++ b/dwm.c
@@ -172,7 +172,7 @@ typedef struct {
 	int monitor;
 } Rule;
 
-/* function declarations */
+/* core client and layout declarations */
 static void applyrules(Client *c);
 static int applysizehints(Client *c, int *x, int *y, int *w, int *h, int interact);
 static void arrange(Monitor *m);
@@ -180,29 +180,17 @@ static void arrangemon(Monitor *m);
 static void attach(Client *c);
 static void attachbottom(Client *c);
 static void attachstack(Client *c);
-static void buttonpress(XEvent *e);
-static void checkotherwm(void);
-static void cleanup(void);
-static void cleanupmon(Monitor *mon);
-static void clientmessage(XEvent *e);
 static void copystr(char *dst, size_t dstsz, const char *src);
 static void configure(Client *c);
-static void configurenotify(XEvent *e);
-static void configurerequest(XEvent *e);
 static Monitor *createmon(void);
-static void destroynotify(XEvent *e);
 static void detach(Client *c);
 static void detachstack(Client *c);
 static Monitor *dirtomon(int dir);
 static void drawbar(Monitor *m);
 static void drawbars(void);
-static void enternotify(XEvent *e);
-static void expose(XEvent *e);
 static void focus(Client *c);
-static void focusin(XEvent *e);
 static void focusmon(const Arg *arg);
 static void focusstack(const Arg *arg);
-static Atom getatomprop(Client *c, Atom prop);
 static pid_t getparentprocess(pid_t p);
 static int getrootptr(int *x, int *y);
 static long getstate(Window w);
@@ -212,16 +200,9 @@ static void grabbuttons(Client *c, int focused);
 static void grabkeys(void);
 static void incnmaster(const Arg *arg);
 static int isdescprocess(pid_t p, pid_t c);
-static void keypress(XEvent *e);
 static void killclient(const Arg *arg);
 static void manage(Window w, XWindowAttributes *wa);
-static void managealtbar(Window win, XWindowAttributes *wa);
-static void managetray(Window win, XWindowAttributes *wa);
-/* Declaration removed: usealtbar is always true (Polybar always used) */
-static void mappingnotify(XEvent *e);
-static void maprequest(XEvent *e);
 static void monocle(Monitor *m);
-static void motionnotify(XEvent *e);
 static void movemouse(const Arg *arg);
 static void movestack(const Arg *arg);
 static void moveorplace(const Arg *arg);
@@ -229,7 +210,6 @@ static Client *nexttiled(Client *c);
 static int noborder(Client *c);
 static void placemouse(const Arg *arg);
 static void pop(Client *c);
-static void propertynotify(XEvent *e);
 static void quit(const Arg *arg);
 static Client *recttoclient(int x, int y, int w, int h);
 static Monitor *recttomon(int x, int y, int w, int h);
@@ -237,31 +217,18 @@ static void resize(Client *c, int x, int y, int w, int h, int interact);
 static void resizeclient(Client *c, int x, int y, int w, int h);
 static void resizemouse(const Arg *arg);
 static void restack(Monitor *m);
-static void run(void);
-static void runautostart(void);
-static void scan(void);
-static void scantray(void);
 static int sendevent(Client *c, Atom proto);
 static void sendmon(Client *c, Monitor *m);
 static void setclientstate(Client *c, long state);
-static void setcurrentdesktop(void);
-static void setdesktopnames(void);
-static void setclientdesktop(Client *c);
 static void setfocus(Client *c);
 static void setfullscreen(Client *c, int fullscreen);
 static void fullscreen(const Arg *arg);
 static void setlayout(const Arg *arg);
 static void setcfact(const Arg *arg);
 static void setmfact(const Arg *arg);
-static void setnumdesktops(void);
-static void setup(void);
-static void setviewport(void);
 static void seturgent(Client *c, int urg);
-static void sigchld(int unused);
 static void showhide(Client *c);
-static void sigstatusbar(const Arg *arg);
 static void spawn(const Arg *arg);
-static void spawnbar();
 static int swallow(Client *p, Client *c);
 static Client *swallowingclient(Window w);
 static void tag(const Arg *arg);
@@ -275,10 +242,6 @@ static void toggletag(const Arg *arg);
 static void toggleview(const Arg *arg);
 static void unfocus(Client *c, int setfocus);
 static void unmanage(Client *c, int destroyed);
-static void unmanagealtbar(Window w);
-static void unmanagetray(Window w);
-static void unmapnotify(XEvent *e);
-static void updatecurrentdesktop(void);
 static void unswallow(Client *c);
 static void updatebarpos(Monitor *m);
 static void updatebars(void);
@@ -295,11 +258,56 @@ static pid_t winpid(Window w);
 static Client *wintoclient(Window w);
 static Monitor *wintomon(Window w);
 static int wmclasscontains(Window win, const char *class, const char *name);
+static void zoom(const Arg *arg);
+
+/* event, startup, and shutdown declarations */
+static void buttonpress(XEvent *e);
+static void checkotherwm(void);
+static void cleanup(void);
+static void cleanupmon(Monitor *mon);
+static void clientmessage(XEvent *e);
+static void configurenotify(XEvent *e);
+static void configurerequest(XEvent *e);
+static void destroynotify(XEvent *e);
+static void enternotify(XEvent *e);
+static void expose(XEvent *e);
+static void focusin(XEvent *e);
+static void keypress(XEvent *e);
+static void mappingnotify(XEvent *e);
+static void maprequest(XEvent *e);
+static void motionnotify(XEvent *e);
+static void propertynotify(XEvent *e);
+static void run(void);
+static void runautostart(void);
+static void scan(void);
+static void sigchld(int unused);
+static void sigstatusbar(const Arg *arg);
+static void setup(void);
+static void unmapnotify(XEvent *e);
+
+/* EWMH declarations */
+static Atom getatomprop(Client *c, Atom prop);
+static void setclientdesktop(Client *c);
+static void setcurrentdesktop(void);
+static void setdesktopnames(void);
+static void setnumdesktops(void);
+static void setviewport(void);
+static void updatecurrentdesktop(void);
+
+/* Polybar and systray declarations */
+static void managealtbar(Window win, XWindowAttributes *wa);
+static void managetray(Window win, XWindowAttributes *wa);
+static void scantray(void);
+static void spawnbar();
+static void unmanagealtbar(Window w);
+static void unmanagetray(Window w);
+
+/* X error declarations */
 static int xerror(Display *dpy, XErrorEvent *ee);
 static int xerrordummy(Display *dpy, XErrorEvent *ee);
 static int xerrorstart(Display *dpy, XErrorEvent *ee);
-static void zoom(const Arg *arg);
-/* hot-reload */
+
+/* runtime TOML declarations */
 static void load_hotkeys_toml(const char *user_path, const char *default_path);
 static void load_themes_toml(const char *user_path, const char *default_path);
 static void load_rules_toml(const char *user_path, const char *default_path);
@@ -422,7 +430,7 @@ static int getmonitorforselectedtag(void);
 static void updatemonitorcount(void);
 static void initmonitortags(void);
 
-/* function implementations */
+/* common utility implementations */
 static void
 copystr(char *dst, size_t dstsz, const char *src)
 {
@@ -513,6 +521,8 @@ applyrules(Client *c)
 		c->tags &= montags;
 	}
 }
+
+/* core client, layout, and input implementations */
 
 int
 applysizehints(Client *c, int *x, int *y, int *w, int *h, int interact)
@@ -643,6 +653,7 @@ attachstack(Client *c)
 	c->mon->stack = c;
 }
 
+/* X event and lifecycle implementations */
 void
 buttonpress(XEvent *e)
 {
@@ -1242,6 +1253,7 @@ focusstack(const Arg *arg)
 	}
 }
 
+/* icon and X property helper implementations */
 #if SHOWWINICON
 void
 freeicon(Client *c)
@@ -1641,6 +1653,7 @@ manage(Window w, XWindowAttributes *wa)
 	focus(NULL);
 }
 
+/* Polybar and systray implementations */
 void
 managealtbar(Window win, XWindowAttributes *wa)
 {
@@ -2384,6 +2397,7 @@ scan(void)
 	}
 }
 
+/* Systray discovery implementation */
 void
 scantray(void)
 {
@@ -2446,6 +2460,7 @@ sendmon(Client *c, Monitor *m)
 	focus(NULL);
 }
 
+/* EWMH property implementations */
 void
 setclientstate(Client *c, long state)
 {
@@ -2674,7 +2689,7 @@ setmfact(const Arg *arg)
 	arrange(selmon);
 }
 
-/* ── Hot-reload implementation ────────────────────────────────────────────── */
+/* runtime TOML implementation */
 
 static void
 sigusr1_handler(int sig)
@@ -4434,6 +4449,7 @@ wmclasscontains(Window win, const char *class, const char *name)
 	return res;
 }
 
+/* X error and shutdown helper implementations */
 /* There's no way to check accesses to destroyed windows, thus those cases are
  * ignored (especially on UnmapNotify's). Other types of errors call Xlibs
  * default error handler, which may call exit. */
@@ -4482,7 +4498,7 @@ zoom(const Arg *arg)
 	pop(c);
 }
 
-/* Monitor-specific tag management functions */
+/* monitor-specific tag management implementations */
 void
 updatemonitorcount(void)
 {

--- a/dwm.c
+++ b/dwm.c
@@ -286,6 +286,14 @@ static void setup(void);
 static void unmapnotify(XEvent *e);
 
 /* EWMH declarations */
+static void ewmh_append_client(Window win);
+static void ewmh_clear_active_window(void);
+static void ewmh_clear_client_list(void);
+static void ewmh_replace_root_cardinal(Atom prop, const long *data, int n);
+static void ewmh_replace_window_cardinal(Window win, Atom prop, const long *data, int n);
+static void ewmh_set_active_window(Window win);
+static void ewmh_set_desktop_names(void);
+static void ewmh_set_fullscreen_state(Client *c, int fullscreen);
 static Atom getatomprop(Client *c, Atom prop);
 static void setclientdesktop(Client *c);
 static void setcurrentdesktop(void);
@@ -764,7 +772,7 @@ cleanup(void)
 	drw_free(drw);
 	XSync(dpy, False);
 	XSetInputFocus(dpy, PointerRoot, RevertToPointerRoot, CurrentTime);
-	XDeleteProperty(dpy, root, netatom[NetActiveWindow]);
+	ewmh_clear_active_window();
 }
 
 void
@@ -1198,7 +1206,7 @@ focus(Client *c)
 		setfocus(c);
 	} else {
 		XSetInputFocus(dpy, root, RevertToPointerRoot, CurrentTime);
-		XDeleteProperty(dpy, root, netatom[NetActiveWindow]);
+		ewmh_clear_active_window();
 	}
 	selmon->sel = c;
 	drawbars();
@@ -1644,8 +1652,7 @@ manage(Window w, XWindowAttributes *wa)
 		XRaiseWindow(dpy, c->win);
 	attachbottom(c);
 	attachstack(c);
-	XChangeProperty(dpy, root, netatom[NetClientList], XA_WINDOW, 32, PropModeAppend,
-		(unsigned char *) &(c->win), 1);
+	ewmh_append_client(c->win);
 	XMoveResizeWindow(dpy, c->win, c->x + 2 * sw, c->y, c->w, c->h); /* some windows require this */
 	setclientstate(c, NormalState);
 	setclientdesktop(c);
@@ -1675,8 +1682,7 @@ managealtbar(Window win, XWindowAttributes *wa)
 	XSelectInput(dpy, win, EnterWindowMask|FocusChangeMask|PropertyChangeMask|StructureNotifyMask|ExposureMask);
 	XMoveResizeWindow(dpy, win, wa->x, wa->y, wa->width, wa->height);
 	XMapWindow(dpy, win);
-	XChangeProperty(dpy, root, netatom[NetClientList], XA_WINDOW, 32, PropModeAppend,
-		(unsigned char *) &win, 1);
+	ewmh_append_client(win);
 	if (!m->traywin)
 		scantray();
 }
@@ -1696,8 +1702,7 @@ managetray(Window win, XWindowAttributes *wa)
 	XSelectInput(dpy, win, EnterWindowMask|FocusChangeMask|PropertyChangeMask|StructureNotifyMask);
 	XMoveResizeWindow(dpy, win, wa->x, wa->y, wa->width, wa->height);
 	XMapWindow(dpy, win);
-	XChangeProperty(dpy, root, netatom[NetClientList], XA_WINDOW, 32, PropModeAppend,
-			(unsigned char *) &win, 1);
+	ewmh_append_client(win);
 }
 
 void
@@ -2449,6 +2454,67 @@ sendmon(Client *c, Monitor *m)
 }
 
 /* EWMH property implementations */
+static void
+ewmh_append_client(Window win)
+{
+	XChangeProperty(dpy, root, netatom[NetClientList], XA_WINDOW, 32,
+		PropModeAppend, (unsigned char *)&win, 1);
+}
+
+static void
+ewmh_clear_active_window(void)
+{
+	XDeleteProperty(dpy, root, netatom[NetActiveWindow]);
+}
+
+static void
+ewmh_clear_client_list(void)
+{
+	XDeleteProperty(dpy, root, netatom[NetClientList]);
+}
+
+static void
+ewmh_replace_root_cardinal(Atom prop, const long *data, int n)
+{
+	XChangeProperty(dpy, root, prop, XA_CARDINAL, 32, PropModeReplace,
+		(unsigned char *)data, n);
+}
+
+static void
+ewmh_replace_window_cardinal(Window win, Atom prop, const long *data, int n)
+{
+	XChangeProperty(dpy, win, prop, XA_CARDINAL, 32, PropModeReplace,
+		(unsigned char *)data, n);
+}
+
+static void
+ewmh_set_active_window(Window win)
+{
+	XChangeProperty(dpy, root, netatom[NetActiveWindow], XA_WINDOW, 32,
+		PropModeReplace, (unsigned char *)&win, 1);
+}
+
+static void
+ewmh_set_desktop_names(void)
+{
+	XTextProperty text;
+
+	Xutf8TextListToTextProperty(dpy, (char **)tags, TAGSLENGTH,
+		XUTF8StringStyle, &text);
+	XSetTextProperty(dpy, root, &text, netatom[NetDesktopNames]);
+}
+
+static void
+ewmh_set_fullscreen_state(Client *c, int fullscreen)
+{
+	if (fullscreen)
+		XChangeProperty(dpy, c->win, netatom[NetWMState], XA_ATOM, 32,
+			PropModeReplace, (unsigned char *)&netatom[NetWMFullscreen], 1);
+	else
+		XChangeProperty(dpy, c->win, netatom[NetWMState], XA_ATOM, 32,
+			PropModeReplace, (unsigned char *)0, 0);
+}
+
 void
 setclientstate(Client *c, long state)
 {
@@ -2464,9 +2530,7 @@ setcurrentdesktop(void){
 }
 
 void setdesktopnames(void){
-	XTextProperty text;
-	Xutf8TextListToTextProperty(dpy, (char**)tags, TAGSLENGTH, XUTF8StringStyle, &text);
-	XSetTextProperty(dpy, root, &text, netatom[NetDesktopNames]);
+	ewmh_set_desktop_names();
 }
 
 void
@@ -2486,8 +2550,7 @@ setclientdesktop(Client *c)
         data[0] = 0xFFFFFFFF;
     }
     
-    XChangeProperty(dpy, c->win, netatom[NetWMDesktop], XA_CARDINAL, 32,
-        PropModeReplace, (unsigned char *)data, 1);
+    ewmh_replace_window_cardinal(c->win, netatom[NetWMDesktop], data, 1);
 }
 
 int
@@ -2518,7 +2581,7 @@ sendevent(Client *c, Atom proto)
 void
 setnumdesktops(void){
 	long data[] = { TAGSLENGTH };
-	XChangeProperty(dpy, root, netatom[NetNumberOfDesktops], XA_CARDINAL, 32, PropModeReplace, (unsigned char *)data, 1);
+	ewmh_replace_root_cardinal(netatom[NetNumberOfDesktops], data, 1);
 }
 
 void
@@ -2526,9 +2589,7 @@ setfocus(Client *c)
 {
 	if (!c->neverfocus) {
 		XSetInputFocus(dpy, c->win, RevertToPointerRoot, CurrentTime);
-		XChangeProperty(dpy, root, netatom[NetActiveWindow],
-			XA_WINDOW, 32, PropModeReplace,
-			(unsigned char *) &(c->win), 1);
+		ewmh_set_active_window(c->win);
 	}
 	sendevent(c, wmatom[WMTakeFocus]);
 }
@@ -2559,12 +2620,7 @@ setfullscreen(Client *c, int fullscreen)
 		c->fakefullscreen = 1;
 
 	if (fullscreen != c->isfullscreen) { // only send property change if necessary
-		if (fullscreen)
-			XChangeProperty(dpy, c->win, netatom[NetWMState], XA_ATOM, 32,
-				PropModeReplace, (unsigned char*)&netatom[NetWMFullscreen], 1);
-		else
-			XChangeProperty(dpy, c->win, netatom[NetWMState], XA_ATOM, 32,
-				PropModeReplace, (unsigned char*)0, 0);
+		ewmh_set_fullscreen_state(c, fullscreen);
 	}
 
 	c->isfullscreen = fullscreen;
@@ -3427,7 +3483,7 @@ setup(void)
 	setcurrentdesktop();
 	setdesktopnames();
 	setviewport();
-	XDeleteProperty(dpy, root, netatom[NetClientList]);
+	ewmh_clear_client_list();
 	/* select events */
 	wa.cursor = cursor[CurNormal]->cursor;
 	wa.event_mask = SubstructureRedirectMask|SubstructureNotifyMask
@@ -3447,7 +3503,7 @@ setup(void)
 void
 setviewport(void){
 	long data[] = { 0, 0 };
-	XChangeProperty(dpy, root, netatom[NetDesktopViewport], XA_CARDINAL, 32, PropModeReplace, (unsigned char *)data, 2);
+	ewmh_replace_root_cardinal(netatom[NetDesktopViewport], data, 2);
 }
 
 void
@@ -3851,7 +3907,7 @@ unfocus(Client *c, int setfocus)
 	XSetWindowBorder(dpy, c->win, scheme[SchemeNorm][ColBorder].pixel);
 	if (setfocus) {
 		XSetInputFocus(dpy, root, RevertToPointerRoot, CurrentTime);
-		XDeleteProperty(dpy, root, netatom[NetActiveWindow]);
+		ewmh_clear_active_window();
 	}
 }
 
@@ -4040,12 +4096,10 @@ updateclientlist(void)
 	Client *c;
 	Monitor *m;
 
-	XDeleteProperty(dpy, root, netatom[NetClientList]);
+	ewmh_clear_client_list();
 	for (m = mons; m; m = m->next)
 		for (c = m->clients; c; c = c->next)
-			XChangeProperty(dpy, root, netatom[NetClientList],
-				XA_WINDOW, 32, PropModeAppend,
-				(unsigned char *) &(c->win), 1);
+			ewmh_append_client(c->win);
 }
 
 void updatecurrentdesktop(void){
@@ -4061,7 +4115,7 @@ void updatecurrentdesktop(void){
 		data[0] = 0;
 	}
 	
-	XChangeProperty(dpy, root, netatom[NetCurrentDesktop], XA_CARDINAL, 32, PropModeReplace, (unsigned char *)data, 1);
+	ewmh_replace_root_cardinal(netatom[NetCurrentDesktop], data, 1);
 }
 
 #if SHOWWINICON

--- a/dwm.c
+++ b/dwm.c
@@ -2499,9 +2499,11 @@ ewmh_set_desktop_names(void)
 {
 	XTextProperty text;
 
-	Xutf8TextListToTextProperty(dpy, (char **)tags, TAGSLENGTH,
-		XUTF8StringStyle, &text);
-	XSetTextProperty(dpy, root, &text, netatom[NetDesktopNames]);
+	if (Xutf8TextListToTextProperty(dpy, (char **)tags, TAGSLENGTH,
+	    XUTF8StringStyle, &text) == Success) {
+		XSetTextProperty(dpy, root, &text, netatom[NetDesktopNames]);
+		XFree(text.value);
+	}
 }
 
 static void
@@ -2833,13 +2835,17 @@ notify_bad_config(const char *filename, const char *reason)
 	const char *base = strrchr(filename, '/');
 	base = base ? base + 1 : filename;
 	char msg[768];
-	snprintf(msg, sizeof(msg),
-	         "notify-send -u critical 'dwm: bad config' '%s: %s \u2014 loaded defaults'",
-	         base, reason);
+	int len = snprintf(msg, sizeof(msg), "%s: %s - loaded defaults",
+	                   base, reason);
+	if (len < 0)
+		return;
+	if ((size_t)len >= sizeof(msg))
+		copystr(msg, sizeof(msg), "config error - loaded defaults");
 	pid_t pid = fork();
 	if (pid == 0) {
-		execl("/bin/sh", "sh", "-c", msg, (char *)NULL);
-		_exit(0);
+		execlp("notify-send", "notify-send", "-u", "critical",
+		       "dwm: bad config", msg, (char *)NULL);
+		_exit(127);
 	}
 }
 
@@ -3271,10 +3277,13 @@ reload_config(void)
 		if (pid == 0) {
 			/* child: find and run the theme-apply script */
 			const char *home = getenv("HOME");
+			char script_dir[PATH_MAX];
 			char script[PATH_MAX];
-			if (home) {
-				snprintf(script, sizeof(script),
-				         "%s/.local/share/dwm-titus/scripts/theme-apply.sh", home);
+			if (home &&
+			    pathjoin(script_dir, sizeof(script_dir),
+			            home, ".local/share/dwm-titus/scripts") &&
+			    pathjoin(script, sizeof(script),
+			            script_dir, "theme-apply.sh")) {
 				execl("/bin/sh", "sh", script, (char *)NULL);
 			}
 			_exit(0);
@@ -3302,12 +3311,16 @@ runtime_config_poll_inotify(void)
 	ssize_t nr = read(inotify_fd, ibuf, sizeof(ibuf));
 	int need_reload = 0;
 	char *ptr = ibuf;
+	char *end;
 
 	if (nr <= 0)
 		return;
+	end = ibuf + nr;
 
-	while (ptr < ibuf + nr) {
+	while (ptr + sizeof(struct inotify_event) <= end) {
 		struct inotify_event *ie = (struct inotify_event *)ptr;
+		if (ptr + sizeof(struct inotify_event) + ie->len > end)
+			break;
 		if (ie->len > 0 &&
 		    (strcmp(ie->name, "hotkeys.toml")      == 0 ||
 		     strcmp(ie->name, "themes.toml")       == 0 ||


### PR DESCRIPTION
# Pull Request

## Title
<!--[Provide a succinct and descriptive title for the pull request.]-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation Update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

This pull request focuses on improving maintainability and documentation for the `dwm-titus` codebase. The main changes include grouping code by subsystem, documenting ownership and invariants for major subsystems, and extracting interfaces for runtime TOML and EWMH property management. These changes clarify code structure, make responsibilities explicit, and lay the groundwork for safer refactoring and future enhancements.

**Documentation and Roadmap Updates:**

- Added a comprehensive `PATCH-OWNERSHIP.md` document that details ownership, invariants, and regression coverage for major subsystems such as EWMH, pertag, swallowing, systray, fullscreen, icons, and runtime TOML. This establishes clear boundaries and expectations for each subsystem.
- Updated `docs/ROADMAP.md` and `TASKS.md` to mark the "Minimal Feature-Complete Desktop" phase as complete and to introduce the "Core Maintainability" phase, reflecting the new documentation and code structure goals. [[1]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L154-R160) [[2]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L171-R188) [[3]](diffhunk://#diff-66ee26543c5fa02b0db4d04d72834581c54f595e095f50d3a5f86a1d6bdb63b0L191-R191) [[4]](diffhunk://#diff-66ee26543c5fa02b0db4d04d72834581c54f595e095f50d3a5f86a1d6bdb63b0R243-R282)

**Code Organization and Refactoring:**

- Grouped static declarations and implementation sections in `dwm.c` by subsystem (core client/layout, event/startup/shutdown, EWMH, Polybar/systray, X error, runtime TOML), making it easier to locate and maintain related code. [[1]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98L175-L205) [[2]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98L215-L264) [[3]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98L278-L281) [[4]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98R261-R330) [[5]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98L425-R447) [[6]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98R539-R540) [[7]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98R670) [[8]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98R1270) [[9]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98R1669)
- Extracted EWMH property update logic behind a narrow interface, replacing direct X property calls with dedicated functions (e.g., `ewmh_clear_active_window()`, `ewmh_append_client()`) to centralize and clarify EWMH handling. [[1]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98L750-R775) [[2]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98L1184-R1209) [[3]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98L1629-R1655)

**Maintainability Improvements:**

- Extracted runtime TOML loading and reload state behind a dedicated interface, preparing the code for safer hot-reload and configuration management.
- Ensured that touched paths now check for allocation and formatting boundaries, improving robustness (see validation notes in documentation).

These changes collectively make the codebase more maintainable, safer to refactor, and easier for new contributors to understand and extend.

**References:**  
[[1]](diffhunk://#diff-c749913e5c2ec3b0721d875484a47a04c8930294302b0be2e687a792a36111e1R1-R165) [[2]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L154-R160) [[3]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L171-R188) [[4]](diffhunk://#diff-66ee26543c5fa02b0db4d04d72834581c54f595e095f50d3a5f86a1d6bdb63b0L191-R191) [[5]](diffhunk://#diff-66ee26543c5fa02b0db4d04d72834581c54f595e095f50d3a5f86a1d6bdb63b0R243-R282) [[6]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98L175-L205) [[7]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98L215-L264) [[8]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98L278-L281) [[9]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98R261-R330) [[10]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98L425-R447) [[11]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98R539-R540) [[12]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98R670) [[13]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98L750-R775) [[14]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98L1184-R1209) [[15]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98R1270) [[16]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98L1629-R1655) [[17]](diffhunk://#diff-62eebf5eaf0e6a76a21dfed9da6556ee5413ddb49f06013bd83403cc1a485d98R1669)

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #

## Screenshots (if applicable)
