### PR TITLE
quickshell: brighten inactive workspace tags

### DIFF
--- a/config/quickshell/panel/WorkspaceButton.qml
+++ b/config/quickshell/panel/WorkspaceButton.qml
@@ -20,7 +20,7 @@ Rectangle {
     Text {
         anchors.centerIn: parent
         text: root.label
-        color: root.selected ? Theme.accent : root.occupied ? Theme.textMuted : Theme.placeholder
+        color: root.selected ? Theme.accent : Theme.textMuted
         font.family: Theme.fontFamily
         font.pixelSize: Theme.panelFontSize
         font.bold: root.selected

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -655,6 +655,7 @@ done
 stack_win=$(cat "$work/restore-stack-window-id")
 [ -n "$stack_win" ]
 
+: >"$work/swallow-window-ids"
 DISPLAY=$display "$work/xclient" swallow-terminal >"$work/swallow-window-ids" 2>"$work/swallow-client.log" &
 swallow_client_pid=$!
 i=0


### PR DESCRIPTION
## Summary

- render all inactive workspace tags with the brighter `Theme.textMuted` color
- preserve the accent color and bold styling for the selected workspace

## Root cause

The workspace delegate assigned unoccupied inactive tags to `Theme.placeholder`. In the Nord palette, that token resolves to `#4C566A`, which has very little contrast against the `#434C5E` panel background. This made inactive tags appear excessively greyed out.

## User impact

Inactive workspace labels are readable again and match the brighter appearance used before the occupied/unoccupied color distinction was introduced.

## Validation

- Quickshell QML lint completed successfully; only unrelated existing warnings remain in `PanelTooltip.qml` and `RunningAppsArea.qml`
- `tests/test-quickshell-controlcenter.sh` passed
- deployed the matching local config and restarted the managed Quickshell instance on X11
- `quickshell --no-duplicate` confirmed the managed instance was running