### PR TITLE
quickshell: complete phase 1 settings foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ versions from `config.mk`.
 
 ### Added
 
+- A unified, read-only Quickshell Settings foundation with Control Center and
+  IPC entry points, searchable keyboard/mouse navigation, and explicit
+  provider availability and unsupported-state reporting.
+- A versioned `dwm-settings-provider` capability-discovery protocol with
+  Fedora-first detection, secondary-platform fallbacks, focused shell/QML/Xvfb
+  tests, and a centralized cross-family QML development package profile.
+- Settings platform contracts for helper lifecycle, UI states, authorization,
+  confirmation, rollback, packaging, and phase validation.
 - Cross-compiler, nested-X11, and Debian/Arch/RHEL container validation in CI.
 - Repository-owned Quickshell QML lint automation.
 - Contributor, security, ownership, dependency-update, and active-task guidance.

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ INSTALL_COMMANDS = \
 	scripts/dwm-packages.sh \
 	scripts/dwm-titus-release \
 	scripts/dwm-screenshot \
+	scripts/dwm-settings \
+	scripts/dwm-settings-provider \
 	scripts/dwm-terminal \
 	scripts/dwm-utils.sh \
 	scripts/nvidia-gpu \
@@ -255,10 +257,10 @@ release: dwm
 	echo "==> Created ${RELEASE_ARCHIVE}"
 
 check-shell:
-	shellcheck install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/quickshell-qmllint scripts/*.sh tests/*.sh
+	shellcheck install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/quickshell-qmllint scripts/*.sh tests/*.sh
 
 check-format:
-	shfmt -d install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/quickshell-qmllint scripts/*.sh tests/*.sh
+	shfmt -d install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/quickshell-qmllint scripts/*.sh tests/*.sh
 
 check-session-guards:
 	tests/test-autostart.sh
@@ -323,6 +325,12 @@ check-quickshell-qml:
 
 check-system-health:
 	tests/test-system-health.sh
+
+check-settings:
+	tests/test-settings.sh
+
+check-quickshell-settings-xvfb: all
+	tests/test-quickshell-settings-xvfb.sh
 
 check-lightdm-config:
 	tests/test-lightdm-config.sh
@@ -451,6 +459,7 @@ check:
 	$(MAKE) check-quickshell-controls
 	$(MAKE) check-quickshell-controlcenter
 	$(MAKE) check-system-health
+	$(MAKE) check-settings
 	$(MAKE) check-quickshell-network
 	$(MAKE) check-terminal
 	$(MAKE) check-lock
@@ -469,6 +478,6 @@ check:
 	check-container-smoke \
 	check-display-profile check-display-setup check-fedora-iso-builder check-format check-install \
 	check-install-manifest check-install-preservation check-kickstart check-lock \
-	check-session-guards check-session-migration check-screenshot check-release-helper check-shell check-diagnostics check-status check-system-health \
-	check-quickshell-launcher check-quickshell-controls check-quickshell-controlcenter check-quickshell-health-xvfb check-quickshell-network check-quickshell-qml check-lightdm-config check-terminal clean install install-system install-user \
+	check-session-guards check-session-migration check-screenshot check-release-helper check-shell check-diagnostics check-status check-system-health check-settings \
+	check-quickshell-launcher check-quickshell-controls check-quickshell-controlcenter check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-qml check-lightdm-config check-terminal clean install install-system install-user \
 	install-cursors native release release-check uninstall

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ RHEL-family existing-system installs retain the supported core desktop.
 ### Patches & Features
 
 - **Quickshell** panel and application launcher for the normal desktop workflow
+- **Settings foundation** with searchable capability discovery and explicit
+  unsupported-state reporting
 - **Window swallowing** — terminals absorb child GUI windows
 - **EWMH** compliance — proper desktop/tag reporting for external tools
 - **Pertag** — independent layouts, master counts, and sizing per tag
@@ -131,6 +133,9 @@ After login, use these first:
 | <kbd>SUPER</kbd> + <kbd>R</kbd> | Toggle Quickshell launcher |
 | <kbd>SUPER</kbd> + <kbd>F1</kbd> | Open control center |
 | <kbd>SUPER</kbd> + <kbd>/</kbd> | Open keybind viewer |
+
+Open Control Center -> Utilities -> Settings for the unified read-only
+capability overview, or run `dwm-settings` from a terminal.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ After login, use these first:
 | <kbd>SUPER</kbd> + <kbd>/</kbd> | Open keybind viewer |
 
 Open Control Center -> Utilities -> Settings for the unified read-only
-capability overview, or run `dwm-settings` from a terminal.
+capability overview, or run `dwm-settings open` from a terminal.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,6 +37,8 @@ and release history rather than in a permanent checked-off task list.
 
 ## Phase 1: Settings Platform Foundation
 
+Status: Complete (2026-07-21)
+
 ### Objective
 
 Establish the architecture and safety boundaries for one discoverable Settings
@@ -62,6 +64,22 @@ application without changing existing desktop behavior.
   covered by focused tests.
 - Existing Control Center, launcher, hotkeys, and runtime configuration remain
   compatible.
+
+### Completion Evidence
+
+- The managed Quickshell shell provides one searchable Settings window with
+  Control Center and IPC entry points and no polling timer.
+- `dwm-settings-provider` reports versioned read-only capability records and
+  clean unavailable, restricted, and unsupported states.
+- Fedora 44 X11 discovery, nested-X11 keyboard/mouse navigation, provider
+  cleanup, and a closed-window CPU sample passed. The full repository check and
+  existing nested-X11 runtime tests also passed.
+- Authorization, helper ownership, confirmation, cancellation, error, preview,
+  rollback, packaging, and validation contracts are recorded in
+  `docs/SETTINGS-PLATFORM.md`.
+- Arch and generic RHEL package mappings and Debian fallback records were
+  statically validated, but real secondary-platform Settings sessions and real
+  input/display hardware behavior remain Phase 2 qualification work.
 
 ## Phase 2: Displays and Input
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -624,12 +624,13 @@ In a real or nested X11 session:
 
 ## 10. Current Gap
 
-The existing desktop already provides dwm, a managed Quickshell panel and
-launcher, notifications, quick controls, power actions, network and Bluetooth
-surfaces, display helpers, and a system-health dashboard. It does not yet
-provide the unified Settings platform or the full desktop settings surface in
-Section 5.10; those outcomes are sequenced in `ROADMAP.md` and the active phase
-is defined in `TASKS.md`.
+The existing desktop provides dwm, a managed Quickshell panel and launcher,
+notifications, quick controls, power actions, network and Bluetooth surfaces,
+display helpers, a system-health dashboard, and the unified read-only Settings
+foundation. Settings currently discovers provider capabilities and reports
+available, partial, restricted, unavailable, and unsupported state. It does not
+yet provide the full settings mutation surface in Section 5.10; those outcomes
+are sequenced in `ROADMAP.md` and the active phase is defined in `TASKS.md`.
 
 The installer contains Debian-, Arch-, and Fedora/RHEL-family package mappings.
 The build uses `pkg-config`, supports staged installation with `DESTDIR`, and

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,86 +1,116 @@
 # Active Project Tasks
 
 `SPEC.md` is the product contract and `ROADMAP.md` defines phase order. This
-file contains implementation work only for the active roadmap phase. Do not
-copy future phases here until the current phase meets its exit criteria.
+file contains implementation work only for the active roadmap phase. Phase 1
+completion evidence is recorded in `ROADMAP.md`, `CHANGELOG.md`, and
+`docs/SETTINGS-PLATFORM.md`.
 
-## Active Phase: Settings Platform Foundation
+## Active Phase: Displays and Input
 
-### SET-001: Capability Inventory
+### DISP-001: Display Provider Contract
 
-- [ ] Inventory existing Control Center, display, network, Bluetooth, audio,
-  power, theme, default-application, and system-health interfaces.
-- [ ] Classify every candidate operation as read-only, user-session,
-  privileged, delegated, or unsupported.
-- [ ] Record Fedora providers and secondary-platform fallback behavior.
-
-Acceptance:
-
-- Each planned Settings section has an owner, state source, mutation path,
-  privilege class, failure behavior, and validation method.
-- No QML component is designated to execute arbitrary elevated commands.
-
-### SET-002: Settings Application Contract
-
-- [ ] Define navigation, search, section lifecycle, and Control Center entry
-  behavior for one Settings window.
-- [ ] Define helper input/output contracts without exposing shell command
-  construction to QML.
-- [ ] Define loading, unavailable, permission-denied, failure, dirty, saved,
-  preview, and rollback states.
+- [ ] Add a versioned display provider for connected outputs, modes, refresh
+  rates, positions, rotations, primary state, profiles, and persistence state.
+- [ ] Reuse `dwm-display-profile` and `dwm-display-setup` parsing and validation
+  instead of duplicating RandR or Xorg policy in QML.
+- [ ] Report unsupported driver properties and missing X11 state explicitly.
 
 Acceptance:
 
-- The contract covers keyboard and mouse use on X11.
-- Closing a section stops watches and helper processes that are no longer
-  needed.
-- Unsupported capabilities are hidden or explained without breaking the rest
-  of the application.
+- Discovery is machine-readable and bounded, with fixtures for single-monitor,
+  multi-monitor, disconnected-output, malformed-output, and unavailable cases.
+- Opening and closing the Displays section starts and stops only section-owned
+  watches and helper processes.
+- Discovery performs no mutation and requires no authorization.
 
-### SET-003: Authorization and Safety Design
+### DISP-002: Display Layout and Preview
 
-- [ ] Define the allowlist and polkit boundary for future privileged helpers.
-- [ ] Define confirmation, timeout, rollback, audit, and cancellation rules.
-- [ ] Define installed-helper ownership and permission requirements.
-
-Acceptance:
-
-- Repository and user-writable helper copies can never be elevated.
-- Denied or unavailable authorization leaves readable state usable.
-- No proposed operation requires broad passwordless sudo access.
-
-### SET-004: Fedora-First Packaging Plan
-
-- [ ] Map Phase 1 runtime and development capabilities to Fedora packages.
-- [ ] Identify which capabilities already exist in the current Kickstarts and
-  shared dependency map.
-- [ ] Define clean behavior for Debian, Arch, and generic RHEL-family installs
-  when a Fedora-specific provider is unavailable.
+- [ ] Add Settings controls for resolution, refresh rate, position, rotation,
+  primary output, output enablement, and saved profiles.
+- [ ] Generate a complete proposed layout and validate it before live apply.
+- [ ] Add explicit preview, Keep, Revert, timeout, and automatic rollback
+  states using the Phase 1 application contract.
 
 Acceptance:
 
-- No package list is duplicated across future implementation paths.
-- Fedora-specific functionality does not weaken the existing core installer
-  contract for secondary platforms.
+- Every preview captures the previous complete layout before applying changes.
+- Rejection, timeout, Settings close, or apply failure restores the previous
+  live layout and reports rollback success or failure.
+- Keyboard and mouse users can recover without relying on the changed output.
 
-### SET-005: Phase 1 Validation Plan
+### DISP-003: Persistent Display Profiles
 
-- [ ] Define focused tests for capability discovery, helper contracts,
-  unsupported states, authorization denial, and process cleanup.
-- [ ] Define nested-X11 interaction checks and a real Fedora runtime checklist.
-- [ ] Define an idle CPU/process sample with the Settings window closed.
+- [ ] Save named user profiles under the existing XDG display-profile path.
+- [ ] Define and implement a narrow installed-helper operation for persistent
+  managed Xorg fragment install and rollback.
+- [ ] Add confirmation, ownership, permission, backup, and polkit-denial tests.
 
 Acceptance:
 
-- Every Phase 1 exit criterion maps to an automated check or a named manual
-  validation with required evidence.
-- Untested environments and hardware cannot be reported as verified.
+- Repository, XDG, home-directory, symlinked, or writable helper copies cannot
+  be elevated.
+- The helper accepts validated structured display data only, never arbitrary
+  paths, commands, or Xorg text.
+- Persistent install creates an isolated managed fragment and recoverable
+  backup without replacing unrelated Xorg configuration.
+
+### INPUT-001: Input Device Provider
+
+- [ ] Discover keyboards, pointers, touchpads, and relevant X11/libinput
+  properties by stable device ID.
+- [ ] Map layout, repeat, modifier, speed, acceleration, natural scrolling,
+  tap-to-click, and other supported properties without assuming every driver
+  exposes them.
+- [ ] Report unsupported properties per device.
+
+Acceptance:
+
+- Device and property output is machine-readable and handles names containing
+  whitespace or punctuation safely.
+- Hotplug updates are event-driven where X11 provides a usable event source;
+  any fallback is bounded and documented.
+- Missing devices or drivers do not break Displays or other Settings sections.
+
+### INPUT-002: Input Changes and Recovery
+
+- [ ] Add per-device Settings controls only for properties reported by the
+  provider.
+- [ ] Apply session changes to the selected stable device ID and define the
+  persistence format and startup application path.
+- [ ] Add reset, invalid-value, disconnected-device, and partial-failure
+  behavior.
+
+Acceptance:
+
+- A change cannot affect a different device because names or enumeration order
+  changed.
+- Keyboard changes preserve a documented recovery path that does not require
+  the changed layout or modifier.
+- Re-running startup application is idempotent and preserves unrelated user
+  configuration.
+
+### DI-VALIDATE: Phase 2 Validation
+
+- [ ] Run focused shell, QML, helper, and nested-X11 tests for display and input
+  providers and interactions.
+- [ ] Validate single- and multi-monitor previews, persistence, restart, and
+  rollback in a real Fedora X11 session.
+- [ ] Validate available input controls on representative keyboard, pointer,
+  and touchpad hardware and record absent hardware.
+- [ ] Run the full repository validation and record secondary-platform gaps.
+
+Acceptance:
+
+- Every Phase 2 exit criterion maps to passing automated evidence or a named
+  manual check with release, hardware, session, and limitation details.
+- No phase is described as hardware- or platform-verified when its required
+  environment was not tested.
 
 ## Phase Completion
 
-When all Phase 1 acceptance criteria pass:
+When all Phase 2 acceptance criteria pass:
 
 1. Record delivered behavior and validation in `CHANGELOG.md`.
-2. Update the Phase 1 status and any changed assumptions in `ROADMAP.md`.
-3. Replace this file's active task set with Phase 2 tasks.
+2. Update the Phase 2 status and limitations in `ROADMAP.md`.
+3. Replace this file's active task set with Phase 3 tasks.
 4. Preserve incomplete or deferred work as explicit roadmap limitations.

--- a/config/quickshell/controlcenter/ControlCenterWindow.qml
+++ b/config/quickshell/controlcenter/ControlCenterWindow.qml
@@ -12,6 +12,7 @@ ClickAwayPopup {
     required property var healthModel
     required property var panelWindow
     required property var powerMenuModel
+    required property var settingsModel
 
     readonly property int cardWidth: Theme.controlCenterWidth
     readonly property int gap: Theme.controlCenterGap
@@ -45,6 +46,11 @@ ClickAwayPopup {
     function openSystemHealth() {
         root.controlCenterModel.close();
         root.healthModel.openOnScreen(root.panelWindow.screen);
+    }
+
+    function openSettings() {
+        root.controlCenterModel.close();
+        root.settingsModel.open();
     }
 
     function openPowerSettings() {
@@ -241,6 +247,11 @@ ClickAwayPopup {
                     visible: root.sidePanel === "utilities"
                     spacing: 8
 
+                    Tile {
+                        Layout.fillWidth: true
+                        label: "Settings  >"
+                        onActivated: root.openSettings()
+                    }
                     Tile {
                         Layout.fillWidth: true
                         label: "System Health  >"

--- a/config/quickshell/core/Commands.qml
+++ b/config/quickshell/core/Commands.qml
@@ -46,4 +46,8 @@ Singleton {
     function systemHealthHelperCommand(action, args) {
         return helperCommand("dwm-system-health", action, args, true);
     }
+
+    function settingsProviderCommand(action, args) {
+        return helperCommand("dwm-settings-provider", action, args, true);
+    }
 }

--- a/config/quickshell/settings/SettingsModel.qml
+++ b/config/quickshell/settings/SettingsModel.qml
@@ -1,0 +1,167 @@
+import Quickshell
+import Quickshell.Io
+import qs.core
+
+Scope {
+    id: root
+
+    property bool visible: false
+    property bool busy: false
+    property string searchQuery: ""
+    property string selectedSectionId: "displays"
+    property string discoveryState: "idle"
+    property string message: ""
+    property string platformId: "unknown"
+    property string platformFamily: "unknown"
+    property string platformName: "Unknown Linux"
+    property var capabilities: []
+    property int selectedIndex: 0
+
+    readonly property var sections: [
+        { "id": "displays", "label": "Displays", "description": "Monitors, layouts, and profiles" },
+        { "id": "input", "label": "Input", "description": "Keyboard, pointer, and touchpad" },
+        { "id": "network", "label": "Network", "description": "Connections and VPN providers" },
+        { "id": "bluetooth", "label": "Bluetooth", "description": "Adapters and devices" },
+        { "id": "audio", "label": "Audio", "description": "Outputs, inputs, and streams" },
+        { "id": "power", "label": "Power", "description": "DPMS, locking, and session policy" },
+        { "id": "defaults", "label": "Defaults", "description": "Applications and autostart" },
+        { "id": "appearance", "label": "Appearance", "description": "Themes and accessibility" },
+        { "id": "system", "label": "System", "description": "Health and administration" }
+    ]
+
+    readonly property var filteredSections: {
+        const query = root.searchQuery.trim().toLowerCase();
+        if (query.length === 0) return root.sections;
+        return root.sections.filter(function(section) {
+            return section.label.toLowerCase().indexOf(query) >= 0
+                || section.description.toLowerCase().indexOf(query) >= 0;
+        });
+    }
+
+    function sectionById(id) {
+        for (const section of root.sections) {
+            if (section.id === id) return section;
+        }
+        return root.sections[0];
+    }
+
+    function selectedSection() {
+        return root.sectionById(root.selectedSectionId);
+    }
+
+    function capabilitiesForSection(id) {
+        return root.capabilities.filter(function(capability) {
+            return capability.section === id;
+        });
+    }
+
+    function setSearch(value) {
+        root.searchQuery = value;
+        root.selectedIndex = 0;
+        if (root.filteredSections.length > 0) {
+            root.selectedSectionId = root.filteredSections[0].id;
+        }
+    }
+
+    function selectSection(id) {
+        for (let index = 0; index < root.filteredSections.length; index++) {
+            if (root.filteredSections[index].id === id) {
+                root.selectedIndex = index;
+                root.selectedSectionId = id;
+                return;
+            }
+        }
+    }
+
+    function selectRelative(delta) {
+        const sections = root.filteredSections;
+        if (sections.length === 0) return;
+        root.selectedIndex = (root.selectedIndex + delta + sections.length) % sections.length;
+        root.selectedSectionId = sections[root.selectedIndex].id;
+    }
+
+    function parseDiscovery(text) {
+        const capabilities = [];
+        const lines = text.trim().length > 0 ? text.trim().split("\n") : [];
+        let validProtocol = false;
+
+        for (const line of lines) {
+            const fields = line.split("\t");
+            if (fields[0] === "settings-protocol" && fields[1] === "1") {
+                validProtocol = true;
+            } else if (fields[0] === "platform" && fields.length >= 4) {
+                root.platformId = fields[1];
+                root.platformFamily = fields[2];
+                root.platformName = fields[3];
+            } else if (fields[0] === "capability" && fields.length >= 8) {
+                capabilities.push({
+                    "section": fields[1],
+                    "id": fields[2],
+                    "label": fields[3],
+                    "status": fields[4],
+                    "capabilityClass": fields[5],
+                    "provider": fields[6],
+                    "detail": fields[7]
+                });
+            }
+        }
+
+        root.busy = false;
+        if (!validProtocol) {
+            root.discoveryState = "failure";
+            root.message = "Capability provider returned an unsupported response";
+            root.capabilities = [];
+            return;
+        }
+
+        root.capabilities = capabilities;
+        root.discoveryState = "ready";
+        root.message = capabilities.length + " capabilities discovered";
+    }
+
+    function refresh() {
+        if (!root.visible || providerProcess.running) return;
+        root.busy = true;
+        root.discoveryState = "loading";
+        root.message = "Discovering capabilities...";
+        providerProcess.running = true;
+    }
+
+    function open() {
+        root.visible = true;
+        root.searchQuery = "";
+        root.selectedIndex = 0;
+        root.selectedSectionId = root.sections[0].id;
+        root.refresh();
+    }
+
+    function close() {
+        providerProcess.running = false;
+        root.visible = false;
+        root.busy = false;
+        root.searchQuery = "";
+        root.selectedIndex = 0;
+    }
+
+    function toggle() {
+        if (root.visible) root.close(); else root.open();
+    }
+
+    Process {
+        id: providerProcess
+
+        command: Commands.settingsProviderCommand("discover")
+        running: false
+
+        stdout: StdioCollector {
+            onStreamFinished: root.parseDiscovery(this.text)
+        }
+
+        stderr: StdioCollector {
+            onStreamFinished: {
+                const error = this.text.trim();
+                if (error.length > 0) root.message = error;
+            }
+        }
+    }
+}

--- a/config/quickshell/settings/SettingsModel.qml
+++ b/config/quickshell/settings/SettingsModel.qml
@@ -64,6 +64,15 @@ Scope {
     }
 
     function selectSection(id) {
+        const exists = root.sections.some(function(section) {
+            return section.id === id;
+        });
+        if (!exists) return;
+        if (root.searchQuery.length > 0 && !root.filteredSections.some(function(section) {
+            return section.id === id;
+        })) {
+            root.searchQuery = "";
+        }
         for (let index = 0; index < root.filteredSections.length; index++) {
             if (root.filteredSections[index].id === id) {
                 root.selectedIndex = index;

--- a/config/quickshell/settings/SettingsWindow.qml
+++ b/config/quickshell/settings/SettingsWindow.qml
@@ -275,13 +275,15 @@ FloatingWindow {
                                 required property var modelData
 
                                 width: capabilityList.width
-                                height: 92
+                                height: Math.max(92, cardColumn.implicitHeight + 22)
                                 color: Theme.bg
                                 border.color: root.statusColor(capabilityCard.modelData.status)
                                 border.width: 1
                                 radius: Theme.radius
 
                                 ColumnLayout {
+                                    id: cardColumn
+
                                     anchors.fill: parent
                                     anchors.margins: 11
                                     spacing: Theme.tightSpacing

--- a/config/quickshell/settings/SettingsWindow.qml
+++ b/config/quickshell/settings/SettingsWindow.qml
@@ -1,0 +1,367 @@
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import qs.core
+
+pragma ComponentBehavior: Bound
+
+FloatingWindow {
+    id: root
+
+    required property var settingsModel
+
+    title: "dwm settings"
+    visible: settingsModel.visible
+    implicitWidth: 980
+    implicitHeight: 620
+    color: Theme.bg
+
+    function statusColor(status) {
+        if (status === "available") return Theme.success;
+        if (status === "partial") return Theme.warning;
+        if (status === "restricted") return Theme.warning;
+        if (status === "unavailable") return Theme.danger;
+        return Theme.textMuted;
+    }
+
+    function focusSearch() {
+        settingsSearch.forceActiveFocus();
+        settingsSearch.cursorPosition = settingsSearch.text.length;
+    }
+
+    onVisibleChanged: {
+        if (visible) {
+            Qt.callLater(root.focusSearch);
+        } else if (root.settingsModel.visible) {
+            root.settingsModel.close();
+        }
+    }
+
+    Item {
+        anchors.fill: parent
+        focus: true
+
+        Keys.onPressed: function(event) {
+            if (event.key === Qt.Key_Escape) {
+                root.settingsModel.close();
+                event.accepted = true;
+            }
+        }
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 22
+            spacing: Theme.sectionSpacing
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Theme.sectionSpacing
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: Theme.tightSpacing
+
+                    Text {
+                        text: "Settings"
+                        color: Theme.textStrong
+                        font.family: Theme.fontFamily
+                        font.pixelSize: 26
+                        font.bold: true
+                    }
+
+                    Text {
+                        text: root.settingsModel.platformName + " - Phase 1 capability overview"
+                        color: Theme.textMuted
+                        font.family: Theme.fontFamily
+                        font.pixelSize: Theme.smallFontSize
+                    }
+                }
+
+                ShellButton {
+                    label: root.settingsModel.busy ? "Discovering..." : "Refresh"
+                    enabled: !root.settingsModel.busy
+                    onActivated: root.settingsModel.refresh()
+                }
+
+                ShellButton {
+                    label: "Close"
+                    onActivated: root.settingsModel.close()
+                }
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 42
+                color: Theme.surface
+                border.color: settingsSearch.activeFocus ? Theme.accent : Theme.border
+                border.width: 1
+                radius: Theme.radius
+
+                TextInput {
+                    id: settingsSearch
+
+                    anchors.fill: parent
+                    anchors.leftMargin: 14
+                    anchors.rightMargin: 14
+                    verticalAlignment: TextInput.AlignVCenter
+                    color: Theme.textStrong
+                    selectionColor: Theme.accent
+                    selectedTextColor: Theme.accentText
+                    text: root.settingsModel.searchQuery
+                    font.family: Theme.fontFamily
+                    font.pixelSize: Theme.inputFontSize
+                    clip: true
+
+                    onTextChanged: root.settingsModel.setSearch(text)
+
+                    Keys.onPressed: function(event) {
+                        if (event.key === Qt.Key_Down) {
+                            root.settingsModel.selectRelative(1);
+                            event.accepted = true;
+                        } else if (event.key === Qt.Key_Up) {
+                            root.settingsModel.selectRelative(-1);
+                            event.accepted = true;
+                        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                            if (root.settingsModel.filteredSections.length > 0) {
+                                root.settingsModel.selectSection(
+                                    root.settingsModel.filteredSections[root.settingsModel.selectedIndex].id
+                                );
+                            }
+                            event.accepted = true;
+                        } else if (event.key === Qt.Key_Escape) {
+                            root.settingsModel.close();
+                            event.accepted = true;
+                        }
+                    }
+                }
+
+                Text {
+                    anchors.left: parent.left
+                    anchors.leftMargin: 14
+                    anchors.verticalCenter: parent.verticalCenter
+                    visible: settingsSearch.text.length === 0
+                    text: "Search settings sections"
+                    color: Theme.placeholder
+                    font.family: Theme.fontFamily
+                    font.pixelSize: Theme.inputFontSize
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                spacing: Theme.sectionSpacing
+
+                Rectangle {
+                    Layout.preferredWidth: 260
+                    Layout.fillHeight: true
+                    color: Theme.surface
+                    border.color: Theme.border
+                    border.width: 1
+                    radius: Theme.radius
+
+                    ListView {
+                        id: sectionList
+
+                        anchors.fill: parent
+                        anchors.margins: 8
+                        clip: true
+                        spacing: Theme.listSpacing
+                        model: root.settingsModel.filteredSections
+
+                        delegate: Rectangle {
+                            id: sectionButton
+
+                            required property var modelData
+
+                            width: sectionList.width
+                            height: 58
+                            color: root.settingsModel.selectedSectionId === sectionButton.modelData.id
+                                ? Theme.surfaceHover : Theme.transparent
+                            border.color: root.settingsModel.selectedSectionId === sectionButton.modelData.id
+                                ? Theme.accent : Theme.transparent
+                            border.width: 1
+                            radius: Theme.radius
+
+                            Column {
+                                anchors.fill: parent
+                                anchors.margins: 9
+                                spacing: 3
+
+                                Text {
+                                    text: sectionButton.modelData.label
+                                    color: Theme.textStrong
+                                    font.family: Theme.fontFamily
+                                    font.pixelSize: Theme.panelFontSize
+                                    font.bold: root.settingsModel.selectedSectionId === sectionButton.modelData.id
+                                }
+
+                                Text {
+                                    width: parent.width
+                                    text: sectionButton.modelData.description
+                                    color: Theme.textMuted
+                                    font.family: Theme.fontFamily
+                                    font.pixelSize: Theme.tinyFontSize
+                                    elide: Text.ElideRight
+                                }
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: root.settingsModel.selectSection(sectionButton.modelData.id)
+                            }
+                        }
+
+                        Text {
+                            anchors.centerIn: parent
+                            visible: sectionList.count === 0
+                            text: "No matching sections"
+                            color: Theme.textMuted
+                            font.family: Theme.fontFamily
+                            font.pixelSize: Theme.bodyFontSize
+                        }
+                    }
+                }
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    color: Theme.surface
+                    border.color: Theme.border
+                    border.width: 1
+                    radius: Theme.radius
+
+                    ColumnLayout {
+                        anchors.fill: parent
+                        anchors.margins: 18
+                        spacing: Theme.sectionSpacing
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: Theme.tightSpacing
+
+                            Text {
+                                text: root.settingsModel.selectedSection().label
+                                color: Theme.textStrong
+                                font.family: Theme.fontFamily
+                                font.pixelSize: Theme.titleFontSize
+                                font.bold: true
+                            }
+
+                            Text {
+                                Layout.fillWidth: true
+                                text: root.settingsModel.selectedSection().description
+                                color: Theme.textMuted
+                                font.family: Theme.fontFamily
+                                font.pixelSize: Theme.bodyFontSize
+                            }
+                        }
+
+                        Rectangle { Layout.fillWidth: true; Layout.preferredHeight: 1; color: Theme.border }
+
+                        ListView {
+                            id: capabilityList
+
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            clip: true
+                            spacing: Theme.listSpacing * 2
+                            model: root.settingsModel.capabilitiesForSection(root.settingsModel.selectedSectionId)
+
+                            delegate: Rectangle {
+                                id: capabilityCard
+
+                                required property var modelData
+
+                                width: capabilityList.width
+                                height: 92
+                                color: Theme.bg
+                                border.color: root.statusColor(capabilityCard.modelData.status)
+                                border.width: 1
+                                radius: Theme.radius
+
+                                ColumnLayout {
+                                    anchors.fill: parent
+                                    anchors.margins: 11
+                                    spacing: Theme.tightSpacing
+
+                                    RowLayout {
+                                        Layout.fillWidth: true
+
+                                        Text {
+                                            Layout.fillWidth: true
+                                            text: capabilityCard.modelData.label
+                                            color: Theme.textStrong
+                                            font.family: Theme.fontFamily
+                                            font.pixelSize: Theme.panelFontSize
+                                            font.bold: true
+                                        }
+
+                                        Text {
+                                            text: capabilityCard.modelData.status.toUpperCase()
+                                            color: root.statusColor(capabilityCard.modelData.status)
+                                            font.family: Theme.fontFamily
+                                            font.pixelSize: Theme.tinyFontSize
+                                            font.bold: true
+                                        }
+                                    }
+
+                                    Text {
+                                        Layout.fillWidth: true
+                                        text: capabilityCard.modelData.detail
+                                        color: Theme.text
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.smallFontSize
+                                        wrapMode: Text.WordWrap
+                                    }
+
+                                    Text {
+                                        Layout.fillWidth: true
+                                        text: capabilityCard.modelData.capabilityClass + " - " + capabilityCard.modelData.provider
+                                        color: Theme.textMuted
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.tinyFontSize
+                                        elide: Text.ElideRight
+                                    }
+                                }
+                            }
+
+                            Text {
+                                anchors.centerIn: parent
+                                visible: capabilityList.count === 0
+                                text: root.settingsModel.discoveryState === "loading"
+                                    ? "Discovering capabilities..."
+                                    : root.settingsModel.discoveryState === "failure"
+                                        ? root.settingsModel.message
+                                        : "No capabilities reported for this section"
+                                color: root.settingsModel.discoveryState === "failure" ? Theme.danger : Theme.textMuted
+                                font.family: Theme.fontFamily
+                                font.pixelSize: Theme.bodyFontSize
+                                wrapMode: Text.WordWrap
+                            }
+                        }
+
+                        Text {
+                            Layout.fillWidth: true
+                            text: root.settingsModel.message
+                            color: root.settingsModel.discoveryState === "failure" ? Theme.danger : Theme.textMuted
+                            font.family: Theme.fontFamily
+                            font.pixelSize: Theme.smallFontSize
+                            elide: Text.ElideRight
+                        }
+                    }
+                }
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: "Phase 1 is read-only. Unsupported controls are explicit and no Settings action requests elevation."
+                color: Theme.textMuted
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.tinyFontSize
+                horizontalAlignment: Text.AlignRight
+            }
+        }
+    }
+}

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -11,6 +11,7 @@ import qs.network
 import qs.notifications
 import qs.panel
 import qs.power
+import qs.settings
 import qs.state
 
 pragma ComponentBehavior: Bound
@@ -54,6 +55,10 @@ ShellRoot {
 
     SystemHealthModel {
         id: systemHealthModel
+    }
+
+    SettingsModel {
+        id: settingsModel
     }
 
     LazyLoader {
@@ -275,6 +280,38 @@ ShellRoot {
         }
     }
 
+    IpcHandler {
+        target: "settings"
+
+        function close(): void {
+            settingsModel.close();
+        }
+
+        function currentSection(): string {
+            return settingsModel.selectedSectionId;
+        }
+
+        function open(): void {
+            settingsModel.open();
+        }
+
+        function refresh(): void {
+            settingsModel.refresh();
+        }
+
+        function select(section: string): void {
+            settingsModel.selectSection(section);
+        }
+
+        function status(): string {
+            return settingsModel.discoveryState;
+        }
+
+        function toggle(): void {
+            settingsModel.toggle();
+        }
+    }
+
     LauncherWindow {
         launcherModel: launcherModel
     }
@@ -325,6 +362,7 @@ ShellRoot {
         panelWindow: panelWindow
         powerMenuModel: powerMenuModel
         healthModel: systemHealthModel
+        settingsModel: settingsModel
     }
 
     UtilityDetailWindow {
@@ -334,5 +372,9 @@ ShellRoot {
     SystemHealthWindow {
         healthModel: systemHealthModel
         screen: systemHealthModel.targetScreen ? systemHealthModel.targetScreen : panelWindow.screen
+    }
+
+    SettingsWindow {
+        settingsModel: settingsModel
     }
 }

--- a/config/window-rules.toml
+++ b/config/window-rules.toml
@@ -41,6 +41,7 @@ rules = [
   { title="dwm control center",       isfloating=1, alwaysontop=1 },
   { title="dwm control center utility", isfloating=1, alwaysontop=1 },
   { title="dwm system health",        isfloating=1, alwaysontop=1 },
+  { title="dwm settings",             isfloating=1, alwaysontop=1 },
   { title="dwm notification history", isfloating=1, alwaysontop=1 },
   # { class="Gimp",           isfloating=1 },
   # { class="pavucontrol",    isfloating=1 },

--- a/docs/SETTINGS-CAPABILITIES.md
+++ b/docs/SETTINGS-CAPABILITIES.md
@@ -1,0 +1,165 @@
+# Settings Capability Inventory
+
+<!-- markdownlint-disable MD013 -->
+
+This document is the Phase 1 `SET-001` inventory for the Settings platform.
+It records the interfaces that exist before the unified Settings application
+is introduced. It is an implementation map, not a promise that every listed
+operation is ready to expose in Settings.
+
+`SPEC.md` and `ROADMAP.md` remain authoritative. The completed application,
+helper, authorization, packaging, and validation contracts are recorded in
+`docs/SETTINGS-PLATFORM.md` and apply before new settings mutations are
+implemented.
+
+## Capability Classes
+
+Every Settings operation uses exactly one primary class:
+
+| Class | Meaning |
+| --- | --- |
+| Read-only | State is readable without changing user or system state. |
+| User-session | The invoking user owns the mutation and no elevation is required. |
+| Privileged | A system mutation requires confirmation and a narrow, installed, root-owned helper. |
+| Delegated | A trusted service or platform tool owns the operation and its authorization. |
+| Unsupported | No suitable provider contract exists yet. The UI must explain or hide it. |
+
+An operation does not become safe for Settings merely because an existing
+script can run it. QML may pass documented arguments to a fixed helper action,
+but it must not construct shell commands or request elevation for repository,
+XDG, or other user-writable helper copies.
+
+## Planned Section Ownership
+
+This table maps every planned Settings section to the current owner and the
+provider work still required.
+
+| Section | Current owner and state source | Current mutation path | Class coverage | Failure and fallback | Validation |
+| --- | --- | --- | --- | --- | --- |
+| Displays | `dwm-display-setup`, `dwm-display-profile`, and RandR state from `xrandr` | RandR preview/profile apply; generated Xorg fragment for persistence | Read-only, user-session, privileged | Report missing X11/RandR; unsupported drivers omit TearFree; persistence must remain unavailable without the future trusted boundary | `make check-display-profile check-display-setup`; nested X11 preview and rollback |
+| Input | X11/libinput is installed on Fedora, but no Settings provider contract exists | None | Unsupported | Explain that device controls are not implemented; do not apply global guesses | Future provider unit tests plus nested X11 and real-device checks |
+| Network and VPN | `dwm-quickshell-network` over NetworkManager's `nmcli`; event stream from `nmcli monitor` | NetworkManager connection activation/deactivation; `nm-connection-editor` for advanced flows | Read-only, delegated | `NET unavailable` when NetworkManager or `nmcli` is absent; hide the editor action when unavailable | `make check-quickshell-network`; NetworkManager runtime exercise |
+| Bluetooth | `dwm-quickshell-controls` over `bluetoothctl` and the BlueZ daemon | BlueZ power, scan, pair/trust/connect, and disconnect operations | Read-only, delegated | `BT unavailable` when BlueZ tooling or an adapter is absent | `make check-quickshell-controls`; real adapter/device check |
+| Audio and media | Native `Quickshell.Services.Pipewire` signals with `pactl` or `wpctl` fallback; `playerctl --follow` for media | PipeWire/WirePlumber volume, mute, and default sink; MPRIS media actions | Read-only, user-session | Show unavailable state when the session services or tools are absent; audio and media fail independently | `make check-quickshell-controls`; live PipeWire and MPRIS exercise |
+| Power and session | `dwm-quickshell-controlcenter power-status`, `xset`, `gsettings`, light-locker state, and `PowerMenuModel.qml` | User `power.conf`, DPMS, lock policy; logind/systemd session actions | Read-only, user-session, delegated | Disable DPMS/lock controls when their commands or schemas are absent; leave system action authorization to logind | `make check-quickshell-controlcenter check-lock`; nested X11 and real-session checks |
+| Defaults and autostart | `dwm-default-apps` over `xdg-settings`, `xdg-mime`, and XDG desktop entries; no settings-ready autostart provider | Browser and MIME writes owned by the user | Read-only, user-session, unsupported | Report missing XDG tools; terminal, file manager, and user-visible autostart controls remain unsupported | `make check-default-apps`; future autostart provider tests |
+| Appearance and accessibility | `themes.toml`, `Theme.qml`, `dwm-quickshell-controlcenter`, `theme-apply.sh`, `feh`, and delegated `nwg-look` | User theme files and toolkit config; session wallpaper; external GTK tool | Read-only, user-session, delegated, unsupported | Missing themes/tools affect only their controls; fonts, cursors, notifications, wallpaper selection, and accessibility still need settings contracts | `make check-quickshell-controlcenter check-quickshell-qml`; live theme reload |
+| System and diagnostics | `dwm-system-health` structured snapshots and the full-screen health window | Allowlisted user repairs; installed-helper privileged repairs; selected trusted-tool entry points | Read-only, user-session, privileged, delegated, unsupported | Authorization denial produces a restricted partial report; high-risk administration stays delegated or unsupported | `make check-system-health check-quickshell-health-xvfb` |
+
+## Existing Operation Inventory
+
+### Control Center and Shell
+
+| Operations | Owner and interface | Class | Settings disposition |
+| --- | --- | --- | --- |
+| Open/close pages, show/hide panel widgets | `ControlCenterModel.qml` in-memory state | User-session | Reuse interaction patterns; persistence is not currently provided for widget visibility. |
+| System summary, theme list, keybind list, power status | `dwm-quickshell-controlcenter info`, `themes`, `keybinds`, `power-status`; tab-separated records | Read-only | Keep as internal interfaces until a future owning phase versions their output and error contracts. |
+| Restart Picom or Quickshell, toggle compositor, reload wallpaper | `dwm-quickshell-controlcenter action` with fixed action names | User-session | Keep allowlisted; surface missing-tool and process failures instead of unconditional success. |
+| Dependency check and installer | Fixed Control Center actions launched in a terminal | Delegated | Keep as explicit delegated workflows, not background Settings mutations. |
+| Open wallpaper folder or GTK settings | `xdg-open` or `nwg-look` through fixed actions | Delegated | Expose only when the target tool is available. |
+| Restart NetworkManager | Legacy fixed action launches `sudo systemctl` in a terminal | Privileged | Do not reuse as a Settings provider. Route future use through the trusted health helper or another installed allowlisted helper. |
+| Lock, logout, reboot, shutdown | `PowerMenuModel.qml` uses `dwm-lock`, `loginctl`, or systemd/logind | User-session for lock; delegated for logout/reboot/shutdown | Preserve confirmation for session-ending actions and rely on logind policy for authorization. |
+
+`Commands.qml` currently limits QML to fixed helper names and argv actions.
+The Settings application may reuse this pattern only for documented helper
+contracts. It must not add a generic command runner or a generic elevated
+action.
+
+### Displays
+
+| Operations | Owner and state/mutation path | Class | Failure and safety behavior |
+| --- | --- | --- | --- |
+| Profile directory/list/current/template | `dwm-display-profile`; XDG profile files and `xrandr --query` | Read-only | Missing profiles produce an empty list; missing RandR is an actionable error. |
+| Detect outputs/modes/drivers/TearFree; show status | `dwm-display-setup detect` and `status` | Read-only | Driver-specific features are reported only when detected. |
+| Generate an Xorg fragment | `dwm-display-setup generate PROFILE` | Read-only | Parses and validates an allowlisted profile grammar without installing it. |
+| Apply a saved profile | `dwm-display-profile apply PROFILE` invokes `xrandr` with validated output names/options | User-session | Reject invalid profiles and disconnected outputs; failure leaves persistence unchanged. |
+| Timed live preview | `dwm-display-setup preview PROFILE` captures the current RandR layout before apply | User-session | Reverts after timeout or rejection; reports rollback failure explicitly. |
+| Wizard, persistent install, and rollback | `dwm-display-setup` writes the managed Xorg fragment and timestamped backups | Privileged | Existing terminal/sudo flow is not the final Settings boundary. Settings needs confirmation plus a root-owned allowlisted helper contract. |
+
+### Network and Bluetooth
+
+| Operations | Owner and interface | Class | Failure and lifecycle behavior |
+| --- | --- | --- | --- |
+| Network status, devices, profiles, Wi-Fi scan | `dwm-quickshell-network` machine-oriented `nmcli` fields | Read-only | Missing NetworkManager tooling yields unavailable state without affecting other sections. |
+| Network change notifications | `dwm-quickshell-network monitor` using `nmcli monitor` | Read-only | The existing shared monitor serves the always-visible panel. A Settings-only watch must stop when its section closes. |
+| Connect saved profile, connect Wi-Fi, disconnect device | Fixed `nmcli connection` and `device` actions | Delegated | NetworkManager owns policy and secrets. Passwords remain argv data and must not be logged or persisted by QML. |
+| Hidden, enterprise, and advanced network editing | `nm-connection-editor` | Delegated | Hide the entry point when the tool is absent. |
+| Bluetooth status and known device list | `dwm-quickshell-controls bluetooth-status` and `bluetooth-devices` | Read-only | Missing `bluetoothctl`, daemon, or adapter is an unavailable capability. |
+| Scan, adapter power, pair/trust/connect, disconnect | Fixed `bluetoothctl` actions | Delegated | BlueZ owns device policy. Scan is bounded to eight seconds; failures must be attributed to the requested device/action. |
+
+### Audio and Media
+
+| Operations | Owner and interface | Class | Failure and lifecycle behavior |
+| --- | --- | --- | --- |
+| Default sink/source volume and mute | Native Quickshell PipeWire objects; `pactl`/`wpctl` snapshot fallback | Read-only | Native signals are preferred; no audio polling or repeated subscription processes. |
+| Output device list and current default | `dwm-quickshell-controls output-devices` and `output-status` | Read-only | Output is unavailable when neither supported session interface responds. |
+| Volume up/down/set, sink mute, default output | Fixed PipeWire/Pulse helper actions | User-session | Arguments are bounded; current streams move only when the selected backend supports it. |
+| Microphone mute status | Native PipeWire source or helper fallback | Read-only | Microphone mutation and input-device selection are not implemented and remain unsupported. |
+| Media state and event stream | `playerctl metadata` and `playerctl --follow` | Read-only | The existing shared stream serves panel controls; section-specific streams must be stopped on close. |
+| Play/pause, previous, next | Fixed `playerctl` actions | User-session | Absent players or MPRIS support affect only media controls. |
+| Per-application streams | No current provider contract | Unsupported | Add a PipeWire-native model in Phase 3; do not parse an unstable display format. |
+
+### Power, Defaults, and Appearance
+
+| Operations | Owner and interface | Class | Failure and safety behavior |
+| --- | --- | --- | --- |
+| DPMS and lock status | `dwm-quickshell-controlcenter power-status`; X11 and light-locker state | Read-only | Availability flags keep missing X11 or lock providers from breaking the section. |
+| Enable/disable DPMS or auto-lock; set timeouts | Fixed power actions write user `power.conf` and apply via `xset`/`gsettings` | User-session | Values are bounded; helper failure must not be reported as saved. |
+| Battery, power profiles, suspend policy, and lid policy | No settings-ready provider contract | Unsupported | Add stable system service providers in Phase 4 and distinguish readable state from privileged policy changes. |
+| Browser/MIME state and browser candidates | `dwm-default-apps status` and `browsers` | Read-only | Missing XDG tools or invalid desktop entries are reported without inventing defaults. |
+| Set browser or MIME handler | `dwm-default-apps set-browser` and `set-mime` | User-session | Desktop IDs and MIME arguments are validated before XDG writes. |
+| Default terminal, file manager, and autostart entries | No settings-ready provider contract | Unsupported | Preserve current configuration and XDG overrides until a provider is defined. |
+| Theme list and active theme | `themes.toml`, `Theme.qml`, and Control Center helper records | Read-only | Missing or invalid user state falls back to managed defaults without overwriting the user file. |
+| Select theme and apply toolkit/terminal/cursor settings | `theme-set`, hot reload, and `theme-apply.sh` user-file writes | User-session | A future contract must report partial toolkit failures and define preview/reset behavior. |
+| Random wallpaper | Fixed `feh` action over the user wallpaper directory | User-session | Missing tools, directory, or images are isolated failures. A selected-wallpaper provider is not yet available. |
+| GTK configuration tool | `nwg-look` | Delegated | Optional entry point only. |
+| Fonts, icons, notification policy, and accessibility | No settings-ready provider contract | Unsupported | Add by Phase 5 with explicit preview, reset, and rollback behavior. |
+
+### System Health and Administration
+
+| Operations | Owner and interface | Class | Failure and safety behavior |
+| --- | --- | --- | --- |
+| Session health snapshot | `dwm-system-health scan-user`; tab-separated typed records | Read-only | Runs on demand and stops when the health window closes. Individual probes report restricted, warning, or unavailable state. |
+| Current-boot logs, failed system services, SMART state | `scan-privileged` selects non-interactive sudo or polkit plus a trusted installed helper | Read-only with privileged authorization | Denial or cancellation leaves the user snapshot visible and labels coverage incomplete. |
+| Copy/export bounded evidence | `share-evidence` to X11 clipboard or private non-overwriting user file | User-session | Only the two documented evidence IDs are accepted. |
+| Restart desktop/audio components; manage failed user services | `repair-user` fixed allowlist | User-session | Every repair requires UI confirmation; service operations are accepted only for currently failed `.service` units. |
+| Manage failed system services; restart NetworkManager/Bluetooth; repair time sync | `repair-privileged` to root-owned installed helper, then fixed `repair-system` allowlist | Privileged | No repository/XDG helper may be elevated. Denial preserves readable health state. |
+| Updates, users, printers, locale/timezone, software sources | No unified provider; some future actions may open trusted Fedora tools | Delegated or unsupported | Phase 6 must choose a stable service/tool per operation and keep high-risk administration out of QML. |
+| Partitions, arbitrary services, firewall policy | Explicitly outside the current helper allowlist | Unsupported | Delegate to trusted administration tools unless a later specification defines a narrow contract. |
+
+## Platform Provider Matrix
+
+Package names remain owned by `scripts/dwm-packages.sh`. This document names
+package profiles and runtime capabilities so future Settings code does not
+duplicate distro-specific lists.
+
+| Provider capability | Fedora path | Secondary-platform behavior |
+| --- | --- | --- |
+| Quickshell Settings frontend | `rhel:desktop` supplies Quickshell on Fedora | Arch maps Quickshell in `arch:desktop`. The Debian map does not currently supply it, so the Settings UI is unsupported there unless a compatible Quickshell is installed separately; core dwm remains usable. |
+| X11 display state | `rhel:x11` supplies the RandR/X11 tools | `arch:x11` and `debian:x11` supply family equivalents. TearFree remains driver-dependent everywhere. |
+| NetworkManager | `rhel:desktop-optional`; enabled by the Fedora image | Arch and Debian optional profiles provide NetworkManager. Without it, the provider reports unavailable and other sections continue. |
+| BlueZ | `rhel:desktop` plus the Fedora image service/package set | Arch and Debian desktop profiles provide their BlueZ equivalents. Adapter absence is a runtime unsupported state. |
+| PipeWire/WirePlumber and controls | `rhel:desktop`; included by the Fedora image | Arch and Debian desktop profiles provide family equivalents. Helpers fall back between supported session commands. |
+| DPMS and auto-lock | X11 tools plus `rhel:desktop` light-locker and GLib settings | Arch and Debian desktop profiles provide equivalents. Missing schemas or locker disable only lock controls. |
+| Defaults | `rhel:runtime-required` XDG utilities | Arch and Debian required profiles provide equivalents. |
+| Themes and GTK integration | `rhel:theme`, `rhel:theme-gtk`, and optional tool profiles | Family theme profiles provide available equivalents; missing optional theme packages do not disable Settings. |
+| Polkit authorization | Fedora desktop/image installs a polkit agent; health helper can use a trusted system install | Other desktop profiles provide a polkit agent where available. Without an agent or trusted helper, privileged capabilities are restricted while read-only state remains available. |
+| System health | Portable helper probes plus Fedora/systemd providers where present | The helper detects Debian, Arch, and RHEL families and emits partial/restricted records for missing commands, services, hardware, or authorization. |
+
+## Phase 1 Constraints Derived From the Inventory
+
+- There is no reusable generic privilege interface. The health helper is the
+  only current trusted-helper pattern and its allowlist must not be widened by
+  accepting arbitrary commands.
+- The display installer's terminal `sudo` flow and the Control Center's legacy
+  NetworkManager restart are not Settings provider contracts.
+- Existing event streams used by persistent panel widgets may stay shared.
+  Watches created only for a Settings section must start on section activation
+  and stop on close.
+- Provider failures must be per section. Missing Quickshell, NetworkManager,
+  BlueZ, PipeWire, X11, or a Fedora-only tool must not damage the core session.
+- The Phase 1 discovery output follows the versioned contract in
+  `docs/SETTINGS-PLATFORM.md`. Other current tab-separated interfaces remain
+  inventory inputs, not automatically stable public APIs.
+- No existing or planned operation requires passwordless broad `sudo`, and no
+  QML component is assigned ownership of an elevated command.

--- a/docs/SETTINGS-PLATFORM.md
+++ b/docs/SETTINGS-PLATFORM.md
@@ -1,0 +1,199 @@
+# Settings Platform Contract
+
+<!-- markdownlint-disable MD013 -->
+
+This document completes the Phase 1 architecture, safety, packaging, and
+validation contracts for the unified Settings application. `SPEC.md` remains
+the product contract, and `docs/SETTINGS-CAPABILITIES.md` records the provider
+inventory that this design uses.
+
+## Application Contract
+
+The Settings application is one Quickshell `FloatingWindow` titled
+`dwm settings`. It is part of the managed Quickshell process and is opened from
+Control Center -> Utilities -> Settings, through the `settings` IPC target, or
+with `dwm-settings`.
+
+### Navigation and Search
+
+- The left navigation contains Displays, Input, Network, Bluetooth, Audio,
+  Power, Defaults, Appearance, and System in stable roadmap order.
+- Typing in the search field filters section names and descriptions. Search
+  never starts a provider or mutates state.
+- Up and Down move between visible sections, Enter selects the highlighted
+  section, Escape closes Settings, and clicking a section selects it.
+- Opening Settings resets navigation to Displays and starts one bounded
+  discovery snapshot. Refresh starts a new snapshot only when no snapshot is
+  already active.
+- Closing Settings stops the discovery process, clears transient search state,
+  and leaves persistent panel providers untouched.
+
+Phase 1 is intentionally read-only. Capability cards report the operation
+class, provider, state, and recovery detail. Unsupported and restricted cards
+stay visible when their explanation helps the user; a missing provider never
+prevents another section from opening.
+
+## Helper Protocol
+
+QML invokes only `dwm-settings-provider discover` through the fixed
+`Commands.settingsProviderCommand()` wrapper. The helper accepts no command
+strings, mutation names, file paths, or elevation flags.
+
+The version 1 output is UTF-8, tab-separated, and line-oriented:
+
+```text
+settings-protocol<TAB>1
+platform<TAB>id<TAB>family<TAB>display-name
+capability<TAB>section<TAB>id<TAB>label<TAB>status<TAB>class<TAB>provider<TAB>detail
+```
+
+Fields are single-line values with tabs and line breaks replaced by spaces.
+Unknown record types may be ignored. A missing or unsupported protocol record
+is a provider failure, not an empty capability set.
+
+Capability statuses are:
+
+| Status | Meaning |
+| --- | --- |
+| `available` | The provider needed for the reported read path is present. |
+| `partial` | Some state is readable, but the complete section contract is not available. |
+| `unavailable` | A normally supported provider is missing or not usable. |
+| `restricted` | Readable state remains available, but an authorization path is absent. |
+| `unsupported` | This phase or platform has no supported provider contract. |
+
+Capability classes are `read-only`, `user-session`, `privileged`, and
+`delegated`. The broader inventory also treats an operation with no provider as
+unsupported; protocol records express that through the `unsupported` status.
+
+The protocol is append-only within version 1. Changing field order, meaning,
+or escaping requires a new protocol version and a compatibility test.
+
+## UI and Operation States
+
+All future section implementations use these states. Phase 1 exercises
+`loading`, `unavailable`, `failure`, and unsupported state through discovery
+and tests. Existing health tests cover restricted authorization while existing
+display tests cover preview rollback. Mutation-specific Settings states become
+active when the owning roadmap phase adds mutations.
+
+| State | Required behavior |
+| --- | --- |
+| `loading` | Keep navigation usable, show progress, and prevent overlapping provider launches. |
+| `unavailable` | Identify the missing provider or service and give the next action. |
+| `permission-denied` | Preserve readable state, clear pending authorization, and allow retry. |
+| `failure` | Attribute the error to one provider and leave other sections usable. |
+| `dirty` | Show unapplied user changes and require Apply, Reset, or explicit navigation handling. |
+| `saved` | Confirm the durable target and the successfully persisted value. |
+| `preview` | Show the deadline, previous state, and explicit Keep/Revert actions. |
+| `rollback` | Restore captured state automatically on timeout, rejection, close, or provider failure. |
+
+Closing a section must stop watches and child processes that exist only for
+that section. Shared event sources required by the persistent panel, such as
+the existing NetworkManager and MPRIS streams, remain owned by their shared
+models and must not be duplicated by Settings.
+
+## Authorization and Safety Contract
+
+Phase 1 Settings exposes no mutation or elevated operation. Future providers
+must follow this boundary:
+
+| Operation class | Allowed execution path |
+| --- | --- |
+| Read-only | Unprivileged service API or fixed helper snapshot. |
+| User-session | Fixed helper action with validated argv that changes only invoking-user state. |
+| Privileged | Explicit confirmation followed by an installed, root-owned, non-writable helper with an operation allowlist. |
+| Delegated | Fixed launch or service request to a trusted platform tool that owns policy and authorization. |
+
+### Privileged Allowlist Boundary
+
+- No Phase 1 Settings operation is on the privileged allowlist.
+- Existing health actions remain limited to failed-service actions,
+  NetworkManager, Bluetooth, and time synchronization as specified in
+  `SPEC.md`; they are not automatically Settings actions.
+- Display persistence may later allow only validated generated-fragment
+  install and rollback operations. It may not accept arbitrary paths, Xorg
+  text, commands, or environment-selected executables.
+- Repository, XDG, home-directory, symlinked, group-writable, and
+  other-user-writable helper copies must never be elevated.
+- A trusted helper must resolve outside user-writable paths, be owned by root,
+  and have no group or other write bits before polkit or sudo executes it.
+- Broad passwordless sudo, a generic command runner, arbitrary service names,
+  and arbitrary file writes are forbidden.
+
+### Confirmation, Cancellation, Audit, and Rollback
+
+- The UI must describe the exact target, new value, impact, authorization need,
+  and recovery path before a privileged or destructive request.
+- Closing the confirmation surface, pressing Escape, rejecting polkit, or
+  timing out cancels the request and preserves readable state.
+- Previewable display changes default to a 15-second rollback deadline. A
+  provider must capture the prior state before applying the preview.
+- Helpers return a typed operation ID, result, and bounded diagnostic. They
+  must not log secrets, passwords, environment dumps, or unbounded command
+  output.
+- Success is reported only after the provider confirms the mutation. A failed
+  persist step after a live preview triggers rollback and reports both results.
+
+The Control Center's legacy terminal `sudo systemctl restart NetworkManager`
+action and `dwm-display-setup` terminal sudo flow remain compatibility paths;
+neither is a Settings provider contract.
+
+## Fedora-First Packaging Plan
+
+Package ownership stays centralized in `scripts/dwm-packages.sh`. Phase 1 adds
+no runtime dependency beyond capabilities already present in the existing
+desktop and image profiles.
+
+| Capability | Fedora source | Current image/map status | Secondary behavior |
+| --- | --- | --- | --- |
+| Settings window | Quickshell 0.3 or newer | `quickshell` is already in both Fedora Kickstarts and `rhel:desktop` | Present in `arch:desktop`; Debian reports the UI unsupported unless Quickshell is installed separately. |
+| Capability helper | POSIX shell and base utilities | Installed as a project command; no new package | Portable across all supported families. |
+| Display/default state | RandR and XDG utilities | Already in Fedora Kickstarts and required profiles | Family X11/runtime profiles provide equivalents. |
+| Network/Bluetooth/audio/power state | NetworkManager, BlueZ, PipeWire/WirePlumber, X11 tools, light-locker | Already in Fedora Kickstarts and desktop profiles | Missing optional providers produce unavailable or partial cards. |
+| Authorization discovery | Polkit agent and trusted installed helper | Fedora image already includes a polkit agent; helper installation remains project-owned | Missing authorization leaves read-only state available. |
+| QML development | Qt declarative development tools | `rhel:qml-development` maps `qt6-qtdeclarative-devel`; intentionally excluded from runtime images | `arch:qml-development` and `debian:qml-development` own their package names. |
+
+The `qml-development` profile is opt-in developer tooling and is not part of
+`required`, `recommended`, `optional`, `full`, or either Kickstart. This avoids
+expanding the installed desktop for users who do not develop QML while keeping
+all family-specific package names in one map.
+
+## Validation Plan
+
+| Phase 1 exit criterion | Automated evidence | Manual or runtime evidence |
+| --- | --- | --- |
+| Settings opens and navigates without idle polling | `make check-settings check-quickshell-settings-xvfb check-quickshell-qml` | Open from Control Center, search, use keyboard/mouse navigation, close, and record the closed CPU/process sample. |
+| Fedora discovery and clean fallback | `make check-settings` exercises Fedora 44 and Debian 13 fixtures | Run `dwm-settings-provider discover` on the Fedora qualification host and record platform/provider rows. |
+| Privilege, rollback, errors, unsupported state | `make check-settings check-system-health check-display-setup` plus source assertions for the no-elevation boundary | Cancel or deny any future authorization prompt; verify readable state remains. Phase 1 has no privileged Settings action to authorize. |
+| Existing desktop compatibility | Existing launcher, Control Center, controls, network, health, runtime, install, and preservation checks in `make check` | Verify existing Control Center and hotkeys in the qualification session. |
+| Packaging and ownership | `make check-install check-install-manifest check-kickstart` | Verify installed helper ownership when a privileged Settings helper is introduced. None is introduced in Phase 1. |
+
+The nested-X11 test must record window geometry, IPC navigation, keyboard and
+mouse selection, Escape close, provider cleanup, and a two-second CPU sample
+with Settings closed. A passing sample requires less than 10 percent of one CPU
+for the managed Quickshell process and no remaining Settings provider process.
+
+Real Fedora evidence must record release, architecture, session type, Settings
+entry path, discovered provider states, CPU/process sample, and limitations.
+Nested X11 does not prove real hardware providers. Debian, Arch, and generic
+RHEL runtime behavior remains unverified until run in those environments even
+when fixture and package-map tests pass.
+
+## Phase 1 Qualification Evidence
+
+Evidence recorded on 2026-07-21:
+
+- Fedora Linux 44, x86_64, X11 reported the `rhel` provider family. RandR,
+  NetworkManager, BlueZ, PipeWire Pulse, DPMS, light-locker, XDG defaults,
+  themes, system health, and the trusted authorization path were discovered as
+  available. Phase 2 display/input mutations and later accessibility/system
+  administration remained explicitly unsupported.
+- Nested X11 at 1280x800 opened the 980x620 Settings window, exercised IPC,
+  keyboard, mouse, search, Escape close, and provider cleanup. The two-second
+  closed-window sample measured 0.00 percent of one CPU for Quickshell.
+- Fedora 44 and Debian 13 fixtures validated available and unavailable provider
+  records. Arch and generic RHEL package names were validated through the
+  centralized package map but were not runtime-tested.
+- The live Fedora check was read-only. No settings mutation, authorization
+  prompt, hardware change, session restart, or managed-shell replacement was
+  performed.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,5 +6,6 @@
 - [Configuration](./configuration.md)
 - [Theming](./theming.md)
 - [Control Center](./control-center.md)
+- [Settings](./settings.md)
 - [Patches & Features](./patches.md)
 - [Troubleshooting](./troubleshooting.md)

--- a/docs/src/control-center.md
+++ b/docs/src/control-center.md
@@ -11,6 +11,10 @@ The popup opens from the panel logo. Its side card contains panel widget
 visibility, utilities, quick actions, appearance controls, and persisted DPMS
 and auto-lock timing. Press <kbd>Esc</kbd> or click outside it to close it.
 
+The Utilities card opens the unified Settings application. Phase 1 Settings is
+a read-only capability overview with section search and keyboard/mouse
+navigation. It can also be opened directly with `dwm-settings`.
+
 ---
 
 ## Network Popover

--- a/docs/src/control-center.md
+++ b/docs/src/control-center.md
@@ -13,7 +13,7 @@ and auto-lock timing. Press <kbd>Esc</kbd> or click outside it to close it.
 
 The Utilities card opens the unified Settings application. Phase 1 Settings is
 a read-only capability overview with section search and keyboard/mouse
-navigation. It can also be opened directly with `dwm-settings`.
+navigation. It can also be opened directly with `dwm-settings open`.
 
 ---
 

--- a/docs/src/settings.md
+++ b/docs/src/settings.md
@@ -1,0 +1,35 @@
+# Settings
+
+The unified Settings application provides one place to inspect desktop
+capabilities and see which features are available, restricted, or planned.
+
+Open Control Center with `Super+F1`, select **Utilities**,
+then select **Settings**. You can also run:
+
+```bash
+dwm-settings
+```
+
+Phase 1 is a read-only foundation. It discovers display, input, network,
+Bluetooth, audio, power, default-application, appearance, and system providers
+without changing their state. Unsupported sections explain when their controls
+are planned, and missing optional services do not prevent other sections from
+opening.
+
+Type to search section names and descriptions. Use Up and Down to move through
+the filtered sections, Enter to select one, or Escape to close Settings. The
+Refresh button runs a new bounded capability snapshot; Settings does not add an
+idle polling timer.
+
+Command-line IPC actions are also available:
+
+```bash
+dwm-settings open
+dwm-settings refresh
+dwm-settings status
+dwm-settings close
+```
+
+Phase 2 adds display and input controls. Later phases add connectivity, audio,
+power, defaults, personalization, and system-management operations while
+preserving the capability and authorization boundaries established here.

--- a/docs/src/settings.md
+++ b/docs/src/settings.md
@@ -7,7 +7,7 @@ Open Control Center with `Super+F1`, select **Utilities**,
 then select **Settings**. You can also run:
 
 ```bash
-dwm-settings
+dwm-settings open
 ```
 
 Phase 1 is a read-only foundation. It discovers display, input, network,
@@ -29,6 +29,16 @@ dwm-settings refresh
 dwm-settings status
 dwm-settings close
 ```
+
+Existing `window-rules.toml` files are preserved during upgrades. If your file
+predates Settings, add this entry inside its `rules` array:
+
+```toml
+{ title="dwm settings", isfloating=1, alwaysontop=1 },
+```
+
+Saving the file applies the rule through dwm's normal hot reload. A customized
+rule with the same title can be retained instead.
 
 Phase 2 adds display and input controls. Later phases add connectivity, audio,
 power, defaults, personalization, and system-management operations while

--- a/scripts/dwm-packages.sh
+++ b/scripts/dwm-packages.sh
@@ -46,6 +46,9 @@ dwm_packages() {
 	arch:fonts)
 		printf '%s\n' noto-fonts-emoji ttf-meslo-nerd
 		;;
+	arch:qml-development)
+		printf '%s\n' qt6-declarative
+		;;
 	arch:lightdm)
 		printf '%s\n' lightdm lightdm-slick-greeter
 		;;
@@ -124,6 +127,9 @@ dwm_packages() {
 	rhel:fonts)
 		printf '%s\n' google-noto-color-emoji-fonts google-noto-sans-mono-fonts
 		;;
+	rhel:qml-development)
+		printf '%s\n' qt6-qtdeclarative-devel
+		;;
 	rhel:lightdm)
 		printf '%s\n' lightdm slick-greeter
 		;;
@@ -168,6 +174,9 @@ dwm_packages() {
 		;;
 	debian:fonts)
 		printf '%s\n' fonts-noto-color-emoji fonts-noto-mono
+		;;
+	debian:qml-development)
+		printf '%s\n' qt6-declarative-dev-tools
 		;;
 	debian:lightdm)
 		printf '%s\n' lightdm slick-greeter

--- a/scripts/dwm-settings
+++ b/scripts/dwm-settings
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eu
+
+config=${XDG_CONFIG_HOME:-$HOME/.config}/quickshell/shell.qml
+
+if [ ! -f "$config" ]; then
+	config=${XDG_DATA_HOME:-$HOME/.local/share}/dwm-titus/config/quickshell/shell.qml
+fi
+
+action=${1:-toggle}
+case $action in
+open | close | toggle | refresh | status) ;;
+*)
+	printf 'usage: %s [open|close|toggle|refresh|status]\n' "$0" >&2
+	exit 2
+	;;
+esac
+
+exec quickshell ipc --path "$config" call settings "$action"

--- a/scripts/dwm-settings
+++ b/scripts/dwm-settings
@@ -7,8 +7,13 @@ if [ ! -f "$config" ]; then
 	config=${XDG_DATA_HOME:-$HOME/.local/share}/dwm-titus/config/quickshell/shell.qml
 fi
 
+if [ ! -f "$config" ]; then
+	printf 'dwm-settings: managed Quickshell configuration not found\n' >&2
+	exit 1
+fi
+
 action=${1:-toggle}
-case $action in
+case "$action" in
 open | close | toggle | refresh | status) ;;
 *)
 	printf 'usage: %s [open|close|toggle|refresh|status]\n' "$0" >&2

--- a/scripts/dwm-settings-provider
+++ b/scripts/dwm-settings-provider
@@ -15,7 +15,7 @@ usage() {
 }
 
 clean_field() {
-	printf '%s' "$1" | tr '\t\r\n' '   '
+	printf '%s' "$1" | tr '\011\015\012' '   '
 }
 
 os_value() {
@@ -43,9 +43,28 @@ platform_family() {
 	esac
 }
 
-provider_available() {
+provider_path() {
 	command_name=$1
-	command -v "$command_name" >/dev/null 2>&1 || [ -x "$script_dir/$command_name" ]
+	if command -v "$command_name" >/dev/null 2>&1; then
+		command -v "$command_name"
+	elif [ -x "$script_dir/$command_name" ]; then
+		printf '%s\n' "$script_dir/$command_name"
+	else
+		return 1
+	fi
+}
+
+provider_available() {
+	provider_path "$1" >/dev/null 2>&1
+}
+
+# Keep discovery responsive even when a service client cannot reach its daemon.
+run_bounded_probe() {
+	command_name=$1
+	shift
+	command_path=$(provider_path "$command_name") || return 1
+	timeout_path=$(command -v timeout 2>/dev/null) || return 1
+	"$timeout_path" 2 "$command_path" "$@" >/dev/null 2>&1
 }
 
 emit_capability() {
@@ -67,25 +86,32 @@ emit_capability() {
 		"$(clean_field "$detail")"
 }
 
-emit_command_capability() {
+emit_probed_command_capability() {
 	section=$1
 	id=$2
 	label=$3
 	class=$4
 	command_name=$5
 	available_detail=$6
-	unavailable_detail=$7
+	missing_detail=$7
+	unready_detail=$8
+	shift 8
 
-	if provider_available "$command_name"; then
+	if ! provider_available "$command_name"; then
+		emit_capability "$section" "$id" "$label" unavailable "$class" "$command_name" "$missing_detail"
+	elif run_bounded_probe "$command_name" "$@"; then
 		emit_capability "$section" "$id" "$label" available "$class" "$command_name" "$available_detail"
 	else
-		emit_capability "$section" "$id" "$label" unavailable "$class" "$command_name" "$unavailable_detail"
+		emit_capability "$section" "$id" "$label" unavailable "$class" "$command_name" "$unready_detail"
 	fi
 }
 
 trusted_health_helper() {
-	for candidate in /usr/local/bin/dwm-system-health /usr/bin/dwm-system-health; do
+	path_candidate=$(command -v dwm-system-health 2>/dev/null || true)
+	for candidate in "$path_candidate" /usr/local/bin/dwm-system-health /usr/bin/dwm-system-health; do
+		[ -n "$candidate" ] || continue
 		[ -f "$candidate" ] || continue
+		[ ! -L "$candidate" ] || continue
 		[ "$(stat -c %u -- "$candidate" 2>/dev/null || printf 1)" = 0 ] || continue
 		find "$candidate" -maxdepth 0 -type f ! -perm /022 -print -quit 2>/dev/null | grep -q . || continue
 		return 0
@@ -113,37 +139,49 @@ discover() {
 		"$(clean_field "$platform_family_name")" \
 		"$(clean_field "$platform_pretty")"
 
-	emit_command_capability displays randr 'Display discovery' read-only xrandr \
+	emit_probed_command_capability displays randr 'Display discovery' read-only xrandr \
 		'RandR display state is available' \
-		'Install the X11 RandR tools and open Settings from X11'
+		'Install the X11 RandR tools and open Settings from X11' \
+		'RandR tools are installed, but no responsive X11 display is available' \
+		--query
 	emit_capability displays display-changes 'Display changes' unsupported user-session \
 		dwm-display-setup 'Display changes begin in Phase 2'
 
 	emit_capability input input-devices 'Input devices' unsupported user-session \
 		xinput 'Input device settings begin in Phase 2'
 
-	emit_command_capability network networkmanager NetworkManager delegated nmcli \
+	emit_probed_command_capability network networkmanager NetworkManager delegated nmcli \
 		'NetworkManager state is available' \
-		'Install and start NetworkManager to enable this section'
-	emit_command_capability bluetooth bluez Bluetooth delegated bluetoothctl \
+		'Install NetworkManager to enable this section' \
+		'NetworkManager is installed, but its service is not responding' \
+		-t -f RUNNING general
+	emit_probed_command_capability bluetooth bluez Bluetooth delegated bluetoothctl \
 		'BlueZ state is available' \
-		'Install BlueZ tools and start Bluetooth to enable this section'
+		'Install BlueZ tools to enable this section' \
+		'BlueZ tools are installed, but no daemon or adapter is responding' \
+		show
 
-	if provider_available pactl; then
+	if run_bounded_probe pactl info; then
 		emit_capability audio pipewire-audio Audio available user-session pactl \
 			'PipeWire Pulse-compatible session controls are available'
-	elif provider_available wpctl; then
+	elif run_bounded_probe wpctl status; then
 		emit_capability audio pipewire-audio Audio available user-session wpctl \
 			'WirePlumber session controls are available'
+	elif provider_available pactl || provider_available wpctl; then
+		emit_capability audio pipewire-audio Audio unavailable user-session pipewire \
+			'Audio tools are installed, but no PipeWire or Pulse session is responding'
 	else
 		emit_capability audio pipewire-audio Audio unavailable user-session pipewire \
 			'Start PipeWire and install pactl or wpctl'
 	fi
 
-	emit_command_capability power dpms 'Display power management' user-session xset \
+	emit_probed_command_capability power dpms 'Display power management' user-session xset \
 		'X11 DPMS state is available' \
-		'Install xset and open Settings from X11'
-	if provider_available xset && provider_available gsettings && provider_available light-locker; then
+		'Install xset and open Settings from X11' \
+		'xset is installed, but no responsive X11 display is available' \
+		q
+	if run_bounded_probe xset q && provider_available light-locker &&
+		run_bounded_probe gsettings get apps.light-locker lock-after-screensaver; then
 		emit_capability power auto-lock 'Automatic locking' available user-session light-locker \
 			'Light-locker session policy is available'
 	else
@@ -151,9 +189,13 @@ discover() {
 			'Install xset, GLib settings, and light-locker for full support'
 	fi
 
-	if provider_available xdg-settings && provider_available xdg-mime; then
+	if run_bounded_probe xdg-settings get default-web-browser &&
+		run_bounded_probe xdg-mime query default text/html; then
 		emit_capability defaults xdg-defaults 'Default applications' available user-session xdg-utils \
 			'Browser and MIME defaults are readable'
+	elif provider_available xdg-settings && provider_available xdg-mime; then
+		emit_capability defaults xdg-defaults 'Default applications' unavailable user-session xdg-utils \
+			'XDG tools are installed, but the current desktop defaults are not readable'
 	else
 		emit_capability defaults xdg-defaults 'Default applications' unavailable user-session xdg-utils \
 			'Install xdg-utils to inspect desktop defaults'

--- a/scripts/dwm-settings-provider
+++ b/scripts/dwm-settings-provider
@@ -1,0 +1,206 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(
+	unset CDPATH
+	cd -- "$(dirname -- "$0")" && pwd
+)
+repo_dir=$(
+	unset CDPATH
+	cd -- "$script_dir/.." && pwd
+)
+
+usage() {
+	printf 'usage: %s discover\n' "$0" >&2
+}
+
+clean_field() {
+	printf '%s' "$1" | tr '\t\r\n' '   '
+}
+
+os_value() {
+	key=$1
+	file=$2
+	awk -F= -v key="$key" '
+		$1 == key {
+			value = substr($0, index($0, "=") + 1)
+			gsub(/^"|"$/, "", value)
+			print value
+			exit
+		}
+	' "$file" 2>/dev/null || true
+}
+
+platform_family() {
+	id=$1
+	id_like=$2
+
+	case " $id $id_like " in
+	*" arch "*) printf '%s\n' arch ;;
+	*" debian "* | *" ubuntu "*) printf '%s\n' debian ;;
+	*" fedora "* | *" rhel "* | *" centos "*) printf '%s\n' rhel ;;
+	*) printf '%s\n' unknown ;;
+	esac
+}
+
+provider_available() {
+	command_name=$1
+	command -v "$command_name" >/dev/null 2>&1 || [ -x "$script_dir/$command_name" ]
+}
+
+emit_capability() {
+	section=$1
+	id=$2
+	label=$3
+	status=$4
+	class=$5
+	provider=$6
+	detail=$7
+
+	printf 'capability\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+		"$(clean_field "$section")" \
+		"$(clean_field "$id")" \
+		"$(clean_field "$label")" \
+		"$(clean_field "$status")" \
+		"$(clean_field "$class")" \
+		"$(clean_field "$provider")" \
+		"$(clean_field "$detail")"
+}
+
+emit_command_capability() {
+	section=$1
+	id=$2
+	label=$3
+	class=$4
+	command_name=$5
+	available_detail=$6
+	unavailable_detail=$7
+
+	if provider_available "$command_name"; then
+		emit_capability "$section" "$id" "$label" available "$class" "$command_name" "$available_detail"
+	else
+		emit_capability "$section" "$id" "$label" unavailable "$class" "$command_name" "$unavailable_detail"
+	fi
+}
+
+trusted_health_helper() {
+	for candidate in /usr/local/bin/dwm-system-health /usr/bin/dwm-system-health; do
+		[ -f "$candidate" ] || continue
+		[ "$(stat -c %u -- "$candidate" 2>/dev/null || printf 1)" = 0 ] || continue
+		find "$candidate" -maxdepth 0 -type f ! -perm /022 -print -quit 2>/dev/null | grep -q . || continue
+		return 0
+	done
+	return 1
+}
+
+discover() {
+	os_release=${DWM_SETTINGS_OS_RELEASE:-/etc/os-release}
+	platform_id=unknown
+	platform_like=
+	platform_pretty='Unknown Linux'
+	if [ -r "$os_release" ]; then
+		platform_id=$(os_value ID "$os_release")
+		platform_like=$(os_value ID_LIKE "$os_release")
+		platform_pretty=$(os_value PRETTY_NAME "$os_release")
+		[ -n "$platform_id" ] || platform_id=unknown
+		[ -n "$platform_pretty" ] || platform_pretty=$platform_id
+	fi
+	platform_family_name=$(platform_family "$platform_id" "$platform_like")
+
+	printf 'settings-protocol\t1\n'
+	printf 'platform\t%s\t%s\t%s\n' \
+		"$(clean_field "$platform_id")" \
+		"$(clean_field "$platform_family_name")" \
+		"$(clean_field "$platform_pretty")"
+
+	emit_command_capability displays randr 'Display discovery' read-only xrandr \
+		'RandR display state is available' \
+		'Install the X11 RandR tools and open Settings from X11'
+	emit_capability displays display-changes 'Display changes' unsupported user-session \
+		dwm-display-setup 'Display changes begin in Phase 2'
+
+	emit_capability input input-devices 'Input devices' unsupported user-session \
+		xinput 'Input device settings begin in Phase 2'
+
+	emit_command_capability network networkmanager NetworkManager delegated nmcli \
+		'NetworkManager state is available' \
+		'Install and start NetworkManager to enable this section'
+	emit_command_capability bluetooth bluez Bluetooth delegated bluetoothctl \
+		'BlueZ state is available' \
+		'Install BlueZ tools and start Bluetooth to enable this section'
+
+	if provider_available pactl; then
+		emit_capability audio pipewire-audio Audio available user-session pactl \
+			'PipeWire Pulse-compatible session controls are available'
+	elif provider_available wpctl; then
+		emit_capability audio pipewire-audio Audio available user-session wpctl \
+			'WirePlumber session controls are available'
+	else
+		emit_capability audio pipewire-audio Audio unavailable user-session pipewire \
+			'Start PipeWire and install pactl or wpctl'
+	fi
+
+	emit_command_capability power dpms 'Display power management' user-session xset \
+		'X11 DPMS state is available' \
+		'Install xset and open Settings from X11'
+	if provider_available xset && provider_available gsettings && provider_available light-locker; then
+		emit_capability power auto-lock 'Automatic locking' available user-session light-locker \
+			'Light-locker session policy is available'
+	else
+		emit_capability power auto-lock 'Automatic locking' partial user-session light-locker \
+			'Install xset, GLib settings, and light-locker for full support'
+	fi
+
+	if provider_available xdg-settings && provider_available xdg-mime; then
+		emit_capability defaults xdg-defaults 'Default applications' available user-session xdg-utils \
+			'Browser and MIME defaults are readable'
+	else
+		emit_capability defaults xdg-defaults 'Default applications' unavailable user-session xdg-utils \
+			'Install xdg-utils to inspect desktop defaults'
+	fi
+
+	themes_file=${XDG_CONFIG_HOME:-${HOME:-}/.config}/dwm-titus/themes.toml
+	if [ -r "$themes_file" ] || [ -r "$repo_dir/config/themes.toml" ]; then
+		emit_capability appearance themes Themes available user-session themes.toml \
+			'Theme state is available through the managed configuration'
+	else
+		emit_capability appearance themes Themes unavailable user-session themes.toml \
+			'Install or restore the managed theme configuration'
+	fi
+	emit_capability appearance accessibility Accessibility unsupported user-session x11 \
+		'Accessibility settings begin in Phase 5'
+
+	if provider_available dwm-system-health; then
+		emit_capability system health 'System health' available read-only dwm-system-health \
+			'Unprivileged health state is available'
+	else
+		emit_capability system health 'System health' unavailable read-only dwm-system-health \
+			'Install the dwm-system-health helper'
+	fi
+	if trusted_health_helper && { provider_available pkexec || provider_available sudo; }; then
+		emit_capability system authorization 'Administrative authorization' available privileged polkit \
+			'A trusted installed helper and authorization tool are available'
+	else
+		emit_capability system authorization 'Administrative authorization' restricted privileged polkit \
+			'Read-only state remains available; install the trusted system helper for authorized actions'
+	fi
+	emit_capability system administration 'Advanced administration' unsupported delegated fedora-tools \
+		'High-risk administration remains delegated to trusted tools'
+}
+
+case ${1:-} in
+discover)
+	[ "$#" -eq 1 ] || {
+		usage
+		exit 2
+	}
+	discover
+	;;
+-h | --help | help)
+	usage
+	;;
+*)
+	usage
+	exit 2
+	;;
+esac

--- a/tests/test-quickshell-settings-xvfb.sh
+++ b/tests/test-quickshell-settings-xvfb.sh
@@ -122,6 +122,8 @@ section=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME
 	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings currentSection)
 [ "$section" = power ]
 
+# These offsets target the first "displays" section entry; update them if the
+# SettingsWindow navigation layout changes.
 DISPLAY=$display xdotool mousemove "$((x + 120))" "$((y + 170))" click 1
 section=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
 	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings currentSection)
@@ -132,6 +134,13 @@ DISPLAY=$display xdotool type --delay 20 network
 section=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
 	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings currentSection)
 [ "$section" = network ]
+
+# IPC selection clears a search that hides the requested section.
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select audio >/dev/null
+section=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings currentSection)
+[ "$section" = audio ]
 
 DISPLAY=$display xdotool key Escape
 i=0

--- a/tests/test-quickshell-settings-xvfb.sh
+++ b/tests/test-quickshell-settings-xvfb.sh
@@ -1,0 +1,163 @@
+#!/bin/sh
+set -eu
+
+repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+
+for command_name in Xvfb dbus-run-session quickshell xdotool xprop pgrep getconf; do
+	if ! command -v "$command_name" >/dev/null 2>&1; then
+		printf 'SKIP: %s is unavailable\n' "$command_name"
+		exit 77
+	fi
+done
+
+if [ "${DWM_SETTINGS_XVFB_DBUS_SESSION:-0}" != 1 ]; then
+	exec env DWM_SETTINGS_XVFB_DBUS_SESSION=1 dbus-run-session -- "$0" "$@"
+fi
+
+work=$(mktemp -d)
+display=":$((($$ % 400) + 700))"
+cleanup() {
+	set +e
+	[ -n "${quickshell_pid:-}" ] && kill "$quickshell_pid" 2>/dev/null
+	[ -n "${dwm_pid:-}" ] && kill "$dwm_pid" 2>/dev/null
+	[ -n "${xvfb_pid:-}" ] && kill "$xvfb_pid" 2>/dev/null
+	rm -rf "$work"
+}
+trap cleanup EXIT HUP INT TERM
+
+home=$work/home
+runtime=$work/runtime
+config_home=$home/.config
+data_home=$home/.local/share
+mkdir -p "$config_home/quickshell" "$config_home/dwm-titus" \
+	"$data_home/dwm-titus/scripts" "$runtime"
+chmod 700 "$runtime"
+cp -a "$repo/config/quickshell/." "$config_home/quickshell/"
+cp "$repo/config/"*.toml "$config_home/dwm-titus/"
+cp "$repo/scripts/dwm-settings-provider" "$repo/scripts/dwm-system-health" \
+	"$repo/scripts/dwm-quickshell-controlcenter" "$repo/scripts/dwm-quickshell-controls" \
+	"$repo/scripts/dwm-quickshell-network" "$repo/scripts/dwm-diagnostics" \
+	"$repo/scripts/dwm-lock" "$data_home/dwm-titus/scripts/"
+
+Xvfb "$display" -screen 0 1280x800x24 -nolisten tcp -extension GLX >"$work/xvfb.log" 2>&1 &
+xvfb_pid=$!
+
+i=0
+while [ "$i" -lt 100 ]; do
+	if DISPLAY=$display xprop -root >/dev/null 2>&1; then
+		break
+	fi
+	i=$((i + 1))
+	sleep 0.05
+done
+DISPLAY=$display xprop -root >/dev/null
+
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime "$repo/dwm" >"$work/dwm.log" 2>&1 &
+dwm_pid=$!
+
+env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
+	XDG_DATA_HOME="$data_home" XDG_RUNTIME_DIR="$runtime" \
+	PATH="$data_home/dwm-titus/scripts:$PATH" \
+	quickshell --no-duplicate >"$work/quickshell.log" 2>&1 &
+quickshell_pid=$!
+
+config=$config_home/quickshell/shell.qml
+i=0
+while [ "$i" -lt 200 ]; do
+	if DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings open >/dev/null 2>&1; then
+		break
+	fi
+	i=$((i + 1))
+	sleep 0.05
+done
+
+window=
+i=0
+while [ "$i" -lt 200 ]; do
+	window=$(DISPLAY=$display xdotool search --onlyvisible --name '^dwm settings$' 2>/dev/null | head -1 || true)
+	[ -n "$window" ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+
+if [ -z "$window" ]; then
+	printf 'Settings window did not open\n' >&2
+	tail -60 "$work/quickshell.log" >&2
+	exit 1
+fi
+
+geometry=$(DISPLAY=$display xdotool getwindowgeometry --shell "$window")
+width=$(printf '%s\n' "$geometry" | awk -F= '$1 == "WIDTH" { print $2 }')
+height=$(printf '%s\n' "$geometry" | awk -F= '$1 == "HEIGHT" { print $2 }')
+x=$(printf '%s\n' "$geometry" | awk -F= '$1 == "X" { print $2 }')
+y=$(printf '%s\n' "$geometry" | awk -F= '$1 == "Y" { print $2 }')
+[ "$width" = 980 ]
+[ "$height" = 620 ]
+
+i=0
+while [ "$i" -lt 100 ]; do
+	status=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings status 2>/dev/null || true)
+	[ "$status" = ready ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$status" = ready ]
+
+section=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings currentSection)
+[ "$section" = displays ]
+
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select audio >/dev/null
+section=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings currentSection)
+[ "$section" = audio ]
+
+DISPLAY=$display xdotool windowactivate --sync "$window"
+DISPLAY=$display xdotool key Down
+section=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings currentSection)
+[ "$section" = power ]
+
+DISPLAY=$display xdotool mousemove "$((x + 120))" "$((y + 170))" click 1
+section=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings currentSection)
+[ "$section" = displays ]
+
+DISPLAY=$display xdotool windowactivate --sync "$window"
+DISPLAY=$display xdotool type --delay 20 network
+section=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings currentSection)
+[ "$section" = network ]
+
+DISPLAY=$display xdotool key Escape
+i=0
+while [ "$i" -lt 100 ]; do
+	if ! DISPLAY=$display xdotool search --onlyvisible --name '^dwm settings$' >/dev/null 2>&1; then
+		break
+	fi
+	i=$((i + 1))
+	sleep 0.05
+done
+if DISPLAY=$display xdotool search --onlyvisible --name '^dwm settings$' >/dev/null 2>&1; then
+	printf 'Settings window did not close on Escape\n' >&2
+	exit 1
+fi
+
+if pgrep -f '[d]wm-settings-provider discover$' >/dev/null; then
+	printf 'Settings capability provider remained active after close\n' >&2
+	exit 1
+fi
+
+clock_ticks=$(getconf CLK_TCK)
+before=$(awk '{ print $14 + $15 }' "/proc/$quickshell_pid/stat")
+sleep 2
+after=$(awk '{ print $14 + $15 }' "/proc/$quickshell_pid/stat")
+cpu_percent=$(awk -v delta="$((after - before))" -v ticks="$clock_ticks" \
+	'BEGIN { printf "%.2f", (delta * 100) / (ticks * 2) }')
+awk -v cpu="$cpu_percent" 'BEGIN { exit !(cpu < 10.0) }'
+
+printf 'Quickshell Settings Xvfb and closed-idle sample: PASS (%s%% CPU)\n' "$cpu_percent"

--- a/tests/test-settings.sh
+++ b/tests/test-settings.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+set -eu
+
+repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+provider=$repo/scripts/dwm-settings-provider
+launcher=$repo/scripts/dwm-settings
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+make_tools() {
+	directory=$1
+	shift
+	mkdir -p "$directory"
+	for tool in "$@"; do
+		target=$(command -v "$tool")
+		ln -s "$target" "$directory/$tool"
+	done
+}
+
+make_stub() {
+	path=$1
+	mkdir -p "${path%/*}"
+	printf '%s\n' '#!/bin/sh' 'exit 0' >"$path"
+	chmod +x "$path"
+}
+
+base_bin=$work/base-bin
+fedora_bin=$work/fedora-bin
+make_tools "$base_bin" dirname awk tr stat find grep
+cp -a "$base_bin" "$fedora_bin"
+
+for command_name in xrandr nmcli bluetoothctl pactl xset gsettings light-locker \
+	xdg-settings xdg-mime pkexec sudo; do
+	make_stub "$fedora_bin/$command_name"
+done
+
+mkdir -p "$work/fedora-config/dwm-titus" "$work/debian-config/dwm-titus"
+cp "$repo/config/themes.toml" "$work/fedora-config/dwm-titus/themes.toml"
+cp "$repo/config/themes.toml" "$work/debian-config/dwm-titus/themes.toml"
+
+cat >"$work/fedora-os-release" <<'EOF'
+ID=fedora
+ID_LIKE="rhel"
+PRETTY_NAME="Fedora Linux 44"
+EOF
+
+fedora_output=$(PATH="$fedora_bin" XDG_CONFIG_HOME="$work/fedora-config" \
+	DWM_SETTINGS_OS_RELEASE="$work/fedora-os-release" "$provider" discover)
+printf '%s\n' "$fedora_output" | grep -Fqx 'settings-protocol	1'
+printf '%s\n' "$fedora_output" | grep -Fqx 'platform	fedora	rhel	Fedora Linux 44'
+printf '%s\n' "$fedora_output" | grep -Fqx \
+	'capability	displays	randr	Display discovery	available	read-only	xrandr	RandR display state is available'
+printf '%s\n' "$fedora_output" | grep -Fqx \
+	'capability	input	input-devices	Input devices	unsupported	user-session	xinput	Input device settings begin in Phase 2'
+printf '%s\n' "$fedora_output" | grep -Fqx \
+	'capability	network	networkmanager	NetworkManager	available	delegated	nmcli	NetworkManager state is available'
+printf '%s\n' "$fedora_output" | grep -Fqx \
+	'capability	audio	pipewire-audio	Audio	available	user-session	pactl	PipeWire Pulse-compatible session controls are available'
+printf '%s\n' "$fedora_output" | grep -Eq \
+	'^capability	system	authorization	Administrative authorization	(available|restricted)	privileged	polkit	'
+
+cat >"$work/debian-os-release" <<'EOF'
+ID=debian
+PRETTY_NAME="Debian GNU/Linux 13"
+EOF
+
+debian_output=$(PATH="$base_bin" XDG_CONFIG_HOME="$work/debian-config" \
+	DWM_SETTINGS_OS_RELEASE="$work/debian-os-release" "$provider" discover)
+printf '%s\n' "$debian_output" | grep -Fqx 'platform	debian	debian	Debian GNU/Linux 13'
+printf '%s\n' "$debian_output" | grep -Fqx \
+	'capability	network	networkmanager	NetworkManager	unavailable	delegated	nmcli	Install and start NetworkManager to enable this section'
+printf '%s\n' "$debian_output" | grep -Fqx \
+	'capability	bluetooth	bluez	Bluetooth	unavailable	delegated	bluetoothctl	Install BlueZ tools and start Bluetooth to enable this section'
+printf '%s\n' "$debian_output" | grep -Fqx \
+	'capability	system	authorization	Administrative authorization	restricted	privileged	polkit	Read-only state remains available; install the trusted system helper for authorized actions'
+
+if "$provider" unknown 2>"$work/provider.err"; then
+	exit 1
+fi
+grep -Fq 'usage:' "$work/provider.err"
+
+mkdir -p "$work/home/.config/quickshell" "$work/home/.local/share/dwm-titus/config/quickshell" "$work/launcher-bin"
+: >"$work/home/.config/quickshell/shell.qml"
+cat >"$work/launcher-bin/quickshell" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$@" >"$DWM_SETTINGS_LAUNCH_LOG"
+EOF
+chmod +x "$work/launcher-bin/quickshell"
+
+PATH="$work/launcher-bin:$PATH" HOME="$work/home" \
+	XDG_CONFIG_HOME="$work/home/.config" XDG_DATA_HOME="$work/home/.local/share" \
+	DWM_SETTINGS_LAUNCH_LOG="$work/launch.log" "$launcher" status
+grep -Fqx 'ipc' "$work/launch.log"
+grep -Fqx -- '--path' "$work/launch.log"
+grep -Fqx "$work/home/.config/quickshell/shell.qml" "$work/launch.log"
+grep -Fqx 'settings' "$work/launch.log"
+grep -Fqx 'status' "$work/launch.log"
+
+if PATH="$work/launcher-bin:$PATH" HOME="$work/home" \
+	XDG_CONFIG_HOME="$work/home/.config" XDG_DATA_HOME="$work/home/.local/share" \
+	DWM_SETTINGS_LAUNCH_LOG="$work/launch.log" "$launcher" invalid 2>"$work/launcher.err"; then
+	exit 1
+fi
+grep -Fq 'usage:' "$work/launcher.err"
+
+grep -Fq 'target: "settings"' "$repo/config/quickshell/shell.qml"
+grep -Fq 'providerProcess.running = false' "$repo/config/quickshell/settings/SettingsModel.qml"
+grep -Fq 'Commands.settingsProviderCommand("discover")' "$repo/config/quickshell/settings/SettingsModel.qml"
+grep -Fq 'title: "dwm settings"' "$repo/config/quickshell/settings/SettingsWindow.qml"
+grep -Fq 'label: "Settings  >"' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
+grep -Fq 'root.settingsModel.open()' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
+grep -Fq '{ title="dwm settings",             isfloating=1, alwaysontop=1 }' \
+	"$repo/config/window-rules.toml"
+
+arch_qml=$(bash -c '. "$1"; dwm_packages arch qml-development' sh \
+	"$repo/scripts/dwm-packages.sh")
+rhel_qml=$(bash -c '. "$1"; dwm_packages rhel qml-development' sh \
+	"$repo/scripts/dwm-packages.sh")
+debian_qml=$(bash -c '. "$1"; dwm_packages debian qml-development' sh \
+	"$repo/scripts/dwm-packages.sh")
+[ "$arch_qml" = qt6-declarative ]
+[ "$rhel_qml" = qt6-qtdeclarative-devel ]
+[ "$debian_qml" = qt6-declarative-dev-tools ]
+
+if grep -Eq '^[[:space:]]*(sudo|pkexec)([[:space:]]|$)' "$provider"; then
+	printf 'Settings discovery must not execute an elevation tool.\n' >&2
+	exit 1
+fi
+
+printf 'Settings capability provider and shell contract: PASS\n'

--- a/tests/test-settings.sh
+++ b/tests/test-settings.sh
@@ -24,9 +24,16 @@ make_stub() {
 	chmod +x "$path"
 }
 
+make_failing_stub() {
+	path=$1
+	mkdir -p "${path%/*}"
+	printf '%s\n' '#!/bin/sh' 'exit 1' >"$path"
+	chmod +x "$path"
+}
+
 base_bin=$work/base-bin
 fedora_bin=$work/fedora-bin
-make_tools "$base_bin" dirname awk tr stat find grep
+make_tools "$base_bin" dirname awk tr stat find grep timeout
 cp -a "$base_bin" "$fedora_bin"
 
 for command_name in xrandr nmcli bluetoothctl pactl xset gsettings light-locker \
@@ -38,11 +45,8 @@ mkdir -p "$work/fedora-config/dwm-titus" "$work/debian-config/dwm-titus"
 cp "$repo/config/themes.toml" "$work/fedora-config/dwm-titus/themes.toml"
 cp "$repo/config/themes.toml" "$work/debian-config/dwm-titus/themes.toml"
 
-cat >"$work/fedora-os-release" <<'EOF'
-ID=fedora
-ID_LIKE="rhel"
-PRETTY_NAME="Fedora Linux 44"
-EOF
+printf 'ID=fedora\nID_LIKE="rhel"\nPRETTY_NAME="Fedora\tLinux 44"\n' \
+	>"$work/fedora-os-release"
 
 fedora_output=$(PATH="$fedora_bin" XDG_CONFIG_HOME="$work/fedora-config" \
 	DWM_SETTINGS_OS_RELEASE="$work/fedora-os-release" "$provider" discover)
@@ -68,11 +72,27 @@ debian_output=$(PATH="$base_bin" XDG_CONFIG_HOME="$work/debian-config" \
 	DWM_SETTINGS_OS_RELEASE="$work/debian-os-release" "$provider" discover)
 printf '%s\n' "$debian_output" | grep -Fqx 'platform	debian	debian	Debian GNU/Linux 13'
 printf '%s\n' "$debian_output" | grep -Fqx \
-	'capability	network	networkmanager	NetworkManager	unavailable	delegated	nmcli	Install and start NetworkManager to enable this section'
+	'capability	network	networkmanager	NetworkManager	unavailable	delegated	nmcli	Install NetworkManager to enable this section'
 printf '%s\n' "$debian_output" | grep -Fqx \
-	'capability	bluetooth	bluez	Bluetooth	unavailable	delegated	bluetoothctl	Install BlueZ tools and start Bluetooth to enable this section'
+	'capability	bluetooth	bluez	Bluetooth	unavailable	delegated	bluetoothctl	Install BlueZ tools to enable this section'
 printf '%s\n' "$debian_output" | grep -Fqx \
 	'capability	system	authorization	Administrative authorization	restricted	privileged	polkit	Read-only state remains available; install the trusted system helper for authorized actions'
+
+runtime_down_bin=$work/runtime-down-bin
+cp -a "$fedora_bin" "$runtime_down_bin"
+for command_name in xrandr nmcli bluetoothctl pactl xset; do
+	make_failing_stub "$runtime_down_bin/$command_name"
+done
+runtime_down_output=$(PATH="$runtime_down_bin" XDG_CONFIG_HOME="$work/fedora-config" \
+	DWM_SETTINGS_OS_RELEASE="$work/fedora-os-release" "$provider" discover)
+printf '%s\n' "$runtime_down_output" | grep -Fqx \
+	'capability	displays	randr	Display discovery	unavailable	read-only	xrandr	RandR tools are installed, but no responsive X11 display is available'
+printf '%s\n' "$runtime_down_output" | grep -Fqx \
+	'capability	network	networkmanager	NetworkManager	unavailable	delegated	nmcli	NetworkManager is installed, but its service is not responding'
+printf '%s\n' "$runtime_down_output" | grep -Fqx \
+	'capability	bluetooth	bluez	Bluetooth	unavailable	delegated	bluetoothctl	BlueZ tools are installed, but no daemon or adapter is responding'
+printf '%s\n' "$runtime_down_output" | grep -Fqx \
+	'capability	audio	pipewire-audio	Audio	unavailable	user-session	pipewire	Audio tools are installed, but no PipeWire or Pulse session is responding'
 
 if "$provider" unknown 2>"$work/provider.err"; then
 	exit 1
@@ -103,9 +123,18 @@ if PATH="$work/launcher-bin:$PATH" HOME="$work/home" \
 fi
 grep -Fq 'usage:' "$work/launcher.err"
 
+rm -f "$work/home/.config/quickshell/shell.qml"
+if PATH="$work/launcher-bin:$PATH" HOME="$work/home" \
+	XDG_CONFIG_HOME="$work/home/.config" XDG_DATA_HOME="$work/home/.local/share" \
+	DWM_SETTINGS_LAUNCH_LOG="$work/launch.log" "$launcher" status 2>"$work/missing-config.err"; then
+	exit 1
+fi
+grep -Fq 'managed Quickshell configuration not found' "$work/missing-config.err"
+
 grep -Fq 'target: "settings"' "$repo/config/quickshell/shell.qml"
 grep -Fq 'providerProcess.running = false' "$repo/config/quickshell/settings/SettingsModel.qml"
 grep -Fq 'Commands.settingsProviderCommand("discover")' "$repo/config/quickshell/settings/SettingsModel.qml"
+grep -Fq 'root.searchQuery = ""' "$repo/config/quickshell/settings/SettingsModel.qml"
 grep -Fq 'title: "dwm settings"' "$repo/config/quickshell/settings/SettingsWindow.qml"
 grep -Fq 'label: "Settings  >"' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
 grep -Fq 'root.settingsModel.open()' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"


### PR DESCRIPTION
## Summary

- add one searchable, keyboard- and mouse-navigable Quickshell Settings window with Control Center, IPC, and command-line entry points
- add a versioned read-only capability-discovery provider with Fedora-first detection and clean secondary-platform fallback states
- define Settings helper, UI-state, authorization, rollback, packaging, and validation contracts
- centralize cross-family QML development package mappings without expanding runtime or Kickstart package sets
- record Phase 1 completion and rotate TASKS.md to the Phase 2 Displays and Input work

## Why

Phase 1 of the Fedora-first desktop roadmap requires a discoverable Settings foundation before any new desktop mutations are added. This establishes the application and safety boundaries while preserving all existing Control Center, launcher, hotkey, and runtime behavior.

## User impact

Control Center -> Utilities -> Settings now opens a read-only capability overview. Users can search and navigate sections, refresh provider discovery, and see available, partial, restricted, unavailable, and unsupported capabilities without changing system state or requesting elevation.

## Validation

- `make check`
- `make check-quickshell-qml`
- `make check-quickshell-settings-xvfb`
- `make check-xvfb-runtime`
- `make check-quickshell-health-xvfb`
- `mdbook test docs`
- `mdbook build docs`
- Markdownlint, ShellCheck, shfmt, and `git diff --check`

Nested X11 validated the 980x620 Settings window, IPC, search, keyboard and mouse navigation, Escape close, provider cleanup, and a two-second closed-window sample of 0.00% CPU.

## Limitations

Phase 1 Settings is intentionally read-only. Real secondary-platform Settings sessions and real display/input hardware changes were not tested; those are scoped to Phase 2.