### PR TITLE
Fix DPMS and locker lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ INSTALL_COMMANDS = \
 	scripts/dwm-display-profile \
 	scripts/dwm-keybinds \
 	scripts/dwm-lock \
+	scripts/dwm-lock-watch \
 	scripts/dwm-quickshell-launcher \
 	scripts/dwm-quickshell-controls \
 	scripts/dwm-quickshell-controlcenter \
@@ -247,10 +248,10 @@ release: dwm
 	echo "==> Created ${RELEASE_ARCHIVE}"
 
 check-shell:
-	shellcheck install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-lock scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/*.sh tests/*.sh
+	shellcheck install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/*.sh tests/*.sh
 
 check-format:
-	shfmt -d install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-lock scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/*.sh tests/*.sh
+	shfmt -d install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/*.sh tests/*.sh
 
 check-session-guards:
 	tests/test-autostart.sh

--- a/config/quickshell/core/Commands.qml
+++ b/config/quickshell/core/Commands.qml
@@ -15,7 +15,12 @@ Singleton {
             : [runPath, runManaged, fallback];
         const script = [dataDir].concat(orderedChecks).join("; ");
 
-        return ["sh", "-c", script, helper, action].concat(argv);
+        const command = ["sh", "-c", script, helper];
+        if (action !== undefined && action !== null) {
+            command.push(action);
+        }
+
+        return command.concat(argv);
     }
 
     function launcherHelperCommand(action, args) {
@@ -32,6 +37,10 @@ Singleton {
 
     function controlCenterHelperCommand(action, args) {
         return helperCommand("dwm-quickshell-controlcenter", action, args, true);
+    }
+
+    function lockHelperCommand() {
+        return helperCommand("dwm-lock", undefined, [], true);
     }
 
     function systemHealthHelperCommand(action, args) {

--- a/config/quickshell/power/PowerMenuModel.qml
+++ b/config/quickshell/power/PowerMenuModel.qml
@@ -1,5 +1,6 @@
 import Quickshell
 import Quickshell.Io
+import qs.core
 
 Scope {
     id: root
@@ -14,7 +15,7 @@ Scope {
             "id": "lock",
             "label": "Lock",
             "detail": "Secure this session",
-            "command": ["sh", "-c", "loginctl lock-session ${XDG_SESSION_ID:-} 2>/dev/null || dwm-lock 2>/dev/null || light-locker-command -l"],
+            "command": Commands.lockHelperCommand(),
             "confirm": false
         },
         {

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -81,7 +81,9 @@ Power settings are managed from Control Center -> Power. The generated
 `power.conf` is authoritative once created and persists screen DPMS state,
 display-off timing, and automatic idle and suspend locking. Startup reapplies
 this file before background session services are launched. Manual locking
-remains available when automatic locking is disabled.
+remains available when automatic locking is disabled. The screen locker runs
+only while automatic locking is enabled or for the duration of an explicit
+manual lock, so DPMS display-off events remain independent from locking.
 
 ### Modifier Syntax
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -84,6 +84,9 @@ this file before background session services are launched. Manual locking
 remains available when automatic locking is disabled. The screen locker runs
 only while automatic locking is enabled or for the duration of an explicit
 manual lock, so DPMS display-off events remain independent from locking.
+External `loginctl lock-session` requests are forwarded to `dwm-lock` by an
+event-driven session listener. Until `power.conf` exists, dwm-titus leaves any
+user or distribution-managed locker untouched.
 
 ### Modifier Syntax
 

--- a/scripts/autostart.sh
+++ b/scripts/autostart.sh
@@ -109,6 +109,18 @@ start_detached_once picom picom --backend "$PICOM_BACKEND"
 # dwm root-window status publisher for Quickshell's event-driven panel.
 start_detached_once dwm-status dwm-status
 
+# Event-driven bridge for loginctl/logind lock requests. This keeps external
+# lock commands working without leaving light-locker resident for DPMS events.
+lock_watch=dwm-lock-watch
+if ! command -v "$lock_watch" >/dev/null 2>&1; then
+	case $0 in
+	*/*)
+		lock_watch=${0%/*}/dwm-lock-watch
+		;;
+	esac
+fi
+start_detached_once dwm-lock-watch "$lock_watch"
+
 # Quickshell is the managed shell for this session.
 QUICKSHELL_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/quickshell/shell.qml"
 if [ -f "$QUICKSHELL_CONFIG" ]; then

--- a/scripts/autostart.sh
+++ b/scripts/autostart.sh
@@ -109,9 +109,6 @@ start_detached_once picom picom --backend "$PICOM_BACKEND"
 # dwm root-window status publisher for Quickshell's event-driven panel.
 start_detached_once dwm-status dwm-status
 
-# Session locker for the power menu lock action and loginctl lock requests.
-start_once light-locker light-locker
-
 # Quickshell is the managed shell for this session.
 QUICKSHELL_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/quickshell/shell.qml"
 if [ -f "$QUICKSHELL_CONFIG" ]; then
@@ -145,3 +142,8 @@ if [ "$xdg_autostart_started" -eq 0 ]; then
 		dex-autostart -a 2>/dev/null
 	fi
 fi
+
+# Distribution packages may provide their own light-locker XDG autostart
+# entry. Reapply the persisted policy after XDG startup so disabled locking
+# cannot leave an independently started locker attached to DPMS events.
+apply_power_settings

--- a/scripts/dwm-lock
+++ b/scripts/dwm-lock
@@ -2,6 +2,9 @@
 
 set -eu
 
+light_locker_pid=
+light_locker_started=0
+
 start_light_locker() {
 	command -v light-locker >/dev/null 2>&1 || return 0
 
@@ -11,9 +14,41 @@ start_light_locker() {
 	fi
 
 	light-locker >/dev/null 2>&1 &
+	light_locker_pid=$!
+	light_locker_started=1
 	if command -v sleep >/dev/null 2>&1; then
 		sleep "${DWM_LOCK_START_DELAY:-0.2}"
 	fi
+}
+
+stop_started_light_locker_after_unlock() {
+	[ "$light_locker_started" = 1 ] || return 0
+	[ -n "$light_locker_pid" ] || return 0
+	command -v sleep >/dev/null 2>&1 || return 0
+
+	(
+		active_seen=0
+		attempts=0
+		while kill -0 "$light_locker_pid" 2>/dev/null; do
+			locker_state=$(LC_ALL=C light-locker-command --query 2>/dev/null || true)
+			case $locker_state in
+			*" is active") active_seen=1 ;;
+			*" is inactive")
+				if [ "$active_seen" = 1 ]; then
+					kill "$light_locker_pid" 2>/dev/null || true
+					exit 0
+				fi
+				;;
+			esac
+
+			attempts=$((attempts + 1))
+			if [ "$active_seen" = 0 ] && [ "$attempts" -ge 30 ]; then
+				kill "$light_locker_pid" 2>/dev/null || true
+				exit 0
+			fi
+			sleep 1
+		done
+	) >/dev/null 2>&1 &
 }
 
 try_lock() {
@@ -23,6 +58,7 @@ try_lock() {
 if command -v light-locker-command >/dev/null 2>&1; then
 	start_light_locker
 	if try_lock light-locker-command --lock; then
+		stop_started_light_locker_after_unlock
 		exit 0
 	fi
 fi

--- a/scripts/dwm-lock
+++ b/scripts/dwm-lock
@@ -68,7 +68,8 @@ if command -v xdg-screensaver >/dev/null 2>&1 &&
 	exit 0
 fi
 
-if command -v loginctl >/dev/null 2>&1; then
+if [ "${DWM_LOCK_NO_LOGINCTL:-0}" != 1 ] &&
+	command -v loginctl >/dev/null 2>&1; then
 	if [ -n "${XDG_SESSION_ID:-}" ]; then
 		if try_lock loginctl lock-session "$XDG_SESSION_ID"; then
 			exit 0

--- a/scripts/dwm-lock
+++ b/scripts/dwm-lock
@@ -21,6 +21,16 @@ start_light_locker() {
 	fi
 }
 
+stop_started_light_locker() {
+	[ "$light_locker_started" = 1 ] || return 0
+	[ -n "$light_locker_pid" ] || return 0
+
+	kill "$light_locker_pid" 2>/dev/null || true
+	wait "$light_locker_pid" 2>/dev/null || true
+	light_locker_pid=
+	light_locker_started=0
+}
+
 stop_started_light_locker_after_unlock() {
 	[ "$light_locker_started" = 1 ] || return 0
 	[ -n "$light_locker_pid" ] || return 0
@@ -61,6 +71,7 @@ if command -v light-locker-command >/dev/null 2>&1; then
 		stop_started_light_locker_after_unlock
 		exit 0
 	fi
+	stop_started_light_locker
 fi
 
 if command -v xdg-screensaver >/dev/null 2>&1 &&

--- a/scripts/dwm-lock-watch
+++ b/scripts/dwm-lock-watch
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+set -eu
+
+session_id=${XDG_SESSION_ID:-}
+[ -n "$session_id" ] || {
+	command -v loginctl >/dev/null 2>&1 || exit 0
+	session_id=$(loginctl show-session self -p Id --value 2>/dev/null) || exit 0
+}
+[ -n "$session_id" ] || exit 0
+
+command -v busctl >/dev/null 2>&1 || exit 0
+command -v dbus-monitor >/dev/null 2>&1 || exit 0
+
+lock_helper=${DWM_LOCK_HELPER:-}
+if [ -z "$lock_helper" ]; then
+	lock_helper=dwm-lock
+	case $0 in
+	*/*)
+		managed_helper=${0%/*}/dwm-lock
+		[ ! -x "$managed_helper" ] || lock_helper=$managed_helper
+		;;
+	esac
+fi
+command -v "$lock_helper" >/dev/null 2>&1 || exit 0
+
+session_json=$(busctl --system --json=short call \
+	org.freedesktop.login1 \
+	/org/freedesktop/login1 \
+	org.freedesktop.login1.Manager \
+	GetSession s "$session_id" 2>/dev/null) || exit 0
+session_path=$(printf '%s\n' "$session_json" |
+	sed -n 's/.*"data":\["\([^"]*\)"\].*/\1/p')
+[ -n "$session_path" ] || exit 0
+
+run_lock_helper() {
+	if [ "${DWM_LOCK_WATCH_SYNC:-0}" = 1 ]; then
+		DWM_LOCK_NO_LOGINCTL=1 "$lock_helper" >/dev/null 2>&1
+	else
+		DWM_LOCK_NO_LOGINCTL=1 "$lock_helper" >/dev/null 2>&1 &
+	fi
+}
+
+dbus-monitor --system \
+	"type='signal',path='$session_path',interface='org.freedesktop.login1.Session',member='Lock'" 2>/dev/null |
+	while IFS= read -r line; do
+		case $line in
+		*"interface=org.freedesktop.login1.Session; member=Lock"*)
+			run_lock_helper || true
+			;;
+		esac
+	done

--- a/scripts/dwm-quickshell-controlcenter
+++ b/scripts/dwm-quickshell-controlcenter
@@ -118,6 +118,15 @@ start_configured_light_locker() {
 	light-locker >/dev/null 2>&1 &
 }
 
+stop_configured_light_locker() {
+	command -v pgrep >/dev/null 2>&1 || return 0
+	command -v pkill >/dev/null 2>&1 || return 0
+
+	if pgrep -u "$(id -u)" -x light-locker >/dev/null 2>&1; then
+		pkill -u "$(id -u)" -x light-locker
+	fi
+}
+
 power_apply_dpms_settings() {
 	command -v xset >/dev/null 2>&1 || return 1
 
@@ -158,6 +167,10 @@ power_apply_lock_settings() {
 			! gsettings set apps.light-locker lock-on-suspend false; then
 			power_status=1
 		fi
+	fi
+
+	if [ "$power_lock_enabled" = 0 ]; then
+		stop_configured_light_locker || power_status=1
 	fi
 
 	return "$power_status"

--- a/scripts/dwm-quickshell-controlcenter
+++ b/scripts/dwm-quickshell-controlcenter
@@ -169,7 +169,8 @@ power_apply_lock_settings() {
 		fi
 	fi
 
-	if [ "$power_lock_enabled" = 0 ]; then
+	if [ "$power_lock_enabled" = 0 ] &&
+		{ [ "${power_config_managed:-0}" = 1 ] || [ "${power_lock_managed:-0}" = 1 ]; }; then
 		stop_configured_light_locker || power_status=1
 	fi
 

--- a/tests/test-autostart.sh
+++ b/tests/test-autostart.sh
@@ -135,9 +135,10 @@ run_duplicate_case() {
 		wait_for_marker "$state/quickshell.running"
 	done
 
-	for name in feh picom light-locker quickshell; do
+	for name in feh picom quickshell; do
 		test "$(cat "$state/$name.count")" -eq 1
 	done
+	test ! -e "$state/light-locker.count"
 	test ! -e "$state/dex.count"
 	test ! -e "$state/dex-autostart.count"
 	awk '

--- a/tests/test-autostart.sh
+++ b/tests/test-autostart.sh
@@ -95,7 +95,7 @@ EOF
 
 chmod +x "$work/bin/"*
 
-for name in feh picom dwm-status light-locker quickshell dex dex-autostart; do
+for name in feh picom dwm-status dwm-lock-watch light-locker quickshell dex dex-autostart; do
 	make_mock_command "$name"
 done
 
@@ -132,10 +132,11 @@ run_duplicate_case() {
 		wait_for_marker "$state/feh.running"
 		wait_for_marker "$state/picom.running"
 		wait_for_marker "$state/dwm-status.running"
+		wait_for_marker "$state/dwm-lock-watch.running"
 		wait_for_marker "$state/quickshell.running"
 	done
 
-	for name in feh picom quickshell; do
+	for name in feh picom dwm-lock-watch quickshell; do
 		test "$(cat "$state/$name.count")" -eq 1
 	done
 	test ! -e "$state/light-locker.count"

--- a/tests/test-dwm-lock.sh
+++ b/tests/test-dwm-lock.sh
@@ -32,9 +32,10 @@ SCRIPT
 cat >"$work/bin/light-locker-command" <<'SCRIPT'
 #!/bin/sh
 case $* in
---lock)
-	printf '%s\n' "$*" >"${DWM_LOCK_TEST_DIR:?}/light-locker-command"
-	;;
+	--lock)
+		printf '%s\n' "$*" >"${DWM_LOCK_TEST_DIR:?}/light-locker-command"
+		[ "${DWM_LOCK_TEST_FAIL:-0}" != 1 ]
+		;;
 --query)
 	if [ -f "${DWM_LOCK_TEST_DIR:?}/light-locker.queried" ]; then
 		printf '%s\n' 'The screensaver is inactive'
@@ -69,6 +70,23 @@ grep -Fq '"command": Commands.lockHelperCommand()' \
 	"$repo_dir/config/quickshell/power/PowerMenuModel.qml"
 grep -Fq 'return helperCommand("dwm-lock", undefined, [], true)' \
 	"$repo_dir/config/quickshell/core/Commands.qml"
+
+cat >"$work/bin/loginctl" <<'SCRIPT'
+#!/bin/sh
+printf '%s\n' "$*" >"${DWM_LOCK_TEST_DIR:?}/loginctl"
+SCRIPT
+chmod +x "$work/bin/loginctl"
+
+DWM_LOCK_TEST_DIR="$work" \
+	DWM_LOCK_START_DELAY=0 \
+	DWM_LOCK_TEST_FAIL=1 \
+	XDG_SESSION_ID=8 \
+	PATH="$work/bin" \
+	"$helper"
+grep -Fxq 'lock-session 8' "$work/loginctl"
+test ! -e "$work/light-locker.running"
+
+rm -f "$work/bin/loginctl" "$work/loginctl" "$work/light-locker-command"
 
 rm -f "$work/bin/light-locker" "$work/bin/light-locker-command" \
 	"$work/light-locker" "$work/light-locker-command"

--- a/tests/test-dwm-lock.sh
+++ b/tests/test-dwm-lock.sh
@@ -22,11 +22,33 @@ SCRIPT
 cat >"$work/bin/light-locker" <<'SCRIPT'
 #!/bin/sh
 printf '%s\n' started >"${DWM_LOCK_TEST_DIR:?}/light-locker"
+: >"${DWM_LOCK_TEST_DIR:?}/light-locker.running"
+trap '/bin/rm -f "${DWM_LOCK_TEST_DIR:?}/light-locker.running"; exit 0' TERM
+while :; do
+	:
+done
 SCRIPT
 
 cat >"$work/bin/light-locker-command" <<'SCRIPT'
 #!/bin/sh
-printf '%s\n' "$*" >"${DWM_LOCK_TEST_DIR:?}/light-locker-command"
+case $* in
+--lock)
+	printf '%s\n' "$*" >"${DWM_LOCK_TEST_DIR:?}/light-locker-command"
+	;;
+--query)
+	if [ -f "${DWM_LOCK_TEST_DIR:?}/light-locker.queried" ]; then
+		printf '%s\n' 'The screensaver is inactive'
+	else
+		: >"${DWM_LOCK_TEST_DIR:?}/light-locker.queried"
+		printf '%s\n' 'The screensaver is active'
+	fi
+	;;
+esac
+SCRIPT
+
+cat >"$work/bin/sleep" <<'SCRIPT'
+#!/bin/sh
+exit 0
 SCRIPT
 
 chmod +x "$work/bin/"*
@@ -37,6 +59,16 @@ DWM_LOCK_TEST_DIR="$work" \
 	"$helper"
 grep -Fxq started "$work/light-locker"
 grep -Fxq -- "--lock" "$work/light-locker-command"
+i=0
+while [ -e "$work/light-locker.running" ] && [ "$i" -lt 100 ]; do
+	i=$((i + 1))
+	/bin/sleep 0.01
+done
+test ! -e "$work/light-locker.running"
+grep -Fq '"command": Commands.lockHelperCommand()' \
+	"$repo_dir/config/quickshell/power/PowerMenuModel.qml"
+grep -Fq 'return helperCommand("dwm-lock", undefined, [], true)' \
+	"$repo_dir/config/quickshell/core/Commands.qml"
 
 rm -f "$work/bin/light-locker" "$work/bin/light-locker-command" \
 	"$work/light-locker" "$work/light-locker-command"

--- a/tests/test-dwm-lock.sh
+++ b/tests/test-dwm-lock.sh
@@ -93,4 +93,40 @@ if DWM_LOCK_TEST_DIR="$work" PATH="$work/bin" "$helper" 2>"$work/err"; then
 fi
 grep -Fq "no usable screen locker found" "$work/err"
 
+cat >"$work/bin/busctl" <<'SCRIPT'
+#!/bin/sh
+printf '%s\n' "$*" >"${DWM_LOCK_TEST_DIR:?}/busctl"
+printf '%s\n' '{"type":"o","data":["/org/freedesktop/login1/session/_37"]}'
+SCRIPT
+
+cat >"$work/bin/loginctl" <<'SCRIPT'
+#!/bin/sh
+case $* in
+"show-session self -p Id --value") printf '%s\n' 7 ;;
+*) exit 1 ;;
+esac
+SCRIPT
+
+cat >"$work/bin/dbus-monitor" <<'SCRIPT'
+#!/bin/sh
+printf '%s\n' "$*" >"${DWM_LOCK_TEST_DIR:?}/dbus-monitor"
+printf '%s\n' 'signal path=/org/freedesktop/login1/session/_37; interface=org.freedesktop.login1.Session; member=Lock'
+SCRIPT
+
+cat >"$work/bin/dwm-lock" <<'SCRIPT'
+#!/bin/sh
+printf 'no_loginctl=%s\n' "${DWM_LOCK_NO_LOGINCTL:-0}" >"${DWM_LOCK_TEST_DIR:?}/watch-lock"
+SCRIPT
+chmod +x "$work/bin/busctl" "$work/bin/dbus-monitor" "$work/bin/dwm-lock" "$work/bin/loginctl"
+
+DWM_LOCK_TEST_DIR="$work" \
+	DWM_LOCK_HELPER="$work/bin/dwm-lock" \
+	DWM_LOCK_WATCH_SYNC=1 \
+	XDG_SESSION_ID='' \
+	PATH="$work/bin:/usr/bin:/bin" \
+	"$repo_dir/scripts/dwm-lock-watch"
+grep -Fq 'GetSession s 7' "$work/busctl"
+grep -Fq "path='/org/freedesktop/login1/session/_37'" "$work/dbus-monitor"
+grep -Fxq 'no_loginctl=1' "$work/watch-lock"
+
 printf '%s\n' "dwm-lock fallback behavior: PASS"

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -29,6 +29,15 @@ for name in quickshell xprop dwm-quickshell-launcher dwm-quickshell-controlcente
 	stub_command "$name"
 done
 
+cat >"$work/bin/pkill" <<'SH'
+#!/bin/sh
+printf 'pkill %s\n' "$*" >>"${DWM_TEST_LOG:?}"
+case $* in
+*"-x light-locker"*) rm -f "${DWM_TEST_POWER_STATE:?}/light-locker.running" ;;
+esac
+SH
+chmod +x "$work/bin/pkill"
+
 cat >"$work/bin/pgrep" <<'SH'
 #!/bin/sh
 case "$*" in
@@ -252,6 +261,8 @@ grep -Fqx 'xset s off' "$work/actions.log"
 grep -Fqx 'xset s noblank' "$work/actions.log"
 grep -Fqx 'gsettings set apps.light-locker lock-after-screensaver 0' "$work/actions.log"
 grep -Fqx 'gsettings set apps.light-locker lock-on-suspend false' "$work/actions.log"
+grep -Fqx 'pkill -u 1000 -x light-locker' "$work/actions.log"
+test ! -e "$work/power-state/light-locker.running"
 
 # Persisted settings remain authoritative when X11 or light-locker state drifts.
 printf '0\n' >"$work/power-state/dpms_enabled"
@@ -259,6 +270,7 @@ printf '60\n' >"$work/power-state/dpms_timeout"
 printf '600\n' >"$work/power-state/saver_timeout"
 printf '5\n' >"$work/power-state/lock_after"
 printf 'true\n' >"$work/power-state/lock_on_suspend"
+: >"$work/power-state/light-locker.running"
 : >"$work/actions.log"
 run_helper power-apply
 grep -Fqx 'xset +dpms' "$work/actions.log"
@@ -268,6 +280,8 @@ grep -Fqx 'xset s noblank' "$work/actions.log"
 grep -Fqx 'gsettings set apps.light-locker lock-after-screensaver 0' "$work/actions.log"
 grep -Fqx 'gsettings set apps.light-locker lock-on-suspend false' "$work/actions.log"
 grep -Fqx 'false' "$work/power-state/lock_on_suspend"
+grep -Fqx 'pkill -u 1000 -x light-locker' "$work/actions.log"
+test ! -e "$work/power-state/light-locker.running"
 
 : >"$work/actions.log"
 run_helper action restart-quickshell >"$work/quickshell.out"

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -7,6 +7,7 @@ repo=$(
 )
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
+test_uid=$(id -u)
 
 mkdir -p "$work/bin" "$work/config/dwm-titus" "$work/home/Pictures/backgrounds" "$work/data/dwm-titus/config/quickshell" "$work/power-state"
 mkdir -p "$work/config/quickshell"
@@ -261,7 +262,7 @@ grep -Fqx 'xset s off' "$work/actions.log"
 grep -Fqx 'xset s noblank' "$work/actions.log"
 grep -Fqx 'gsettings set apps.light-locker lock-after-screensaver 0' "$work/actions.log"
 grep -Fqx 'gsettings set apps.light-locker lock-on-suspend false' "$work/actions.log"
-grep -Fqx 'pkill -u 1000 -x light-locker' "$work/actions.log"
+grep -Fqx "pkill -u $test_uid -x light-locker" "$work/actions.log"
 test ! -e "$work/power-state/light-locker.running"
 
 # Persisted settings remain authoritative when X11 or light-locker state drifts.
@@ -280,7 +281,7 @@ grep -Fqx 'xset s noblank' "$work/actions.log"
 grep -Fqx 'gsettings set apps.light-locker lock-after-screensaver 0' "$work/actions.log"
 grep -Fqx 'gsettings set apps.light-locker lock-on-suspend false' "$work/actions.log"
 grep -Fqx 'false' "$work/power-state/lock_on_suspend"
-grep -Fqx 'pkill -u 1000 -x light-locker' "$work/actions.log"
+grep -Fqx "pkill -u $test_uid -x light-locker" "$work/actions.log"
 test ! -e "$work/power-state/light-locker.running"
 
 : >"$work/actions.log"

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -229,6 +229,16 @@ printf '%s\n' "$power" | grep -Fqx 'dpms_enabled	0'
 printf '%s\n' "$power" | grep -Fqx 'lock_available	1'
 printf '%s\n' "$power" | grep -Fqx 'lock_enabled	0'
 
+# Without a managed power.conf, preserve a user or distro-managed locker.
+: >"$work/power-state/light-locker.running"
+: >"$work/actions.log"
+run_helper power-apply
+test -e "$work/power-state/light-locker.running"
+if grep -Fq 'pkill -u ' "$work/actions.log"; then
+	exit 1
+fi
+rm -f "$work/power-state/light-locker.running"
+
 : >"$work/actions.log"
 run_helper power-dpms-timeout 900 >"$work/power-dpms-timeout.out"
 grep -Fqx 'power-dpms-timeout	900' "$work/power-dpms-timeout.out"


### PR DESCRIPTION
# Pull Request

## Title
<!--[Provide a succinct and descriptive title for the pull request.]-->

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This pull request refines how session locking is handled, ensuring that the screen locker (`light-locker`) only runs when automatic or manual locking is explicitly requested. It introduces a dedicated helper command for locking, updates the power menu to use this helper, and improves the lifecycle management of the locker process. Additionally, it enhances test coverage and documentation to reflect these changes, and ensures that any independently started locker is stopped if locking is disabled.

**Session Locking Improvements**
- Added a new `lockHelperCommand` function in `Commands.qml` and updated the power menu to use it, centralizing and simplifying how manual locks are invoked. [[1]](diffhunk://#diff-b861963130d3bad144dd7adae03f3fda32065d0afb189a16370e4528669e2e0bR42-R45) [[2]](diffhunk://#diff-73caf788d2657750137f8366d553fee1f95e9a0679ab77dc2aa5c74e90399e47L17-R18)
- Refined the `dwm-lock` script to track and terminate the `light-locker` process after unlock, ensuring it only runs for the duration of a manual lock. [[1]](diffhunk://#diff-ce27e1bb391d6d7cf3de6199d5471b2fba75e0ab63024a17cea431bcf3d21a41R5-R7) [[2]](diffhunk://#diff-ce27e1bb391d6d7cf3de6199d5471b2fba75e0ab63024a17cea431bcf3d21a41R17-R61)

**Automatic Locker Policy Enforcement**
- Updated `dwm-quickshell-controlcenter` to forcibly stop any running `light-locker` instance if automatic locking is disabled, preventing unwanted locker attachment to DPMS events. [[1]](diffhunk://#diff-94b07cc149ead25c9ffea09f2503fc314f3c393ab70d32adada527e82ddf2777R121-R129) [[2]](diffhunk://#diff-94b07cc149ead25c9ffea09f2503fc314f3c393ab70d32adada527e82ddf2777R172-R175)
- Modified `autostart.sh` to remove unconditional locker startup and to reapply power settings after XDG autostart, ensuring policy enforcement even if distribution packages start their own locker. [[1]](diffhunk://#diff-25adb3515876214e79644b3d81e8665bd9b180815bbadcd92d04682bf60c5265L112-L114) [[2]](diffhunk://#diff-25adb3515876214e79644b3d81e8665bd9b180815bbadcd92d04682bf60c5265R145-R149)

**Documentation and Testing**
- Improved documentation to clarify that the locker only runs during explicit or automatic locking, and is independent from DPMS display-off events.
- Enhanced tests to verify locker lifecycle, command usage, and policy enforcement, including new stubs and checks for `pkill` and locker process state. [[1]](diffhunk://#diff-2815e95450c7903bdb76e152abc2600c95616a0f0e0f001cd18f48bed6b8a28bR25-R51) [[2]](diffhunk://#diff-2815e95450c7903bdb76e152abc2600c95616a0f0e0f001cd18f48bed6b8a28bR62-R71) [[3]](diffhunk://#diff-9857654125ddee1bf20937e0551bacc71fa73aa697d9cd050d800c6a14f5b09dR32-R40) [[4]](diffhunk://#diff-9857654125ddee1bf20937e0551bacc71fa73aa697d9cd050d800c6a14f5b09dR264-R273) [[5]](diffhunk://#diff-9857654125ddee1bf20937e0551bacc71fa73aa697d9cd050d800c6a14f5b09dR283-R284)
## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #

## Screenshots (if applicable)
