### PR TITLE
Fix wallpaper reload hotkey

### DIFF
--- a/config/hotkeys.toml
+++ b/config/hotkeys.toml
@@ -63,7 +63,7 @@ keys = [
   { mod="SUPER",            key="r",       desc="App launcher",            func="spawn",       cmd="quickshell ipc --path \"${XDG_CONFIG_HOME:-$HOME/.config}/quickshell/shell.qml\" call launcher toggle" },
   { mod="SUPER",            key="x",       desc="Terminal",                func="spawn",       exec=["$terminal"] },
   { mod="SUPER",            key="w",       desc="Looking Glass (VM)",      func="spawn",       cmd="looking-glass-client -F" },
-  { mod="SUPER SHIFT",      key="w",       desc="Randomize wallpaper",     func="spawn",       cmd="feh --randomize --bg-fill ~/Pictures/backgrounds/*" },
+  { mod="SUPER SHIFT",      key="w",       desc="Randomize wallpaper",     func="spawn",       cmd="dwm-quickshell-controlcenter action reload-wallpaper" },
 
   # ── Web apps ─────────────────────────────────────────────────────────────────
   { mod="SUPER",            key="a",       desc="ChatGPT",                 func="spawn",       exec=["$webapp", "https://chatgpt.com"] },

--- a/scripts/dwm-quickshell-controlcenter
+++ b/scripts/dwm-quickshell-controlcenter
@@ -258,11 +258,30 @@ restart_quickshell() {
 }
 
 reload_wallpaper() {
-	if command -v feh >/dev/null 2>&1 && [ -d "${HOME:-}/Pictures/backgrounds" ]; then
-		feh --randomize --bg-fill "${HOME:-}/Pictures/backgrounds"/* >/dev/null 2>&1 || true
+	wallpaper_dir=${HOME:-}/Pictures/backgrounds
+
+	if ! command -v feh >/dev/null 2>&1; then
+		printf 'feh is unavailable\n' >&2
+		return 1
+	fi
+	if [ ! -d "$wallpaper_dir" ]; then
+		printf 'wallpaper folder is unavailable: %s\n' "$wallpaper_dir" >&2
+		notify "Wallpaper folder missing" "$wallpaper_dir"
+		return 1
+	fi
+	if ! find "$wallpaper_dir" -type f \
+		\( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' -o -iname '*.webp' -o -iname '*.bmp' -o -iname '*.gif' \) \
+		-print -quit | grep -q .; then
+		printf 'no loadable wallpaper images found in %s\n' "$wallpaper_dir" >&2
+		notify "No wallpapers found" "$wallpaper_dir"
+		return 1
+	fi
+	if find "$wallpaper_dir" -type f \
+		\( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' -o -iname '*.webp' -o -iname '*.bmp' -o -iname '*.gif' \) \
+		-exec feh --randomize --bg-fill {} + >/dev/null 2>&1; then
 		notify "Wallpaper reloaded"
 	else
-		printf 'feh or wallpaper folder is unavailable\n' >&2
+		printf 'failed to reload wallpaper from %s\n' "$wallpaper_dir" >&2
 		return 1
 	fi
 }

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -108,6 +108,17 @@ run_helper action open-wallpapers >"$work/wallpapers.out"
 grep -Fqx 'action	open-wallpapers' "$work/wallpapers.out"
 grep -Fq "xdg-open $work/home/Pictures/backgrounds" "$work/actions.log"
 
+: >"$work/actions.log"
+run_helper action reload-wallpaper >"$work/reload-wallpaper.out"
+grep -Fqx 'action	reload-wallpaper' "$work/reload-wallpaper.out"
+grep -Fq "feh --randomize --bg-fill $work/home/Pictures/backgrounds/wallpaper.png" "$work/actions.log"
+
+rm -f "$work/home/Pictures/backgrounds/wallpaper.png"
+if run_helper action reload-wallpaper 2>"$work/reload-wallpaper.err"; then
+	exit 1
+fi
+grep -Fqx "no loadable wallpaper images found in $work/home/Pictures/backgrounds" "$work/reload-wallpaper.err"
+
 if run_helper action not-real 2>"$work/action.err"; then
 	exit 1
 fi


### PR DESCRIPTION
## Summary

- Route the Super+Shift+W wallpaper hotkey through the existing control-center reload helper.
- Make wallpaper reload failures explicit for missing feh, missing wallpaper directory, empty image sets, or feh failures.
- Add regression coverage for successful wallpaper reload and empty-folder failure behavior.

## Root Cause

The old hotkey invoked `feh --randomize --bg-fill ~/Pictures/backgrounds/*` directly. When the wallpaper folder was missing or empty, `feh` failed with no loadable images, but dwm hid stderr so the shortcut looked like a no-op.

## Validation

- `sh -n scripts/dwm-quickshell-controlcenter tests/test-quickshell-controlcenter.sh`
- `shellcheck scripts/dwm-quickshell-controlcenter tests/test-quickshell-controlcenter.sh`
- `./tests/test-quickshell-controlcenter.sh`
- `make clean && make`

`shfmt` was not available in the local environment.