### PR TITLE
fix quickshell systray icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ program.log
 
 # Local CI validation virtualenv
 /.ci-pykickstart/
+
+# Local Serena project metadata/cache
+/.serena/

--- a/config/quickshell/controlcenter/ControlCenterWindow.qml
+++ b/config/quickshell/controlcenter/ControlCenterWindow.qml
@@ -3,6 +3,8 @@ import QtQuick.Layouts
 import Quickshell
 import qs.core
 
+pragma ComponentBehavior: Bound
+
 FloatingWindow {
     id: root
 
@@ -180,18 +182,20 @@ FloatingWindow {
                 model: root.controlCenterModel.themeRows
 
                 delegate: ControlCenterRow {
+                    id: appearanceThemeRow
+
                     required property var modelData
 
                     width: ListView.view.width
-                    title: modelData.name
-                    detail: modelData.status === "active" ? "Active theme" : "Click to apply"
-                    status: modelData.status === "active" ? "ok" : ""
+                    title: appearanceThemeRow.modelData.name
+                    detail: appearanceThemeRow.modelData.status === "active" ? "Active theme" : "Click to apply"
+                    status: appearanceThemeRow.modelData.status === "active" ? "ok" : ""
 
                     MouseArea {
                         anchors.fill: parent
-                        enabled: modelData.status !== "active" && !root.controlCenterModel.busy
+                        enabled: appearanceThemeRow.modelData.status !== "active" && !root.controlCenterModel.busy
                         cursorShape: Qt.PointingHandCursor
-                        onClicked: root.controlCenterModel.setTheme(modelData.name)
+                        onClicked: root.controlCenterModel.setTheme(appearanceThemeRow.modelData.name)
                     }
                 }
             }

--- a/config/quickshell/core/Icons.qml
+++ b/config/quickshell/core/Icons.qml
@@ -17,12 +17,111 @@ Singleton {
     }
 
     function addIconSource(sources, source) {
+        if (typeof source !== "string" && !(source instanceof String)) {
+            return;
+        }
+
         if (source.length === 0) {
             return;
         }
 
         if (sources.indexOf(source) < 0) {
             sources.push(source);
+        }
+    }
+
+    function decodeIconPart(value) {
+        try {
+            return decodeURIComponent(value);
+        } catch (error) {
+            return value;
+        }
+    }
+
+    function iconNameFallbacks(iconName) {
+        const names = [iconName];
+
+        if (iconName.indexOf("-symbolic") < 0) {
+            names.push(iconName + "-symbolic");
+        }
+
+        if (iconName === "blueman" || iconName === "blueman-tray") {
+            names.push("blueman-tray");
+            names.push("blueman");
+            names.push("blueman-active");
+            names.push("bluetooth-active-symbolic");
+            names.push("bluetooth-symbolic");
+        } else if (iconName === "org.remmina.Remmina-status") {
+            names.push("org.remmina.Remmina");
+            names.push("org.remmina.Remmina-symbolic");
+        }
+
+        return names;
+    }
+
+    function addIconThemeFileSources(sources, themeRoot, iconName) {
+        if (themeRoot.length === 0 || iconName.length === 0) {
+            return;
+        }
+
+        const rootPath = themeRoot.replace(/\/+$/, "");
+        const names = iconNameFallbacks(iconName);
+        const sizes = ["24x24", "32x32", "22x22", "16x16", "48x48", "64x64", "96x96", "128x128", "192x192", "256x256", "512x512", "scalable"];
+        const categories = ["status", "apps", "devices", "actions", "emblems"];
+        const extensions = ["svg", "png"];
+
+        for (let nameIndex = 0; nameIndex < names.length; nameIndex++) {
+            const name = names[nameIndex];
+
+            for (let sizeIndex = 0; sizeIndex < sizes.length; sizeIndex++) {
+                const size = sizes[sizeIndex];
+
+                for (let categoryIndex = 0; categoryIndex < categories.length; categoryIndex++) {
+                    const category = categories[categoryIndex];
+
+                    for (let extensionIndex = 0; extensionIndex < extensions.length; extensionIndex++) {
+                        addIconSource(sources, "file://" + rootPath + "/" + size + "/" + category + "/" + name + "." + extensions[extensionIndex]);
+                    }
+                }
+            }
+
+            for (let categoryIndex = 0; categoryIndex < categories.length; categoryIndex++) {
+                const category = categories[categoryIndex];
+
+                for (let extensionIndex = 0; extensionIndex < extensions.length; extensionIndex++) {
+                    addIconSource(sources, "file://" + rootPath + "/" + category + "/" + name + "." + extensions[extensionIndex]);
+                }
+            }
+
+            addIconSource(sources, "file://" + rootPath + "/" + name);
+
+            for (let extensionIndex = 0; extensionIndex < extensions.length; extensionIndex++) {
+                addIconSource(sources, "file://" + rootPath + "/" + name + "." + extensions[extensionIndex]);
+            }
+        }
+    }
+
+    function addHicolorFallbacks(sources, iconName) {
+        const home = Quickshell.env("HOME") || "";
+        const xdgDataHome = Quickshell.env("XDG_DATA_HOME") || (home.length > 0 ? home + "/.local/share" : "");
+
+        addIconThemeFileSources(sources, "/usr/share/icons/hicolor", iconName);
+        addIconThemeFileSources(sources, "/usr/local/share/icons/hicolor", iconName);
+
+        if (xdgDataHome.length > 0) {
+            addIconThemeFileSources(sources, xdgDataHome + "/icons/hicolor", iconName);
+        }
+
+        if (home.length > 0) {
+            addIconThemeFileSources(sources, home + "/.icons/hicolor", iconName);
+        }
+    }
+
+    function addCheckedThemeSources(sources, iconName) {
+        const names = iconNameFallbacks(iconName);
+
+        for (let index = 0; index < names.length; index++) {
+            addIconSource(sources, Quickshell.iconPath(names[index], true));
         }
     }
 
@@ -57,17 +156,34 @@ Singleton {
         if (icon.indexOf("image://icon/") === 0) {
             const queryIndex = icon.indexOf("?path=");
             const iconStart = "image://icon/".length;
-            const iconName = queryIndex >= 0 ? icon.substring(iconStart, queryIndex) : icon.substring(iconStart);
+            const iconName = decodeIconPart(queryIndex >= 0 ? icon.substring(iconStart, queryIndex) : icon.substring(iconStart));
+
+            if (iconName.indexOf("/") === 0) {
+                addIconSource(sources, "file://" + iconName);
+            }
 
             if (queryIndex >= 0) {
-                const iconPath = icon.substring(queryIndex + "?path=".length);
-                addIconSource(sources, "file://" + iconPath + "/" + iconName + ".png");
-                addIconSource(sources, "file://" + iconPath + "/" + iconName + ".svg");
-                addIconSource(sources, "file://" + iconPath + "/" + iconName + ".ico");
-                addIconSource(sources, "file://" + iconPath + "/" + iconName + ".tga");
+                let iconPath = icon.substring(queryIndex + "?path=".length);
+                const iconPathEnd = iconPath.indexOf("&");
+
+                if (iconPathEnd >= 0) {
+                    iconPath = iconPath.substring(0, iconPathEnd);
+                }
+
+                iconPath = decodeIconPart(iconPath);
+                if (iconName.indexOf("/") !== 0) {
+                    addIconSource(sources, "file://" + iconPath + "/" + iconName);
+                    addIconSource(sources, "file://" + iconPath + "/" + iconName + ".png");
+                    addIconSource(sources, "file://" + iconPath + "/" + iconName + ".svg");
+                    addIconSource(sources, "file://" + iconPath + "/" + iconName + ".ico");
+                    addIconSource(sources, "file://" + iconPath + "/" + iconName + ".tga");
+                    addIconThemeFileSources(sources, iconPath, iconName);
+                }
             }
 
             addThemeFallbacks(sources, iconName);
+            addHicolorFallbacks(sources, iconName);
+            addCheckedThemeSources(sources, iconName);
             addIconSource(sources, icon);
             return sources;
         }
@@ -86,9 +202,10 @@ Singleton {
             addIconSource(sources, Quickshell.iconPath("dialog-password-symbolic", true));
         }
 
-        addIconSource(sources, Quickshell.iconPath(icon, true));
-        addIconSource(sources, icon);
         addThemeFallbacks(sources, icon);
+        addHicolorFallbacks(sources, icon);
+        addCheckedThemeSources(sources, icon);
+        addIconSource(sources, icon);
         return sources;
     }
 }

--- a/config/quickshell/core/Icons.qml
+++ b/config/quickshell/core/Icons.qml
@@ -38,6 +38,10 @@ Singleton {
         }
     }
 
+    function looksLikeIconFilePath(path) {
+        return /\.(ico|png|svg|tga|webp|xpm)$/i.test(path);
+    }
+
     function iconNameFallbacks(iconName) {
         const names = [iconName];
 
@@ -66,7 +70,7 @@ Singleton {
 
         const rootPath = themeRoot.replace(/\/+$/, "");
         const names = iconNameFallbacks(iconName);
-        const sizes = ["24x24", "32x32", "22x22", "16x16", "48x48", "64x64", "96x96", "128x128", "192x192", "256x256", "512x512", "scalable"];
+        const sizes = ["24x24", "32x32", "22x22", "16x16", "48x48", "scalable"];
         const categories = ["status", "apps", "devices", "actions", "emblems"];
         const extensions = ["svg", "png"];
 
@@ -160,6 +164,8 @@ Singleton {
 
             if (iconName.indexOf("/") === 0) {
                 addIconSource(sources, "file://" + iconName);
+                addIconSource(sources, icon);
+                return sources;
             }
 
             if (queryIndex >= 0) {
@@ -172,6 +178,10 @@ Singleton {
 
                 iconPath = decodeIconPart(iconPath);
                 if (iconName.indexOf("/") !== 0) {
+                    if (iconPath.indexOf("/") === 0 && looksLikeIconFilePath(iconPath)) {
+                        addIconSource(sources, "file://" + iconPath);
+                    }
+
                     addIconSource(sources, "file://" + iconPath + "/" + iconName);
                     addIconSource(sources, "file://" + iconPath + "/" + iconName + ".png");
                     addIconSource(sources, "file://" + iconPath + "/" + iconName + ".svg");

--- a/config/quickshell/core/ShellButton.qml
+++ b/config/quickshell/core/ShellButton.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Layouts
 import qs.core
 
 Rectangle {

--- a/config/quickshell/launcher/LauncherCategoryRow.qml
+++ b/config/quickshell/launcher/LauncherCategoryRow.qml
@@ -2,6 +2,8 @@ import QtQuick
 import QtQuick.Layouts
 import qs.core
 
+pragma ComponentBehavior: Bound
+
 Flickable {
     id: root
 
@@ -22,22 +24,24 @@ Flickable {
             model: root.launcherModel.categories
 
             delegate: Rectangle {
+                id: categoryDelegate
+
                 required property var modelData
 
                 Layout.preferredHeight: Theme.chipHeight
                 Layout.preferredWidth: launcherCategoryLabel.width + 22
                 radius: Theme.radius
-                color: root.launcherModel.category === modelData.id ? Theme.accent : launcherCategoryMouse.containsMouse ? Theme.surfaceHover : Theme.surface
+                color: root.launcherModel.category === categoryDelegate.modelData.id ? Theme.accent : launcherCategoryMouse.containsMouse ? Theme.surfaceHover : Theme.surface
 
                 Text {
                     id: launcherCategoryLabel
 
                     anchors.centerIn: parent
-                    text: modelData.label + " " + modelData.count
-                    color: root.launcherModel.category === parent.modelData.id ? Theme.accentText : Theme.text
+                    text: categoryDelegate.modelData.label + " " + categoryDelegate.modelData.count
+                    color: root.launcherModel.category === categoryDelegate.modelData.id ? Theme.accentText : Theme.text
                     font.family: Theme.fontFamily
                     font.pixelSize: Theme.smallFontSize
-                    font.bold: root.launcherModel.category === parent.modelData.id
+                    font.bold: root.launcherModel.category === categoryDelegate.modelData.id
                 }
 
                 MouseArea {
@@ -46,7 +50,7 @@ Flickable {
                     anchors.fill: parent
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
-                    onClicked: root.launcherModel.setCategory(parent.modelData.id)
+                    onClicked: root.launcherModel.setCategory(categoryDelegate.modelData.id)
                 }
             }
         }

--- a/config/quickshell/launcher/LauncherWindow.qml
+++ b/config/quickshell/launcher/LauncherWindow.qml
@@ -1,8 +1,9 @@
 import QtQuick
 import QtQuick.Layouts
 import Quickshell
-import Quickshell.Widgets
 import qs.core
+
+pragma ComponentBehavior: Bound
 
 FloatingWindow {
     id: root

--- a/config/quickshell/network/NetworkWindow.qml
+++ b/config/quickshell/network/NetworkWindow.qml
@@ -3,6 +3,8 @@ import QtQuick.Layouts
 import Quickshell
 import qs.core
 
+pragma ComponentBehavior: Bound
+
 PopupWindow {
     id: root
 

--- a/config/quickshell/notifications/NotificationHistoryWindow.qml
+++ b/config/quickshell/notifications/NotificationHistoryWindow.qml
@@ -3,6 +3,8 @@ import QtQuick.Layouts
 import Quickshell
 import qs.core
 
+pragma ComponentBehavior: Bound
+
 FloatingWindow {
     id: root
 
@@ -78,13 +80,15 @@ FloatingWindow {
                         model: root.notificationModel.history
 
                         delegate: Rectangle {
+                            id: historyEntry
+
                             required property var modelData
 
                             Layout.fillWidth: true
                             Layout.preferredHeight: Math.max(74, historyContent.implicitHeight + 22)
                             radius: Theme.radius
-                            color: modelData.urgencyName === "critical" ? Theme.dangerSurface : Theme.surface
-                            border.color: modelData.urgencyName === "critical" ? Theme.danger : Theme.border
+                            color: historyEntry.modelData.urgencyName === "critical" ? Theme.dangerSurface : Theme.surface
+                            border.color: historyEntry.modelData.urgencyName === "critical" ? Theme.danger : Theme.border
                             border.width: 1
 
                             ColumnLayout {
@@ -100,7 +104,7 @@ FloatingWindow {
 
                                     Text {
                                         Layout.fillWidth: true
-                                        text: modelData.appName || "Notification"
+                                        text: historyEntry.modelData.appName || "Notification"
                                         color: Theme.textMuted
                                         font.family: Theme.fontFamily
                                         font.pixelSize: Theme.smallFontSize
@@ -108,7 +112,7 @@ FloatingWindow {
                                     }
 
                                     Text {
-                                        text: Qt.formatTime(new Date(modelData.timestamp || Date.now()), "hh:mm")
+                                        text: Qt.formatTime(new Date(historyEntry.modelData.timestamp || Date.now()), "hh:mm")
                                         color: Theme.textMuted
                                         font.family: Theme.fontFamily
                                         font.pixelSize: Theme.smallFontSize
@@ -117,7 +121,7 @@ FloatingWindow {
 
                                 Text {
                                     Layout.fillWidth: true
-                                    text: modelData.summary || modelData.urgencyName || ""
+                                    text: historyEntry.modelData.summary || historyEntry.modelData.urgencyName || ""
                                     color: Theme.textStrong
                                     font.family: Theme.fontFamily
                                     font.pixelSize: Theme.bodyFontSize
@@ -128,7 +132,7 @@ FloatingWindow {
                                 Text {
                                     Layout.fillWidth: true
                                     visible: text.length > 0
-                                    text: modelData.body || ""
+                                    text: historyEntry.modelData.body || ""
                                     color: Theme.text
                                     font.family: Theme.fontFamily
                                     font.pixelSize: Theme.smallFontSize

--- a/config/quickshell/notifications/NotificationModel.qml
+++ b/config/quickshell/notifications/NotificationModel.qml
@@ -3,6 +3,8 @@ import Quickshell
 import Quickshell.Io
 import Quickshell.Services.Notifications
 
+pragma ComponentBehavior: Bound
+
 Scope {
     id: root
 
@@ -105,11 +107,11 @@ Scope {
     }
 
     function loadHistory() {
-        root.history = (historyAdapter.notifications || []).slice(0, root.maxHistory);
+        root.history = (historyFile.notifications || []).slice(0, root.maxHistory);
     }
 
     function saveHistory() {
-        historyAdapter.notifications = root.history;
+        historyFile.notifications = root.history;
         historyFile.writeAdapter();
     }
 
@@ -132,6 +134,8 @@ Scope {
     FileView {
         id: historyFile
 
+        property alias notifications: historyAdapter.notifications
+
         path: root.historyPath
         printErrors: false
         onLoaded: root.loadHistory()
@@ -141,7 +145,8 @@ Scope {
             }
         }
 
-        JsonAdapter {
+        // qmllint disable unresolved-type
+        adapter: JsonAdapter {
             id: historyAdapter
 
             property var notifications: []

--- a/config/quickshell/notifications/NotificationPopupWindow.qml
+++ b/config/quickshell/notifications/NotificationPopupWindow.qml
@@ -3,6 +3,8 @@ import QtQuick.Layouts
 import Quickshell
 import qs.core
 
+pragma ComponentBehavior: Bound
+
 PopupWindow {
     id: root
 
@@ -31,11 +33,13 @@ PopupWindow {
             model: root.notificationModel.notifications
 
             delegate: NotificationCard {
+                id: notificationCard
+
                 required property var modelData
 
-                item: modelData
-                onDismiss: root.notificationModel.dismiss(modelData.key)
-                onExpired: root.notificationModel.expire(modelData.key)
+                item: notificationCard.modelData
+                onDismiss: root.notificationModel.dismiss(notificationCard.modelData.key)
+                onExpired: root.notificationModel.expire(notificationCard.modelData.key)
             }
         }
     }

--- a/config/quickshell/panel/DwmPanel.qml
+++ b/config/quickshell/panel/DwmPanel.qml
@@ -1,9 +1,11 @@
 import QtQuick
 import QtQuick.Layouts
 import Quickshell
-import Quickshell.Widgets
 import qs.core
 
+pragma ComponentBehavior: Bound
+
+// qmllint disable uncreatable-type
 PanelWindow {
     id: root
 

--- a/config/quickshell/panel/TrayItem.qml
+++ b/config/quickshell/panel/TrayItem.qml
@@ -45,18 +45,15 @@ Rectangle {
         anchor.item: root
     }
 
-    Image {
+    IconImage {
         id: trayIcon
 
         anchors.centerIn: parent
         width: Theme.trayIconSize
         height: Theme.trayIconSize
         source: root.iconSources.length > root.iconSourceIndex ? root.iconSources[root.iconSourceIndex] : ""
-        sourceSize.width: Theme.trayIconSize
-        sourceSize.height: Theme.trayIconSize
-        fillMode: Image.PreserveAspectFit
+        implicitSize: Theme.trayIconSize
         asynchronous: true
-        smooth: true
         mipmap: true
         visible: status === Image.Ready
 

--- a/config/quickshell/power/PowerMenuActionButton.qml
+++ b/config/quickshell/power/PowerMenuActionButton.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Layouts
 import qs.core
 
 Rectangle {
@@ -28,9 +27,9 @@ Rectangle {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
-        anchors.leftMargin: compact ? 12 : 14
-        anchors.rightMargin: compact ? 12 : 14
-        spacing: compact ? Theme.compactSpacing : Theme.listSpacing
+        anchors.leftMargin: root.compact ? 12 : 14
+        anchors.rightMargin: root.compact ? 12 : 14
+        spacing: root.compact ? Theme.compactSpacing : Theme.listSpacing
 
         Text {
             width: parent.width

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -13,6 +13,8 @@ import qs.panel
 import qs.power
 import qs.state
 
+pragma ComponentBehavior: Bound
+
 ShellRoot {
     id: root
 


### PR DESCRIPTION
## Summary

Fix Quickshell systray icon rendering for tray apps that expose theme names, absolute icon paths, or Quickshell pixmap/provider sources.

## Details

The old tray renderer could get stuck on `image://icon/...` provider placeholders before trying real icon-theme files. It also did not handle provider URLs that embed an absolute icon file path, such as Synergy's `/run/user/...png` icon. This updates the tray icon source resolver to prefer concrete hicolor/status file paths, decode provider path fields, handle absolute icon names, and keep provider sources as later fallbacks. The tray item renderer now uses Quickshell's `IconImage` widget.

This also cleans up QML lint warnings now that `qmllint` is available by adding bounded component behavior, qualifying delegate model access, and removing unused imports. Narrow suppressions remain only for known Quickshell qmltypes limitations.

## Validation

- `quickshell-qmllint --root config/quickshell`
- `git diff --check`
- `make check`

Runtime spot check was performed against the managed `~/.config/quickshell` shell with blueman, Remmina, Flameshot, and Synergy tray items visible.