### PR TITLE
Install PAM support for GNOME Keyring login unlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ versions from `config.mk`.
 
 ### Fixed
 
+- Install the PAM integration package alongside GNOME Keyring so LightDM can
+  unlock the login keyring without a second password prompt.
 - Restore independent Quickshell StatusNotifier tray rendering and resilient
   icon fallbacks for background-only tray clients.
 - Prevent nested dwm/Xvfb instances from terminating the active graphical login

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Profiles:
 |---------|-------------------|
 | `core` | dwm, required X11/session packages, and one terminal |
 | `recommended` | `core` plus Quickshell, Picom, fonts, theming, screenshots, audio, and brightness tools |
-| `full` | `recommended` plus optional extras such as Thunar with SMB-share browsing, portals, wallpapers, and display-manager setup; x86_64 Fedora can also add Steam, Gamescope, GameMode, and MangoHud after repository approval |
+| `full` | `recommended` plus optional extras such as Thunar with SMB-share browsing, portals, keyring login integration, wallpapers, and display-manager setup; x86_64 Fedora can also add Steam, Gamescope, GameMode, and MangoHud after repository approval |
 
 The installer detects the distribution from `/etc/os-release`, resolves package
 names for the detected family, preserves existing `config.h` and user TOML

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -30,9 +30,9 @@ names for Debian-, Arch-, and Fedora/RHEL-family systems from the shared map:
 
 Use `core` for the required build/X11/session packages and one terminal,
 `recommended` for the desktop layer, or `full` for optional extras such as
-file-manager integration, portals, wallpapers, and display-manager setup. On
-x86_64 Fedora, `full` can also install Steam, Gamescope, GameMode, and MangoHud
-after repository approval.
+file-manager integration, portals, keyring login integration, wallpapers, and
+display-manager setup. On x86_64 Fedora, `full` can also install Steam,
+Gamescope, GameMode, and MangoHud after repository approval.
 The installer separately asks before enabling the `christitustech/copr-fedora`
 COPR for patched Gamescope and RPM Fusion nonfree for Steam. Declining skips the
 gaming subset without affecting other full-profile extras.
@@ -76,9 +76,10 @@ Installer package profiles are selected with `DWM_INSTALL_PROFILE`:
   control and tray tools, and brightness tools. It also installs portable GTK theme packages where available and
   installs Nordic system-wide for the default Nord theme.
 - `full`: `recommended` plus optional extras such as Thunar with SMB-share
-  browsing, network tray utilities, portals, wallpapers, and display-manager
-  setup. x86_64 Fedora full installs also include Steam, Gamescope, and 64-bit
-  and 32-bit GameMode and MangoHud support after separate repository approval.
+  browsing, network tray utilities, portals, keyring login integration,
+  wallpapers, and display-manager setup. x86_64 Fedora full installs also
+  include Steam, Gamescope, and 64-bit and 32-bit GameMode and MangoHud support
+  after separate repository approval.
   The installer enables the `christitustech/copr-fedora` COPR for Gamescope and
   RPM Fusion nonfree for Steam, then adds the invoking user to the `gamemode`
   group; log out and back in before using its privileged tuning helpers.

--- a/dwm-fedora-nvidia.ks
+++ b/dwm-fedora-nvidia.ks
@@ -129,6 +129,7 @@ file-roller
 xdg-user-dirs
 xdg-desktop-portal-gtk
 gnome-keyring
+gnome-keyring-pam
 nwg-look
 kernel-devel
 kernel-headers

--- a/dwm-fedora.ks
+++ b/dwm-fedora.ks
@@ -128,6 +128,7 @@ file-roller
 xdg-user-dirs
 xdg-desktop-portal-gtk
 gnome-keyring
+gnome-keyring-pam
 nwg-look
 %end
 

--- a/scripts/dwm-packages.sh
+++ b/scripts/dwm-packages.sh
@@ -97,7 +97,7 @@ dwm_packages() {
 	rhel:desktop-optional)
 		printf '%s\n' \
 			Thunar gvfs gvfs-smb tumbler thunar-archive-plugin file-roller \
-			xdg-user-dirs xdg-desktop-portal-gtk gnome-keyring NetworkManager \
+			xdg-user-dirs xdg-desktop-portal-gtk gnome-keyring gnome-keyring-pam NetworkManager \
 			rsync nwg-look
 		if [[ ${DISTRO_ID:-} != fedora ]]; then
 			printf '%s\n' playerctl
@@ -160,7 +160,7 @@ dwm_packages() {
 	debian:desktop-optional)
 		printf '%s\n' \
 			thunar gvfs gvfs-backends tumbler thunar-archive-plugin file-roller \
-			xdg-user-dirs xdg-desktop-portal-gtk gnome-keyring \
+			xdg-user-dirs xdg-desktop-portal-gtk gnome-keyring libpam-gnome-keyring \
 			network-manager rsync
 		;;
 	debian:theme)

--- a/tests/test-kickstart-variants.sh
+++ b/tests/test-kickstart-variants.sh
@@ -44,6 +44,7 @@ required_packages=(
 	xdg-user-dirs
 	xdg-desktop-portal-gtk
 	gnome-keyring
+	gnome-keyring-pam
 	qt6ct
 	qt5ct
 	arc-theme
@@ -67,6 +68,13 @@ fi
 DISTRO_ID=rocky dwm_packages rhel optional | grep -Fx playerctl >/dev/null
 
 for mapping in arch:gvfs-smb rhel:gvfs-smb debian:gvfs-backends; do
+	family=${mapping%%:*}
+	package=${mapping#*:}
+	DISTRO_ID=$([[ $family == rhel ]] && printf fedora || printf '%s' "$family") \
+		dwm_packages "$family" full | grep -Fx "$package" >/dev/null
+done
+
+for mapping in arch:gnome-keyring rhel:gnome-keyring-pam debian:libpam-gnome-keyring; do
 	family=${mapping%%:*}
 	package=${mapping#*:}
 	DISTRO_ID=$([[ $family == rhel ]] && printf fedora || printf '%s' "$family") \


### PR DESCRIPTION
## Summary

- install the GNOME Keyring PAM integration alongside the keyring daemon on Fedora/RHEL and Debian full-profile installs
- include `gnome-keyring-pam` in both Fedora Kickstart variants
- add package-map and Kickstart regression coverage
- document keyring login integration in the full installer profile

## Root cause

LightDM was already configured to call `pam_gnome_keyring.so`, but the Fedora image and shared dependency map installed only `gnome-keyring`. Without the separate PAM package, LightDM could not pass the login password to unlock the keyring. A startup application using libsecret then caused a second password prompt immediately after login.

## Impact

Fresh Fedora images and full existing-system installs now include the PAM module needed to unlock the login keyring during LightDM authentication. Debian uses its equivalent `libpam-gnome-keyring` package; Arch continues to use the PAM module shipped by `gnome-keyring` itself.

## Validation

- `make check`
- `make check-kickstart`
- `bash -n scripts/dwm-packages.sh tests/test-kickstart-variants.sh`
- `shellcheck scripts/dwm-packages.sh tests/test-kickstart-variants.sh`
- `shfmt -d scripts/dwm-packages.sh tests/test-kickstart-variants.sh`
- installed `gnome-keyring-pam-50.0-1.fc44.x86_64` on the live Fedora host and verified `/usr/lib64/security/pam_gnome_keyring.so`

A fresh LightDM login is required to exercise the new PAM session path.