### PR TITLE
Clean up graphical sessions when dwm exits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,7 @@ check-format:
 
 check-session-guards:
 	tests/test-autostart.sh
+	tests/test-autostop.sh
 
 check-session-migration:
 	tests/test-graphical-session-migration.sh

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ See [docs/src/keybinds.md](docs/src/keybinds.md) for the full reference.
 | <kbd>SUPER</kbd> + <kbd>F</kbd> | Floating layout |
 | <kbd>SUPER</kbd> + <kbd>M</kbd> | Fullscreen |
 | <kbd>SUPER</kbd> + <kbd>Space</kbd> | Toggle floating |
-| <kbd>SUPER</kbd> + <kbd>Shift</kbd> + <kbd>Q</kbd> | Quit dwm |
+| <kbd>SUPER</kbd> + <kbd>Shift</kbd> + <kbd>Q</kbd> | Quit dwm and cleanly end the graphical session |
 | <kbd>SUPER</kbd> + <kbd>Ctrl</kbd> + <kbd>Q</kbd> | Power menu |
 
 ---

--- a/docs/src/keybinds.md
+++ b/docs/src/keybinds.md
@@ -101,7 +101,7 @@ Bindings are defined in `config/hotkeys.toml` and reload instantly on save — n
 | Keys | Action |
 |------|--------|
 | `Super` + `Ctrl` + `Q` | Power menu |
-| `Super` + `Shift` + `Q` | Quit dwm |
+| `Super` + `Shift` + `Q` | Quit dwm and cleanly end the graphical session |
 | `Super` + `Ctrl` + `Shift` + `R` | Reboot |
 | `Super` + `Ctrl` + `Shift` + `S` | Suspend |
 

--- a/dwm.c
+++ b/dwm.c
@@ -289,7 +289,9 @@ static void maprequest(XEvent *e);
 static void motionnotify(XEvent *e);
 static void propertynotify(XEvent *e);
 static void run(void);
+static void runautoscript(const char *script);
 static void runautostart(void);
+static void runautostop(void);
 static void scan(void);
 static void sigchld(int unused);
 static void sigstatusbar(const Arg *arg);
@@ -343,6 +345,7 @@ static void *toml_alloc(size_t sz);
 
 /* variables */
 static const char autostartsh[] = "scripts/autostart.sh";
+static const char autostopsh[] = "scripts/autostop.sh";
 static const char broken[] = "broken";
 static const char dwmdir[] = "dwm-titus";
 static const char localshare[] = ".local/share";
@@ -2605,7 +2608,7 @@ run(void)
 }
 
 void
-runautostart(void)
+runautoscript(const char *script)
 {
 	char *pathpfx;
 	char *path;
@@ -2659,10 +2662,11 @@ runautostart(void)
 	}
 
 	/* try the autostart script */
-	path = ecalloc(1, strlen(pathpfx) + strlen(autostartsh) + 2);
-	if (sprintf(path, "%s/%s", pathpfx, autostartsh) <= 0) {
+	path = ecalloc(1, strlen(pathpfx) + strlen(script) + 2);
+	if (sprintf(path, "%s/%s", pathpfx, script) <= 0) {
 		free(path);
 		free(pathpfx);
+		return;
 	}
 
 	if (access(path, X_OK) == 0) {
@@ -2677,6 +2681,18 @@ runautostart(void)
 
 	free(pathpfx);
 	free(path);
+}
+
+void
+runautostart(void)
+{
+	runautoscript(autostartsh);
+}
+
+void
+runautostop(void)
+{
+	runautoscript(autostopsh);
 }
 
 void
@@ -5099,5 +5115,6 @@ main(int argc, char *argv[])
 	run();
 	cleanup();
 	XCloseDisplay(dpy);
+	runautostop();
 	return EXIT_SUCCESS;
 }

--- a/dwm.c
+++ b/dwm.c
@@ -289,7 +289,7 @@ static void maprequest(XEvent *e);
 static void motionnotify(XEvent *e);
 static void propertynotify(XEvent *e);
 static void run(void);
-static void runautoscript(const char *script);
+static pid_t runautoscript(const char *script);
 static void runautostart(void);
 static void runautostop(void);
 static void scan(void);
@@ -2607,18 +2607,19 @@ run(void)
 	}
 }
 
-void
+pid_t
 runautoscript(const char *script)
 {
 	char *pathpfx;
 	char *path;
 	char *xdgdatahome;
 	char *home;
+	pid_t pid = 0;
 	struct stat sb;
 
 	if ((home = getenv("HOME")) == NULL)
 		/* this is almost impossible */
-		return;
+		return 0;
 
 	/* if $XDG_DATA_HOME is set and not empty, use $XDG_DATA_HOME/dwm,
 	 * otherwise use ~/.local/share/dwm as autostart script directory
@@ -2630,7 +2631,7 @@ runautoscript(const char *script)
 
 		if (sprintf(pathpfx, "%s/%s", xdgdatahome, dwmdir) <= 0) {
 			free(pathpfx);
-			return;
+			return 0;
 		}
 	} else {
 		/* space for path segments, separators and nul */
@@ -2639,7 +2640,7 @@ runautoscript(const char *script)
 
 		if (sprintf(pathpfx, "%s/%s/%s", home, localshare, dwmdir) < 0) {
 			free(pathpfx);
-			return;
+			return 0;
 		}
 	}
 
@@ -2651,36 +2652,49 @@ runautoscript(const char *script)
 		char *pathpfx_new = realloc(pathpfx, strlen(home) + strlen(dwmdir) + 3);
 		if(pathpfx_new == NULL) {
 			free(pathpfx);
-			return;
+			return 0;
 		}
 		pathpfx = pathpfx_new;
 
 		if (sprintf(pathpfx, "%s/.%s", home, dwmdir) <= 0) {
 			free(pathpfx);
-			return;
+			return 0;
 		}
 	}
 
-	/* try the autostart script */
+	/* try the requested session script */
 	path = ecalloc(1, strlen(pathpfx) + strlen(script) + 2);
 	if (sprintf(path, "%s/%s", pathpfx, script) <= 0) {
 		free(path);
 		free(pathpfx);
-		return;
+		return 0;
 	}
 
 	if (access(path, X_OK) == 0) {
-		pid_t pid = fork();
+		pid = fork();
 		if (pid == 0) {
+			sigset_t mask;
+
 			setsid();
+			/* A synchronous caller blocks SIGCHLD while it waits. Do not
+			 * leak that temporary mask into the session script. */
+			if (sigprocmask(SIG_SETMASK, NULL, &mask) == 0) {
+				sigdelset(&mask, SIGCHLD);
+				sigprocmask(SIG_SETMASK, &mask, NULL);
+			}
 			execl(path, path, (char *)NULL);
 			_exit(127);
 		}
-		/* parent returns immediately — dwm is not blocked by autostart */
+		if (pid < 0) {
+			perror("dwm: cannot launch session script");
+			pid = 0;
+		}
+		/* The caller decides whether it needs to wait for completion. */
 	}
 
 	free(pathpfx);
 	free(path);
+	return pid;
 }
 
 void
@@ -2692,7 +2706,55 @@ runautostart(void)
 void
 runautostop(void)
 {
-	runautoscript(autostopsh);
+	const int timeout_ms = 5000;
+	const int interval_us = 50000;
+	int elapsed_ms = 0;
+	int status;
+	pid_t result;
+	pid_t pid;
+	sigset_t mask, oldmask;
+	int restore_mask = 0;
+
+	/* sigchld() reaps detached startup helpers. Block it here so this
+	 * completion-aware shutdown path can inspect the hook's exit status. */
+	sigemptyset(&mask);
+	sigaddset(&mask, SIGCHLD);
+	if (sigprocmask(SIG_BLOCK, &mask, &oldmask) == 0)
+		restore_mask = 1;
+
+	pid = runautoscript(autostopsh);
+
+	if (pid <= 0)
+		goto restore;
+
+	while (elapsed_ms < timeout_ms) {
+		result = waitpid(pid, &status, WNOHANG);
+		if (result == pid) {
+			if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+				fprintf(stderr, "dwm: autostop failed with status %d\n",
+					WIFEXITED(status) ? WEXITSTATUS(status) : -1);
+			goto restore;
+		}
+		if (result < 0) {
+			if (errno == EINTR)
+				continue;
+			/* The SIGCHLD handler may have reaped a completed hook. */
+			if (errno == ECHILD)
+				goto restore;
+			perror("dwm: cannot wait for autostop");
+			goto restore;
+		}
+		usleep(interval_us);
+		elapsed_ms += interval_us / 1000;
+	}
+
+	fprintf(stderr, "dwm: autostop timed out after %d ms\n", timeout_ms);
+	if (kill(-pid, SIGTERM) < 0 && errno == ESRCH)
+		kill(pid, SIGTERM);
+
+restore:
+	if (restore_mask)
+		sigprocmask(SIG_SETMASK, &oldmask, NULL);
 }
 
 void

--- a/scripts/autostop.sh
+++ b/scripts/autostop.sh
@@ -2,10 +2,55 @@
 
 set -eu
 
+session_id=${XDG_SESSION_ID:-}
+command -v loginctl >/dev/null 2>&1 || exit 0
+if [ -z "$session_id" ]; then
+	session_id=$(loginctl show-session self -p Id --value 2>/dev/null) || exit 0
+fi
+[ -n "$session_id" ] || exit 0
+
+session_details=$(loginctl show-session "$session_id" \
+	-p Name -p Type -p Class -p Active -p Display 2>/dev/null) || exit 0
+session_owner=$(printf '%s\n' "$session_details" | sed -n 's/^Name=//p')
+session_type=$(printf '%s\n' "$session_details" | sed -n 's/^Type=//p')
+session_class=$(printf '%s\n' "$session_details" | sed -n 's/^Class=//p')
+session_display=$(printf '%s\n' "$session_details" | sed -n 's/^Display=//p')
+user_name=$(id -un)
+user_id=$(id -u)
+[ "$session_owner" = "$user_name" ] || exit 0
+
+# The systemd user manager and its graphical targets are shared across all
+# sessions for this user. Leave them active when another graphical login still
+# needs them.
+stop_targets=1
+user_sessions=$(loginctl show-user "$user_id" -p Sessions --value 2>/dev/null) || stop_targets=0
+if [ "$stop_targets" -eq 1 ]; then
+	for other_id in $user_sessions; do
+		[ "$other_id" != "$session_id" ] || continue
+		other_details=$(loginctl show-session "$other_id" \
+			-p Name -p Type -p Class -p Active 2>/dev/null) || {
+			stop_targets=0
+			break
+		}
+		other_owner=$(printf '%s\n' "$other_details" | sed -n 's/^Name=//p')
+		other_type=$(printf '%s\n' "$other_details" | sed -n 's/^Type=//p')
+		other_class=$(printf '%s\n' "$other_details" | sed -n 's/^Class=//p')
+		other_active=$(printf '%s\n' "$other_details" | sed -n 's/^Active=//p')
+		case $other_type:$other_class:$other_active in
+		x11:user:yes | wayland:user:yes)
+			if [ "$other_owner" = "$user_name" ]; then
+				stop_targets=0
+				break
+			fi
+			;;
+		esac
+	done
+fi
+
 # A display manager can start a new X11 login before the per-user systemd
-# manager has stopped the previous graphical target. Stop it explicitly so
-# XDG autostart services are activated again in the next dwm session.
-if command -v systemctl >/dev/null 2>&1; then
+# manager has stopped the previous graphical target. Stop it explicitly only
+# when no other graphical login shares the user manager.
+if [ "$stop_targets" -eq 1 ] && command -v systemctl >/dev/null 2>&1; then
 	systemctl --user stop \
 		xdg-desktop-autostart.target \
 		wm-graphical-session.service \
@@ -13,13 +58,9 @@ if command -v systemctl >/dev/null 2>&1; then
 		>/dev/null 2>&1 || true
 fi
 
-# setsid(1) does not move Quickshell, Picom, or the other managed helpers out
-# of the login session's systemd scope. Explicitly terminating our own session
-# prevents stale helpers from making the next autostart pass skip replacements.
-session_id=${XDG_SESSION_ID:-}
-if [ -n "$session_id" ] && command -v loginctl >/dev/null 2>&1; then
-	session_owner=$(loginctl show-session "$session_id" -p Name 2>/dev/null || true)
-	if [ "$session_owner" = "Name=$(id -un)" ]; then
-		loginctl terminate-session "$session_id" >/dev/null 2>&1 || true
-	fi
-fi
+# A display-manager X11 session has its own logind scope, so terminate it to
+# remove detached helpers before LightDM starts the next login. startx inherits
+# a TTY session instead; let dwm return to that TTY without logging the user out.
+case $session_type:$session_class:$session_display in
+x11:user:?*) loginctl terminate-session "$session_id" >/dev/null 2>&1 || true ;;
+esac

--- a/scripts/autostop.sh
+++ b/scripts/autostop.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -eu
+
+# A display manager can start a new X11 login before the per-user systemd
+# manager has stopped the previous graphical target. Stop it explicitly so
+# XDG autostart services are activated again in the next dwm session.
+if command -v systemctl >/dev/null 2>&1; then
+	systemctl --user stop \
+		xdg-desktop-autostart.target \
+		wm-graphical-session.service \
+		graphical-session.target \
+		>/dev/null 2>&1 || true
+fi
+
+# setsid(1) does not move Quickshell, Picom, or the other managed helpers out
+# of the login session's systemd scope. Explicitly terminating our own session
+# prevents stale helpers from making the next autostart pass skip replacements.
+session_id=${XDG_SESSION_ID:-}
+if [ -n "$session_id" ] && command -v loginctl >/dev/null 2>&1; then
+	session_owner=$(loginctl show-session "$session_id" -p Name 2>/dev/null || true)
+	if [ "$session_owner" = "Name=$(id -un)" ]; then
+		loginctl terminate-session "$session_id" >/dev/null 2>&1 || true
+	fi
+fi

--- a/scripts/autostop.sh
+++ b/scripts/autostop.sh
@@ -2,12 +2,13 @@
 
 set -eu
 
-session_id=${XDG_SESSION_ID:-}
 command -v loginctl >/dev/null 2>&1 || exit 0
-if [ -z "$session_id" ]; then
-	session_id=$(loginctl show-session self -p Id --value 2>/dev/null) || exit 0
-fi
-[ -n "$session_id" ] || exit 0
+self_session_id=$(loginctl show-session self -p Id --value 2>/dev/null) || exit 0
+[ -n "$self_session_id" ] || exit 0
+case "${XDG_SESSION_ID:-$self_session_id}" in
+"$self_session_id") session_id=$self_session_id ;;
+*) exit 0 ;;
+esac
 
 session_details=$(loginctl show-session "$session_id" \
 	-p Name -p Type -p Class -p Active -p Display 2>/dev/null) || exit 0
@@ -36,7 +37,7 @@ if [ "$stop_targets" -eq 1 ]; then
 		other_type=$(printf '%s\n' "$other_details" | sed -n 's/^Type=//p')
 		other_class=$(printf '%s\n' "$other_details" | sed -n 's/^Class=//p')
 		other_active=$(printf '%s\n' "$other_details" | sed -n 's/^Active=//p')
-		case $other_type:$other_class:$other_active in
+		case "$other_type:$other_class:$other_active" in
 		x11:user:yes | wayland:user:yes)
 			if [ "$other_owner" = "$user_name" ]; then
 				stop_targets=0
@@ -61,6 +62,6 @@ fi
 # A display-manager X11 session has its own logind scope, so terminate it to
 # remove detached helpers before LightDM starts the next login. startx inherits
 # a TTY session instead; let dwm return to that TTY without logging the user out.
-case $session_type:$session_class:$session_display in
+case "$session_type:$session_class:$session_display" in
 x11:user:?*) loginctl terminate-session "$session_id" >/dev/null 2>&1 || true ;;
 esac

--- a/scripts/dwm-lock-watch
+++ b/scripts/dwm-lock-watch
@@ -24,7 +24,8 @@ if [ -z "$lock_helper" ]; then
 fi
 command -v "$lock_helper" >/dev/null 2>&1 || exit 0
 
-session_json=$(busctl --system --json=short call \
+session_json=$(DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket \
+	busctl --system --json=short call \
 	org.freedesktop.login1 \
 	/org/freedesktop/login1 \
 	org.freedesktop.login1.Manager \

--- a/scripts/dwm-lock-watch
+++ b/scripts/dwm-lock-watch
@@ -41,7 +41,8 @@ run_lock_helper() {
 	fi
 }
 
-dbus-monitor --system \
+DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket \
+	dbus-monitor --system \
 	"type='signal',path='$session_path',interface='org.freedesktop.login1.Session',member='Lock'" 2>/dev/null |
 	while IFS= read -r line; do
 		case $line in

--- a/tests/test-autostop.sh
+++ b/tests/test-autostop.sh
@@ -17,10 +17,11 @@ EOF
 cat >"$work/bin/loginctl" <<'EOF'
 #!/bin/sh
 printf 'loginctl %s\n' "$*" >>"${TEST_LOG:?}"
-case $* in
+case "$*" in
 "show-session self -p Id --value")
-	[ -n "${TEST_SELF_SESSION:-}" ] || exit 1
-	printf '%s\n' "$TEST_SELF_SESSION"
+	self_session=${TEST_SELF_SESSION-${XDG_SESSION_ID:-}}
+	[ -n "$self_session" ] || exit 1
+	printf '%s\n' "$self_session"
 	;;
 "show-session "*" -p Name -p Type -p Class -p Active -p Display")
 	if [ "${2:-}" = "${TEST_OTHER_SESSION_ID:-not-an-id}" ]; then
@@ -58,7 +59,7 @@ EOF
 
 cat >"$work/bin/id" <<'EOF'
 #!/bin/sh
-case ${1:-} in
+case "${1:-}" in
 -u) printf '%s\n' 1000 ;;
 -un) printf '%s\n' test-user ;;
 *) exit 1 ;;
@@ -78,6 +79,7 @@ run_case() {
 
 run_case normal env XDG_SESSION_ID=42
 cat >"$work/normal.expected" <<'EOF'
+loginctl show-session self -p Id --value
 loginctl show-session 42 -p Name -p Type -p Class -p Active -p Display
 loginctl show-user 1000 -p Sessions --value
 systemctl --user stop xdg-desktop-autostart.target wm-graphical-session.service graphical-session.target
@@ -119,22 +121,29 @@ if grep -q '^systemctl \|^loginctl terminate-session ' "$work/no_session.log"; t
 	exit 1
 fi
 
-run_case wrong_owner env XDG_SESSION_ID=47 TEST_SESSION_OWNER=another-user
-grep -Fqx 'loginctl show-session 47 -p Name -p Type -p Class -p Active -p Display' \
+run_case mismatched_session env XDG_SESSION_ID=47 TEST_SELF_SESSION=48
+grep -Fqx 'loginctl show-session self -p Id --value' "$work/mismatched_session.log"
+if grep -q '^systemctl \|^loginctl terminate-session ' "$work/mismatched_session.log"; then
+	printf '%s\n' 'autostop must not clean up a mismatched environment session' >&2
+	exit 1
+fi
+
+run_case wrong_owner env XDG_SESSION_ID=49 TEST_SESSION_OWNER=another-user
+grep -Fqx 'loginctl show-session 49 -p Name -p Type -p Class -p Active -p Display' \
 	"$work/wrong_owner.log"
 if grep -q '^systemctl \|^loginctl terminate-session ' "$work/wrong_owner.log"; then
 	printf '%s\n' 'autostop must not clean up another user session' >&2
 	exit 1
 fi
 
-run_case topology_failure env XDG_SESSION_ID=48 TEST_SHOW_USER_STATUS=1
-grep -Fqx 'loginctl terminate-session 48' "$work/topology_failure.log"
+run_case topology_failure env XDG_SESSION_ID=50 TEST_SHOW_USER_STATUS=1
+grep -Fqx 'loginctl terminate-session 50' "$work/topology_failure.log"
 if grep -q '^systemctl ' "$work/topology_failure.log"; then
 	printf '%s\n' 'autostop must preserve shared targets when session discovery fails' >&2
 	exit 1
 fi
 
-run_case systemctl_failure env XDG_SESSION_ID=49 TEST_SYSTEMCTL_STATUS=1
-grep -Fqx 'loginctl terminate-session 49' "$work/systemctl_failure.log"
+run_case systemctl_failure env XDG_SESSION_ID=51 TEST_SYSTEMCTL_STATUS=1
+grep -Fqx 'loginctl terminate-session 51' "$work/systemctl_failure.log"
 
 printf '%s\n' 'Autostop graphical target and login session cleanup: PASS'

--- a/tests/test-autostop.sh
+++ b/tests/test-autostop.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+set -eu
+
+repo_dir=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+mkdir -p "$work/bin"
+
+cat >"$work/bin/systemctl" <<'EOF'
+#!/bin/sh
+printf 'systemctl %s\n' "$*" >>"${TEST_LOG:?}"
+exit "${TEST_SYSTEMCTL_STATUS:-0}"
+EOF
+
+cat >"$work/bin/loginctl" <<'EOF'
+#!/bin/sh
+printf 'loginctl %s\n' "$*" >>"${TEST_LOG:?}"
+case ${1:-} in
+show-session)
+	printf 'Name=%s\n' "${TEST_SESSION_OWNER:-test-user}"
+	;;
+esac
+EOF
+
+cat >"$work/bin/id" <<'EOF'
+#!/bin/sh
+case ${1:-} in
+-un) printf '%s\n' test-user ;;
+*) exit 1 ;;
+esac
+EOF
+
+chmod +x "$work/bin/systemctl" "$work/bin/loginctl" "$work/bin/id"
+
+run_case() {
+	case_name=$1
+	shift
+	case_log=$work/$case_name.log
+	: >"$case_log"
+	env TEST_LOG="$case_log" PATH="$work/bin:/usr/bin:/bin" "$@" \
+		sh "$repo_dir/scripts/autostop.sh"
+}
+
+run_case normal env XDG_SESSION_ID=42
+cat >"$work/normal.expected" <<'EOF'
+systemctl --user stop xdg-desktop-autostart.target wm-graphical-session.service graphical-session.target
+loginctl show-session 42 -p Name
+loginctl terminate-session 42
+EOF
+cmp "$work/normal.expected" "$work/normal.log"
+
+run_case no_session env -u XDG_SESSION_ID
+grep -Fqx 'systemctl --user stop xdg-desktop-autostart.target wm-graphical-session.service graphical-session.target' \
+	"$work/no_session.log"
+if grep -q '^loginctl ' "$work/no_session.log"; then
+	printf '%s\n' 'loginctl must not run without a session ID' >&2
+	exit 1
+fi
+
+run_case wrong_owner env XDG_SESSION_ID=43 TEST_SESSION_OWNER=another-user
+grep -Fqx 'loginctl show-session 43 -p Name' "$work/wrong_owner.log"
+if grep -q '^loginctl terminate-session ' "$work/wrong_owner.log"; then
+	printf '%s\n' 'autostop must not terminate another user session' >&2
+	exit 1
+fi
+
+run_case systemctl_failure env XDG_SESSION_ID=44 TEST_SYSTEMCTL_STATUS=1
+grep -Fqx 'loginctl terminate-session 44' "$work/systemctl_failure.log"
+
+printf '%s\n' 'Autostop graphical target and login session cleanup: PASS'

--- a/tests/test-autostop.sh
+++ b/tests/test-autostop.sh
@@ -17,16 +17,49 @@ EOF
 cat >"$work/bin/loginctl" <<'EOF'
 #!/bin/sh
 printf 'loginctl %s\n' "$*" >>"${TEST_LOG:?}"
-case ${1:-} in
-show-session)
-	printf 'Name=%s\n' "${TEST_SESSION_OWNER:-test-user}"
+case $* in
+"show-session self -p Id --value")
+	[ -n "${TEST_SELF_SESSION:-}" ] || exit 1
+	printf '%s\n' "$TEST_SELF_SESSION"
 	;;
+"show-session "*" -p Name -p Type -p Class -p Active -p Display")
+	if [ "${2:-}" = "${TEST_OTHER_SESSION_ID:-not-an-id}" ]; then
+		printf 'Name=%s\nType=%s\nClass=%s\nActive=%s\nDisplay=%s\n' \
+			"${TEST_OTHER_SESSION_OWNER:-test-user}" \
+			"${TEST_OTHER_SESSION_TYPE:-x11}" \
+			"${TEST_OTHER_SESSION_CLASS:-user}" \
+			"${TEST_OTHER_SESSION_ACTIVE:-yes}" \
+			"${TEST_OTHER_SESSION_DISPLAY-:1}"
+	else
+		printf 'Name=%s\nType=%s\nClass=%s\nActive=%s\nDisplay=%s\n' \
+			"${TEST_SESSION_OWNER:-test-user}" \
+			"${TEST_SESSION_TYPE:-x11}" \
+			"${TEST_SESSION_CLASS:-user}" \
+			"${TEST_SESSION_ACTIVE:-yes}" \
+			"${TEST_SESSION_DISPLAY-:0}"
+	fi
+	;;
+"show-session "*" -p Name -p Type -p Class -p Active")
+	[ "${TEST_OTHER_SESSION_STATUS:-0}" -eq 0 ] || exit "$TEST_OTHER_SESSION_STATUS"
+	printf 'Name=%s\nType=%s\nClass=%s\nActive=%s\n' \
+		"${TEST_OTHER_SESSION_OWNER:-test-user}" \
+		"${TEST_OTHER_SESSION_TYPE:-x11}" \
+		"${TEST_OTHER_SESSION_CLASS:-user}" \
+		"${TEST_OTHER_SESSION_ACTIVE:-yes}"
+	;;
+"show-user 1000 -p Sessions --value")
+	[ "${TEST_SHOW_USER_STATUS:-0}" -eq 0 ] || exit "$TEST_SHOW_USER_STATUS"
+	printf '%s\n' "${TEST_USER_SESSIONS:-${XDG_SESSION_ID:-${TEST_SELF_SESSION:-}}}"
+	;;
+"terminate-session "*) ;;
+*) exit 1 ;;
 esac
 EOF
 
 cat >"$work/bin/id" <<'EOF'
 #!/bin/sh
 case ${1:-} in
+-u) printf '%s\n' 1000 ;;
 -un) printf '%s\n' test-user ;;
 *) exit 1 ;;
 esac
@@ -45,28 +78,63 @@ run_case() {
 
 run_case normal env XDG_SESSION_ID=42
 cat >"$work/normal.expected" <<'EOF'
+loginctl show-session 42 -p Name -p Type -p Class -p Active -p Display
+loginctl show-user 1000 -p Sessions --value
 systemctl --user stop xdg-desktop-autostart.target wm-graphical-session.service graphical-session.target
-loginctl show-session 42 -p Name
 loginctl terminate-session 42
 EOF
 cmp "$work/normal.expected" "$work/normal.log"
 
-run_case no_session env -u XDG_SESSION_ID
+run_case startx env XDG_SESSION_ID=43 TEST_SESSION_TYPE=tty TEST_SESSION_DISPLAY=
 grep -Fqx 'systemctl --user stop xdg-desktop-autostart.target wm-graphical-session.service graphical-session.target' \
-	"$work/no_session.log"
-if grep -q '^loginctl ' "$work/no_session.log"; then
-	printf '%s\n' 'loginctl must not run without a session ID' >&2
+	"$work/startx.log"
+if grep -q '^loginctl terminate-session ' "$work/startx.log"; then
+	printf '%s\n' 'autostop must not terminate a startx TTY session' >&2
 	exit 1
 fi
 
-run_case wrong_owner env XDG_SESSION_ID=43 TEST_SESSION_OWNER=another-user
-grep -Fqx 'loginctl show-session 43 -p Name' "$work/wrong_owner.log"
-if grep -q '^loginctl terminate-session ' "$work/wrong_owner.log"; then
-	printf '%s\n' 'autostop must not terminate another user session' >&2
+run_case other_graphical env \
+	XDG_SESSION_ID=44 \
+	TEST_USER_SESSIONS='44 45' \
+	TEST_OTHER_SESSION_ID=45
+grep -Fqx 'loginctl show-session 45 -p Name -p Type -p Class -p Active' \
+	"$work/other_graphical.log"
+grep -Fqx 'loginctl terminate-session 44' "$work/other_graphical.log"
+if grep -q '^systemctl ' "$work/other_graphical.log"; then
+	printf '%s\n' 'autostop must preserve shared targets for another graphical login' >&2
 	exit 1
 fi
 
-run_case systemctl_failure env XDG_SESSION_ID=44 TEST_SYSTEMCTL_STATUS=1
-grep -Fqx 'loginctl terminate-session 44' "$work/systemctl_failure.log"
+run_case fallback_session env \
+	-u XDG_SESSION_ID \
+	TEST_SELF_SESSION=46 \
+	TEST_USER_SESSIONS=46
+grep -Fqx 'loginctl show-session self -p Id --value' "$work/fallback_session.log"
+grep -Fqx 'loginctl terminate-session 46' "$work/fallback_session.log"
+
+run_case no_session env -u XDG_SESSION_ID TEST_SELF_SESSION=
+grep -Fqx 'loginctl show-session self -p Id --value' "$work/no_session.log"
+if grep -q '^systemctl \|^loginctl terminate-session ' "$work/no_session.log"; then
+	printf '%s\n' 'autostop must not clean up without a verified session' >&2
+	exit 1
+fi
+
+run_case wrong_owner env XDG_SESSION_ID=47 TEST_SESSION_OWNER=another-user
+grep -Fqx 'loginctl show-session 47 -p Name -p Type -p Class -p Active -p Display' \
+	"$work/wrong_owner.log"
+if grep -q '^systemctl \|^loginctl terminate-session ' "$work/wrong_owner.log"; then
+	printf '%s\n' 'autostop must not clean up another user session' >&2
+	exit 1
+fi
+
+run_case topology_failure env XDG_SESSION_ID=48 TEST_SHOW_USER_STATUS=1
+grep -Fqx 'loginctl terminate-session 48' "$work/topology_failure.log"
+if grep -q '^systemctl ' "$work/topology_failure.log"; then
+	printf '%s\n' 'autostop must preserve shared targets when session discovery fails' >&2
+	exit 1
+fi
+
+run_case systemctl_failure env XDG_SESSION_ID=49 TEST_SYSTEMCTL_STATUS=1
+grep -Fqx 'loginctl terminate-session 49' "$work/systemctl_failure.log"
 
 printf '%s\n' 'Autostop graphical target and login session cleanup: PASS'

--- a/tests/test-dwm-lock.sh
+++ b/tests/test-dwm-lock.sh
@@ -113,7 +113,8 @@ grep -Fq "no usable screen locker found" "$work/err"
 
 cat >"$work/bin/busctl" <<'SCRIPT'
 #!/bin/sh
-printf '%s\n' "$*" >"${DWM_LOCK_TEST_DIR:?}/busctl"
+printf 'address=%s\nargs=%s\n' \
+	"${DBUS_SYSTEM_BUS_ADDRESS:-}" "$*" >"${DWM_LOCK_TEST_DIR:?}/busctl"
 printf '%s\n' '{"type":"o","data":["/org/freedesktop/login1/session/_37"]}'
 SCRIPT
 
@@ -144,6 +145,8 @@ DWM_LOCK_TEST_DIR="$work" \
 	XDG_SESSION_ID='' \
 	PATH="$work/bin:/usr/bin:/bin" \
 	"$repo_dir/scripts/dwm-lock-watch"
+grep -Fxq 'address=unix:path=/run/dbus/system_bus_socket' "$work/busctl"
+grep -Fq 'args=--system --json=short call org.freedesktop.login1' "$work/busctl"
 grep -Fq 'GetSession s 7' "$work/busctl"
 grep -Fxq 'address=unix:path=/run/dbus/system_bus_socket' "$work/dbus-monitor"
 grep -Fq "path='/org/freedesktop/login1/session/_37'" "$work/dbus-monitor"

--- a/tests/test-dwm-lock.sh
+++ b/tests/test-dwm-lock.sh
@@ -127,7 +127,8 @@ SCRIPT
 
 cat >"$work/bin/dbus-monitor" <<'SCRIPT'
 #!/bin/sh
-printf '%s\n' "$*" >"${DWM_LOCK_TEST_DIR:?}/dbus-monitor"
+printf 'address=%s\nargs=%s\n' \
+	"${DBUS_SYSTEM_BUS_ADDRESS:-}" "$*" >"${DWM_LOCK_TEST_DIR:?}/dbus-monitor"
 printf '%s\n' 'signal path=/org/freedesktop/login1/session/_37; interface=org.freedesktop.login1.Session; member=Lock'
 SCRIPT
 
@@ -144,6 +145,7 @@ DWM_LOCK_TEST_DIR="$work" \
 	PATH="$work/bin:/usr/bin:/bin" \
 	"$repo_dir/scripts/dwm-lock-watch"
 grep -Fq 'GetSession s 7' "$work/busctl"
+grep -Fxq 'address=unix:path=/run/dbus/system_bus_socket' "$work/dbus-monitor"
 grep -Fq "path='/org/freedesktop/login1/session/_37'" "$work/dbus-monitor"
 grep -Fxq 'no_loginctl=1' "$work/watch-lock"
 

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -683,4 +683,38 @@ kill "$stack_client_pid"
 wait "$stack_client_pid" 2>/dev/null || true
 stack_client_pid=
 
+# Restore the normal key map and verify that Super+Shift+Q exits cleanly and
+# launches the session-stop hook. Use an isolated marker instead of touching
+# the host's real graphical-session targets from the nested X11 test.
+mkdir -p "$home/.local/share/dwm-titus/scripts"
+cat >"$home/.local/share/dwm-titus/scripts/autostop.sh" <<EOF
+#!/bin/sh
+: >"$work/autostop.called"
+EOF
+chmod +x "$home/.local/share/dwm-titus/scripts/autostop.sh"
+cp "$repo_dir/config/hotkeys.toml" "$home/.config/dwm-titus/hotkeys.toml"
+kill -USR1 "$dwm_pid"
+sleep 0.2
+DISPLAY=$display xdotool key Super+Shift+q
+i=0
+while [ "$i" -lt 100 ] && kill -0 "$dwm_pid" 2>/dev/null; do
+	i=$((i + 1))
+	sleep 0.05
+done
+if kill -0 "$dwm_pid" 2>/dev/null; then
+	printf '%s\n' 'Super+Shift+Q did not exit dwm' >&2
+	exit 1
+fi
+wait "$dwm_pid"
+dwm_pid=
+i=0
+while [ "$i" -lt 100 ] && [ ! -f "$work/autostop.called" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+if [ ! -f "$work/autostop.called" ]; then
+	printf '%s\n' 'dwm did not launch the session-stop hook' >&2
+	exit 1
+fi
+
 printf '%s\n' "Xvfb runtime smoke: PASS"

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -689,6 +689,7 @@ stack_client_pid=
 mkdir -p "$home/.local/share/dwm-titus/scripts"
 cat >"$home/.local/share/dwm-titus/scripts/autostop.sh" <<EOF
 #!/bin/sh
+sleep 0.2
 : >"$work/autostop.called"
 EOF
 chmod +x "$home/.local/share/dwm-titus/scripts/autostop.sh"
@@ -707,13 +708,8 @@ if kill -0 "$dwm_pid" 2>/dev/null; then
 fi
 wait "$dwm_pid"
 dwm_pid=
-i=0
-while [ "$i" -lt 100 ] && [ ! -f "$work/autostop.called" ]; do
-	i=$((i + 1))
-	sleep 0.05
-done
 if [ ! -f "$work/autostop.called" ]; then
-	printf '%s\n' 'dwm did not launch the session-stop hook' >&2
+	printf '%s\n' 'dwm exited before the session-stop hook completed' >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary

- run a managed session-stop hook after dwm exits cleanly
- stop the user graphical and XDG autostart targets before the next LightDM login
- terminate only the current login session after verifying its owner
- force the lock watcher onto the host system D-Bus socket so Linuxbrew environment state cannot break it
- document that Super+Shift+Q cleanly ends the graphical session

## Root cause

After Super+Shift+Q exited dwm, LightDM started a new X11 login while helpers and user graphical targets from the previous login were still active. The next autostart pass then treated stale same-user processes and already-active targets as healthy, leaving the new session without a relaunched shell.

The lock watcher also inherited a stale Linuxbrew system-bus address and exited immediately, so the patch pins that system-bus subscription to the host socket.

## Impact

A normal dwm quit now establishes a clean graphical-session boundary so the next display-manager login can relaunch Quickshell, Picom, XDG autostart applications, and the remaining managed helpers normally.

## Validation

- `make clean`
- `make`
- POSIX `sh -n` for changed shell files
- ShellCheck for changed shell files
- `shfmt -d` for changed shell files
- `make check-session-guards check-lock`
- `git diff --check`

The quit-key Xvfb test is included but was not rerun after the explicit instruction not to quit DWM again; it received syntax, ShellCheck, and formatting validation only. No live DWM quit or restart was performed during final validation.