### PR TITLE
Add Herdr-on-Alacritty terminal workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ versions from `config.mk`.
 
 ### Fixed
 
+- Keep `install-herdr --dry-run` side-effect free, skip unsupported automatic
+  ARMv7 installs, and warn when a preserved legacy terminal hotkey bypasses
+  Herdr.
 - Install the PAM integration package alongside GNOME Keyring so LightDM can
   unlock the login keyring without a second password prompt.
 - Restore independent Quickshell StatusNotifier tray rendering and resilient

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,9 @@ versions from `config.mk`.
 
 ### Fixed
 
-- Keep `install-herdr --dry-run` side-effect free, skip unsupported automatic
-  ARMv7 installs, and warn when a preserved legacy terminal hotkey bypasses
-  Herdr.
+- Keep `install-herdr --dry-run` side-effect free, have `install.sh` skip
+  unsupported automatic ARMv7 installs, and warn when a preserved legacy
+  terminal hotkey bypasses Herdr.
 - Install the PAM integration package alongside GNOME Keyring so LightDM can
   unlock the login keyring without a second password prompt.
 - Restore independent Quickshell StatusNotifier tray rendering and resilient

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ versions from `config.mk`.
 
 ### Added
 
+- A checksum-verified Herdr installer and default Herdr-on-Alacritty terminal
+  workspace for recommended, full, and dedicated Fedora image installs.
 - A unified, read-only Quickshell Settings foundation with Control Center and
   IPC entry points, searchable keyboard/mouse navigation, and explicit
   provider availability and unsupported-state reporting.
@@ -22,6 +24,9 @@ versions from `config.mk`.
 
 ### Changed
 
+- Plain `dwm-terminal` launches now open Herdr when available, while explicit
+  command launches bypass Herdr and retain the existing terminal-emulator
+  contract.
 - The Control Center now uses one clean dropdown card with direct Applications
   and utility entries, in-place secondary pages, and consistent click-away and
   Escape dismissal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ versions from `config.mk`.
 ### Added
 
 - A checksum-verified Herdr installer and default Herdr-on-Alacritty terminal
-  workspace for recommended, full, and dedicated Fedora image installs.
+  workspace for recommended, full, and dedicated Fedora image installs, with
+  automatic integration setup for detected Codex and Claude Code CLIs.
 - A unified, read-only Quickshell Settings foundation with Control Center and
   IPC entry points, searchable keyboard/mouse navigation, and explicit
   provider availability and unsupported-state reporting.

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ INSTALL_COMMANDS = \
 	scripts/dwm-settings-provider \
 	scripts/dwm-terminal \
 	scripts/dwm-utils.sh \
+	scripts/install-herdr \
 	scripts/nvidia-gpu \
 	scripts/nvidia-suspend-test.sh \
 	scripts/nvidia-temp \
@@ -257,10 +258,10 @@ release: dwm
 	echo "==> Created ${RELEASE_ARCHIVE}"
 
 check-shell:
-	shellcheck install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/quickshell-qmllint scripts/*.sh tests/*.sh
+	shellcheck install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/install-herdr scripts/quickshell-qmllint scripts/*.sh tests/*.sh
 
 check-format:
-	shfmt -d install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/quickshell-qmllint scripts/*.sh tests/*.sh
+	shfmt -d install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/install-herdr scripts/quickshell-qmllint scripts/*.sh tests/*.sh
 
 check-session-guards:
 	tests/test-autostart.sh
@@ -283,6 +284,9 @@ check-build-config:
 
 check-terminal:
 	tests/test-dwm-terminal.sh
+
+check-herdr-install:
+	tests/test-install-herdr.sh
 
 check-lock:
 	tests/test-dwm-lock.sh
@@ -466,6 +470,7 @@ check:
 	$(MAKE) check-settings
 	$(MAKE) check-quickshell-network
 	$(MAKE) check-terminal
+	$(MAKE) check-herdr-install
 	$(MAKE) check-lock
 	$(MAKE) check-session-guards
 	$(MAKE) check-session-migration
@@ -481,7 +486,7 @@ check:
 .PHONY: all check check-build-config check-build-deps check-default-apps \
 	check-container-smoke \
 	check-display-profile check-display-setup check-fedora-iso-builder check-format check-install \
-	check-install-manifest check-install-preservation check-kickstart check-lock \
+	check-herdr-install check-install-manifest check-install-preservation check-kickstart check-lock \
 	check-session-guards check-session-migration check-screenshot check-release-helper check-shell check-diagnostics check-status check-system-health check-settings \
 	check-quickshell-launcher check-quickshell-controls check-quickshell-controlcenter check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-qml check-lightdm-config check-terminal clean install install-system install-user \
 	install-cursors native release release-check uninstall

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ configuration, and installs the managed desktop components.
 
 | Profile | Includes |
 | --- | --- |
-| `core` | The X11 session, required dependencies, and one terminal. |
-| `recommended` | The complete everyday desktop, including Quickshell, theming, screenshots, audio, and brightness tools. |
+| `core` | The X11 session, required dependencies, and one terminal emulator. |
+| `recommended` | The complete everyday desktop, including Alacritty with Herdr, Quickshell, theming, screenshots, audio, and brightness tools. |
 | `full` | The recommended desktop plus optional file-manager, portal, keyring, wallpaper, display-manager, and supported Fedora gaming integrations. |
 
 ## First Login
@@ -87,7 +87,7 @@ configuration, and installs the managed desktop components.
 | Action | Keybind |
 | --- | --- |
 | Open the application launcher | <kbd>Super</kbd> + <kbd>R</kbd> |
-| Open a terminal | <kbd>Super</kbd> + <kbd>X</kbd> |
+| Open Herdr in Alacritty | <kbd>Super</kbd> + <kbd>X</kbd> |
 | Open Control Center | <kbd>Super</kbd> + <kbd>F1</kbd> |
 | Show the interactive keybind viewer | <kbd>Super</kbd> + <kbd>/</kbd> |
 | Close the focused window | <kbd>Super</kbd> + <kbd>Q</kbd> |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ configuration, and installs the managed desktop components.
 | Action | Keybind |
 | --- | --- |
 | Open the application launcher | <kbd>Super</kbd> + <kbd>R</kbd> |
-| Open Herdr in Alacritty | <kbd>Super</kbd> + <kbd>X</kbd> |
+| Open terminal workspace (Herdr when available) | <kbd>Super</kbd> + <kbd>X</kbd> |
 | Open Control Center | <kbd>Super</kbd> + <kbd>F1</kbd> |
 | Show the interactive keybind viewer | <kbd>Super</kbd> + <kbd>/</kbd> |
 | Close the focused window | <kbd>Super</kbd> + <kbd>Q</kbd> |

--- a/SPEC.md
+++ b/SPEC.md
@@ -378,10 +378,13 @@ must be validated against each tested release.
 
 Runtime dependencies are classified as:
 
-- Core: an X11 server/session, D-Bus session support, one usable terminal, and
-  the tools required by configured core keybindings.
-- Recommended desktop: Quickshell, Picom, Feh, Dex, a polkit agent,
-  notification tools, audio controls, screenshot tooling, and Nerd/emoji fonts.
+- Core: an X11 server/session, D-Bus session support, one usable terminal
+  emulator, and the tools required by configured core keybindings. Alacritty
+  is the preferred emulator, with the existing supported-terminal fallback
+  chain retained when Alacritty is unavailable.
+- Recommended desktop: the Herdr terminal workspace layered over Alacritty,
+  Quickshell, Picom, Feh, Dex, a polkit agent, notification tools, audio
+  controls, screenshot tooling, and Nerd/emoji fonts.
 - Optional: file manager, network tray, theme utilities, display-manager
   greeter customization, wallpapers, and hardware-specific helpers.
 
@@ -540,8 +543,12 @@ configuration and unrelated application configuration by default.
   guidance rather than relying on silent background commands.
 - Error messages must identify the missing command, library, package
   capability, or file and provide the next action.
-- The terminal command must select an installed supported terminal or provide a
-  clear configuration path.
+- A plain `dwm-terminal` launch must open Herdr inside the selected terminal
+  emulator when Herdr is installed, and otherwise open the emulator directly.
+  Explicit terminal arguments such as `dwm-terminal -e command` must bypass
+  Herdr so delegated commands retain their existing execution contract.
+- The terminal command must prefer Alacritty, select another installed
+  supported emulator when needed, and provide a clear configuration path.
 - Font aliases must accommodate common Meslo Nerd Font naming differences.
 - Multi-monitor setup must expose EWMH tags correctly to Quickshell and EWMH
   inspection tools.
@@ -554,6 +561,9 @@ configuration and unrelated application configuration by default.
 - Do not execute remote scripts through a shell as part of the required
   installation path.
 - Do not download or execute unverified binaries.
+- Third-party executable installers must run as the target user in an isolated
+  staging directory. Both the reviewed installer and resulting binary must
+  match repository-pinned checksums before the binary is installed.
 - Do not run user configuration or desktop helpers as root.
 - Quote paths and arguments that may contain whitespace.
 - Prevent command injection through distribution metadata, configuration
@@ -597,6 +607,9 @@ On at least one current representative of each family:
 In a real or nested X11 session:
 
 - dwm starts and can launch a terminal.
+- With Herdr installed, the default terminal binding opens Herdr inside
+  Alacritty. Without Herdr, the same binding opens the selected emulator
+  directly, and explicit `dwm-terminal -e` commands bypass Herdr in both cases.
 - Tiling, floating, tags, focus, and close-window actions work.
 - Runtime TOML configuration loads and reloads.
 - A display-manager session and `startx` path both launch.

--- a/config/hotkeys.toml
+++ b/config/hotkeys.toml
@@ -61,7 +61,7 @@ keys = [
 
   # ── Launchers ────────────────────────────────────────────────────────────────
   { mod="SUPER",            key="r",       desc="App launcher",            func="spawn",       cmd="quickshell ipc --path \"${XDG_CONFIG_HOME:-$HOME/.config}/quickshell/shell.qml\" call launcher toggle" },
-  { mod="SUPER",            key="x",       desc="Herdr terminal",          func="spawn",       exec=["$terminal"] },
+  { mod="SUPER",            key="x",       desc="Terminal workspace (Herdr when available)", func="spawn",       exec=["$terminal"] },
   { mod="SUPER",            key="w",       desc="Looking Glass (VM)",      func="spawn",       cmd="looking-glass-client -F" },
   { mod="SUPER SHIFT",      key="w",       desc="Randomize wallpaper",     func="spawn",       cmd="dwm-quickshell-controlcenter action reload-wallpaper" },
 

--- a/config/hotkeys.toml
+++ b/config/hotkeys.toml
@@ -61,7 +61,7 @@ keys = [
 
   # ── Launchers ────────────────────────────────────────────────────────────────
   { mod="SUPER",            key="r",       desc="App launcher",            func="spawn",       cmd="quickshell ipc --path \"${XDG_CONFIG_HOME:-$HOME/.config}/quickshell/shell.qml\" call launcher toggle" },
-  { mod="SUPER",            key="x",       desc="Terminal",                func="spawn",       exec=["$terminal"] },
+  { mod="SUPER",            key="x",       desc="Herdr terminal",          func="spawn",       exec=["$terminal"] },
   { mod="SUPER",            key="w",       desc="Looking Glass (VM)",      func="spawn",       cmd="looking-glass-client -F" },
   { mod="SUPER SHIFT",      key="w",       desc="Randomize wallpaper",     func="spawn",       cmd="dwm-quickshell-controlcenter action reload-wallpaper" },
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -62,9 +62,14 @@ keys = [
 ]
 ```
 
-`dwm-terminal` selects the first installed supported terminal at launch time.
-Set `DWM_TERMINAL` or replace `terminal` with a specific command if you want a
-fixed terminal.
+`dwm-terminal` prefers Alacritty and opens Herdr inside it for a plain
+interactive launch. If Herdr is unavailable, it opens the selected emulator
+directly. Explicit arguments such as `dwm-terminal -e command` always bypass
+Herdr so application launchers and maintenance actions keep working.
+
+Set `DWM_TERMINAL` to choose another outer emulator, set `DWM_HERDR=0` to
+disable the Herdr layer, or set `DWM_HERDR_COMMAND` to another Herdr binary
+path.
 
 Default applications use freedesktop settings. Run `dwm-default-apps browsers`
 to list browser desktop files, `dwm-default-apps set-browser firefox.desktop`

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -8,7 +8,7 @@ Press <kbd>Super</kbd> + <kbd>/</kbd> at any time to open the interactive keybin
 
 | Action | Keys |
 |--------|------|
-| Open terminal | `Super` + `X` |
+| Open Herdr in Alacritty | `Super` + `X` |
 | App launcher (Quickshell) | `Super` + `R` |
 | Close window | `Super` + `Q` |
 | Power menu | `Super` + `Ctrl` + `Q` |

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -8,7 +8,7 @@ Press <kbd>Super</kbd> + <kbd>/</kbd> at any time to open the interactive keybin
 
 | Action | Keys |
 |--------|------|
-| Open Herdr in Alacritty | `Super` + `X` |
+| Open terminal workspace (Herdr when available) | `Super` + `X` |
 | App launcher (Quickshell) | `Super` + `R` |
 | Close window | `Super` + `Q` |
 | Power menu | `Super` + `Ctrl` + `Q` |

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -75,6 +75,10 @@ workspace inside Alacritty. The repository downloads the official
 repository-pinned SHA-256 checksums for both that installer and its resulting
 Herdr binary before copying it into `~/.local/bin`. A checksum mismatch or
 network failure leaves Alacritty usable and reports that Herdr was skipped.
+When the `codex` or `claude` command is already available, the helper also runs
+Herdr's matching `integration install` command so native Codex and Claude Code
+sessions can be restored. Integration failures are reported separately from
+binary installation failures.
 
 When matching vendor XDG entries exist for Picom, the polkit agent, or Light
 Locker, the installer copies each entry to the user autostart directory and

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -129,14 +129,24 @@ packaging checks, or scripted validation, use the non-interactive flags:
 Without `--enable-fedora-gaming-repos`, unattended Fedora full installs skip
 Steam, Gamescope, GameMode, and MangoHud rather than changing repository trust.
 
-Use `--skip-herdr` or `DWM_INSTALL_HERDR=false` to keep plain Alacritty. Use
-`--install-herdr` or `DWM_INSTALL_HERDR=true` to include Herdr with the core
-profile. Herdr can also be installed or repaired separately:
+Use `--skip-herdr` or `DWM_INSTALL_HERDR=false` to skip Herdr installation.
+These installation controls do not disable a Herdr executable that is already
+available; set `DWM_HERDR=0` in the session environment to bypass an existing
+Herdr installation at runtime. Use `--install-herdr` or
+`DWM_INSTALL_HERDR=true` to include Herdr with the core profile. Automatic
+recommended/full-profile installation is limited to x86_64 and aarch64 because
+those are the Linux architectures published by Herdr. Herdr can also be
+installed or repaired separately:
 
 ```bash
 install-herdr
 install-herdr --force
 ```
+
+Upgrades preserve an existing `hotkeys.toml`. If an earlier installer seeded
+its `terminal` variable to `alacritty`, `kitty`, or another direct terminal,
+the installer prints the exact change needed to use `dwm-terminal` and Herdr
+from Super+X without overwriting that user-owned file.
 
 ## Starting dwm
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -14,6 +14,13 @@ curl -fsSL https://christitus.com/linux | sh
 In the TUI, press `v` to multi-select, then select **dwm**, **bash prompt**,
 and **alacritty**. Press `Enter` to install.
 
+Current dwm-titus installs provide the checksum-verified Herdr helper. Run it
+after the Linutil path:
+
+```bash
+install-herdr
+```
+
 ![linutil-appinstall](images/linutil-applications.png)
 
 ## Manual Install
@@ -28,11 +35,12 @@ names for Debian-, Arch-, and Fedora/RHEL-family systems from the shared map:
 ./install.sh --profile full
 ```
 
-Use `core` for the required build/X11/session packages and one terminal,
-`recommended` for the desktop layer, or `full` for optional extras such as
-file-manager integration, portals, keyring login integration, wallpapers, and
-display-manager setup. On x86_64 Fedora, `full` can also install Steam,
-Gamescope, GameMode, and MangoHud after repository approval.
+Use `core` for the required build/X11/session packages and one terminal
+emulator, `recommended` for the desktop layer plus Herdr on top of Alacritty,
+or `full` for optional extras such as file-manager integration, portals,
+keyring login integration, wallpapers, and display-manager setup. On x86_64
+Fedora, `full` can also install Steam, Gamescope, GameMode, and MangoHud after
+repository approval.
 The installer separately asks before enabling the `christitustech/copr-fedora`
 COPR for patched Gamescope and RPM Fusion nonfree for Steam. Declining skips the
 gaming subset without affecting other full-profile extras.
@@ -61,6 +69,13 @@ the known legacy `dwm-graphical-session.service` and
 start only after the X11 display environment is available; customized user
 units are disabled from early startup but otherwise preserved.
 
+Recommended and full profiles install Herdr as the default interactive
+workspace inside Alacritty. The repository downloads the official
+`https://herdr.dev/install.sh` into an isolated staging directory and verifies
+repository-pinned SHA-256 checksums for both that installer and its resulting
+Herdr binary before copying it into `~/.local/bin`. A checksum mismatch or
+network failure leaves Alacritty usable and reports that Herdr was skipped.
+
 When matching vendor XDG entries exist for Picom, the polkit agent, or Light
 Locker, the installer copies each entry to the user autostart directory and
 adds only the dwm session exclusion. Original commands and vendor session
@@ -70,11 +85,12 @@ existing user entries are preserved.
 Installer package profiles are selected with `DWM_INSTALL_PROFILE`:
 
 - `core`: required build packages, X11/session runtime, and one supported
-  terminal.
+  terminal emulator. Herdr is skipped unless `--install-herdr` is provided.
 - `recommended`: `core` plus the recommended desktop layer such as Quickshell,
-  Quickshell, Picom, Feh, Dex, fonts, theming, screenshot, audio, Bluetooth
-  control and tray tools, and brightness tools. It also installs portable GTK theme packages where available and
-  installs Nordic system-wide for the default Nord theme.
+  Herdr on top of Alacritty, Picom, Feh, Dex, fonts, theming, screenshot,
+  audio, Bluetooth control and tray tools, and brightness tools. It also
+  installs portable GTK theme packages where available and installs Nordic
+  system-wide for the default Nord theme.
 - `full`: `recommended` plus optional extras such as Thunar with SMB-share
   browsing, network tray utilities, portals, keyring login integration,
   wallpapers, and display-manager setup. x86_64 Fedora full installs also
@@ -108,6 +124,15 @@ packaging checks, or scripted validation, use the non-interactive flags:
 
 Without `--enable-fedora-gaming-repos`, unattended Fedora full installs skip
 Steam, Gamescope, GameMode, and MangoHud rather than changing repository trust.
+
+Use `--skip-herdr` or `DWM_INSTALL_HERDR=false` to keep plain Alacritty. Use
+`--install-herdr` or `DWM_INSTALL_HERDR=true` to include Herdr with the core
+profile. Herdr can also be installed or repaired separately:
+
+```bash
+install-herdr
+install-herdr --force
+```
 
 ## Starting dwm
 
@@ -169,3 +194,6 @@ dwm-terminal --print-command
 
 `dwm-diagnostics` must report zero required failures before treating the
 minimal profile as ready. Optional degraded features can remain unresolved.
+When Herdr is installed, a plain `dwm-terminal` opens it in Alacritty. Commands
+such as `dwm-terminal -e sh -c 'command'` bypass Herdr and run directly in the
+outer emulator.

--- a/docs/src/keybinds.md
+++ b/docs/src/keybinds.md
@@ -14,7 +14,7 @@ Bindings are defined in `config/hotkeys.toml` and reload instantly on save — n
 | Keys | Action |
 |------|--------|
 | `Super` + `R` | App launcher (Quickshell) |
-| `Super` + `X` | Terminal |
+| `Super` + `X` | Herdr terminal workspace |
 | `Super` + `E` | File manager |
 | `Super` + `B` | Browser |
 | `Super` + `/` | Keybind viewer |
@@ -132,3 +132,6 @@ See the comments in `hotkeys.toml` for a full list of `func` values and modifier
 
 The browser binding uses `dwm-default-apps open`. Configure it with
 `dwm-default-apps browsers` and `dwm-default-apps set-browser <desktop-id>`.
+
+The default `dwm-terminal` wrapper opens Herdr inside Alacritty when Herdr is
+installed. Set `DWM_HERDR=0` to keep the same binding as a plain terminal.

--- a/docs/src/keybinds.md
+++ b/docs/src/keybinds.md
@@ -14,7 +14,7 @@ Bindings are defined in `config/hotkeys.toml` and reload instantly on save — n
 | Keys | Action |
 |------|--------|
 | `Super` + `R` | App launcher (Quickshell) |
-| `Super` + `X` | Herdr terminal workspace |
+| `Super` + `X` | Terminal workspace (Herdr when available) |
 | `Super` + `E` | File manager |
 | `Super` + `B` | Browser |
 | `Super` + `/` | Keybind viewer |

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -36,6 +36,8 @@ Or use the [Control Center](./control-center.md) → **System Health**.
 ## Terminal Won't Open (`Super`+`X`)
 
 - Run `dwm-terminal` from an existing shell to see the exact fallback message
+- Run `install-herdr --force` if Alacritty opens but Herdr does not
+- Set `DWM_HERDR=0` to confirm the outer terminal works without Herdr
 - Install a supported terminal: `alacritty`, `kitty`, `st`,
   `warp-terminal`, or `xterm`
 - Or set a fixed terminal in `config/hotkeys.toml`:
@@ -43,6 +45,10 @@ Or use the [Control Center](./control-center.md) → **System Health**.
   [vars]
   terminal = "alacritty"
   ```
+
+Herdr is a terminal workspace, not a graphical terminal emulator. The default
+stack is Herdr running inside Alacritty. X11 therefore reports the window class
+as `Alacritty`, which is already covered by the terminal swallowing rules.
 
 ## Browser Won't Open (`Super`+`B`)
 

--- a/dwm-fedora-nvidia.ks
+++ b/dwm-fedora-nvidia.ks
@@ -183,7 +183,7 @@ chown -R "$target_user:$target_group" "$target_repo_dir"
 install -m 0440 /dev/null "$install_sudoers"
 printf '%s ALL=(ALL) NOPASSWD: ALL\n' "$target_user" > "$install_sudoers"
 
-su - "$target_user" -c 'cd "$HOME/.local/share/dwm-titus" && ./install.sh --non-interactive --profile core'
+su - "$target_user" -c 'cd "$HOME/.local/share/dwm-titus" && ./install.sh --non-interactive --profile core --install-herdr'
 
 if getent group gamemode >/dev/null 2>&1; then
 	usermod -aG gamemode "$target_user"

--- a/dwm-fedora.ks
+++ b/dwm-fedora.ks
@@ -174,7 +174,7 @@ chown -R "$target_user:$target_group" "$target_repo_dir"
 install -m 0440 /dev/null "$install_sudoers"
 printf '%s ALL=(ALL) NOPASSWD: ALL\n' "$target_user" > "$install_sudoers"
 
-su - "$target_user" -c 'cd "$HOME/.local/share/dwm-titus" && ./install.sh --non-interactive --profile core'
+su - "$target_user" -c 'cd "$HOME/.local/share/dwm-titus" && ./install.sh --non-interactive --profile core --install-herdr'
 
 if getent group gamemode >/dev/null 2>&1; then
 	usermod -aG gamemode "$target_user"

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,8 @@ Options:
                          Defaults to DWM_INSTALL_PROFILE or full.
   --non-interactive      Use unattended defaults and do not prompt.
   --yes                  Accept the interactive install summary.
+  --install-herdr        Install verified Herdr even with the core profile.
+  --skip-herdr           Do not install Herdr.
   --enable-fedora-gaming-repos
                          Approve the Gamescope COPR and RPM Fusion nonfree.
   --dry-run              Print the resolved plan and exit before changes.
@@ -66,6 +68,7 @@ NORDIC_THEME_REF="master"
 ARCH="$(uname -m)"
 FEDORA_GAMING_COPR="christitustech/copr-fedora"
 INSTALL_PROFILE="${DWM_INSTALL_PROFILE:-full}"
+HERDR_INSTALL_MODE="${DWM_INSTALL_HERDR:-auto}"
 NON_INTERACTIVE=false
 ASSUME_YES=false
 FEDORA_GAMING_REPOS_APPROVED=false
@@ -92,6 +95,14 @@ while (($# > 0)); do
 		;;
 	--yes)
 		ASSUME_YES=true
+		shift
+		;;
+	--install-herdr)
+		HERDR_INSTALL_MODE=true
+		shift
+		;;
+	--skip-herdr)
+		HERDR_INSTALL_MODE=false
 		shift
 		;;
 	--enable-fedora-gaming-repos)
@@ -126,6 +137,21 @@ recommended | full) ;;
 	;;
 esac
 
+case "$HERDR_INSTALL_MODE" in
+auto) ;;
+1 | true | yes)
+	HERDR_INSTALL_MODE=true
+	;;
+0 | false | no)
+	HERDR_INSTALL_MODE=false
+	;;
+*)
+	err "Unsupported DWM_INSTALL_HERDR: $HERDR_INSTALL_MODE"
+	err "Supported values: auto, true, false"
+	exit 1
+	;;
+esac
+
 if [[ ! -t 0 || ! -t 1 ]]; then
 	NON_INTERACTIVE=true
 	ASSUME_YES=true
@@ -147,6 +173,19 @@ install_recommended_profile() {
 
 install_optional_profile() {
 	[[ $INSTALL_PROFILE == "full" ]]
+}
+
+install_herdr_profile() {
+	case $HERDR_INSTALL_MODE in
+	true)
+		return 0
+		;;
+	false)
+		return 1
+		;;
+	esac
+
+	install_recommended_profile
 }
 
 enable_optional_service() {
@@ -312,6 +351,11 @@ print_install_summary() {
 	else
 		print_summary_profile "Terminal candidates" terminal
 	fi
+	if install_herdr_profile; then
+		printf '  Herdr workspace: verified user install from https://herdr.dev/install.sh\n'
+	else
+		printf '  Herdr workspace: skipped\n'
+	fi
 	echo ""
 }
 
@@ -414,20 +458,6 @@ install_supported_terminal() {
 		err "No supported terminal is available in the enabled repositories."
 		return 1
 	fi
-}
-
-configure_seeded_terminal() {
-	local hotkeys_file=$1
-	local terminal=$2
-
-	if [[ $HOTKEYS_EXISTED == true ]]; then
-		return
-	fi
-
-	sed -i -E \
-		"s|^terminal = \"[^\"]*\"|terminal = \"$terminal\"|" \
-		"$hotkeys_file"
-	ok "Configured the default terminal: $terminal"
 }
 
 configure_quickshell_picom_opacity() {
@@ -698,17 +728,37 @@ fi
 
 # ── Terminal emulator ────────────────────────────────────
 terminal=""
-for t in alacritty kitty; do command -v "$t" &>/dev/null && {
-	terminal="$t"
-	break
-}; done
-
-if [ -n "$terminal" ]; then
-	ok "Terminal already installed: $terminal"
+if command -v alacritty &>/dev/null; then
+	terminal="alacritty"
+	ok "Preferred terminal already installed: $terminal"
 else
-	info "No supported terminal found - installing one from enabled repositories..."
-	install_supported_terminal
-	terminal="$(detect_terminal)"
+	info "Installing the preferred Alacritty terminal from enabled repositories..."
+	if dwm_install_first_available_profile terminal-primary; then
+		terminal="alacritty"
+		ok "Preferred terminal installed: $terminal"
+	else
+		warn "Alacritty is unavailable; falling back to another supported terminal."
+		for t in kitty st warp-terminal xterm; do command -v "$t" &>/dev/null && {
+			terminal="$t"
+			break
+		}; done
+		if [ -z "$terminal" ]; then
+			install_supported_terminal
+			terminal="$(detect_terminal)"
+		fi
+	fi
+fi
+
+# ── Herdr terminal workspace ─────────────────────────────
+if install_herdr_profile; then
+	info "Installing the verified Herdr workspace for interactive terminals..."
+	if "$REPO_DIR/scripts/install-herdr"; then
+		ok "Herdr is ready; plain dwm-terminal launches will open it in $terminal."
+	else
+		warn "Herdr installation failed; plain dwm-terminal launches will use $terminal directly."
+	fi
+else
+	warn "Skipping Herdr installation for the $INSTALL_PROFILE profile."
 fi
 
 # ── XDG dirs + wallpapers ────────────────────────────────
@@ -766,13 +816,6 @@ if is_arch_arm; then
 fi
 
 # ── Build & Install ──────────────────────────────────────
-HOTKEYS_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/dwm-titus/hotkeys.toml"
-if [[ -f $HOTKEYS_FILE ]]; then
-	HOTKEYS_EXISTED=true
-else
-	HOTKEYS_EXISTED=false
-fi
-
 cd "$REPO_DIR"
 make clean
 make
@@ -782,7 +825,6 @@ sudo make install \
 	DATADIR="/usr/share" \
 	XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}" \
 	XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
-configure_seeded_terminal "$HOTKEYS_FILE" "$terminal"
 configure_displays_after_install
 
 # ── Done ─────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -73,6 +73,7 @@ NON_INTERACTIVE=false
 ASSUME_YES=false
 FEDORA_GAMING_REPOS_APPROVED=false
 DRY_RUN=false
+HERDR_READY=false
 
 while (($# > 0)); do
 	case "$1" in
@@ -175,6 +176,17 @@ install_optional_profile() {
 	[[ $INSTALL_PROFILE == "full" ]]
 }
 
+herdr_arch_supported() {
+	case $ARCH in
+	x86_64 | amd64 | aarch64 | arm64)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
 install_herdr_profile() {
 	case $HERDR_INSTALL_MODE in
 	true)
@@ -185,7 +197,17 @@ install_herdr_profile() {
 		;;
 	esac
 
-	install_recommended_profile
+	herdr_arch_supported && install_recommended_profile
+}
+
+report_herdr_hotkey_migration() {
+	local hotkeys_file="${XDG_CONFIG_HOME:-$HOME/.config}/dwm-titus/hotkeys.toml"
+	local legacy_terminal
+
+	if legacy_terminal="$(dwm_legacy_seeded_terminal_hotkey "$hotkeys_file")"; then
+		warn "Existing hotkeys still launch $legacy_terminal directly for Super+X."
+		warn "To use Herdr from Super+X, set terminal = \"dwm-terminal\" in $hotkeys_file."
+	fi
 }
 
 enable_optional_service() {
@@ -353,6 +375,9 @@ print_install_summary() {
 	fi
 	if install_herdr_profile; then
 		printf '  Herdr workspace: verified user install from https://herdr.dev/install.sh\n'
+	elif [[ $HERDR_INSTALL_MODE == auto ]] &&
+		install_recommended_profile && ! herdr_arch_supported; then
+		printf '  Herdr workspace: skipped (unsupported architecture: %s)\n' "$ARCH"
 	else
 		printf '  Herdr workspace: skipped\n'
 	fi
@@ -753,15 +778,20 @@ fi
 if install_herdr_profile; then
 	info "Installing the verified Herdr workspace for interactive terminals..."
 	if "$REPO_DIR/scripts/install-herdr"; then
+		HERDR_READY=true
 		ok "Herdr is ready; plain dwm-terminal launches will open it in $terminal."
 	else
 		herdr_status=$?
 		if [[ $herdr_status -eq 2 ]]; then
+			HERDR_READY=true
 			warn "Herdr is ready, but one or more detected agent integrations could not be installed."
 		else
 			warn "Herdr installation failed; plain dwm-terminal launches will use $terminal directly."
 		fi
 	fi
+elif [[ $HERDR_INSTALL_MODE == auto ]] &&
+	install_recommended_profile && ! herdr_arch_supported; then
+	warn "Skipping automatic Herdr installation on unsupported architecture: $ARCH."
 else
 	warn "Skipping Herdr installation for the $INSTALL_PROFILE profile."
 fi
@@ -830,6 +860,9 @@ sudo make install \
 	DATADIR="/usr/share" \
 	XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}" \
 	XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+if [[ $HERDR_READY == true ]]; then
+	report_herdr_hotkey_migration
+fi
 configure_displays_after_install
 
 # ── Done ─────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -755,7 +755,12 @@ if install_herdr_profile; then
 	if "$REPO_DIR/scripts/install-herdr"; then
 		ok "Herdr is ready; plain dwm-terminal launches will open it in $terminal."
 	else
-		warn "Herdr installation failed; plain dwm-terminal launches will use $terminal directly."
+		herdr_status=$?
+		if [[ $herdr_status -eq 2 ]]; then
+			warn "Herdr is ready, but one or more detected agent integrations could not be installed."
+		else
+			warn "Herdr installation failed; plain dwm-terminal launches will use $terminal directly."
+		fi
 	fi
 else
 	warn "Skipping Herdr installation for the $INSTALL_PROFILE profile."

--- a/install.sh
+++ b/install.sh
@@ -210,6 +210,23 @@ report_herdr_hotkey_migration() {
 	fi
 }
 
+runtime_herdr_available() {
+	case ${DWM_HERDR:-1} in
+	0 | false | no)
+		return 1
+		;;
+	esac
+
+	if [[ -n ${DWM_HERDR_COMMAND:-} ]]; then
+		command -v "$DWM_HERDR_COMMAND" >/dev/null 2>&1 ||
+			[[ -x $DWM_HERDR_COMMAND ]]
+		return
+	fi
+
+	command -v herdr >/dev/null 2>&1 ||
+		[[ -x ${HOME:-}/.local/bin/herdr ]]
+}
+
 enable_optional_service() {
 	local service=$1
 
@@ -785,6 +802,9 @@ if install_herdr_profile; then
 		if [[ $herdr_status -eq 2 ]]; then
 			HERDR_READY=true
 			warn "Herdr is ready, but one or more detected agent integrations could not be installed."
+		elif runtime_herdr_available; then
+			warn "Herdr setup failed, but dwm-terminal can still select an existing Herdr executable."
+			warn "Set DWM_HERDR=0 or remove the rejected executable to force plain $terminal."
 		else
 			warn "Herdr installation failed; plain dwm-terminal launches will use $terminal directly."
 		fi

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -135,6 +135,13 @@ if [ $TERM_FOUND -eq 0 ]; then
 	printf "  ${RED}✗${NC} No supported terminal found ${YELLOW}(install alacritty, kitty, or st)${NC}\n"
 	MISSING=$((MISSING + 1))
 fi
+if command -v herdr &>/dev/null; then
+	printf "  ${GREEN}✓${NC} Herdr workspace\n"
+elif [ -x "$HOME/.local/bin/herdr" ]; then
+	printf "  ${GREEN}✓${NC} Herdr workspace ($HOME/.local/bin/herdr)\n"
+else
+	printf "  ${YELLOW}○${NC} Herdr workspace ${YELLOW}(optional; plain terminals remain available)${NC}\n"
+fi
 echo ""
 
 # ── Optional but recommended ────────────────────────────

--- a/scripts/dwm-diagnostics
+++ b/scripts/dwm-diagnostics
@@ -151,6 +151,18 @@ check_terminal() {
 	required_missing terminal "terminal (alacritty kitty st warp-terminal xterm)" "No supported terminal is available"
 }
 
+check_herdr() {
+	local path="${HOME:-}/.local/bin/herdr"
+
+	if have_cmd herdr; then
+		ok herdr "Herdr workspace" "Herdr is available on PATH"
+	elif [[ -n ${HOME:-} && -x $path ]]; then
+		ok herdr "Herdr workspace" "$path is available"
+	else
+		optional_missing herdr "Herdr workspace" "Install with install-herdr; dwm-terminal will use the outer terminal directly"
+	fi
+}
+
 check_path_optional() {
 	local id=$1
 	local path=$2
@@ -186,6 +198,7 @@ main() {
 	for cmd in quickshell picom feh flameshot xdg-open notify-send amixer brightnessctl light-locker gsettings xprop; do
 		check_optional_cmd "$cmd"
 	done
+	check_herdr
 	check_optional_cmd blueman-applet
 	check_any_optional_cmd "XDG autostart runner" dex dex-autostart
 	check_any_optional_cmd "audio control" pactl wpctl amixer

--- a/scripts/dwm-packages.sh
+++ b/scripts/dwm-packages.sh
@@ -184,6 +184,9 @@ dwm_packages() {
 	debian:terminal)
 		printf '%s\n' alacritty kitty
 		;;
+	*:terminal-primary)
+		printf '%s\n' alacritty
+		;;
 	*:required)
 		dwm_packages "$family" build
 		dwm_packages "$family" x11

--- a/scripts/dwm-terminal
+++ b/scripts/dwm-terminal
@@ -9,12 +9,46 @@ DEFAULT_TERMINALS=(
 	xterm
 )
 
+print_only=0
 if [[ ${1:-} == "--print-command" ]]; then
 	print_only=1
 	shift
-else
-	print_only=0
 fi
+
+find_herdr() {
+	local candidate
+
+	case ${DWM_HERDR:-1} in
+	0 | false | no)
+		return 1
+		;;
+	esac
+
+	if [[ -n ${DWM_HERDR_COMMAND:-} ]]; then
+		if command -v "$DWM_HERDR_COMMAND" >/dev/null 2>&1; then
+			command -v "$DWM_HERDR_COMMAND"
+			return
+		fi
+		if [[ -x $DWM_HERDR_COMMAND ]]; then
+			printf '%s\n' "$DWM_HERDR_COMMAND"
+			return
+		fi
+		return 1
+	fi
+
+	if candidate=$(command -v herdr 2>/dev/null); then
+		printf '%s\n' "$candidate"
+		return
+	fi
+
+	candidate="${HOME:-}/.local/bin/herdr"
+	if [[ -n ${HOME:-} && -x $candidate ]]; then
+		printf '%s\n' "$candidate"
+		return
+	fi
+
+	return 1
+}
 
 terminals=()
 
@@ -30,6 +64,11 @@ for terminal in "${terminals[@]}"; do
 			printf '%s\n' "$terminal"
 			exit 0
 		fi
+
+		if (($# == 0)) && herdr=$(find_herdr); then
+			exec "$terminal" -e "$herdr"
+		fi
+
 		exec "$terminal" "$@"
 	fi
 done

--- a/scripts/dwm-utils.sh
+++ b/scripts/dwm-utils.sh
@@ -164,3 +164,24 @@ detect_terminal() {
 	done
 	echo "xterm"
 }
+
+dwm_legacy_seeded_terminal_hotkey() {
+	local hotkeys_file=$1
+	local terminal_value
+
+	[[ -f $hotkeys_file ]] || return 1
+	terminal_value="$(
+		sed -n -E \
+			's/^[[:space:]]*terminal[[:space:]]*=[[:space:]]*"([^"]*)".*/\1/p' \
+			"$hotkeys_file" | head -n 1
+	)"
+
+	case $terminal_value in
+	alacritty | kitty | st | warp-terminal | xterm)
+		printf '%s\n' "$terminal_value"
+		;;
+	*)
+		return 1
+		;;
+	esac
+}

--- a/scripts/dwm-utils.sh
+++ b/scripts/dwm-utils.sh
@@ -166,10 +166,10 @@ detect_terminal() {
 }
 
 dwm_legacy_seeded_terminal_hotkey() {
-	local hotkeys_file=$1
+	local hotkeys_file="$1"
 	local terminal_value
 
-	[[ -f $hotkeys_file ]] || return 1
+	[[ -f "$hotkeys_file" ]] || return 1
 	terminal_value="$(
 		sed -n -E \
 			's/^[[:space:]]*terminal[[:space:]]*=[[:space:]]*"([^"]*)".*/\1/p' \

--- a/scripts/install-herdr
+++ b/scripts/install-herdr
@@ -76,6 +76,37 @@ binary_matches_pin() {
 	[ "$actual_sha256" = "$asset_sha256" ]
 }
 
+wrapper_selected_herdr() {
+	if [ -n "${DWM_HERDR_COMMAND:-}" ]; then
+		if command -v "$DWM_HERDR_COMMAND" >/dev/null 2>&1; then
+			command -v "$DWM_HERDR_COMMAND"
+			return
+		fi
+		if [ -x "$DWM_HERDR_COMMAND" ]; then
+			printf '%s\n' "$DWM_HERDR_COMMAND"
+			return
+		fi
+		return 1
+	fi
+
+	if command -v herdr >/dev/null 2>&1; then
+		command -v herdr
+		return
+	fi
+
+	if [ -n "${HOME:-}" ] && [ -x "$HOME/.local/bin/herdr" ]; then
+		printf '%s\n' "$HOME/.local/bin/herdr"
+		return
+	fi
+
+	return 1
+}
+
+wrapper_selects_pinned_herdr() {
+	selected=$(wrapper_selected_herdr 2>/dev/null || true)
+	[ -n "$selected" ] && binary_matches_pin "$selected"
+}
+
 install_detected_integrations() {
 	integration_herdr=$1
 	integration_failed=false
@@ -107,7 +138,7 @@ if [ "$dry_run" = true ]; then
 	exit 0
 fi
 
-existing=$(command -v herdr 2>/dev/null || true)
+existing=$(wrapper_selected_herdr 2>/dev/null || true)
 if [ -z "$existing" ] && [ -x "$target" ]; then
 	existing=$target
 fi
@@ -124,11 +155,17 @@ if [ -n "$existing" ] && [ "$force" != true ]; then
 			"$target" >&2
 		exit 1
 	fi
-	if ! install_detected_integrations "$existing"; then
+	if ! wrapper_selects_pinned_herdr; then
+		printf 'install-herdr: Herdr is verified at %s, but the terminal wrapper would select an unverified executable: %s\n' \
+			"$existing" "${selected:-none}" >&2
+		printf 'Adjust PATH, HERDR_INSTALL_DIR, or DWM_HERDR_COMMAND so the verified executable is selected.\n' >&2
+		exit 1
+	fi
+	if ! install_detected_integrations "$selected"; then
 		printf 'install-herdr: Herdr is verified, but one or more detected agent integrations failed.\n' >&2
 		exit 2
 	fi
-	printf 'Herdr is already installed and verified: %s\n' "$existing"
+	printf 'Herdr is already installed and verified: %s\n' "$selected"
 	exit 0
 fi
 
@@ -188,14 +225,10 @@ else
 fi
 install -m 0755 "$staged_binary" "$target"
 
-selected=$(command -v herdr 2>/dev/null || true)
-if [ -z "$selected" ] && [ "$target" = "${HOME:-}/.local/bin/herdr" ]; then
-	selected=$target
-fi
-if [ -z "$selected" ] || ! binary_matches_pin "$selected"; then
+if ! wrapper_selects_pinned_herdr; then
 	printf 'install-herdr: installed verified Herdr %s to %s, but the terminal wrapper would select an unverified executable: %s\n' \
 		"$HERDR_VERSION" "$target" "${selected:-none}" >&2
-	printf 'Adjust PATH or HERDR_INSTALL_DIR so the verified executable is selected.\n' >&2
+	printf 'Adjust PATH, HERDR_INSTALL_DIR, or DWM_HERDR_COMMAND so the verified executable is selected.\n' >&2
 	exit 1
 fi
 

--- a/scripts/install-herdr
+++ b/scripts/install-herdr
@@ -99,6 +99,14 @@ install_detected_integrations() {
 	[ "$integration_failed" = false ]
 }
 
+if [ "$dry_run" = true ]; then
+	printf 'Herdr version: %s\n' "$HERDR_VERSION"
+	printf 'Official installer: %s\n' "$HERDR_INSTALLER_URL"
+	printf 'Install path: %s\n' "$target"
+	printf 'Verification: pinned SHA-256 checksums\n'
+	exit 0
+fi
+
 existing=$(command -v herdr 2>/dev/null || true)
 if [ -z "$existing" ] && [ -x "$target" ]; then
 	existing=$target
@@ -121,14 +129,6 @@ if [ -n "$existing" ] && [ "$force" != true ]; then
 		exit 2
 	fi
 	printf 'Herdr is already installed and verified: %s\n' "$existing"
-	exit 0
-fi
-
-if [ "$dry_run" = true ]; then
-	printf 'Herdr version: %s\n' "$HERDR_VERSION"
-	printf 'Official installer: %s\n' "$HERDR_INSTALLER_URL"
-	printf 'Install path: %s\n' "$target"
-	printf 'Verification: pinned SHA-256 checksums\n'
 	exit 0
 fi
 

--- a/scripts/install-herdr
+++ b/scripts/install-herdr
@@ -52,15 +52,6 @@ fi
 
 install_dir=${HERDR_INSTALL_DIR:-"$HOME/.local/bin"}
 target="$install_dir/herdr"
-existing=$(command -v herdr 2>/dev/null || true)
-if [ -z "$existing" ] && [ -x "$target" ]; then
-	existing=$target
-fi
-
-if [ -n "$existing" ] && [ "$force" != true ]; then
-	printf 'Herdr is already installed: %s\n' "$existing"
-	exit 0
-fi
 
 case $(uname -m) in
 x86_64 | amd64)
@@ -78,6 +69,60 @@ esac
 
 installer_sha256=${HERDR_INSTALLER_SHA256:-$HERDR_INSTALLER_SHA256_DEFAULT}
 asset_sha256=${HERDR_ASSET_SHA256:-$asset_sha256}
+
+binary_matches_pin() {
+	actual_sha256=$(sha256sum "$1" 2>/dev/null) || return 1
+	actual_sha256=${actual_sha256%% *}
+	[ "$actual_sha256" = "$asset_sha256" ]
+}
+
+install_detected_integrations() {
+	integration_herdr=$1
+	integration_failed=false
+
+	if command -v codex >/dev/null 2>&1; then
+		printf 'Installing the Herdr integration for Codex...\n'
+		if ! "$integration_herdr" integration install codex; then
+			printf 'install-herdr: failed to install the Herdr integration for Codex.\n' >&2
+			integration_failed=true
+		fi
+	fi
+
+	if command -v claude >/dev/null 2>&1; then
+		printf 'Installing the Herdr integration for Claude Code...\n'
+		if ! "$integration_herdr" integration install claude; then
+			printf 'install-herdr: failed to install the Herdr integration for Claude Code.\n' >&2
+			integration_failed=true
+		fi
+	fi
+
+	[ "$integration_failed" = false ]
+}
+
+existing=$(command -v herdr 2>/dev/null || true)
+if [ -z "$existing" ] && [ -x "$target" ]; then
+	existing=$target
+fi
+
+if [ -n "$existing" ] && [ "$force" != true ]; then
+	if ! command -v sha256sum >/dev/null 2>&1; then
+		printf 'install-herdr: required command not found: sha256sum\n' >&2
+		exit 1
+	fi
+	if ! binary_matches_pin "$existing"; then
+		printf 'install-herdr: the selected Herdr executable is not the verified %s release: %s\n' \
+			"$HERDR_VERSION" "$existing" >&2
+		printf 'Remove it from PATH or rerun with --force after ensuring %s will be selected.\n' \
+			"$target" >&2
+		exit 1
+	fi
+	if ! install_detected_integrations "$existing"; then
+		printf 'install-herdr: Herdr is verified, but one or more detected agent integrations failed.\n' >&2
+		exit 2
+	fi
+	printf 'Herdr is already installed and verified: %s\n' "$existing"
+	exit 0
+fi
 
 if [ "$dry_run" = true ]; then
 	printf 'Herdr version: %s\n' "$HERDR_VERSION"
@@ -132,6 +177,31 @@ if ! printf '%s  %s\n' "$asset_sha256" "$staged_binary" |
 	exit 1
 fi
 
-install -d -m 0755 "$install_dir"
+if [ -e "$install_dir" ]; then
+	if [ ! -d "$install_dir" ]; then
+		printf 'install-herdr: install path exists but is not a directory: %s\n' \
+			"$install_dir" >&2
+		exit 1
+	fi
+else
+	install -d -m 0755 "$install_dir"
+fi
 install -m 0755 "$staged_binary" "$target"
+
+selected=$(command -v herdr 2>/dev/null || true)
+if [ -z "$selected" ] && [ "$target" = "${HOME:-}/.local/bin/herdr" ]; then
+	selected=$target
+fi
+if [ -z "$selected" ] || ! binary_matches_pin "$selected"; then
+	printf 'install-herdr: installed verified Herdr %s to %s, but the terminal wrapper would select an unverified executable: %s\n' \
+		"$HERDR_VERSION" "$target" "${selected:-none}" >&2
+	printf 'Adjust PATH or HERDR_INSTALL_DIR so the verified executable is selected.\n' >&2
+	exit 1
+fi
+
+if ! install_detected_integrations "$selected"; then
+	printf 'install-herdr: Herdr was installed and verified, but one or more detected agent integrations failed.\n' >&2
+	exit 2
+fi
+
 printf 'Installed verified Herdr %s to %s\n' "$HERDR_VERSION" "$target"

--- a/scripts/install-herdr
+++ b/scripts/install-herdr
@@ -169,7 +169,7 @@ if [ -n "$existing" ] && [ "$force" != true ]; then
 	exit 0
 fi
 
-for command in curl install mktemp sha256sum; do
+for command in curl install mktemp mv sha256sum; do
 	if ! command -v "$command" >/dev/null 2>&1; then
 		printf 'install-herdr: required command not found: %s\n' "$command" >&2
 		exit 1
@@ -177,7 +177,9 @@ for command in curl install mktemp sha256sum; do
 done
 
 tmp_dir=$(mktemp -d)
-trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
+pending_target=
+trap 'rm -rf "$tmp_dir"; if [ -n "$pending_target" ]; then rm -f "$pending_target"; fi' \
+	EXIT HUP INT TERM
 installer="$tmp_dir/install.sh"
 stage_dir="$tmp_dir/stage"
 
@@ -223,7 +225,17 @@ if [ -e "$install_dir" ]; then
 else
 	install -d -m 0755 "$install_dir"
 fi
-install -m 0755 "$staged_binary" "$target"
+
+pending_target=$(mktemp "$install_dir/.herdr.XXXXXX")
+if ! install -m 0755 "$staged_binary" "$pending_target"; then
+	printf 'install-herdr: failed to copy the verified Herdr binary into the install directory.\n' >&2
+	exit 1
+fi
+if ! mv -f "$pending_target" "$target"; then
+	printf 'install-herdr: failed to atomically install the verified Herdr binary.\n' >&2
+	exit 1
+fi
+pending_target=
 
 if ! wrapper_selects_pinned_herdr; then
 	printf 'install-herdr: installed verified Herdr %s to %s, but the terminal wrapper would select an unverified executable: %s\n' \

--- a/scripts/install-herdr
+++ b/scripts/install-herdr
@@ -1,0 +1,137 @@
+#!/bin/sh
+set -eu
+
+HERDR_VERSION="0.7.5"
+HERDR_INSTALLER_URL="https://herdr.dev/install.sh"
+HERDR_INSTALLER_SHA256_DEFAULT="57c35622122f672ac311cbd7784be6af60912910287229492679033162b4604c"
+HERDR_X86_64_SHA256="3dc83288073e4c2d3c679a30e7be97bcca9141c6fd17dbbb9219142e95c59253"
+HERDR_AARCH64_SHA256="32e763a1499a6b694b1d708e4f062b743be1da9f34fcfa4d212d6db6fe09a8b9"
+
+usage() {
+	cat <<EOF
+Usage: install-herdr [--dry-run] [--force]
+
+Install the pinned Herdr ${HERDR_VERSION} release through the official installer.
+The installer and staged binary are checksum-verified before Herdr is installed.
+
+Options:
+  --dry-run  Print the verified source and destination without downloading.
+  --force    Replace an existing Herdr installation after verification.
+  -h, --help Show this help.
+EOF
+}
+
+dry_run=false
+force=false
+
+while [ "$#" -gt 0 ]; do
+	case $1 in
+	--dry-run)
+		dry_run=true
+		;;
+	--force)
+		force=true
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		printf 'install-herdr: unknown option: %s\n' "$1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+	shift
+done
+
+if [ "$(id -u)" -eq 0 ] && [ "${HERDR_ALLOW_ROOT:-0}" != 1 ]; then
+	printf 'install-herdr: run as the target user, not as root.\n' >&2
+	exit 1
+fi
+
+install_dir=${HERDR_INSTALL_DIR:-"$HOME/.local/bin"}
+target="$install_dir/herdr"
+existing=$(command -v herdr 2>/dev/null || true)
+if [ -z "$existing" ] && [ -x "$target" ]; then
+	existing=$target
+fi
+
+if [ -n "$existing" ] && [ "$force" != true ]; then
+	printf 'Herdr is already installed: %s\n' "$existing"
+	exit 0
+fi
+
+case $(uname -m) in
+x86_64 | amd64)
+	asset_sha256=$HERDR_X86_64_SHA256
+	;;
+aarch64 | arm64)
+	asset_sha256=$HERDR_AARCH64_SHA256
+	;;
+*)
+	printf 'install-herdr: unsupported architecture: %s\n' "$(uname -m)" >&2
+	printf 'Herdr publishes Linux binaries for x86_64 and aarch64.\n' >&2
+	exit 1
+	;;
+esac
+
+installer_sha256=${HERDR_INSTALLER_SHA256:-$HERDR_INSTALLER_SHA256_DEFAULT}
+asset_sha256=${HERDR_ASSET_SHA256:-$asset_sha256}
+
+if [ "$dry_run" = true ]; then
+	printf 'Herdr version: %s\n' "$HERDR_VERSION"
+	printf 'Official installer: %s\n' "$HERDR_INSTALLER_URL"
+	printf 'Install path: %s\n' "$target"
+	printf 'Verification: pinned SHA-256 checksums\n'
+	exit 0
+fi
+
+for command in curl install mktemp sha256sum; do
+	if ! command -v "$command" >/dev/null 2>&1; then
+		printf 'install-herdr: required command not found: %s\n' "$command" >&2
+		exit 1
+	fi
+done
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
+installer="$tmp_dir/install.sh"
+stage_dir="$tmp_dir/stage"
+
+printf 'Downloading the official Herdr installer from %s\n' "$HERDR_INSTALLER_URL"
+if ! curl --fail --silent --show-error --location \
+	--retry 3 --connect-timeout 10 --max-time 30 \
+	"$HERDR_INSTALLER_URL" --output "$installer"; then
+	printf 'install-herdr: failed to download the official installer.\n' >&2
+	exit 1
+fi
+
+if ! printf '%s  %s\n' "$installer_sha256" "$installer" |
+	sha256sum --check --status; then
+	printf 'install-herdr: installer checksum verification failed.\n' >&2
+	printf 'The upstream installer may have changed; update the reviewed pins before installing.\n' >&2
+	exit 1
+fi
+
+mkdir -p "$stage_dir"
+if ! HERDR_INSTALL_DIR="$stage_dir" sh "$installer"; then
+	printf 'install-herdr: the official installer failed in the staging directory.\n' >&2
+	exit 1
+fi
+
+staged_binary="$stage_dir/herdr"
+if [ ! -f "$staged_binary" ]; then
+	printf 'install-herdr: the official installer did not produce a Herdr binary.\n' >&2
+	exit 1
+fi
+
+if ! printf '%s  %s\n' "$asset_sha256" "$staged_binary" |
+	sha256sum --check --status; then
+	printf 'install-herdr: Herdr %s binary checksum verification failed.\n' "$HERDR_VERSION" >&2
+	exit 1
+fi
+
+install -d -m 0755 "$install_dir"
+install -m 0755 "$staged_binary" "$target"
+printf 'Installed verified Herdr %s to %s\n' "$HERDR_VERSION" "$target"

--- a/tests/test-dwm-terminal.sh
+++ b/tests/test-dwm-terminal.sh
@@ -25,6 +25,42 @@ grep -Fqx "$work/bin/alacritty" "$work/out"
 grep -Fqx -- "--class" "$work/out"
 grep -Fqx "dwm-test" "$work/out"
 
+cat >"$work/bin/herdr" <<'SCRIPT'
+#!/bin/sh
+exit 0
+SCRIPT
+chmod +x "$work/bin/herdr"
+
+DWM_TERMINAL_TEST_OUT="$work/herdr-out" \
+	PATH="$work/bin" \
+	"$BASH_BIN" "$HELPER"
+
+grep -Fqx "$work/bin/alacritty" "$work/herdr-out"
+grep -Fqx -- "-e" "$work/herdr-out"
+grep -Fqx "$work/bin/herdr" "$work/herdr-out"
+
+DWM_TERMINAL_TEST_OUT="$work/direct-out" \
+	PATH="$work/bin" \
+	"$BASH_BIN" "$HELPER" -e sh -c "printf direct"
+
+grep -Fqx "$work/bin/alacritty" "$work/direct-out"
+grep -Fqx -- "-e" "$work/direct-out"
+grep -Fqx "sh" "$work/direct-out"
+if grep -Fqx "$work/bin/herdr" "$work/direct-out"; then
+	echo "dwm-terminal wrapped an explicit command in Herdr" >&2
+	exit 1
+fi
+
+DWM_TERMINAL_TEST_OUT="$work/disabled-out" \
+	DWM_HERDR=0 \
+	PATH="$work/bin" \
+	"$BASH_BIN" "$HELPER"
+
+if grep -Fqx -- "-e" "$work/disabled-out"; then
+	echo "dwm-terminal launched Herdr while DWM_HERDR=0" >&2
+	exit 1
+fi
+
 cat >"$work/bin/custom-term" <<'SCRIPT'
 #!/bin/sh
 printf 'custom\n' >"$DWM_TERMINAL_TEST_OUT"
@@ -38,7 +74,7 @@ DWM_TERMINAL_TEST_OUT="$work/custom-out" \
 
 grep -Fqx "custom" "$work/custom-out"
 
-rm -f "$work/bin/alacritty" "$work/bin/custom-term"
+rm -f "$work/bin/alacritty" "$work/bin/custom-term" "$work/bin/herdr"
 
 if PATH="$work/bin" "$BASH_BIN" "$HELPER" 2>"$work/err"; then
 	echo "dwm-terminal succeeded without a terminal" >&2

--- a/tests/test-install-herdr.sh
+++ b/tests/test-install-herdr.sh
@@ -206,6 +206,42 @@ env \
 grep -Fq "Herdr is already installed and verified: $work/custom/herdr" \
 	"$work/custom-selected.out"
 
+cat >"$work/herdr-binary-new" <<'SCRIPT'
+#!/bin/sh
+printf 'herdr 0.7.5 replacement\n'
+SCRIPT
+chmod +x "$work/herdr-binary-new"
+replacement_sha256="$(sha256sum "$work/herdr-binary-new" | awk '{print $1}')"
+
+mkdir -p "$work/fail-bin"
+cat >"$work/fail-bin/mv" <<'SCRIPT'
+#!/bin/sh
+exit 1
+SCRIPT
+chmod +x "$work/fail-bin/mv"
+
+if env \
+	HOME="$work/home" \
+	HERDR_ALLOW_ROOT=1 \
+	HERDR_INSTALL_DIR="$work/home/.local/bin" \
+	HERDR_INSTALLER_SHA256="$installer_sha256" \
+	HERDR_ASSET_SHA256="$replacement_sha256" \
+	HERDR_TEST_BINARY="$work/herdr-binary-new" \
+	HERDR_TEST_INSTALLER="$work/remote-installer.sh" \
+	PATH="$work/home/.local/bin:$work/fail-bin:$work/bin:/usr/bin:/bin" \
+	"$HELPER" --force >"$work/atomic.out" 2>"$work/atomic.err"; then
+	echo "install-herdr ignored an atomic replacement failure" >&2
+	exit 1
+fi
+
+grep -Fq "failed to atomically install" "$work/atomic.err"
+test "$("$work/home/.local/bin/herdr" --version)" = "herdr 0.7.5"
+if find "$work/home/.local/bin" -maxdepth 1 -name '.herdr.*' -print -quit |
+	grep -q .; then
+	echo "install-herdr left a failed replacement temporary file" >&2
+	exit 1
+fi
+
 if env \
 	HOME="$work/home" \
 	HERDR_ALLOW_ROOT=1 \

--- a/tests/test-install-herdr.sh
+++ b/tests/test-install-herdr.sh
@@ -177,6 +177,35 @@ grep -Fq "terminal wrapper would select an unverified executable" \
 	"$work/shadowed.err"
 test "$(stat -c '%a' "$work/home/.local/bin")" = "700"
 
+mkdir -p "$work/custom" "$work/custom-home"
+install -m 0755 "$work/herdr-binary" "$work/custom/herdr"
+
+if env \
+	HOME="$work/custom-home" \
+	HERDR_ALLOW_ROOT=1 \
+	HERDR_INSTALL_DIR="$work/custom" \
+	HERDR_ASSET_SHA256="$asset_sha256" \
+	PATH="$work/bin:/usr/bin:/bin" \
+	"$HELPER" >"$work/custom-unselected.out" 2>"$work/custom-unselected.err"; then
+	echo "install-herdr accepted a custom install the wrapper could not select" >&2
+	exit 1
+fi
+
+grep -Fq "terminal wrapper would select an unverified executable: none" \
+	"$work/custom-unselected.err"
+
+env \
+	HOME="$work/custom-home" \
+	HERDR_ALLOW_ROOT=1 \
+	HERDR_INSTALL_DIR="$work/custom" \
+	HERDR_ASSET_SHA256="$asset_sha256" \
+	DWM_HERDR_COMMAND="$work/custom/herdr" \
+	PATH="$work/bin:/usr/bin:/bin" \
+	"$HELPER" >"$work/custom-selected.out"
+
+grep -Fq "Herdr is already installed and verified: $work/custom/herdr" \
+	"$work/custom-selected.out"
+
 if env \
 	HOME="$work/home" \
 	HERDR_ALLOW_ROOT=1 \
@@ -195,20 +224,45 @@ grep -Fq "binary checksum verification failed" "$work/tampered.err"
 test "$("$work/home/.local/bin/herdr" --version)" = "herdr 0.7.5"
 test "$(stat -c '%a' "$work/home/.local/bin")" = "700"
 
-mkdir -p "$work/arm-bin"
-cat >"$work/arm-bin/uname" <<'SCRIPT'
+mkdir -p "$work/plan-bin"
+cat >"$work/plan-bin/uname" <<'SCRIPT'
 #!/bin/sh
-printf 'armv7l\n'
+printf '%s\n' "$DWM_TEST_UNAME"
 SCRIPT
-chmod +x "$work/arm-bin/uname"
+chmod +x "$work/plan-bin/uname"
 
 env \
 	HOME="$work/home" \
-	PATH="$work/arm-bin:$PATH" \
+	DWM_TEST_UNAME=armv7l \
+	PATH="$work/plan-bin:$PATH" \
 	"$ROOT_DIR/install.sh" --dry-run --non-interactive --profile recommended \
 	>"$work/arm-plan.out"
 
 grep -Fq "Herdr workspace: skipped (unsupported architecture: armv7l)" \
 	"$work/arm-plan.out"
+
+env \
+	HOME="$work/home" \
+	DWM_TEST_UNAME=x86_64 \
+	PATH="$work/plan-bin:$PATH" \
+	"$ROOT_DIR/install.sh" --dry-run --non-interactive --profile recommended \
+	>"$work/recommended-plan.out"
+grep -Fq "Herdr workspace: verified user install" "$work/recommended-plan.out"
+
+env \
+	HOME="$work/home" \
+	DWM_TEST_UNAME=x86_64 \
+	PATH="$work/plan-bin:$PATH" \
+	"$ROOT_DIR/install.sh" --dry-run --non-interactive --profile core \
+	--install-herdr >"$work/forced-plan.out"
+grep -Fq "Herdr workspace: verified user install" "$work/forced-plan.out"
+
+env \
+	HOME="$work/home" \
+	DWM_TEST_UNAME=x86_64 \
+	PATH="$work/plan-bin:$PATH" \
+	"$ROOT_DIR/install.sh" --dry-run --non-interactive --profile recommended \
+	--skip-herdr >"$work/skipped-plan.out"
+grep -Fq "Herdr workspace: skipped" "$work/skipped-plan.out"
 
 printf 'install-herdr tests: PASS\n'

--- a/tests/test-install-herdr.sh
+++ b/tests/test-install-herdr.sh
@@ -7,7 +7,8 @@ HELPER="$ROOT_DIR/scripts/install-herdr"
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 
-mkdir -p "$work/bin" "$work/home"
+mkdir -p "$work/bin" "$work/agent-bin" "$work/home"
+install -d -m 0700 "$work/home/.local/bin"
 
 cat >"$work/remote-installer.sh" <<'SCRIPT'
 #!/bin/sh
@@ -18,9 +19,24 @@ SCRIPT
 
 cat >"$work/herdr-binary" <<'SCRIPT'
 #!/bin/sh
+if [ "${1:-}" = "integration" ] && [ "${2:-}" = "install" ]; then
+	if [ "${HERDR_TEST_FAIL_INTEGRATION:-}" = "${3:-}" ]; then
+		exit 1
+	fi
+	printf '%s\n' "$3" >>"$HERDR_TEST_INTEGRATION_LOG"
+	exit 0
+fi
 printf 'herdr 0.7.5\n'
 SCRIPT
 chmod +x "$work/herdr-binary"
+
+for agent in codex claude; do
+	cat >"$work/agent-bin/$agent" <<'SCRIPT'
+#!/bin/sh
+exit 0
+SCRIPT
+	chmod +x "$work/agent-bin/$agent"
+done
 
 cat >"$work/bin/curl" <<'SCRIPT'
 #!/bin/sh
@@ -53,21 +69,85 @@ env \
 	HERDR_ASSET_SHA256="$asset_sha256" \
 	HERDR_TEST_BINARY="$work/herdr-binary" \
 	HERDR_TEST_INSTALLER="$work/remote-installer.sh" \
-	PATH="$work/bin:/usr/bin:/bin" \
+	HERDR_TEST_INTEGRATION_LOG="$work/integrations.log" \
+	PATH="$work/agent-bin:$work/bin:/usr/bin:/bin" \
 	"$HELPER" >"$work/install.out"
 
 grep -Fq "Installed verified Herdr 0.7.5" "$work/install.out"
 test -x "$work/home/.local/bin/herdr"
 test "$("$work/home/.local/bin/herdr" --version)" = "herdr 0.7.5"
+test "$(stat -c '%a' "$work/home/.local/bin")" = "700"
+printf 'codex\nclaude\n' >"$work/expected-integrations"
+cmp "$work/expected-integrations" "$work/integrations.log"
 
+: >"$work/integrations.log"
 env \
 	HOME="$work/home" \
 	HERDR_ALLOW_ROOT=1 \
 	HERDR_INSTALL_DIR="$work/home/.local/bin" \
-	PATH="$work/home/.local/bin:$work/bin:/usr/bin:/bin" \
+	HERDR_ASSET_SHA256="$asset_sha256" \
+	HERDR_TEST_INTEGRATION_LOG="$work/integrations.log" \
+	PATH="$work/home/.local/bin:$work/agent-bin:$work/bin:/usr/bin:/bin" \
 	"$HELPER" >"$work/reinstall.out"
 
-grep -Fq "Herdr is already installed" "$work/reinstall.out"
+grep -Fq "Herdr is already installed and verified" "$work/reinstall.out"
+cmp "$work/expected-integrations" "$work/integrations.log"
+
+if env \
+	HOME="$work/home" \
+	HERDR_ALLOW_ROOT=1 \
+	HERDR_INSTALL_DIR="$work/home/.local/bin" \
+	HERDR_ASSET_SHA256="$asset_sha256" \
+	HERDR_TEST_FAIL_INTEGRATION=claude \
+	HERDR_TEST_INTEGRATION_LOG="$work/integrations.log" \
+	PATH="$work/home/.local/bin:$work/agent-bin:$work/bin:/usr/bin:/bin" \
+	"$HELPER" >"$work/integration-failure.out" 2>"$work/integration-failure.err"; then
+	echo "install-herdr ignored a detected agent integration failure" >&2
+	exit 1
+fi
+
+grep -Fq "integration for Claude Code" "$work/integration-failure.err"
+grep -Fq "one or more detected agent integrations failed" \
+	"$work/integration-failure.err"
+
+mkdir -p "$work/early"
+cat >"$work/early/herdr" <<'SCRIPT'
+#!/bin/sh
+printf 'herdr 0.6.0\n'
+SCRIPT
+chmod +x "$work/early/herdr"
+
+if env \
+	HOME="$work/home" \
+	HERDR_ALLOW_ROOT=1 \
+	HERDR_INSTALL_DIR="$work/home/.local/bin" \
+	HERDR_ASSET_SHA256="$asset_sha256" \
+	PATH="$work/early:$work/home/.local/bin:$work/bin:/usr/bin:/bin" \
+	"$HELPER" >"$work/unverified.out" 2>"$work/unverified.err"; then
+	echo "install-herdr accepted an unverified executable from PATH" >&2
+	exit 1
+fi
+
+grep -Fq "selected Herdr executable is not the verified 0.7.5 release" \
+	"$work/unverified.err"
+
+if env \
+	HOME="$work/home" \
+	HERDR_ALLOW_ROOT=1 \
+	HERDR_INSTALL_DIR="$work/home/.local/bin" \
+	HERDR_INSTALLER_SHA256="$installer_sha256" \
+	HERDR_ASSET_SHA256="$asset_sha256" \
+	HERDR_TEST_BINARY="$work/herdr-binary" \
+	HERDR_TEST_INSTALLER="$work/remote-installer.sh" \
+	PATH="$work/early:$work/home/.local/bin:$work/bin:/usr/bin:/bin" \
+	"$HELPER" --force >"$work/shadowed.out" 2>"$work/shadowed.err"; then
+	echo "install-herdr reported success while PATH selected another executable" >&2
+	exit 1
+fi
+
+grep -Fq "terminal wrapper would select an unverified executable" \
+	"$work/shadowed.err"
+test "$(stat -c '%a' "$work/home/.local/bin")" = "700"
 
 if env \
 	HOME="$work/home" \
@@ -85,5 +165,6 @@ fi
 
 grep -Fq "binary checksum verification failed" "$work/tampered.err"
 test "$("$work/home/.local/bin/herdr" --version)" = "herdr 0.7.5"
+test "$(stat -c '%a' "$work/home/.local/bin")" = "700"
 
 printf 'install-herdr tests: PASS\n'

--- a/tests/test-install-herdr.sh
+++ b/tests/test-install-herdr.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$ROOT_DIR/scripts/install-herdr"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+mkdir -p "$work/bin" "$work/home"
+
+cat >"$work/remote-installer.sh" <<'SCRIPT'
+#!/bin/sh
+set -eu
+install -d -m 0755 "$HERDR_INSTALL_DIR"
+install -m 0755 "$HERDR_TEST_BINARY" "$HERDR_INSTALL_DIR/herdr"
+SCRIPT
+
+cat >"$work/herdr-binary" <<'SCRIPT'
+#!/bin/sh
+printf 'herdr 0.7.5\n'
+SCRIPT
+chmod +x "$work/herdr-binary"
+
+cat >"$work/bin/curl" <<'SCRIPT'
+#!/bin/sh
+set -eu
+output=
+while [ "$#" -gt 0 ]; do
+	case $1 in
+	--output)
+		output=$2
+		shift 2
+		;;
+	*)
+		shift
+		;;
+	esac
+done
+test -n "$output"
+cp "$HERDR_TEST_INSTALLER" "$output"
+SCRIPT
+chmod +x "$work/bin/curl"
+
+installer_sha256="$(sha256sum "$work/remote-installer.sh" | awk '{print $1}')"
+asset_sha256="$(sha256sum "$work/herdr-binary" | awk '{print $1}')"
+
+env \
+	HOME="$work/home" \
+	HERDR_ALLOW_ROOT=1 \
+	HERDR_INSTALL_DIR="$work/home/.local/bin" \
+	HERDR_INSTALLER_SHA256="$installer_sha256" \
+	HERDR_ASSET_SHA256="$asset_sha256" \
+	HERDR_TEST_BINARY="$work/herdr-binary" \
+	HERDR_TEST_INSTALLER="$work/remote-installer.sh" \
+	PATH="$work/bin:/usr/bin:/bin" \
+	"$HELPER" >"$work/install.out"
+
+grep -Fq "Installed verified Herdr 0.7.5" "$work/install.out"
+test -x "$work/home/.local/bin/herdr"
+test "$("$work/home/.local/bin/herdr" --version)" = "herdr 0.7.5"
+
+env \
+	HOME="$work/home" \
+	HERDR_ALLOW_ROOT=1 \
+	HERDR_INSTALL_DIR="$work/home/.local/bin" \
+	PATH="$work/home/.local/bin:$work/bin:/usr/bin:/bin" \
+	"$HELPER" >"$work/reinstall.out"
+
+grep -Fq "Herdr is already installed" "$work/reinstall.out"
+
+if env \
+	HOME="$work/home" \
+	HERDR_ALLOW_ROOT=1 \
+	HERDR_INSTALL_DIR="$work/home/.local/bin" \
+	HERDR_INSTALLER_SHA256="$installer_sha256" \
+	HERDR_ASSET_SHA256="0000000000000000000000000000000000000000000000000000000000000000" \
+	HERDR_TEST_BINARY="$work/herdr-binary" \
+	HERDR_TEST_INSTALLER="$work/remote-installer.sh" \
+	PATH="$work/bin:/usr/bin:/bin" \
+	"$HELPER" --force >"$work/tampered.out" 2>"$work/tampered.err"; then
+	echo "install-herdr accepted a binary with the wrong checksum" >&2
+	exit 1
+fi
+
+grep -Fq "binary checksum verification failed" "$work/tampered.err"
+test "$("$work/home/.local/bin/herdr" --version)" = "herdr 0.7.5"
+
+printf 'install-herdr tests: PASS\n'

--- a/tests/test-install-herdr.sh
+++ b/tests/test-install-herdr.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HELPER="$ROOT_DIR/scripts/install-herdr"
+# shellcheck source=scripts/dwm-utils.sh
+source "$ROOT_DIR/scripts/dwm-utils.sh"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -88,6 +90,21 @@ env \
 	HERDR_ASSET_SHA256="$asset_sha256" \
 	HERDR_TEST_INTEGRATION_LOG="$work/integrations.log" \
 	PATH="$work/home/.local/bin:$work/agent-bin:$work/bin:/usr/bin:/bin" \
+	"$HELPER" --dry-run >"$work/dry-run.out"
+
+grep -Fq "Herdr version: 0.7.5" "$work/dry-run.out"
+if [ -s "$work/integrations.log" ]; then
+	echo "install-herdr modified integrations during a dry run" >&2
+	exit 1
+fi
+
+env \
+	HOME="$work/home" \
+	HERDR_ALLOW_ROOT=1 \
+	HERDR_INSTALL_DIR="$work/home/.local/bin" \
+	HERDR_ASSET_SHA256="$asset_sha256" \
+	HERDR_TEST_INTEGRATION_LOG="$work/integrations.log" \
+	PATH="$work/home/.local/bin:$work/agent-bin:$work/bin:/usr/bin:/bin" \
 	"$HELPER" >"$work/reinstall.out"
 
 grep -Fq "Herdr is already installed and verified" "$work/reinstall.out"
@@ -109,6 +126,17 @@ fi
 grep -Fq "integration for Claude Code" "$work/integration-failure.err"
 grep -Fq "one or more detected agent integrations failed" \
 	"$work/integration-failure.err"
+
+for legacy_terminal in alacritty kitty st warp-terminal xterm; do
+	printf '[vars]\nterminal = "%s"\n' "$legacy_terminal" >"$work/hotkeys.toml"
+	test "$(dwm_legacy_seeded_terminal_hotkey "$work/hotkeys.toml")" = \
+		"$legacy_terminal"
+done
+printf '[vars]\nterminal = "dwm-terminal"\n' >"$work/hotkeys.toml"
+if dwm_legacy_seeded_terminal_hotkey "$work/hotkeys.toml" >/dev/null; then
+	echo "dwm-terminal was misidentified as a legacy seeded terminal" >&2
+	exit 1
+fi
 
 mkdir -p "$work/early"
 cat >"$work/early/herdr" <<'SCRIPT'
@@ -166,5 +194,21 @@ fi
 grep -Fq "binary checksum verification failed" "$work/tampered.err"
 test "$("$work/home/.local/bin/herdr" --version)" = "herdr 0.7.5"
 test "$(stat -c '%a' "$work/home/.local/bin")" = "700"
+
+mkdir -p "$work/arm-bin"
+cat >"$work/arm-bin/uname" <<'SCRIPT'
+#!/bin/sh
+printf 'armv7l\n'
+SCRIPT
+chmod +x "$work/arm-bin/uname"
+
+env \
+	HOME="$work/home" \
+	PATH="$work/arm-bin:$PATH" \
+	"$ROOT_DIR/install.sh" --dry-run --non-interactive --profile recommended \
+	>"$work/arm-plan.out"
+
+grep -Fq "Herdr workspace: skipped (unsupported architecture: armv7l)" \
+	"$work/arm-plan.out"
 
 printf 'install-herdr tests: PASS\n'

--- a/tests/test-kickstart-variants.sh
+++ b/tests/test-kickstart-variants.sh
@@ -98,7 +98,7 @@ for ks in "$standard_ks" "$nvidia_ks"; do
 	grep -Fq "url --metalink=\"https://mirrors.fedoraproject.org/metalink?repo=fedora-\$releasever&arch=\$basearch\"" "$ks"
 	grep -Fq 'firstboot --disable' "$ks"
 	grep -Fq 'selinux --disabled' "$ks"
-	grep -Fq './install.sh --non-interactive --profile core' "$ks"
+	grep -Fq './install.sh --non-interactive --profile core --install-herdr' "$ks"
 	grep -Fq '%include /tmp/dwm-titus-gaming-repo' "$ks"
 	grep -Fq '%include /tmp/dwm-titus-gaming-packages' "$ks"
 	# shellcheck disable=SC2016


### PR DESCRIPTION
## Summary

- make Herdr the default interactive terminal workspace on top of Alacritty
- keep explicit `dwm-terminal -e ...` launches outside Herdr so delegated maintenance and launcher commands preserve their existing behavior
- add a repeatable `install-herdr` helper that downloads the official `https://herdr.dev/install.sh` into isolated staging and verifies pinned SHA-256 checksums for both the installer and Herdr 0.7.5 binary before installation
- install Herdr by default for recommended/full profiles and both Fedora image variants, with opt-in/opt-out flags for other profiles
- preserve plain-terminal fallback behavior when Herdr is missing, unsupported, or cannot be downloaded
- update diagnostics, product requirements, user documentation, changelog, and regression coverage

## Validation

- `make check`
- `make check-shell check-format`
- `mdbook build docs`
- `mdbook test docs`
- `git diff --check origin/main...HEAD`
- installer dry runs for core, recommended, forced-core Herdr, and full without Herdr
- real official Herdr installer and binary download into a temporary directory; both pinned checksums matched and `herdr --version` reported 0.7.5
- live Fedora X11 launch: `scripts/dwm-terminal` created an `Alacritty` window whose process tree contained `alacritty -e ~/.local/bin/herdr`
- current-head GitHub CI passed: validate, clang build, CodeQL, docs, Quickshell QML, and Debian/Arch/RHEL distro smoke jobs

## Current limitations

- local `make check-container-smoke` could not start because this host's rootless Podman fails before repository code runs with `creating /etc/mtab symlink: operation not permitted`; the equivalent hosted Debian, Arch, and RHEL smoke jobs all passed on this commit.
- local CodeRabbit CLI review is temporarily rate-limited, and hosted CodeRabbit review is skipped while this pull request remains a draft.
- Kickstarts passed static validation, but no ISO build/install or first-boot test was performed for this change.
