### PR TITLE
Clean up Control Center menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ versions from `config.mk`.
 
 ### Changed
 
+- The Control Center now uses one clean dropdown card with direct Applications
+  and utility entries, in-place secondary pages, and consistent click-away and
+  Escape dismissal.
 - Documentation is built and tested from `docs/src/`; generated mdBook output
   is no longer version controlled.
 - Release guidance requires validated, committed source and explicit platform

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ After login, use these first:
 | <kbd>SUPER</kbd> + <kbd>F1</kbd> | Open control center |
 | <kbd>SUPER</kbd> + <kbd>/</kbd> | Open keybind viewer |
 
-Open Control Center -> Utilities -> Settings for the unified read-only
+Open Control Center -> Settings for the unified read-only
 capability overview, or run `dwm-settings open` from a terminal.
 
 ---

--- a/config/quickshell/controlcenter/ControlCenterModel.qml
+++ b/config/quickshell/controlcenter/ControlCenterModel.qml
@@ -54,6 +54,7 @@ Scope {
 
     function close() {
         root.visible = false;
+        root.page = "overview";
         root.message = "";
     }
 
@@ -93,6 +94,10 @@ Scope {
 
     function openOverview() {
         root.openPage("overview", "", null);
+    }
+
+    function openWidgets() {
+        root.openPage("widgets", "", null);
     }
 
     function openActions() {

--- a/config/quickshell/controlcenter/ControlCenterWindow.qml
+++ b/config/quickshell/controlcenter/ControlCenterWindow.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Layouts
-import Quickshell
 import qs.core
 
 pragma ComponentBehavior: Bound
@@ -10,12 +9,13 @@ ClickAwayPopup {
 
     required property var controlCenterModel
     required property var healthModel
+    required property var launcherModel
     required property var panelWindow
     required property var powerMenuModel
     required property var settingsModel
 
     readonly property int cardWidth: Theme.controlCenterWidth
-    readonly property int gap: Theme.controlCenterGap
+    readonly property int maximumHeight: Math.max(240, panelWindow.screen.height - Theme.panelHeight - Theme.popupMargin)
     readonly property var powerPresets: [
         { "label": "5m", "seconds": 300 },
         { "label": "10m", "seconds": 600 },
@@ -23,14 +23,13 @@ ClickAwayPopup {
         { "label": "30m", "seconds": 1800 },
         { "label": "1h", "seconds": 3600 }
     ]
-    property string sidePanel: "none"
 
-    function sideTitle() {
-        if (sidePanel === "utilities") return "Utilities";
-        if (sidePanel === "actions") return "Quick Actions";
-        if (sidePanel === "appearance") return "Appearance";
-        if (sidePanel === "power") return "Power Settings";
-        return "Widgets";
+    function pageTitle() {
+        if (controlCenterModel.page === "widgets") return "Bar Widgets";
+        if (controlCenterModel.page === "actions") return "Quick Actions";
+        if (controlCenterModel.page === "appearance") return "Appearance";
+        if (controlCenterModel.page === "power") return "Power Settings";
+        return "Control Center";
     }
 
     function formatDuration(seconds) {
@@ -43,32 +42,59 @@ ClickAwayPopup {
         return seconds + "s";
     }
 
+    function openApplications() {
+        root.controlCenterModel.close();
+        Qt.callLater(function() {
+            root.launcherModel.open();
+        });
+    }
+
+    function openSessionPower() {
+        root.controlCenterModel.close();
+        Qt.callLater(function() {
+            root.powerMenuModel.open("controlcenter");
+        });
+    }
+
     function openSystemHealth() {
         root.controlCenterModel.close();
-        root.healthModel.openOnScreen(root.panelWindow.screen);
+        Qt.callLater(function() {
+            root.healthModel.openOnScreen(root.panelWindow.screen);
+        });
     }
 
     function openSettings() {
         root.controlCenterModel.close();
-        root.settingsModel.open();
+        Qt.callLater(function() {
+            root.settingsModel.open();
+        });
     }
 
-    function openPowerSettings() {
-        root.controlCenterModel.openPower();
-        root.sidePanel = "power";
+    function openKeybinds() {
+        root.controlCenterModel.close();
+        Qt.callLater(function() {
+            root.controlCenterModel.openKeybinds();
+        });
+    }
+
+    function openSystemInfo() {
+        root.controlCenterModel.close();
+        Qt.callLater(function() {
+            root.controlCenterModel.openInfo();
+        });
     }
 
     visible: controlCenterModel.visible
     targetWindow: panelWindow
     popupX: Theme.controlCenterX
     popupY: Theme.panelHeight
-    popupWidth: cardWidth + (sidePanel === "none" ? 0 : cardWidth + gap)
-    popupHeight: sidePanel === "none" ? controlCard.implicitHeight : Math.max(controlCard.implicitHeight, sideCard.implicitHeight)
+    popupWidth: cardWidth
+    popupHeight: Math.min(controlCard.implicitHeight, maximumHeight)
     onDismissed: controlCenterModel.close()
 
     onVisibleChanged: {
         if (visible) {
-            sidePanel = "none";
+            root.powerMenuModel.close();
             Qt.callLater(function() {
                 controlCard.forceActiveFocus();
             });
@@ -77,69 +103,148 @@ ClickAwayPopup {
         }
     }
 
-    component Tile: Rectangle {
-        id: tile
+    Connections {
+        target: root.controlCenterModel
+
+        function onPageChanged() {
+            menuFlick.contentY = 0;
+            Qt.callLater(function() {
+                controlCard.forceActiveFocus();
+            });
+        }
+    }
+
+    component MenuRow: Rectangle {
+        id: menuRow
+
+        property string label: ""
+        property string detail: ""
+        property bool active: false
+        property bool navigates: false
+        signal activated()
+
+        implicitHeight: 32
+        radius: Theme.smallRadius
+        color: rowMouse.containsMouse ? Theme.surfaceHover : Theme.transparent
+
+        UiText {
+            anchors.left: parent.left
+            anchors.leftMargin: 9
+            anchors.right: rowDetail.left
+            anchors.rightMargin: 8
+            anchors.verticalCenter: parent.verticalCenter
+            text: menuRow.label
+            color: menuRow.active ? Theme.accentSecondary : rowMouse.containsMouse ? Theme.textStrong : Theme.text
+            elide: Text.ElideRight
+        }
+
+        UiText {
+            id: rowDetail
+
+            anchors.right: parent.right
+            anchors.rightMargin: 9
+            anchors.verticalCenter: parent.verticalCenter
+            text: menuRow.detail.length > 0 ? menuRow.detail : menuRow.navigates ? ">" : ""
+            color: menuRow.active ? Theme.accentSecondary : Theme.textMuted
+        }
+
+        MouseArea {
+            id: rowMouse
+
+            anchors.fill: parent
+            enabled: menuRow.enabled
+            hoverEnabled: true
+            cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+            onClicked: menuRow.activated()
+        }
+    }
+
+    component PresetButton: Rectangle {
+        id: presetButton
 
         property string label: ""
         property bool active: false
         signal activated()
 
-        implicitHeight: 26
+        implicitHeight: 28
         radius: Theme.smallRadius
-        color: active ? Theme.surfaceActive : tileMouse.containsMouse ? Theme.surfaceHover : Theme.surface
-        border.color: active ? Theme.accentSecondary : tileMouse.containsMouse ? Theme.borderStrong : Theme.border
+        color: active ? Theme.surfaceActive : presetMouse.containsMouse ? Theme.surfaceHover : Theme.surface
+        border.color: active ? Theme.accentSecondary : presetMouse.containsMouse ? Theme.borderStrong : Theme.border
         border.width: Theme.pillBorderWidth
 
         UiText {
             anchors.centerIn: parent
-            text: tile.label
-            color: tile.active ? Theme.accentSecondary : tileMouse.containsMouse ? Theme.textStrong : Theme.text
+            text: presetButton.label
+            color: presetButton.active ? Theme.accentSecondary : Theme.text
         }
 
         MouseArea {
-            id: tileMouse
+            id: presetMouse
+
             anchors.fill: parent
-            enabled: tile.enabled
+            enabled: presetButton.enabled
             hoverEnabled: true
             cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-            onClicked: tile.activated()
+            onClicked: presetButton.activated()
         }
     }
 
-    RowLayout {
+    ShellSurface {
+        id: controlCard
+
         anchors.fill: parent
-        spacing: root.gap
+        implicitHeight: menuColumn.implicitHeight + margin * 2
+        margin: 10
+        focus: true
 
-        ShellSurface {
-            id: controlCard
-
-            Layout.preferredWidth: root.cardWidth
-            Layout.maximumHeight: implicitHeight
-            Layout.alignment: Qt.AlignTop
-            margin: 12
-            implicitHeight: controlColumn.implicitHeight + margin * 2
-            focus: true
-
-            Keys.onPressed: function(event) {
-                if (event.key === Qt.Key_Escape) {
-                    root.controlCenterModel.close();
-                    event.accepted = true;
-                }
+        Keys.onPressed: function(event) {
+            if (event.key === Qt.Key_Escape) {
+                root.controlCenterModel.close();
+                event.accepted = true;
             }
+        }
+
+        Flickable {
+            id: menuFlick
+
+            anchors.fill: parent
+            contentWidth: width
+            contentHeight: menuColumn.implicitHeight
+            boundsBehavior: Flickable.StopAtBounds
+            clip: true
 
             ColumnLayout {
-                id: controlColumn
-                width: parent.width
-                spacing: 8
+                id: menuColumn
+
+                width: menuFlick.width
+                spacing: 4
 
                 RowLayout {
                     Layout.fillWidth: true
+                    Layout.preferredHeight: 26
+                    spacing: 8
+
+                    UiText {
+                        visible: root.controlCenterModel.page !== "overview"
+                        text: "< Back"
+                        color: backMouse.containsMouse ? Theme.accent : Theme.textMuted
+
+                        MouseArea {
+                            id: backMouse
+
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: root.controlCenterModel.openOverview()
+                        }
+                    }
 
                     UiText {
                         Layout.fillWidth: true
-                        text: "Control"
+                        text: root.pageTitle()
                         color: Theme.textStrong
-                        font.letterSpacing: 2
+                        font.letterSpacing: root.controlCenterModel.page === "overview" ? 2 : 1
+                        elide: Text.ElideRight
                     }
 
                     UiText {
@@ -148,6 +253,7 @@ ClickAwayPopup {
 
                         MouseArea {
                             id: closeMouse
+
                             anchors.fill: parent
                             hoverEnabled: true
                             cursorShape: Qt.PointingHandCursor
@@ -164,78 +270,112 @@ ClickAwayPopup {
                     elide: Text.ElideRight
                 }
 
-                Rectangle { Layout.fillWidth: true; Layout.preferredHeight: 1; color: Theme.border }
-
-                UiText { text: "Actions"; color: Theme.textMuted; font.letterSpacing: 1 }
-                Tile {
+                Rectangle {
                     Layout.fillWidth: true
-                    label: "Reload QS-Config"
-                    enabled: !root.controlCenterModel.busy
-                    onActivated: root.controlCenterModel.runAction("restart-quickshell")
+                    Layout.preferredHeight: 1
+                    color: Theme.border
                 }
-                Tile {
+
+                ColumnLayout {
                     Layout.fillWidth: true
-                    label: "Power  >"
-                    onActivated: {
-                        root.powerMenuModel.open("controlcenter");
+                    visible: root.controlCenterModel.page === "overview"
+                    spacing: 2
+
+                    SectionLabel { label: "Launch" }
+
+                    MenuRow {
+                        Layout.fillWidth: true
+                        label: "Applications"
+                        onActivated: root.openApplications()
+                    }
+                    MenuRow {
+                        Layout.fillWidth: true
+                        label: "Power"
+                        navigates: true
+                        onActivated: root.openSessionPower()
+                    }
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 1
+                        Layout.topMargin: 3
+                        Layout.bottomMargin: 3
+                        color: Theme.border
+                    }
+
+                    SectionLabel { label: "Desktop" }
+
+                    MenuRow {
+                        Layout.fillWidth: true
+                        label: "Bar Widgets"
+                        navigates: true
+                        onActivated: root.controlCenterModel.openWidgets()
+                    }
+                    MenuRow {
+                        Layout.fillWidth: true
+                        label: "Quick Actions"
+                        navigates: true
+                        onActivated: root.controlCenterModel.openActions()
+                    }
+                    MenuRow {
+                        Layout.fillWidth: true
+                        label: "Appearance"
+                        navigates: true
+                        onActivated: root.controlCenterModel.openAppearance()
+                    }
+                    MenuRow {
+                        Layout.fillWidth: true
+                        label: "Power Settings"
+                        navigates: true
+                        onActivated: root.controlCenterModel.openPower()
+                    }
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 1
+                        Layout.topMargin: 3
+                        Layout.bottomMargin: 3
+                        color: Theme.border
+                    }
+
+                    SectionLabel { label: "Utilities" }
+
+                    MenuRow {
+                        Layout.fillWidth: true
+                        label: "Settings"
+                        onActivated: root.openSettings()
+                    }
+                    MenuRow {
+                        Layout.fillWidth: true
+                        label: "System Health"
+                        onActivated: root.openSystemHealth()
+                    }
+                    MenuRow {
+                        Layout.fillWidth: true
+                        label: "Keybinds"
+                        onActivated: root.openKeybinds()
+                    }
+                    MenuRow {
+                        Layout.fillWidth: true
+                        label: "System Info"
+                        onActivated: root.openSystemInfo()
                     }
                 }
 
-                Rectangle { Layout.fillWidth: true; Layout.preferredHeight: 1; color: Theme.border }
-                UiText { text: "Bar Functions"; color: Theme.textMuted; font.letterSpacing: 1 }
-                Tile {
+                ColumnLayout {
                     Layout.fillWidth: true
-                    label: root.sidePanel === "widgets" ? "Bar Functions  <" : "Bar Functions  >"
-                    active: root.sidePanel === "widgets"
-                    onActivated: root.sidePanel = root.sidePanel === "widgets" ? "none" : "widgets"
-                }
-
-                Rectangle { Layout.fillWidth: true; Layout.preferredHeight: 1; color: Theme.border }
-                UiText { text: "Utilities"; color: Theme.textMuted; font.letterSpacing: 1 }
-                Tile {
-                    Layout.fillWidth: true
-                    label: root.sidePanel === "utilities" ? "Utilities  <" : "Utilities  >"
-                    active: root.sidePanel === "utilities"
-                    onActivated: root.sidePanel = root.sidePanel === "utilities" ? "none" : "utilities"
-                }
-            }
-        }
-
-        ShellSurface {
-            id: sideCard
-
-            Layout.preferredWidth: root.cardWidth
-            Layout.maximumHeight: implicitHeight
-            Layout.alignment: Qt.AlignTop
-            margin: 12
-            implicitHeight: sideColumn.implicitHeight + margin * 2
-            visible: root.sidePanel !== "none"
-
-            ColumnLayout {
-                id: sideColumn
-                width: parent.width
-                spacing: 8
-
-                UiText {
-                    text: root.sideTitle()
-                    color: Theme.textStrong
-                    font.letterSpacing: 2
-                }
-                Rectangle { Layout.fillWidth: true; Layout.preferredHeight: 1; color: Theme.border }
-
-                GridLayout {
-                    Layout.fillWidth: true
-                    visible: root.sidePanel === "widgets"
-                    columns: 2
-                    columnSpacing: 8
-                    rowSpacing: 8
+                    visible: root.controlCenterModel.page === "widgets"
+                    spacing: 2
 
                     Repeater {
                         model: ["Volume", "Bluetooth", "Network", "Power", "Workspaces"]
-                        delegate: Tile {
+
+                        delegate: MenuRow {
                             required property string modelData
+
                             Layout.fillWidth: true
                             label: modelData
+                            detail: root.controlCenterModel.widgetEnabled(modelData) ? "On" : "Off"
                             active: root.controlCenterModel.widgetEnabled(modelData)
                             onActivated: root.controlCenterModel.toggleWidget(modelData)
                         }
@@ -244,61 +384,15 @@ ClickAwayPopup {
 
                 ColumnLayout {
                     Layout.fillWidth: true
-                    visible: root.sidePanel === "utilities"
-                    spacing: 8
-
-                    Tile {
-                        Layout.fillWidth: true
-                        label: "Settings  >"
-                        onActivated: root.openSettings()
-                    }
-                    Tile {
-                        Layout.fillWidth: true
-                        label: "System Health  >"
-                        onActivated: root.openSystemHealth()
-                    }
-                    Tile {
-                        Layout.fillWidth: true
-                        label: "Quick Actions  >"
-                        onActivated: {
-                            root.controlCenterModel.openActions();
-                            root.sidePanel = "actions";
-                        }
-                    }
-                    Tile {
-                        Layout.fillWidth: true
-                        label: "Appearance  >"
-                        onActivated: {
-                            root.controlCenterModel.openAppearance();
-                            root.sidePanel = "appearance";
-                        }
-                    }
-                    Tile {
-                        Layout.fillWidth: true
-                        label: "Keybinds  >"
-                        onActivated: root.controlCenterModel.openKeybinds()
-                    }
-                    Tile {
-                        Layout.fillWidth: true
-                        label: "Power Settings  >"
-                        onActivated: root.openPowerSettings()
-                    }
-                    Tile {
-                        Layout.fillWidth: true
-                        label: "System Info  >"
-                        onActivated: root.controlCenterModel.openInfo()
-                    }
-                }
-
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    visible: root.sidePanel === "actions"
-                    spacing: 8
+                    visible: root.controlCenterModel.page === "actions"
+                    spacing: 2
 
                     Repeater {
                         model: root.controlCenterModel.actions
-                        delegate: Tile {
+
+                        delegate: MenuRow {
                             required property var modelData
+
                             Layout.fillWidth: true
                             label: modelData.label
                             enabled: !root.controlCenterModel.busy
@@ -309,15 +403,18 @@ ClickAwayPopup {
 
                 ColumnLayout {
                     Layout.fillWidth: true
-                    visible: root.sidePanel === "appearance"
-                    spacing: 8
+                    visible: root.controlCenterModel.page === "appearance"
+                    spacing: 2
 
                     Repeater {
                         model: root.controlCenterModel.themeRows
-                        delegate: Tile {
+
+                        delegate: MenuRow {
                             required property var modelData
+
                             Layout.fillWidth: true
                             label: modelData.name
+                            detail: modelData.status === "active" ? "Active" : ""
                             active: modelData.status === "active"
                             enabled: !root.controlCenterModel.busy
                             onActivated: root.controlCenterModel.setTheme(modelData.name)
@@ -327,19 +424,20 @@ ClickAwayPopup {
 
                 ColumnLayout {
                     Layout.fillWidth: true
-                    visible: root.sidePanel === "power"
-                    spacing: 8
+                    visible: root.controlCenterModel.page === "power"
+                    spacing: 6
 
                     UiText {
                         Layout.fillWidth: true
                         text: root.controlCenterModel.powerDpmsEnabled
                             ? "Screen off after " + root.formatDuration(root.controlCenterModel.powerDpmsTimeout)
-                            : "Screen DPMS disabled"
+                            : "Screen timeout disabled"
                         color: Theme.textMuted
                     }
-                    Tile {
+                    MenuRow {
                         Layout.fillWidth: true
-                        label: root.controlCenterModel.powerDpmsEnabled ? "Disable Screen DPMS" : "Enable Screen DPMS"
+                        label: "Screen Timeout"
+                        detail: root.controlCenterModel.powerDpmsEnabled ? "On" : "Off"
                         active: root.controlCenterModel.powerDpmsEnabled
                         enabled: root.controlCenterModel.powerDpmsAvailable && !root.controlCenterModel.busy
                         onActivated: root.controlCenterModel.setPowerDpms(!root.controlCenterModel.powerDpmsEnabled)
@@ -352,8 +450,10 @@ ClickAwayPopup {
 
                         Repeater {
                             model: root.powerPresets
-                            delegate: Tile {
+
+                            delegate: PresetButton {
                                 required property var modelData
+
                                 Layout.fillWidth: true
                                 label: modelData.label
                                 active: root.controlCenterModel.powerDpmsEnabled
@@ -364,18 +464,25 @@ ClickAwayPopup {
                         }
                     }
 
-                    Rectangle { Layout.fillWidth: true; Layout.preferredHeight: 1; color: Theme.border }
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 1
+                        Layout.topMargin: 3
+                        Layout.bottomMargin: 3
+                        color: Theme.border
+                    }
 
                     UiText {
                         Layout.fillWidth: true
                         text: root.controlCenterModel.powerLockEnabled
                             ? "Lock after " + root.formatDuration(root.controlCenterModel.powerLockTimeout)
-                            : "Auto Lock disabled"
+                            : "Auto lock disabled"
                         color: Theme.textMuted
                     }
-                    Tile {
+                    MenuRow {
                         Layout.fillWidth: true
-                        label: root.controlCenterModel.powerLockEnabled ? "Disable Auto Lock" : "Enable Auto Lock"
+                        label: "Auto Lock"
+                        detail: root.controlCenterModel.powerLockEnabled ? "On" : "Off"
                         active: root.controlCenterModel.powerLockEnabled
                         enabled: root.controlCenterModel.powerLockAvailable && !root.controlCenterModel.busy
                         onActivated: root.controlCenterModel.setPowerLock(!root.controlCenterModel.powerLockEnabled)
@@ -388,8 +495,10 @@ ClickAwayPopup {
 
                         Repeater {
                             model: root.powerPresets
-                            delegate: Tile {
+
+                            delegate: PresetButton {
                                 required property var modelData
+
                                 Layout.fillWidth: true
                                 label: modelData.label
                                 active: root.controlCenterModel.powerLockEnabled

--- a/config/quickshell/core/Theme.qml
+++ b/config/quickshell/core/Theme.qml
@@ -98,7 +98,6 @@ Singleton {
     readonly property int popupSpacing: 12
     readonly property int controlCenterX: 6
     readonly property int controlCenterWidth: 276
-    readonly property int controlCenterGap: 8
     readonly property int rowSpacing: 10
     readonly property int listSpacing: 4
     readonly property int compactSpacing: 2

--- a/config/quickshell/power/PowerMenuWindow.qml
+++ b/config/quickshell/power/PowerMenuWindow.qml
@@ -20,7 +20,7 @@ ClickAwayPopup {
     popupWidth: cardWidth
     popupHeight: powerMenuModel.confirming ? confirmHeight : menuHeight
     popupX: powerMenuModel.anchorSource === "controlcenter"
-        ? Theme.controlCenterX + Theme.controlCenterWidth + Theme.controlCenterGap
+        ? Theme.controlCenterX
         : Math.max(edgeMargin, panelWindow.width - cardWidth - edgeMargin)
     popupY: Theme.panelHeight
     onDismissed: powerMenuModel.close()

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -397,6 +397,7 @@ ShellRoot {
 
     ControlCenterWindow {
         controlCenterModel: controlCenterModel
+        launcherModel: launcherModel
         panelWindow: panelWindow
         powerMenuModel: powerMenuModel
         healthModel: systemHealthModel

--- a/docs/SETTINGS-PLATFORM.md
+++ b/docs/SETTINGS-PLATFORM.md
@@ -11,7 +11,7 @@ inventory that this design uses.
 
 The Settings application is one Quickshell `FloatingWindow` titled
 `dwm settings`. It is part of the managed Quickshell process and is opened from
-Control Center -> Utilities -> Settings, through the `settings` IPC target, or
+Control Center -> Settings, through the `settings` IPC target, or
 with `dwm-settings`.
 
 ### Navigation and Search

--- a/docs/src/control-center.md
+++ b/docs/src/control-center.md
@@ -1,19 +1,21 @@
 # Control Center
 
-The Control Center is an anchored Quickshell popup for panel settings, system
-health, quick actions, appearance settings, power management, and keybind
-discovery.
+The Control Center is a single-card anchored Quickshell menu for launching
+applications, panel settings, system health, quick actions, appearance
+settings, power management, and keybind discovery.
 
 **Open:** <kbd>Super</kbd> + <kbd>F1</kbd>, or run `dwm-controlcenter` from a
 terminal.
 
-The popup opens from the panel logo. Its side card contains panel widget
-visibility, utilities, quick actions, appearance controls, and persisted DPMS
-and auto-lock timing. Press <kbd>Esc</kbd> or click outside it to close it.
+The popup opens from the panel logo. Applications, Power, Settings, System
+Health, Keybinds, and System Info are available directly from the main menu.
+Bar Widgets, Quick Actions, Appearance, and Power Settings replace the menu
+contents in the same card and provide a Back control. Press <kbd>Esc</kbd> or
+click outside the card to close it from any page.
 
-The Utilities card opens the unified Settings application. Phase 1 Settings is
-a read-only capability overview with section search and keyboard/mouse
-navigation. It can also be opened directly with `dwm-settings open`.
+The Utilities section opens the unified Settings application directly. Phase
+1 Settings is a read-only capability overview with section search and
+keyboard/mouse navigation. It can also be opened with `dwm-settings open`.
 
 ---
 
@@ -35,7 +37,7 @@ paired device, and disconnect a connected device through `bluetoothctl`.
 
 ## Panel Widgets
 
-The Bar Functions card can show or hide the workspace, volume, Bluetooth,
+The Bar Widgets page can show or hide the workspace, volume, Bluetooth,
 network, and power widgets for the current Quickshell session. The redesigned
 panel retains the active-window title, status segments, and system tray, and
 shows all nine dwm tags (workspaces). Hovering icon-only panel controls displays
@@ -105,11 +107,13 @@ root-owned installed helper.
 | Action | Description |
 |--------|-------------|
 | Restart Picom | Kill and relaunch the compositor |
+| Restart Quickshell | Reload the managed Quickshell shell |
 | Reload Wallpaper | Randomize from `~/Pictures/backgrounds/` |
-| Toggle Compositor | Start or stop picom |
 | Restart NetworkManager | `sudo systemctl restart NetworkManager` |
 | Run Dependency Check | Opens `check-deps.sh` in a terminal |
 | Install Missing Deps | Runs `install.sh` in a terminal |
+| Wallpaper Folder | Open `~/Pictures/backgrounds/` in the file manager |
+| GTK Settings | Launch `nwg-look` for GTK theming |
 
 ### Appearance
 

--- a/docs/src/settings.md
+++ b/docs/src/settings.md
@@ -3,8 +3,8 @@
 The unified Settings application provides one place to inspect desktop
 capabilities and see which features are available, restricted, or planned.
 
-Open Control Center with `Super+F1`, select **Utilities**,
-then select **Settings**. You can also run:
+Open Control Center with `Super+F1`, then select **Settings** from the main
+menu. You can also run:
 
 ```bash
 dwm-settings open

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -358,8 +358,25 @@ grep -Fq 'function applyThemes(themeText)' "$repo/config/quickshell/core/Theme.q
 grep -Fq 'root.text = value("normfgcolor", root.text)' "$repo/config/quickshell/core/Theme.qml"
 grep -Fq 'text: root.busy ? "Connecting..." : "Connect"' "$repo/config/quickshell/network/NetworkWifiRow.qml"
 grep -Fq 'readonly property int cardWidth: Theme.controlCenterWidth' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
-grep -Fq '? Theme.controlCenterX + Theme.controlCenterWidth + Theme.controlCenterGap' "$repo/config/quickshell/power/PowerMenuWindow.qml"
-grep -Fq 'tileMouse.containsMouse ? Theme.surfaceHover' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
+grep -Fq '? Theme.controlCenterX' "$repo/config/quickshell/power/PowerMenuWindow.qml"
+grep -Fq 'property bool navigates: false' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
+grep -Fq 'label: "Applications"' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
+grep -Fq 'root.launcherModel.open();' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
+grep -Fq 'launcherModel: launcherModel' "$repo/config/quickshell/shell.qml"
+grep -Fq 'label: "Quick Actions"' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
+grep -Fq 'model: root.controlCenterModel.actions' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
+grep -Fq 'function openWidgets()' "$repo/config/quickshell/controlcenter/ControlCenterModel.qml"
+grep -Fq 'label: "Settings"' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
+grep -Fq 'label: "System Health"' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
+grep -Fq 'label: "Keybinds"' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
+grep -Fq 'label: "System Info"' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
+if grep -Fq 'Reload QS-Config' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"; then
+	exit 1
+fi
+if grep -Fq 'property string sidePanel' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"; then
+	exit 1
+fi
+[ "$(grep -Fc 'ShellSurface {' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml")" -eq 1 ]
 grep -Fq 'PanelTooltip {' "$repo/config/quickshell/panel/DwmPanel.qml"
 grep -Fq 'mask: Region {}' "$repo/config/quickshell/core/PanelTooltip.qml"
 grep -Fq 'anchor.edges: Edges.Left | Edges.Top' "$repo/config/quickshell/core/PanelTooltip.qml"

--- a/tests/test-quickshell-health-xvfb.sh
+++ b/tests/test-quickshell-health-xvfb.sh
@@ -37,7 +37,8 @@ cp "$repo/config/"*.toml "$config_home/dwm-titus/"
 # rule must also cover the newly added utility window.
 sed -i '/title="dwm control center utility"/d' "$config_home/dwm-titus/window-rules.toml"
 cp "$repo/scripts/dwm-system-health" "$repo/scripts/dwm-diagnostics" \
-	"$repo/scripts/dwm-quickshell-controlcenter" "$data_home/dwm-titus/scripts/"
+	"$repo/scripts/dwm-quickshell-controlcenter" "$repo/scripts/dwm-quickshell-launcher" \
+	"$data_home/dwm-titus/scripts/"
 
 Xvfb "$display" -screen 0 1024x768x24 -nolisten tcp -extension GLX >"$work/xvfb.log" 2>&1 &
 xvfb_pid=$!
@@ -187,6 +188,84 @@ while [ "$i" -lt 100 ]; do
 done
 if DISPLAY=$display xdotool search --onlyvisible --pid "$quickshell_pid" 2>/dev/null | grep -Fqx "$window"; then
 	printf 'Control Center popup did not close on Escape\n' >&2
+	exit 1
+fi
+
+# An in-place page keeps one popup surface and Escape still closes the menu.
+visible_windows=$(DISPLAY=$display xdotool search --onlyvisible --pid "$quickshell_pid" 2>/dev/null || true)
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home XDG_RUNTIME_DIR=$runtime \
+	quickshell ipc --path "$config" call controlcenter open >/dev/null
+
+window=
+i=0
+while [ "$i" -lt 200 ]; do
+	for candidate in $(DISPLAY=$display xdotool search --onlyvisible --pid "$quickshell_pid" 2>/dev/null || true); do
+		was_visible=0
+		for existing in $visible_windows; do
+			[ "$candidate" = "$existing" ] && was_visible=1
+		done
+		if [ "$was_visible" = 0 ]; then
+			window=$candidate
+			break
+		fi
+	done
+	[ -n "$window" ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ -n "$window" ]
+
+DISPLAY=$display xdotool mousemove 120 205 click 1
+sleep 0.1
+DISPLAY=$display xdotool key Escape
+i=0
+while [ "$i" -lt 100 ]; do
+	if ! DISPLAY=$display xdotool search --onlyvisible --pid "$quickshell_pid" 2>/dev/null | grep -Fqx "$window"; then
+		break
+	fi
+	i=$((i + 1))
+	sleep 0.05
+done
+if DISPLAY=$display xdotool search --onlyvisible --pid "$quickshell_pid" 2>/dev/null | grep -Fqx "$window"; then
+	printf 'Control Center in-place page did not close on Escape\n' >&2
+	exit 1
+fi
+
+# Applications closes the dropdown before opening and focusing the launcher.
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home XDG_RUNTIME_DIR=$runtime \
+	quickshell ipc --path "$config" call controlcenter open >/dev/null
+sleep 0.1
+DISPLAY=$display xdotool mousemove 120 105 click 1
+
+launcher_window=
+i=0
+while [ "$i" -lt 200 ]; do
+	launcher_window=$(DISPLAY=$display xdotool search --onlyvisible --name '^dwm launcher$' 2>/dev/null | head -1 || true)
+	[ -n "$launcher_window" ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+if [ -z "$launcher_window" ]; then
+	printf 'Applications menu item did not open the launcher\n' >&2
+	tail -40 "$work/quickshell.log" >&2
+	exit 1
+fi
+if DISPLAY=$display xdotool search --onlyvisible --pid "$quickshell_pid" 2>/dev/null | grep -Fqx "$window"; then
+	printf 'Control Center remained open behind the launcher\n' >&2
+	exit 1
+fi
+DISPLAY=$display xdotool windowactivate --sync "$launcher_window"
+DISPLAY=$display xdotool key Escape
+i=0
+while [ "$i" -lt 100 ]; do
+	if ! DISPLAY=$display xdotool search --onlyvisible --name '^dwm launcher$' >/dev/null 2>&1; then
+		break
+	fi
+	i=$((i + 1))
+	sleep 0.05
+done
+if DISPLAY=$display xdotool search --onlyvisible --name '^dwm launcher$' >/dev/null 2>&1; then
+	printf 'Launcher did not close on Escape\n' >&2
 	exit 1
 fi
 

--- a/tests/test-settings.sh
+++ b/tests/test-settings.sh
@@ -136,7 +136,7 @@ grep -Fq 'providerProcess.running = false' "$repo/config/quickshell/settings/Set
 grep -Fq 'Commands.settingsProviderCommand("discover")' "$repo/config/quickshell/settings/SettingsModel.qml"
 grep -Fq 'root.searchQuery = ""' "$repo/config/quickshell/settings/SettingsModel.qml"
 grep -Fq 'title: "dwm settings"' "$repo/config/quickshell/settings/SettingsWindow.qml"
-grep -Fq 'label: "Settings  >"' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
+grep -Fq 'label: "Settings"' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
 grep -Fq 'root.settingsModel.open()' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
 grep -Fq '{ title="dwm settings",             isfloating=1, alwaysontop=1 }' \
 	"$repo/config/window-rules.toml"


### PR DESCRIPTION
## Summary

- replace the Control Center's adjacent outlined cards with one anchored dropdown and in-place secondary pages
- move Utilities into the main menu and add a direct Applications launcher entry
- remove the duplicate QS reload action while keeping Restart Quickshell under Quick Actions
- close the dropdown before handing focus to Applications, Power, Settings, System Health, Keybinds, or System Info
- update user documentation and runtime/contract coverage

## Why

The previous layout presented nearly every row as a bordered button and opened secondary content in a separate outlined card. That made the top-left menu feel visually disconnected and could leave multiple popup layers active. Utilities also required an unnecessary submenu, while Quickshell reload appeared in two places.

## User impact

The Control Center now behaves like a conventional click menu: one outer card, flat hoverable rows, direct utility entries, explicit Back navigation for compact secondary pages, and consistent outside-click or Escape dismissal. Applications opens the existing launcher and transfers focus to its search field.

## Validation

- `make check`
- Quickshell-aware QML lint
- targeted Control Center, launcher, and Settings checks
- nested X11 coverage for click-away, Escape, in-place navigation, and launcher handoff
- live X11 verification for click-away, launcher focus, managed-config parity, single-instance operation, and idle CPU