### PR TITLE
Debian - LightDM config fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -541,6 +541,11 @@ install_lightdm_config() {
 		lightdm_logind_check=true
 	fi
 
+	if [[ $DISTRO_FAMILY == "debian" ]]; then
+		lightdm_greeter_session="slick-greeter"
+		lightdm_session_wrapper=""
+	fi
+
 	sudo make -C "$REPO_DIR/lightdm" \
 		LIGHTDM_SEAT_SECTION="$lightdm_seat_section" \
 		LIGHTDM_GREETER_SESSION="$lightdm_greeter_session" \


### PR DESCRIPTION
…ick-greeter

## Summary

<!-- What changed and why? Include the root cause for bug fixes. -->

## Type

- [X] Bug fix

## Validation

- [X] `make clean && make`
- [X] `make check`
- [X] Focused X11, Quickshell, installer, or documentation checks as applicable
- [X] `git diff --check`

Tested distributions, architectures, and X11 environments:

<!-- List exact coverage and clearly identify anything not tested. -->

## User Impact and Risk

Fixes the issue with lightdm not working correctly because it points to the wrong name for slick-greeter and points to the wrapper script that does not exist

## Related Issue

Closes #131 

## Screenshots

<!-- Required only for visible UI changes. -->
