### PR TITLE
Fix Quickshell audio client leak

### DIFF
--- a/config/quickshell/controls/ControlsModel.qml
+++ b/config/quickshell/controls/ControlsModel.qml
@@ -41,6 +41,9 @@ Scope {
             root.volumeMuted = false;
             root.outputDeviceName = "";
             root.outputDeviceDescription = "";
+            if (!volumeStatusProcess.running) {
+                volumeStatusProcess.running = true;
+            }
         }
 
         const source = root.audioSource;
@@ -48,6 +51,9 @@ Scope {
             root.micText = source.audio.muted ? "MIC muted" : "MIC on";
         } else {
             root.micText = "MIC unavailable";
+            if (!micStatusProcess.running) {
+                micStatusProcess.running = true;
+            }
         }
     }
 
@@ -122,6 +128,20 @@ Scope {
         }
 
         root.mediaText = (labelParts.length > 0 ? labelParts.join(" ") : "MEDIA") + (titleParts.length > 0 ? ": " + titleParts.join(" - ") : "");
+    }
+
+    function parseVolume(text) {
+        const trimmed = text.trim();
+
+        if (trimmed.length > 0) {
+            root.volumeText = trimmed;
+        }
+
+        const match = trimmed.match(/([0-9]+)%/);
+        if (match !== null) {
+            root.volumePercent = root.clampPercent(parseInt(match[1], 10));
+        }
+        root.volumeMuted = trimmed.indexOf("VOL muted") === 0;
     }
 
     function parseOutputDevices(text) {
@@ -238,6 +258,22 @@ Scope {
     }
 
     Connections {
+        target: Pipewire.nodes
+
+        function onObjectInsertedPost(object, index) {
+            if (root.visible) {
+                root.refreshOutputDevices();
+            }
+        }
+
+        function onObjectRemovedPost(object, index) {
+            if (root.visible) {
+                root.refreshOutputDevices();
+            }
+        }
+    }
+
+    Connections {
         target: root.audioSink
 
         function onReadyChanged() {
@@ -270,6 +306,39 @@ Scope {
 
         function onMutedChanged() {
             root.refreshAudioStatus();
+        }
+    }
+
+    Process {
+        id: volumeStatusProcess
+
+        command: Commands.controlsHelperCommand("volume-status")
+        running: false
+
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const sink = root.audioSink;
+                if (sink === null || !sink.ready || sink.audio === null) {
+                    root.parseVolume(this.text.length > 0 ? this.text : "VOL unavailable");
+                }
+            }
+        }
+    }
+
+    Process {
+        id: micStatusProcess
+
+        command: Commands.controlsHelperCommand("mic-status")
+        running: false
+
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const source = root.audioSource;
+                if (source === null || !source.ready || source.audio === null) {
+                    const text = this.text.trim();
+                    root.micText = text.length > 0 ? text : "MIC unavailable";
+                }
+            }
         }
     }
 

--- a/config/quickshell/controls/ControlsModel.qml
+++ b/config/quickshell/controls/ControlsModel.qml
@@ -1,5 +1,7 @@
+import QtQuick
 import Quickshell
 import Quickshell.Io
+import Quickshell.Services.Pipewire
 import qs.core
 
 Scope {
@@ -22,6 +24,32 @@ Scope {
     property string mediaTitle: ""
     property string bluetoothText: "BT unavailable"
     property string message: ""
+    readonly property var audioSink: Pipewire.defaultAudioSink
+    readonly property var audioSource: Pipewire.defaultAudioSource
+
+    function refreshAudioStatus() {
+        const sink = root.audioSink;
+
+        if (sink !== null && sink.ready && sink.audio !== null) {
+            root.volumePercent = root.clampPercent(sink.audio.volume * 100);
+            root.volumeMuted = sink.audio.muted;
+            root.volumeText = (root.volumeMuted ? "VOL muted " : "VOL ") + root.volumePercent.toString() + "%";
+            root.outputDeviceName = sink.name;
+            root.outputDeviceDescription = sink.description.length > 0 ? sink.description : sink.name;
+        } else {
+            root.volumeText = "VOL unavailable";
+            root.volumeMuted = false;
+            root.outputDeviceName = "";
+            root.outputDeviceDescription = "";
+        }
+
+        const source = root.audioSource;
+        if (source !== null && source.ready && source.audio !== null) {
+            root.micText = source.audio.muted ? "MIC muted" : "MIC on";
+        } else {
+            root.micText = "MIC unavailable";
+        }
+    }
 
     function open() {
         root.visible = true;
@@ -42,12 +70,7 @@ Scope {
     }
 
     function refresh() {
-        if (!volumeStatusProcess.running) {
-            volumeStatusProcess.running = true;
-        }
-        if (!micStatusProcess.running) {
-            micStatusProcess.running = true;
-        }
+        root.refreshAudioStatus();
         root.refreshOutputDevices();
         if (!mediaStatusProcess.running) {
             mediaStatusProcess.running = true;
@@ -99,20 +122,6 @@ Scope {
         }
 
         root.mediaText = (labelParts.length > 0 ? labelParts.join(" ") : "MEDIA") + (titleParts.length > 0 ? ": " + titleParts.join(" - ") : "");
-    }
-
-    function parseVolume(text) {
-        const trimmed = text.trim();
-
-        if (trimmed.length > 0) {
-            root.volumeText = trimmed;
-        }
-
-        const match = trimmed.match(/([0-9]+)%/);
-        if (match !== null) {
-            root.volumePercent = root.clampPercent(parseInt(match[1], 10));
-        }
-        root.volumeMuted = trimmed.indexOf("VOL muted") === 0;
     }
 
     function parseOutputDevices(text) {
@@ -207,41 +216,60 @@ Scope {
         root.runAction("media-previous");
     }
 
-    Process {
-        id: volumeStatusProcess
+    PwObjectTracker {
+        objects: [root.audioSink, root.audioSource]
+    }
 
-        command: Commands.controlsHelperCommand("volume-status")
-        running: false
+    Connections {
+        target: Pipewire
 
-        stdout: StdioCollector {
-            onStreamFinished: root.parseVolume(this.text.length > 0 ? this.text : "VOL unavailable")
+        function onDefaultAudioSinkChanged() {
+            root.refreshAudioStatus();
+            root.refreshOutputDevices();
+        }
+
+        function onDefaultAudioSourceChanged() {
+            root.refreshAudioStatus();
+        }
+
+        function onReadyChanged() {
+            root.refreshAudioStatus();
         }
     }
 
-    Process {
-        command: Commands.controlsHelperCommand("volume-watch")
-        running: true
+    Connections {
+        target: root.audioSink
 
-        stdout: SplitParser {
-            onRead: function(data) {
-                root.parseVolume(data);
-                root.refreshOutputDevices();
-            }
+        function onReadyChanged() {
+            root.refreshAudioStatus();
         }
     }
 
-    Process {
-        id: micStatusProcess
+    Connections {
+        target: root.audioSink !== null ? root.audioSink.audio : null
 
-        command: Commands.controlsHelperCommand("mic-status")
-        running: false
+        function onMutedChanged() {
+            root.refreshAudioStatus();
+        }
 
-        stdout: StdioCollector {
-            onStreamFinished: {
-                const text = this.text.trim();
+        function onVolumesChanged() {
+            root.refreshAudioStatus();
+        }
+    }
 
-                root.micText = text.length > 0 ? text : "MIC unavailable";
-            }
+    Connections {
+        target: root.audioSource
+
+        function onReadyChanged() {
+            root.refreshAudioStatus();
+        }
+    }
+
+    Connections {
+        target: root.audioSource !== null ? root.audioSource.audio : null
+
+        function onMutedChanged() {
+            root.refreshAudioStatus();
         }
     }
 
@@ -306,4 +334,6 @@ Scope {
             }
         }
     }
+
+    Component.onCompleted: root.refreshAudioStatus()
 }

--- a/scripts/dwm-quickshell-controls
+++ b/scripts/dwm-quickshell-controls
@@ -121,20 +121,10 @@ volume_status() {
 }
 
 volume_watch() {
+	# Compatibility snapshot for older deployed QML. Audio change notifications
+	# are handled by Quickshell.Services.Pipewire; keeping a pactl subscription
+	# here would orphan one client every time Quickshell reloads.
 	volume_status
-
-	if ! command -v pactl >/dev/null 2>&1; then
-		return 0
-	fi
-
-	pactl subscribe 2>/dev/null |
-		while IFS= read -r event; do
-			case "$event" in
-			*" on sink"* | *" on server"* | *" on card"*)
-				volume_status
-				;;
-			esac
-		done
 }
 
 volume_up() {

--- a/tests/test-quickshell-controls.sh
+++ b/tests/test-quickshell-controls.sh
@@ -47,10 +47,7 @@ list\ short\ sink-inputs)
 	printf 'Mute: %s\n' "${DWM_TEST_SOURCE_MUTE:-no}"
 	;;
 "subscribe")
-	if [ -n "${DWM_TEST_SINK_VOLUME_FILE:-}" ]; then
-		printf '45\n' >"$DWM_TEST_SINK_VOLUME_FILE"
-	fi
-	printf "Event 'change' on sink #1\n"
+	: >"$DWM_TEST_SUBSCRIBE_MARKER"
 	;;
 "set-sink-volume @DEFAULT_SINK@ +5%")
 	printf 'volume up\n' >>"$DWM_TEST_PACTL_LOG"
@@ -178,11 +175,12 @@ grep -Fqx "alsa_output.pci-0000_00_1f.3.analog-stereo	Built-in Audio Analog Ster
 grep -Fqx "bluez_output.00_11_22_33_44_55.a2dp-sink	Wireless Headphones	1" "$work/output-devices-bluez.out"
 
 printf '40\n' >"$work/volume-state"
-DWM_TEST_SINK_VOLUME_FILE="$work/volume-state" \
+DWM_TEST_SUBSCRIBE_MARKER="$work/subscribed" \
+	DWM_TEST_SINK_VOLUME_FILE="$work/volume-state" \
 	PATH="$work/bin:$PATH" \
 	"$repo/scripts/dwm-quickshell-controls" volume-watch >"$work/volume-watch.out"
 grep -Fqx "VOL 40%" "$work/volume-watch.out"
-grep -Fqx "VOL 45%" "$work/volume-watch.out"
+[ ! -e "$work/subscribed" ]
 
 PATH="$work/bin:$PATH" "$repo/scripts/dwm-quickshell-controls" mic-status >"$work/mic.out"
 grep -Fqx "MIC on" "$work/mic.out"


### PR DESCRIPTION
# Pull Request

## Title
<!--[Provide a succinct and descriptive title for the pull request.]-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This pull request refactors the audio status handling in the `ControlsModel.qml` to use the Pipewire service directly, removing the need for shell-based polling processes. It introduces new reactive connections to Pipewire objects, ensuring that UI updates occur immediately when audio device states change. The supporting shell script and tests are updated for compatibility with the new approach.

**Migration to Pipewire-based audio status (ControlsModel.qml):**
- Replaces shell-based polling (`Process` components for volume and mic status) with direct access to Pipewire's `defaultAudioSink` and `defaultAudioSource`, including new properties and a `refreshAudioStatus` function to update UI state reactively. [[1]](diffhunk://#diff-2177ad76e4759dbd6891d2ef037c5cf55722e9ec8aeedda7f2b2f0e488a6eb94R1-R4) [[2]](diffhunk://#diff-2177ad76e4759dbd6891d2ef037c5cf55722e9ec8aeedda7f2b2f0e488a6eb94R27-R52) [[3]](diffhunk://#diff-2177ad76e4759dbd6891d2ef037c5cf55722e9ec8aeedda7f2b2f0e488a6eb94L45-R73) [[4]](diffhunk://#diff-2177ad76e4759dbd6891d2ef037c5cf55722e9ec8aeedda7f2b2f0e488a6eb94L104-L117) [[5]](diffhunk://#diff-2177ad76e4759dbd6891d2ef037c5cf55722e9ec8aeedda7f2b2f0e488a6eb94L210-R273) [[6]](diffhunk://#diff-2177ad76e4759dbd6891d2ef037c5cf55722e9ec8aeedda7f2b2f0e488a6eb94R337-R338)
- Adds `Connections` to relevant Pipewire objects and their properties, ensuring the UI responds immediately to changes in audio device readiness, mute status, and volume.

**Shell script compatibility update:**
- Updates `volume_watch()` in `scripts/dwm-quickshell-controls` to remove the `pactl subscribe` logic, since Pipewire now provides notifications; retains a compatibility snapshot for older QML.

**Test adjustments:**
- Updates test script logic to match the new notification mechanism, removing the expectation of multiple volume status outputs and using a marker file to indicate subscription. [[1]](diffhunk://#diff-fe2d4c1ba665088b9069f693a6d85d16c34b636e008f752229c8c92ac9a1a16dL50-R50) [[2]](diffhunk://#diff-fe2d4c1ba665088b9069f693a6d85d16c34b636e008f752229c8c92ac9a1a16dR178-R183)
## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #

## Screenshots (if applicable)
