### PR TITLE
Add compact battery status widget

### DIFF
--- a/config/quickshell/panel/DwmPanel.qml
+++ b/config/quickshell/panel/DwmPanel.qml
@@ -10,6 +10,23 @@ pragma ComponentBehavior: Bound
 PanelWindow {
     id: root
 
+    function batteryIcon(percent, status) {
+        if (status.toLowerCase() === "charging") {
+            return "󰂄";
+        }
+
+        if (percent >= 90) return "󰁹";
+        if (percent >= 80) return "󰂂";
+        if (percent >= 70) return "󰂁";
+        if (percent >= 60) return "󰂀";
+        if (percent >= 50) return "󰁿";
+        if (percent >= 40) return "󰁾";
+        if (percent >= 30) return "󰁽";
+        if (percent >= 20) return "󰁼";
+        if (percent >= 10) return "󰁻";
+        return "󰂎";
+    }
+
     required property var state
     required property var clock
     required property var networkModel
@@ -161,6 +178,37 @@ PanelWindow {
                     TrayArea {}
 
                     PanelPill {
+                        id: batteryPill
+                        visible: root.state.batteryAvailable
+                        Layout.preferredWidth: batteryRow.implicitWidth + Theme.compactWidgetHorizontalPadding * 2
+                        Layout.preferredHeight: Theme.compactWidgetSize
+
+                        RowLayout {
+                            id: batteryRow
+                            anchors.centerIn: parent
+                            spacing: Theme.compactSpacing
+
+                            IconText {
+                                text: root.batteryIcon(root.state.batteryPercent, root.state.batteryStatus)
+                                color: Theme.textStrong
+                                font.pixelSize: Math.round((Theme.panelFontSize + 1) * 1.1)
+                            }
+
+                            UiText {
+                                text: root.state.batteryPercent.toString() + "%"
+                                color: Theme.textStrong
+                                font.pixelSize: Theme.panelFontSize
+                            }
+                        }
+
+                        MouseArea {
+                            id: batteryMouse
+                            anchors.fill: parent
+                            hoverEnabled: true
+                        }
+                    }
+
+                    PanelPill {
                         visible: root.controlCenterModel.showBluetoothWidget
                         Layout.preferredWidth: bluetoothRow.implicitWidth + Theme.compactWidgetHorizontalPadding * 2
                         Layout.preferredHeight: Theme.compactWidgetSize
@@ -281,6 +329,15 @@ PanelWindow {
         anchorItem: logoButton
         label: "Control Center"
         anchorY: Theme.panelHeight
+    }
+
+    PanelTooltip {
+        visible: root.state.batteryAvailable && batteryMouse.containsMouse
+        anchorWindow: root
+        anchorItem: batteryPill
+        label: root.state.batteryPercent.toString() + "% - " + root.state.batteryStatus
+        anchorY: Theme.panelHeight
+        rightAligned: true
     }
 
     PanelTooltip {

--- a/config/quickshell/state/DwmState.qml
+++ b/config/quickshell/state/DwmState.qml
@@ -12,6 +12,9 @@ Scope {
     property string activeWindowClass: "application-x-executable"
     property string statusText: ""
     property var statusSegments: []
+    property bool batteryAvailable: false
+    property int batteryPercent: 0
+    property string batteryStatus: ""
 
     function parseState(text) {
         const lines = text.trim().split("\n");
@@ -59,6 +62,10 @@ Scope {
     function updateStatusSegments() {
         const text = root.statusText.trim();
 
+        root.batteryAvailable = false;
+        root.batteryPercent = 0;
+        root.batteryStatus = "";
+
         if (text.length === 0 || text.indexOf("dwm-titus:") === 0) {
             root.statusSegments = [];
             return;
@@ -66,6 +73,18 @@ Scope {
 
         root.statusSegments = text.split(/\s+\|\s+| {2,}/).filter(function(segment) {
             const trimmed = segment.trim();
+
+            if (trimmed.indexOf("BAT ") === 0) {
+                const battery = trimmed.match(/^BAT\s+([0-9]+)%\s*(.*)$/);
+
+                if (battery) {
+                    root.batteryAvailable = true;
+                    root.batteryPercent = Math.max(0, Math.min(100, parseInt(battery[1], 10)));
+                    root.batteryStatus = battery[2].trim();
+                }
+
+                return false;
+            }
 
             return trimmed.length > 0 && trimmed !== "AC"
                 && trimmed.indexOf("NET ") !== 0 && trimmed.indexOf("VOL ") !== 0;

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -373,6 +373,10 @@ grep -Fq 'onFocusRequested: windowId => root.state.focusWindow(windowId)' "$repo
 grep -Fq 'source: Icons.launcherIcon(root.app.appClass)' "$repo/config/quickshell/panel/RunningAppItem.qml"
 grep -Fq 'root.state.activeWindowTitle' "$repo/config/quickshell/panel/DwmPanel.qml"
 grep -Fq 'root.state.statusSegments' "$repo/config/quickshell/panel/DwmPanel.qml"
+grep -Fq 'root.state.batteryPercent.toString() + "%"' "$repo/config/quickshell/panel/DwmPanel.qml"
+grep -Fq 'visible: root.state.batteryAvailable' "$repo/config/quickshell/panel/DwmPanel.qml"
+grep -Fq 'root.batteryAvailable = true;' "$repo/config/quickshell/state/DwmState.qml"
+grep -Fq 'trimmed.indexOf("BAT ") === 0' "$repo/config/quickshell/state/DwmState.qml"
 grep -Fq 'color: Theme.barBackground' "$repo/config/quickshell/panel/DwmPanel.qml"
 if grep -Fq 'color: Theme.transparent' "$repo/config/quickshell/panel/DwmPanel.qml"; then
 	exit 1


### PR DESCRIPTION
## What changed

- replace the verbose battery status pill with a compact battery icon and percentage
- show a charging glyph while charging and level-specific glyphs while discharging
- retain the full percentage and charge state in a hover tooltip
- keep unrelated status segments on the existing generic status path

## Why

The panel previously rendered the raw `BAT 37% Charging` text next to tray icons. That made battery status visually oversized and easy to confuse with the separate TUXEDO Control Center tray icon.

## Validation

- `make check-quickshell-controlcenter`
- `make check-quickshell-qml`
- `make check-quickshell-health-xvfb`
- clean build with `make clean && make`
- installed and verified in the live managed Quickshell session
