### PR TITLE
Honor EWMH always-on-top states

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -78,7 +78,7 @@
 enum { CurResizeBR, CurResizeBL, CurResizeTR, CurResizeTL, CurNormal, CurResize, CurMove, CurLast }; /* cursor */
 enum { SchemeNorm, SchemeSel }; /* color schemes */
 enum { NetSupported, NetWMName, NetWMState, NetWMCheck,
-       NetWMFullscreen, NetActiveWindow, NetWMWindowType, NetWMIcon,
+       NetWMFullscreen, NetWMAbove, NetWMStaysOnTop, NetActiveWindow, NetWMWindowType, NetWMIcon,
        NetWMWindowTypeDialog, NetWMWindowTypeDock, NetClientList, NetDesktopNames, NetDesktopViewport, NetNumberOfDesktops, NetCurrentDesktop, NetWMDesktop, NetLast }; /* EWMH atoms */
 enum { WMProtocols, WMDelete, WMState, WMTakeFocus, WMLast }; /* default atoms */
 enum { ClkTagBar, ClkLtSymbol, ClkStatusText, ClkWinTitle,
@@ -110,7 +110,7 @@ struct Client {
 	int basew, baseh, incw, inch, maxw, maxh, minw, minh;
 	int bw, oldbw;
 	unsigned int tags;
-	int isfixed, isfloating, isurgent, neverfocus, oldstate, isfullscreen, isterminal, noswallow, alwaysontop;
+	int isfixed, isfloating, isurgent, neverfocus, oldstate, isfullscreen, isterminal, noswallow, alwaysontop, ewmhabove;
 	int issteam;
 	int beingmoved;
 	int fakefullscreen;
@@ -195,6 +195,7 @@ static void focusmon(const Arg *arg);
 static void focusstack(const Arg *arg);
 static pid_t getparentprocess(pid_t p);
 static int getrootptr(int *x, int *y);
+static int hasatomprop(Client *c, Atom prop, Atom atom);
 static long getstate(Window w);
 static pid_t getstatusbarpid();
 static int gettextprop(Window w, Atom atom, char *text, unsigned int size);
@@ -225,6 +226,7 @@ static void restack(Monitor *m);
 static int sendevent(Client *c, Atom proto);
 static void sendmon(Client *c, Monitor *m);
 static void setclientstate(Client *c, long state);
+static void setatomprop(Client *c, Atom prop, Atom atom, int enabled);
 static void setfocus(Client *c);
 static void setfullscreen(Client *c, int fullscreen);
 static void fullscreen(const Arg *arg);
@@ -847,6 +849,8 @@ clientmessage(XEvent *e)
 {
 	XClientMessageEvent *cme = &e->xclient;
 	Client *c = wintoclient(cme->window);
+	Atom state;
+	int enabled, i, updateabove = 0;
 
 	if (cme->message_type == netatom[NetCurrentDesktop]) {
 		long desktop = cme->data.l[0];
@@ -866,6 +870,22 @@ clientmessage(XEvent *e)
 				c->fakefullscreen = 3;
 			setfullscreen(c, (cme->data.l[0] == 1 /* _NET_WM_STATE_ADD    */
 				|| (cme->data.l[0] == 2 /* _NET_WM_STATE_TOGGLE */ && !c->isfullscreen)));
+		}
+		for (i = 1; i <= 2; i++) {
+			state = (Atom)cme->data.l[i];
+			if (state != netatom[NetWMAbove] && state != netatom[NetWMStaysOnTop])
+				continue;
+			if (cme->data.l[0] < 0 || cme->data.l[0] > 2)
+				continue;
+			enabled = cme->data.l[0] == 1
+				|| (cme->data.l[0] == 2 && !hasatomprop(c, netatom[NetWMState], state));
+			setatomprop(c, netatom[NetWMState], state, enabled);
+			updateabove = 1;
+		}
+		if (updateabove) {
+			c->ewmhabove = hasatomprop(c, netatom[NetWMState], netatom[NetWMAbove])
+				|| hasatomprop(c, netatom[NetWMState], netatom[NetWMStaysOnTop]);
+			restack(c->mon);
 		}
 	} else if (cme->message_type == netatom[NetActiveWindow]) {
 		if (c != selmon->sel && !c->isurgent)
@@ -1359,6 +1379,73 @@ getatomprop(Client *c, Atom prop)
 		XFree(p);
 	}
 	return atom;
+}
+
+static Atom *
+getatomproplist(Client *c, Atom prop, unsigned long *nitems)
+{
+	int format;
+	unsigned long extra;
+	unsigned char *data = NULL;
+	Atom actual;
+
+	*nitems = 0;
+	if (XGetWindowProperty(dpy, c->win, prop, 0L, LONG_MAX, False, XA_ATOM,
+	    &actual, &format, nitems, &extra, &data) != Success)
+		return NULL;
+	if (actual != XA_ATOM || format != 32) {
+		if (data)
+			XFree(data);
+		*nitems = 0;
+		return NULL;
+	}
+	return (Atom *)data;
+}
+
+int
+hasatomprop(Client *c, Atom prop, Atom atom)
+{
+	Atom *atoms;
+	unsigned long i, nitems;
+	int found = 0;
+
+	atoms = getatomproplist(c, prop, &nitems);
+	for (i = 0; atoms && i < nitems; i++)
+		if (atoms[i] == atom) {
+			found = 1;
+			break;
+		}
+	if (atoms)
+		XFree(atoms);
+	return found;
+}
+
+void
+setatomprop(Client *c, Atom prop, Atom atom, int enabled)
+{
+	Atom *atoms;
+	unsigned long i, nitems, out;
+	int found = 0;
+
+	atoms = getatomproplist(c, prop, &nitems);
+	for (i = 0; atoms && i < nitems; i++)
+		if (atoms[i] == atom) {
+			found = 1;
+			break;
+		}
+	if (enabled && !found) {
+		XChangeProperty(dpy, c->win, prop, XA_ATOM, 32,
+			atoms ? PropModeAppend : PropModeReplace,
+			(unsigned char *)&atom, 1);
+	} else if (!enabled && found) {
+		for (i = 0, out = 0; i < nitems; i++)
+			if (atoms[i] != atom)
+				atoms[out++] = atoms[i];
+		XChangeProperty(dpy, c->win, prop, XA_ATOM, 32, PropModeReplace,
+			(unsigned char *)atoms, (int)out);
+	}
+	if (atoms)
+		XFree(atoms);
 }
 
 Atom
@@ -2441,7 +2528,7 @@ raisealwaysontop(Monitor *m)
 	Client *c;
 
 	for (c = m->stack; c; c = c->snext)
-		if (c->alwaysontop && ISVISIBLE(c))
+		if ((c->alwaysontop || c->ewmhabove) && ISVISIBLE(c))
 			XRaiseWindow(dpy, c->win);
 }
 
@@ -2707,12 +2794,7 @@ ewmh_set_desktop_names(void)
 static void
 ewmh_set_fullscreen_state(Client *c, int fullscreen)
 {
-	if (fullscreen)
-		XChangeProperty(dpy, c->win, netatom[NetWMState], XA_ATOM, 32,
-			PropModeReplace, (unsigned char *)&netatom[NetWMFullscreen], 1);
-	else
-		XChangeProperty(dpy, c->win, netatom[NetWMState], XA_ATOM, 32,
-			PropModeReplace, (unsigned char *)0, 0);
+	setatomprop(c, netatom[NetWMState], netatom[NetWMFullscreen], fullscreen);
 }
 
 void
@@ -3652,6 +3734,8 @@ setup(void)
 	netatom[NetWMState] = XInternAtom(dpy, "_NET_WM_STATE", False);
 	netatom[NetWMCheck] = XInternAtom(dpy, "_NET_SUPPORTING_WM_CHECK", False);
 	netatom[NetWMFullscreen] = XInternAtom(dpy, "_NET_WM_STATE_FULLSCREEN", False);
+	netatom[NetWMAbove] = XInternAtom(dpy, "_NET_WM_STATE_ABOVE", False);
+	netatom[NetWMStaysOnTop] = XInternAtom(dpy, "_NET_WM_STATE_STAYS_ON_TOP", False);
 	netatom[NetWMWindowType] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE", False);
 	netatom[NetWMWindowTypeDialog] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DIALOG", False);
 	netatom[NetWMWindowTypeDock] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DOCK", False);
@@ -4532,11 +4616,12 @@ updatetitle(Client *c)
 void
 updatewindowtype(Client *c)
 {
-	Atom state = getatomprop(c, netatom[NetWMState]);
 	Atom wtype = getatomprop(c, netatom[NetWMWindowType]);
 
-	if (state == netatom[NetWMFullscreen])
+	if (hasatomprop(c, netatom[NetWMState], netatom[NetWMFullscreen]))
 		setfullscreen(c, 1);
+	c->ewmhabove = hasatomprop(c, netatom[NetWMState], netatom[NetWMAbove])
+		|| hasatomprop(c, netatom[NetWMState], netatom[NetWMStaysOnTop]);
 	if (wtype == netatom[NetWMWindowTypeDialog])
 		c->isfloating = 1;
 }

--- a/dwm.c
+++ b/dwm.c
@@ -197,7 +197,7 @@ static void focusstack(const Arg *arg);
 static pid_t getparentprocess(pid_t p);
 static int getrootptr(int *x, int *y);
 static int atomlistcontains(const Atom *atoms, unsigned long nitems, Atom atom);
-static unsigned long getatomproplist(Client *c, Atom prop, Atom *atoms, unsigned long maxitems);
+static unsigned long getatomproplist(Client *c, Atom prop, Atom *atoms, unsigned long maxitems, int *truncated);
 static long getstate(Window w);
 static pid_t getstatusbarpid();
 static int gettextprop(Window w, Atom atom, char *text, unsigned int size);
@@ -854,7 +854,7 @@ clientmessage(XEvent *e)
 	Client *c = wintoclient(cme->window);
 	Atom state, states[NET_WM_STATE_MAX];
 	unsigned long i, j, nstates, out;
-	int changed = 0, enabled, updateabove = 0;
+	int changed = 0, enabled, truncated, updateabove = 0;
 
 	if (cme->message_type == netatom[NetCurrentDesktop]) {
 		long desktop = cme->data.l[0];
@@ -875,13 +875,17 @@ clientmessage(XEvent *e)
 			setfullscreen(c, (cme->data.l[0] == 1 /* _NET_WM_STATE_ADD    */
 				|| (cme->data.l[0] == 2 /* _NET_WM_STATE_TOGGLE */ && !c->isfullscreen)));
 		}
-		nstates = getatomproplist(c, netatom[NetWMState], states, LENGTH(states));
+		nstates = getatomproplist(c, netatom[NetWMState], states, LENGTH(states), &truncated);
 		for (i = 1; i <= 2; i++) {
 			state = (Atom)cme->data.l[i];
 			if (state != netatom[NetWMAbove] && state != netatom[NetWMStaysOnTop])
 				continue;
 			if (cme->data.l[0] < 0 || cme->data.l[0] > 2)
 				continue;
+			if (truncated) {
+				updateabove = 1;
+				continue;
+			}
 			enabled = cme->data.l[0] == 1
 				|| (cme->data.l[0] == 2 && !atomlistcontains(states, nstates, state));
 			if (enabled && !atomlistcontains(states, nstates, state)) {
@@ -1414,13 +1418,15 @@ atomlistcontains(const Atom *atoms, unsigned long nitems, Atom atom)
 }
 
 unsigned long
-getatomproplist(Client *c, Atom prop, Atom *atoms, unsigned long maxitems)
+getatomproplist(Client *c, Atom prop, Atom *atoms, unsigned long maxitems, int *truncated)
 {
 	int format;
 	unsigned long extra, nitems = 0;
 	unsigned char *data = NULL;
 	Atom actual;
 
+	if (truncated)
+		*truncated = 0;
 	if (XGetWindowProperty(dpy, c->win, prop, 0L, maxitems, False, XA_ATOM,
 	    &actual, &format, &nitems, &extra, &data) != Success)
 		return 0;
@@ -1431,6 +1437,8 @@ getatomproplist(Client *c, Atom prop, Atom *atoms, unsigned long maxitems)
 	}
 	if (nitems)
 		memcpy(atoms, data, nitems * sizeof(*atoms));
+	if (truncated)
+		*truncated = extra != 0;
 	if (data)
 		XFree(data);
 	return nitems;
@@ -1441,8 +1449,11 @@ setatomprop(Client *c, Atom prop, Atom atom, int enabled)
 {
 	Atom atoms[NET_WM_STATE_MAX];
 	unsigned long i, nitems, out;
+	int truncated;
 
-	nitems = getatomproplist(c, prop, atoms, LENGTH(atoms));
+	nitems = getatomproplist(c, prop, atoms, LENGTH(atoms), &truncated);
+	if (truncated)
+		return;
 	if (enabled) {
 		if (atomlistcontains(atoms, nitems, atom) || nitems == LENGTH(atoms))
 			return;
@@ -2536,7 +2547,7 @@ restack(Monitor *m)
 void
 raisealwaysontop(Monitor *m)
 {
-	if (m->sel && m->sel->isfullscreen) {
+	if (m->sel && m->sel->isfullscreen && m->sel->fakefullscreen != 1) {
 		XRaiseWindow(dpy, m->sel->win);
 		return;
 	}
@@ -4645,7 +4656,7 @@ updatewindowtype(Client *c)
 	Atom wtype = getatomprop(c, netatom[NetWMWindowType]);
 	unsigned long nstates;
 
-	nstates = getatomproplist(c, netatom[NetWMState], states, LENGTH(states));
+	nstates = getatomproplist(c, netatom[NetWMState], states, LENGTH(states), NULL);
 	if (atomlistcontains(states, nstates, netatom[NetWMFullscreen]))
 		setfullscreen(c, 1);
 	c->ewmhabove = atomlistcontains(states, nstates, netatom[NetWMAbove])

--- a/dwm.c
+++ b/dwm.c
@@ -73,6 +73,7 @@
 #define TAGMASK                 ((1 << LENGTH(tags)) - 1)
 #define TAGSLENGTH              (LENGTH(tags))
 #define TEXTW(X)                (drw_fontset_getwidth(drw, (X)) + lrpad)
+#define NET_WM_STATE_MAX        64
 
 /* enums */
 enum { CurResizeBR, CurResizeBL, CurResizeTR, CurResizeTL, CurNormal, CurResize, CurMove, CurLast }; /* cursor */
@@ -195,7 +196,8 @@ static void focusmon(const Arg *arg);
 static void focusstack(const Arg *arg);
 static pid_t getparentprocess(pid_t p);
 static int getrootptr(int *x, int *y);
-static int hasatomprop(Client *c, Atom prop, Atom atom);
+static int atomlistcontains(const Atom *atoms, unsigned long nitems, Atom atom);
+static unsigned long getatomproplist(Client *c, Atom prop, Atom *atoms, unsigned long maxitems);
 static long getstate(Window w);
 static pid_t getstatusbarpid();
 static int gettextprop(Window w, Atom atom, char *text, unsigned int size);
@@ -222,6 +224,7 @@ static void resizeclient(Client *c, int x, int y, int w, int h);
 static void resizemouse(const Arg *arg);
 static int resizetiledmouse(const Arg *arg);
 static void raisealwaysontop(Monitor *m);
+static void raisealwaysontopclients(Client *c);
 static void restack(Monitor *m);
 static int sendevent(Client *c, Atom proto);
 static void sendmon(Client *c, Monitor *m);
@@ -849,8 +852,9 @@ clientmessage(XEvent *e)
 {
 	XClientMessageEvent *cme = &e->xclient;
 	Client *c = wintoclient(cme->window);
-	Atom state;
-	int enabled, i, updateabove = 0;
+	Atom state, states[NET_WM_STATE_MAX];
+	unsigned long i, j, nstates, out;
+	int changed = 0, enabled, updateabove = 0;
 
 	if (cme->message_type == netatom[NetCurrentDesktop]) {
 		long desktop = cme->data.l[0];
@@ -871,6 +875,7 @@ clientmessage(XEvent *e)
 			setfullscreen(c, (cme->data.l[0] == 1 /* _NET_WM_STATE_ADD    */
 				|| (cme->data.l[0] == 2 /* _NET_WM_STATE_TOGGLE */ && !c->isfullscreen)));
 		}
+		nstates = getatomproplist(c, netatom[NetWMState], states, LENGTH(states));
 		for (i = 1; i <= 2; i++) {
 			state = (Atom)cme->data.l[i];
 			if (state != netatom[NetWMAbove] && state != netatom[NetWMStaysOnTop])
@@ -878,13 +883,29 @@ clientmessage(XEvent *e)
 			if (cme->data.l[0] < 0 || cme->data.l[0] > 2)
 				continue;
 			enabled = cme->data.l[0] == 1
-				|| (cme->data.l[0] == 2 && !hasatomprop(c, netatom[NetWMState], state));
-			setatomprop(c, netatom[NetWMState], state, enabled);
+				|| (cme->data.l[0] == 2 && !atomlistcontains(states, nstates, state));
+			if (enabled && !atomlistcontains(states, nstates, state)) {
+				if (nstates < LENGTH(states)) {
+					states[nstates++] = state;
+					changed = 1;
+				}
+			} else if (!enabled) {
+				for (j = 0, out = 0; j < nstates; j++)
+					if (states[j] != state)
+						states[out++] = states[j];
+				if (out != nstates) {
+					nstates = out;
+					changed = 1;
+				}
+			}
 			updateabove = 1;
 		}
 		if (updateabove) {
-			c->ewmhabove = hasatomprop(c, netatom[NetWMState], netatom[NetWMAbove])
-				|| hasatomprop(c, netatom[NetWMState], netatom[NetWMStaysOnTop]);
+			if (changed)
+				XChangeProperty(dpy, c->win, netatom[NetWMState], XA_ATOM, 32,
+					PropModeReplace, (unsigned char *)states, (int)nstates);
+			c->ewmhabove = atomlistcontains(states, nstates, netatom[NetWMAbove])
+				|| atomlistcontains(states, nstates, netatom[NetWMStaysOnTop]);
 			restack(c->mon);
 		}
 	} else if (cme->message_type == netatom[NetActiveWindow]) {
@@ -1381,71 +1402,61 @@ getatomprop(Client *c, Atom prop)
 	return atom;
 }
 
-static Atom *
-getatomproplist(Client *c, Atom prop, unsigned long *nitems)
+int
+atomlistcontains(const Atom *atoms, unsigned long nitems, Atom atom)
+{
+	unsigned long i;
+
+	for (i = 0; i < nitems; i++)
+		if (atoms[i] == atom)
+			return 1;
+	return 0;
+}
+
+unsigned long
+getatomproplist(Client *c, Atom prop, Atom *atoms, unsigned long maxitems)
 {
 	int format;
-	unsigned long extra;
+	unsigned long extra, nitems = 0;
 	unsigned char *data = NULL;
 	Atom actual;
 
-	*nitems = 0;
-	if (XGetWindowProperty(dpy, c->win, prop, 0L, LONG_MAX, False, XA_ATOM,
-	    &actual, &format, nitems, &extra, &data) != Success)
-		return NULL;
+	if (XGetWindowProperty(dpy, c->win, prop, 0L, maxitems, False, XA_ATOM,
+	    &actual, &format, &nitems, &extra, &data) != Success)
+		return 0;
 	if (actual != XA_ATOM || format != 32) {
 		if (data)
 			XFree(data);
-		*nitems = 0;
-		return NULL;
+		return 0;
 	}
-	return (Atom *)data;
-}
-
-int
-hasatomprop(Client *c, Atom prop, Atom atom)
-{
-	Atom *atoms;
-	unsigned long i, nitems;
-	int found = 0;
-
-	atoms = getatomproplist(c, prop, &nitems);
-	for (i = 0; atoms && i < nitems; i++)
-		if (atoms[i] == atom) {
-			found = 1;
-			break;
-		}
-	if (atoms)
-		XFree(atoms);
-	return found;
+	if (nitems)
+		memcpy(atoms, data, nitems * sizeof(*atoms));
+	if (data)
+		XFree(data);
+	return nitems;
 }
 
 void
 setatomprop(Client *c, Atom prop, Atom atom, int enabled)
 {
-	Atom *atoms;
+	Atom atoms[NET_WM_STATE_MAX];
 	unsigned long i, nitems, out;
-	int found = 0;
 
-	atoms = getatomproplist(c, prop, &nitems);
-	for (i = 0; atoms && i < nitems; i++)
-		if (atoms[i] == atom) {
-			found = 1;
-			break;
-		}
-	if (enabled && !found) {
-		XChangeProperty(dpy, c->win, prop, XA_ATOM, 32,
-			atoms ? PropModeAppend : PropModeReplace,
-			(unsigned char *)&atom, 1);
-	} else if (!enabled && found) {
+	nitems = getatomproplist(c, prop, atoms, LENGTH(atoms));
+	if (enabled) {
+		if (atomlistcontains(atoms, nitems, atom) || nitems == LENGTH(atoms))
+			return;
+		atoms[nitems++] = atom;
+	} else {
 		for (i = 0, out = 0; i < nitems; i++)
 			if (atoms[i] != atom)
 				atoms[out++] = atoms[i];
-		XChangeProperty(dpy, c->win, prop, XA_ATOM, 32, PropModeReplace,
-			(unsigned char *)atoms, (int)out);
+		if (out == nitems)
+			return;
+		nitems = out;
 	}
-	if (atoms)
-		XFree(atoms);
+	XChangeProperty(dpy, c->win, prop, XA_ATOM, 32, PropModeReplace,
+		(unsigned char *)atoms, (int)nitems);
 }
 
 Atom
@@ -2525,11 +2536,21 @@ restack(Monitor *m)
 void
 raisealwaysontop(Monitor *m)
 {
-	Client *c;
+	if (m->sel && m->sel->isfullscreen) {
+		XRaiseWindow(dpy, m->sel->win);
+		return;
+	}
+	raisealwaysontopclients(m->stack);
+}
 
-	for (c = m->stack; c; c = c->snext)
-		if ((c->alwaysontop || c->ewmhabove) && ISVISIBLE(c))
-			XRaiseWindow(dpy, c->win);
+void
+raisealwaysontopclients(Client *c)
+{
+	if (!c)
+		return;
+	raisealwaysontopclients(c->snext);
+	if ((c->alwaysontop || c->ewmhabove) && ISVISIBLE(c))
+		XRaiseWindow(dpy, c->win);
 }
 
 void
@@ -3876,6 +3897,9 @@ swallow(Client *p, Client *c)
 	Window w = p->win;
 	p->win = c->win;
 	c->win = w;
+	int ewmhabove = p->ewmhabove;
+	p->ewmhabove = c->ewmhabove;
+	c->ewmhabove = ewmhabove;
 
 	#if SHOWWINICON
 	Window icon = p->icon;
@@ -4318,6 +4342,7 @@ void
 unswallow(Client *c)
 {
 	c->win = c->swallowing->win;
+	c->ewmhabove = c->swallowing->ewmhabove;
 
 	#if SHOWWINICON
 	freeicon(c);
@@ -4616,12 +4641,15 @@ updatetitle(Client *c)
 void
 updatewindowtype(Client *c)
 {
+	Atom states[NET_WM_STATE_MAX];
 	Atom wtype = getatomprop(c, netatom[NetWMWindowType]);
+	unsigned long nstates;
 
-	if (hasatomprop(c, netatom[NetWMState], netatom[NetWMFullscreen]))
+	nstates = getatomproplist(c, netatom[NetWMState], states, LENGTH(states));
+	if (atomlistcontains(states, nstates, netatom[NetWMFullscreen]))
 		setfullscreen(c, 1);
-	c->ewmhabove = hasatomprop(c, netatom[NetWMState], netatom[NetWMAbove])
-		|| hasatomprop(c, netatom[NetWMState], netatom[NetWMStaysOnTop]);
+	c->ewmhabove = atomlistcontains(states, nstates, netatom[NetWMAbove])
+		|| atomlistcontains(states, nstates, netatom[NetWMStaysOnTop]);
 	if (wtype == netatom[NetWMWindowTypeDialog])
 		c->isfloating = 1;
 }

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -73,6 +73,38 @@ wait_for_window_state() {
 	return 1
 }
 
+wait_for_window_state_absent() {
+	win=$1
+	needle=$2
+	i=0
+	while [ "$i" -lt 100 ]; do
+		if ! DISPLAY=$display xprop -id "$win" _NET_WM_STATE 2>/dev/null |
+			grep -q "$needle"; then
+			return 0
+		fi
+		i=$((i + 1))
+		sleep 0.05
+	done
+	printf '%s\n' "window $win retained state $needle" >&2
+	return 1
+}
+
+wait_for_top_window() {
+	expected=$1
+	i=0
+	while [ "$i" -lt 100 ]; do
+		top=$(DISPLAY=$display xdotool search --class '^DwmXvfbRuntime$' 2>/dev/null |
+			tail -n 1 || true)
+		if [ -n "$top" ] && [ "$(printf '0x%x' "$top")" = "$expected" ]; then
+			return 0
+		fi
+		i=$((i + 1))
+		sleep 0.05
+	done
+	printf '%s\n' "window $expected did not reach the top of the stack" >&2
+	return 1
+}
+
 wait_for_active_window() {
 	expected_win=$1
 	i=0
@@ -89,11 +121,11 @@ wait_for_active_window() {
 	return 1
 }
 
-require_cmd Xvfb awk cc pkg-config xdotool xprop sed grep
+require_cmd Xvfb awk cc pkg-config xdotool xprop sed grep tail
 pkg-config --exists x11
 
 work=$(mktemp -d)
-trap 'set +e; [ -n "${second_client_pid:-}" ] && kill "$second_client_pid" 2>/dev/null; [ -n "${client_pid:-}" ] && kill "$client_pid" 2>/dev/null; [ -n "${dwm_pid:-}" ] && kill "$dwm_pid" 2>/dev/null; [ -n "${xvfb_pid:-}" ] && kill "$xvfb_pid" 2>/dev/null; rm -rf "$work"' EXIT HUP INT TERM
+trap 'set +e; [ -n "${stack_client_pid:-}" ] && kill "$stack_client_pid" 2>/dev/null; [ -n "${above_client_pid:-}" ] && kill "$above_client_pid" 2>/dev/null; [ -n "${second_client_pid:-}" ] && kill "$second_client_pid" 2>/dev/null; [ -n "${client_pid:-}" ] && kill "$client_pid" 2>/dev/null; [ -n "${dwm_pid:-}" ] && kill "$dwm_pid" 2>/dev/null; [ -n "${xvfb_pid:-}" ] && kill "$xvfb_pid" 2>/dev/null; rm -rf "$work"' EXIT HUP INT TERM
 
 home="$work/home"
 mkdir -p "$home/.config/dwm-titus" "$home/.local/share/dwm-titus/config"
@@ -131,6 +163,8 @@ main(int argc, char **argv)
 	XEvent ev;
 	int set_hints = 1;
 	int malformed_icon = 0;
+	int initial_above = 0;
+	int override_redirect = 0;
 
 	signal(SIGTERM, stop);
 	signal(SIGINT, stop);
@@ -138,20 +172,27 @@ main(int argc, char **argv)
 	dpy = XOpenDisplay(NULL);
 	if (!dpy)
 		return 2;
-
-	if (argc == 3 && strcmp(argv[1], "fullscreen") == 0) {
+	if ((argc == 3 && strcmp(argv[1], "fullscreen") == 0)
+	|| (argc == 5 && strcmp(argv[1], "state") == 0)) {
 		XEvent ev;
 		Atom state = XInternAtom(dpy, "_NET_WM_STATE", False);
-		Atom fullscreen = XInternAtom(dpy, "_NET_WM_STATE_FULLSCREEN", False);
+		Atom requested;
+		long action = 1;
 
 		win = strtoul(argv[2], NULL, 0);
+		if (strcmp(argv[1], "fullscreen") == 0) {
+			requested = XInternAtom(dpy, "_NET_WM_STATE_FULLSCREEN", False);
+		} else {
+			action = strtol(argv[3], NULL, 10);
+			requested = XInternAtom(dpy, argv[4], False);
+		}
 		memset(&ev, 0, sizeof(ev));
 		ev.xclient.type = ClientMessage;
 		ev.xclient.window = win;
 		ev.xclient.message_type = state;
 		ev.xclient.format = 32;
-		ev.xclient.data.l[0] = 1;
-		ev.xclient.data.l[1] = fullscreen;
+		ev.xclient.data.l[0] = action;
+		ev.xclient.data.l[1] = requested;
 		XSendEvent(dpy, DefaultRootWindow(dpy), False,
 			SubstructureRedirectMask | SubstructureNotifyMask, &ev);
 		XFlush(dpy);
@@ -162,9 +203,18 @@ main(int argc, char **argv)
 		set_hints = 0;
 	else if (argc == 2 && strcmp(argv[1], "malformed-icon") == 0)
 		malformed_icon = 1;
+	else if (argc == 2 && strcmp(argv[1], "initial-above") == 0)
+		initial_above = 1;
+	else if (argc == 2 && strcmp(argv[1], "override") == 0)
+		override_redirect = 1;
 
 	win = XCreateSimpleWindow(dpy, DefaultRootWindow(dpy),
 		20, 20, 320, 180, 0, 0, WhitePixel(dpy, DefaultScreen(dpy)));
+	if (override_redirect) {
+		XSetWindowAttributes attributes = { .override_redirect = True };
+
+		XChangeWindowAttributes(dpy, win, CWOverrideRedirect, &attributes);
+	}
 	if (set_hints) {
 		XStoreName(dpy, win, "dwm-xvfb-runtime");
 		classhint.res_name = "dwm-xvfb-runtime";
@@ -176,6 +226,14 @@ main(int argc, char **argv)
 		Atom net_wm_icon = XInternAtom(dpy, "_NET_WM_ICON", False);
 		XChangeProperty(dpy, win, net_wm_icon, XA_CARDINAL, 32,
 			PropModeReplace, (unsigned char *)icon, 3);
+	}
+	if (initial_above) {
+		Atom states[2];
+
+		states[0] = XInternAtom(dpy, "_NET_WM_STATE_ABOVE", False);
+		states[1] = XInternAtom(dpy, "_NET_WM_STATE_STAYS_ON_TOP", False);
+		XChangeProperty(dpy, win, XInternAtom(dpy, "_NET_WM_STATE", False),
+			XA_ATOM, 32, PropModeReplace, (unsigned char *)states, 2);
 	}
 	wm_delete = XInternAtom(dpy, "WM_DELETE_WINDOW", False);
 	XSetWMProtocols(dpy, win, &wm_delete, 1);
@@ -218,6 +276,8 @@ dwm_pid=$!
 wait_for_root_property _NET_SUPPORTED
 wait_for_root_property _NET_NUMBER_OF_DESKTOPS
 wait_for_current_desktop 0
+DISPLAY=$display xprop -root _NET_SUPPORTED | grep -q _NET_WM_STATE_ABOVE
+DISPLAY=$display xprop -root _NET_SUPPORTED | grep -q _NET_WM_STATE_STAYS_ON_TOP
 
 DISPLAY=$display "$work/xclient" >"$work/window-id" 2>"$work/xclient.log" &
 client_pid=$!
@@ -377,5 +437,55 @@ icon_win=$(cat "$work/icon-window-id")
 wait_for_active_window "$icon_win"
 DISPLAY=$display xprop -root _NET_CLIENT_LIST | grep -q "$icon_win"
 kill -0 "$dwm_pid"
+
+DISPLAY=$display "$work/xclient" initial-above >"$work/above-window-id" 2>"$work/above-client.log" &
+above_client_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ ! -s "$work/above-window-id" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+above_win=$(cat "$work/above-window-id")
+[ -n "$above_win" ]
+wait_for_window_state "$above_win" _NET_WM_STATE_ABOVE
+wait_for_window_state "$above_win" _NET_WM_STATE_STAYS_ON_TOP
+DISPLAY=$display "$work/xclient" override >"$work/stack-window-id" 2>"$work/stack-client.log" &
+stack_client_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ ! -s "$work/stack-window-id" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+stack_win=$(cat "$work/stack-window-id")
+[ -n "$stack_win" ]
+wait_for_top_window "$stack_win"
+DISPLAY=$display xdotool key Super+t
+wait_for_top_window "$above_win"
+
+DISPLAY=$display "$work/xclient" state "$above_win" 0 _NET_WM_STATE_STAYS_ON_TOP
+wait_for_window_state_absent "$above_win" _NET_WM_STATE_STAYS_ON_TOP
+wait_for_top_window "$above_win"
+
+DISPLAY=$display "$work/xclient" state "$above_win" 0 _NET_WM_STATE_ABOVE
+wait_for_window_state_absent "$above_win" _NET_WM_STATE_ABOVE
+DISPLAY=$display xdotool windowraise "$stack_win"
+wait_for_top_window "$stack_win"
+
+DISPLAY=$display "$work/xclient" state "$above_win" 1 _NET_WM_STATE_STAYS_ON_TOP
+wait_for_window_state "$above_win" _NET_WM_STATE_STAYS_ON_TOP
+wait_for_top_window "$above_win"
+DISPLAY=$display "$work/xclient" fullscreen "$above_win"
+wait_for_window_state "$above_win" _NET_WM_STATE_FULLSCREEN
+wait_for_window_state "$above_win" _NET_WM_STATE_STAYS_ON_TOP
+DISPLAY=$display "$work/xclient" state "$above_win" 0 _NET_WM_STATE_FULLSCREEN
+wait_for_window_state_absent "$above_win" _NET_WM_STATE_FULLSCREEN
+wait_for_window_state "$above_win" _NET_WM_STATE_STAYS_ON_TOP
+
+kill "$stack_client_pid"
+wait "$stack_client_pid" 2>/dev/null || true
+stack_client_pid=
+kill "$above_client_pid"
+wait "$above_client_pid" 2>/dev/null || true
+above_client_pid=
 
 printf '%s\n' "Xvfb runtime smoke: PASS"

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -93,7 +93,7 @@ wait_for_top_window() {
 	expected=$1
 	i=0
 	while [ "$i" -lt 100 ]; do
-		top=$(DISPLAY=$display xdotool search --class '^DwmXvfbRuntime$' 2>/dev/null |
+		top=$(DISPLAY=$display xdotool search --class '^DwmXvfb(Runtime|Terminal)$' 2>/dev/null |
 			tail -n 1 || true)
 		if [ -n "$top" ] && [ "$(printf '0x%x' "$top")" = "$expected" ]; then
 			return 0
@@ -121,11 +121,26 @@ wait_for_active_window() {
 	return 1
 }
 
+wait_for_client_window() {
+	expected_win=$1
+	i=0
+	while [ "$i" -lt 100 ]; do
+		if DISPLAY=$display xprop -root _NET_CLIENT_LIST 2>/dev/null |
+			grep -q "$expected_win"; then
+			return 0
+		fi
+		i=$((i + 1))
+		sleep 0.05
+	done
+	printf '%s\n' "window $expected_win did not enter the client list" >&2
+	return 1
+}
+
 require_cmd Xvfb awk cc pkg-config xdotool xprop sed grep tail
 pkg-config --exists x11
 
 work=$(mktemp -d)
-trap 'set +e; [ -n "${stack_client_pid:-}" ] && kill "$stack_client_pid" 2>/dev/null; [ -n "${above_client_pid:-}" ] && kill "$above_client_pid" 2>/dev/null; [ -n "${second_client_pid:-}" ] && kill "$second_client_pid" 2>/dev/null; [ -n "${client_pid:-}" ] && kill "$client_pid" 2>/dev/null; [ -n "${dwm_pid:-}" ] && kill "$dwm_pid" 2>/dev/null; [ -n "${xvfb_pid:-}" ] && kill "$xvfb_pid" 2>/dev/null; rm -rf "$work"' EXIT HUP INT TERM
+trap 'set +e; [ -n "${swallow_client_pid:-}" ] && kill "$swallow_client_pid" 2>/dev/null; [ -n "${fullscreen_client_pid:-}" ] && kill "$fullscreen_client_pid" 2>/dev/null; [ -n "${second_above_client_pid:-}" ] && kill "$second_above_client_pid" 2>/dev/null; [ -n "${stack_client_pid:-}" ] && kill "$stack_client_pid" 2>/dev/null; [ -n "${above_client_pid:-}" ] && kill "$above_client_pid" 2>/dev/null; [ -n "${second_client_pid:-}" ] && kill "$second_client_pid" 2>/dev/null; [ -n "${client_pid:-}" ] && kill "$client_pid" 2>/dev/null; [ -n "${dwm_pid:-}" ] && kill "$dwm_pid" 2>/dev/null; [ -n "${xvfb_pid:-}" ] && kill "$xvfb_pid" 2>/dev/null; rm -rf "$work"' EXIT HUP INT TERM
 
 home="$work/home"
 mkdir -p "$home/.config/dwm-titus" "$home/.local/share/dwm-titus/config"
@@ -133,6 +148,8 @@ cp "$repo_dir/config/hotkeys.toml" "$home/.config/dwm-titus/hotkeys.toml"
 cp "$repo_dir/config/themes.toml" "$home/.config/dwm-titus/themes.toml"
 cp "$repo_dir/config/window-rules.toml" "$home/.config/dwm-titus/window-rules.toml"
 cp "$repo_dir/config/"*.toml "$home/.local/share/dwm-titus/config/"
+sed -i '/^rules = \[/a\  { class="DwmXvfbTerminal", isterminal=1 },' \
+	"$home/.config/dwm-titus/window-rules.toml"
 
 cat >"$work/xclient.c" <<'EOF'
 #include <X11/Xlib.h>
@@ -142,6 +159,7 @@ cat >"$work/xclient.c" <<'EOF'
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 static volatile sig_atomic_t running = 1;
@@ -165,6 +183,8 @@ main(int argc, char **argv)
 	int malformed_icon = 0;
 	int initial_above = 0;
 	int override_redirect = 0;
+	int swallow_terminal = 0;
+	pid_t child_pid = -1;
 
 	signal(SIGTERM, stop);
 	signal(SIGINT, stop);
@@ -207,6 +227,8 @@ main(int argc, char **argv)
 		initial_above = 1;
 	else if (argc == 2 && strcmp(argv[1], "override") == 0)
 		override_redirect = 1;
+	else if (argc == 2 && strcmp(argv[1], "swallow-terminal") == 0)
+		swallow_terminal = 1;
 
 	win = XCreateSimpleWindow(dpy, DefaultRootWindow(dpy),
 		20, 20, 320, 180, 0, 0, WhitePixel(dpy, DefaultScreen(dpy)));
@@ -218,8 +240,14 @@ main(int argc, char **argv)
 	if (set_hints) {
 		XStoreName(dpy, win, "dwm-xvfb-runtime");
 		classhint.res_name = "dwm-xvfb-runtime";
-		classhint.res_class = "DwmXvfbRuntime";
+		classhint.res_class = swallow_terminal ? "DwmXvfbTerminal" : "DwmXvfbRuntime";
 		XSetClassHint(dpy, win, &classhint);
+	}
+	if (swallow_terminal) {
+		unsigned long pid = (unsigned long)getpid();
+
+		XChangeProperty(dpy, win, XInternAtom(dpy, "_NET_WM_PID", False),
+			XA_CARDINAL, 32, PropModeReplace, (unsigned char *)&pid, 1);
 	}
 	if (malformed_icon) {
 		unsigned long icon[] = { 8, 8, 0xff00ff00 };
@@ -243,6 +271,47 @@ main(int argc, char **argv)
 
 	printf("0x%lx\n", win);
 	fflush(stdout);
+	if (swallow_terminal && (child_pid = fork()) == 0) {
+		Atom states[1];
+		Display *child_dpy;
+		Window child_win;
+		unsigned long pid = (unsigned long)getpid();
+
+		close(ConnectionNumber(dpy));
+		usleep(200000);
+		child_dpy = XOpenDisplay(NULL);
+		if (!child_dpy)
+			return 3;
+		child_win = XCreateSimpleWindow(child_dpy, DefaultRootWindow(child_dpy),
+			40, 40, 320, 180, 0, 0, WhitePixel(child_dpy, DefaultScreen(child_dpy)));
+		XStoreName(child_dpy, child_win, "dwm-xvfb-swallowed");
+		classhint.res_name = "dwm-xvfb-swallowed";
+		classhint.res_class = "DwmXvfbRuntime";
+		XSetClassHint(child_dpy, child_win, &classhint);
+		XChangeProperty(child_dpy, child_win,
+			XInternAtom(child_dpy, "_NET_WM_PID", False), XA_CARDINAL, 32,
+			PropModeReplace, (unsigned char *)&pid, 1);
+		states[0] = XInternAtom(child_dpy, "_NET_WM_STATE_ABOVE", False);
+		XChangeProperty(child_dpy, child_win,
+			XInternAtom(child_dpy, "_NET_WM_STATE", False), XA_ATOM, 32,
+			PropModeReplace, (unsigned char *)states, 1);
+		XSelectInput(child_dpy, child_win, StructureNotifyMask);
+		XMapWindow(child_dpy, child_win);
+		XFlush(child_dpy);
+		printf("0x%lx\n", child_win);
+		fflush(stdout);
+		while (running) {
+			while (XPending(child_dpy)) {
+				XNextEvent(child_dpy, &ev);
+				if (ev.type == DestroyNotify)
+					running = 0;
+			}
+			usleep(50000);
+		}
+		XDestroyWindow(child_dpy, child_win);
+		XCloseDisplay(child_dpy);
+		return 0;
+	}
 
 	while (running) {
 		while (XPending(dpy)) {
@@ -251,6 +320,10 @@ main(int argc, char **argv)
 				running = 0;
 		}
 		usleep(50000);
+	}
+	if (child_pid > 0) {
+		kill(child_pid, SIGTERM);
+		waitpid(child_pid, NULL, 0);
 	}
 
 	XDestroyWindow(dpy, win);
@@ -302,6 +375,7 @@ printf '%s\n' \
 	'  { mod="SUPER", key="o", desc="Xvfb monocle", func="setlayout", layout_idx=2 },' \
 	'  { mod="SUPER", key="t", desc="Xvfb tile", func="setlayout", layout_idx=0 },' \
 	'  { mod="SUPER", key="f", desc="Xvfb toggle floating", func="togglefloating" },' \
+	'  { mod="SUPER", key="k", desc="Xvfb focus previous", func="focusstack", i=-1 },' \
 	'  { mod="SUPER", key="v", desc="Xvfb mouse resize", func="resizemouse" },' \
 	'  { mod="SUPER", key="u", desc="Xvfb reload tag", func="view", ui=16 },' \
 	']' >"$home/.config/dwm-titus/hotkeys.toml"
@@ -449,6 +523,20 @@ above_win=$(cat "$work/above-window-id")
 [ -n "$above_win" ]
 wait_for_window_state "$above_win" _NET_WM_STATE_ABOVE
 wait_for_window_state "$above_win" _NET_WM_STATE_STAYS_ON_TOP
+DISPLAY=$display "$work/xclient" initial-above >"$work/second-above-window-id" 2>"$work/second-above-client.log" &
+second_above_client_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ ! -s "$work/second-above-window-id" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+second_above_win=$(cat "$work/second-above-window-id")
+[ -n "$second_above_win" ]
+wait_for_top_window "$second_above_win"
+DISPLAY=$display xdotool key Super+k
+wait_for_active_window "$above_win"
+wait_for_top_window "$above_win"
+
 DISPLAY=$display "$work/xclient" override >"$work/stack-window-id" 2>"$work/stack-client.log" &
 stack_client_pid=$!
 i=0
@@ -474,6 +562,27 @@ wait_for_top_window "$stack_win"
 DISPLAY=$display "$work/xclient" state "$above_win" 1 _NET_WM_STATE_STAYS_ON_TOP
 wait_for_window_state "$above_win" _NET_WM_STATE_STAYS_ON_TOP
 wait_for_top_window "$above_win"
+
+DISPLAY=$display "$work/xclient" >"$work/fullscreen-window-id" 2>"$work/fullscreen-client.log" &
+fullscreen_client_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ ! -s "$work/fullscreen-window-id" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+fullscreen_win=$(cat "$work/fullscreen-window-id")
+[ -n "$fullscreen_win" ]
+wait_for_active_window "$fullscreen_win"
+DISPLAY=$display "$work/xclient" fullscreen "$fullscreen_win"
+wait_for_window_state "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
+DISPLAY=$display xdotool key Super+t
+wait_for_top_window "$fullscreen_win"
+DISPLAY=$display "$work/xclient" state "$fullscreen_win" 0 _NET_WM_STATE_FULLSCREEN
+wait_for_window_state_absent "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
+kill "$fullscreen_client_pid"
+wait "$fullscreen_client_pid" 2>/dev/null || true
+fullscreen_client_pid=
+
 DISPLAY=$display "$work/xclient" fullscreen "$above_win"
 wait_for_window_state "$above_win" _NET_WM_STATE_FULLSCREEN
 wait_for_window_state "$above_win" _NET_WM_STATE_STAYS_ON_TOP
@@ -481,11 +590,53 @@ DISPLAY=$display "$work/xclient" state "$above_win" 0 _NET_WM_STATE_FULLSCREEN
 wait_for_window_state_absent "$above_win" _NET_WM_STATE_FULLSCREEN
 wait_for_window_state "$above_win" _NET_WM_STATE_STAYS_ON_TOP
 
+kill "$second_above_client_pid"
+wait "$second_above_client_pid" 2>/dev/null || true
+second_above_client_pid=
 kill "$stack_client_pid"
 wait "$stack_client_pid" 2>/dev/null || true
 stack_client_pid=
 kill "$above_client_pid"
 wait "$above_client_pid" 2>/dev/null || true
 above_client_pid=
+
+DISPLAY=$display "$work/xclient" override >"$work/restore-stack-window-id" 2>"$work/restore-stack-client.log" &
+stack_client_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ ! -s "$work/restore-stack-window-id" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+stack_win=$(cat "$work/restore-stack-window-id")
+[ -n "$stack_win" ]
+
+DISPLAY=$display "$work/xclient" swallow-terminal >"$work/swallow-window-ids" 2>"$work/swallow-client.log" &
+swallow_client_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ "$(wc -l <"$work/swallow-window-ids")" -lt 2 ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+terminal_win=$(sed -n '1p' "$work/swallow-window-ids")
+swallowed_win=$(sed -n '2p' "$work/swallow-window-ids")
+[ -n "$terminal_win" ]
+[ -n "$swallowed_win" ]
+wait_for_active_window "$swallowed_win"
+DISPLAY=$display xdotool windowraise "$stack_win"
+DISPLAY=$display xdotool key Super+t
+wait_for_top_window "$swallowed_win"
+
+DISPLAY=$display xdotool windowkill "$swallowed_win"
+wait_for_client_window "$terminal_win"
+DISPLAY=$display xdotool windowraise "$stack_win"
+DISPLAY=$display xdotool key Super+t
+wait_for_top_window "$stack_win"
+
+kill "$swallow_client_pid"
+wait "$swallow_client_pid" 2>/dev/null || true
+swallow_client_pid=
+kill "$stack_client_pid"
+wait "$stack_client_pid" 2>/dev/null || true
+stack_client_pid=
 
 printf '%s\n' "Xvfb runtime smoke: PASS"

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -140,7 +140,7 @@ require_cmd Xvfb awk cc pkg-config xdotool xprop sed grep tail
 pkg-config --exists x11
 
 work=$(mktemp -d)
-trap 'set +e; [ -n "${swallow_client_pid:-}" ] && kill "$swallow_client_pid" 2>/dev/null; [ -n "${fullscreen_client_pid:-}" ] && kill "$fullscreen_client_pid" 2>/dev/null; [ -n "${second_above_client_pid:-}" ] && kill "$second_above_client_pid" 2>/dev/null; [ -n "${stack_client_pid:-}" ] && kill "$stack_client_pid" 2>/dev/null; [ -n "${above_client_pid:-}" ] && kill "$above_client_pid" 2>/dev/null; [ -n "${second_client_pid:-}" ] && kill "$second_client_pid" 2>/dev/null; [ -n "${client_pid:-}" ] && kill "$client_pid" 2>/dev/null; [ -n "${dwm_pid:-}" ] && kill "$dwm_pid" 2>/dev/null; [ -n "${xvfb_pid:-}" ] && kill "$xvfb_pid" 2>/dev/null; rm -rf "$work"' EXIT HUP INT TERM
+trap 'set +e; [ -n "${swallow_client_pid:-}" ] && kill "$swallow_client_pid" 2>/dev/null; [ -n "${many_state_client_pid:-}" ] && kill "$many_state_client_pid" 2>/dev/null; [ -n "${fullscreen_client_pid:-}" ] && kill "$fullscreen_client_pid" 2>/dev/null; [ -n "${second_above_client_pid:-}" ] && kill "$second_above_client_pid" 2>/dev/null; [ -n "${stack_client_pid:-}" ] && kill "$stack_client_pid" 2>/dev/null; [ -n "${above_client_pid:-}" ] && kill "$above_client_pid" 2>/dev/null; [ -n "${second_client_pid:-}" ] && kill "$second_client_pid" 2>/dev/null; [ -n "${client_pid:-}" ] && kill "$client_pid" 2>/dev/null; [ -n "${dwm_pid:-}" ] && kill "$dwm_pid" 2>/dev/null; [ -n "${xvfb_pid:-}" ] && kill "$xvfb_pid" 2>/dev/null; rm -rf "$work"' EXIT HUP INT TERM
 
 home="$work/home"
 mkdir -p "$home/.config/dwm-titus" "$home/.local/share/dwm-titus/config"
@@ -182,6 +182,7 @@ main(int argc, char **argv)
 	int set_hints = 1;
 	int malformed_icon = 0;
 	int initial_above = 0;
+	int initial_many_states = 0;
 	int override_redirect = 0;
 	int swallow_terminal = 0;
 	pid_t child_pid = -1;
@@ -225,6 +226,8 @@ main(int argc, char **argv)
 		malformed_icon = 1;
 	else if (argc == 2 && strcmp(argv[1], "initial-above") == 0)
 		initial_above = 1;
+	else if (argc == 2 && strcmp(argv[1], "initial-many-states") == 0)
+		initial_many_states = 1;
 	else if (argc == 2 && strcmp(argv[1], "override") == 0)
 		override_redirect = 1;
 	else if (argc == 2 && strcmp(argv[1], "swallow-terminal") == 0)
@@ -255,7 +258,20 @@ main(int argc, char **argv)
 		XChangeProperty(dpy, win, net_wm_icon, XA_CARDINAL, 32,
 			PropModeReplace, (unsigned char *)icon, 3);
 	}
-	if (initial_above) {
+	if (initial_many_states) {
+		Atom states[65];
+		char name[64];
+		int i;
+
+		states[0] = XInternAtom(dpy, "_NET_WM_STATE_ABOVE", False);
+		for (i = 1; i < 64; i++) {
+			snprintf(name, sizeof(name), "_DWM_XVFB_STATE_%d", i);
+			states[i] = XInternAtom(dpy, name, False);
+		}
+		states[64] = XInternAtom(dpy, "_NET_WM_STATE_STAYS_ON_TOP", False);
+		XChangeProperty(dpy, win, XInternAtom(dpy, "_NET_WM_STATE", False),
+			XA_ATOM, 32, PropModeReplace, (unsigned char *)states, 65);
+	} else if (initial_above) {
 		Atom states[2];
 
 		states[0] = XInternAtom(dpy, "_NET_WM_STATE_ABOVE", False);
@@ -378,6 +394,7 @@ printf '%s\n' \
 	'  { mod="SUPER", key="k", desc="Xvfb focus previous", func="focusstack", i=-1 },' \
 	'  { mod="SUPER", key="v", desc="Xvfb mouse resize", func="resizemouse" },' \
 	'  { mod="SUPER", key="u", desc="Xvfb reload tag", func="view", ui=16 },' \
+	'  { mod="SUPER SHIFT", key="y", desc="Xvfb fake fullscreen", func="togglefakefullscreen" },' \
 	']' >"$home/.config/dwm-titus/hotkeys.toml"
 kill -USR1 "$dwm_pid"
 sleep 0.2
@@ -573,6 +590,14 @@ done
 fullscreen_win=$(cat "$work/fullscreen-window-id")
 [ -n "$fullscreen_win" ]
 wait_for_active_window "$fullscreen_win"
+DISPLAY=$display xdotool key Super+Shift+y
+wait_for_window_state "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
+DISPLAY=$display xdotool windowraise "$stack_win"
+DISPLAY=$display xdotool key Super+t
+wait_for_top_window "$above_win"
+DISPLAY=$display xdotool key Super+Shift+y
+wait_for_window_state_absent "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
+
 DISPLAY=$display "$work/xclient" fullscreen "$fullscreen_win"
 wait_for_window_state "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
 DISPLAY=$display xdotool key Super+t
@@ -582,6 +607,25 @@ wait_for_window_state_absent "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
 kill "$fullscreen_client_pid"
 wait "$fullscreen_client_pid" 2>/dev/null || true
 fullscreen_client_pid=
+
+DISPLAY=$display "$work/xclient" initial-many-states >"$work/many-state-window-id" 2>"$work/many-state-client.log" &
+many_state_client_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ ! -s "$work/many-state-window-id" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+many_state_win=$(cat "$work/many-state-window-id")
+[ -n "$many_state_win" ]
+wait_for_window_state "$many_state_win" _NET_WM_STATE_ABOVE
+wait_for_window_state "$many_state_win" _NET_WM_STATE_STAYS_ON_TOP
+DISPLAY=$display "$work/xclient" state "$many_state_win" 0 _NET_WM_STATE_ABOVE
+sleep 0.2
+wait_for_window_state "$many_state_win" _NET_WM_STATE_ABOVE
+wait_for_window_state "$many_state_win" _NET_WM_STATE_STAYS_ON_TOP
+kill "$many_state_client_pid"
+wait "$many_state_client_pid" 2>/dev/null || true
+many_state_client_pid=
 
 DISPLAY=$display "$work/xclient" fullscreen "$above_win"
 wait_for_window_state "$above_win" _NET_WM_STATE_FULLSCREEN


### PR DESCRIPTION
## What changed

- advertise and honor `_NET_WM_STATE_ABOVE` and legacy `_NET_WM_STATE_STAYS_ON_TOP`
- read the full `_NET_WM_STATE` atom list when managing a window
- handle EWMH add, remove, and toggle client messages for both above states
- preserve unrelated window states when fullscreen is added or removed
- extend the Xvfb runtime smoke test with real stacking-order coverage

## Why

DaVinci Resolve marks its **Create New Project** dialog as modal, above, and stays-on-top. dwm only handled fullscreen state and ignored the above-state atoms, so the larger Project Manager window could be raised over the creation dialog. Resolve's dialogs also share an unmanaged group-leader window, which means transient-parent ordering cannot correct the stack by itself.

This makes dwm honor the states Resolve already sends and fixes the behavior generically for other EWMH applications.

## Validation

- `make clean`
- `make`
- `shellcheck tests/test-xvfb-runtime.sh`
- `shfmt -d tests/test-xvfb-runtime.sh`
- `tests/test-xvfb-runtime.sh`
- `git diff --check`