### PR TITLE
Show volume percentage in panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ versions from `config.mk`.
 - The Control Center now uses one clean dropdown card with direct Applications
   and utility entries, in-place secondary pages, and consistent click-away and
   Escape dismissal.
+- The panel audio widget now shows the current volume percentage beside the
+  speaker icon and hides the percentage when audio is unavailable.
 - Power actions now use the same compact menu header, flat rows, spacing, and
   confirmation layout as the Control Center.
 - Documentation is built and tested from `docs/src/`; generated mdBook output

--- a/config/quickshell/panel/DwmPanel.qml
+++ b/config/quickshell/panel/DwmPanel.qml
@@ -284,6 +284,7 @@ PanelWindow {
                             }
 
                             UiText {
+                                visible: root.controlsModel.volumeText !== "VOL unavailable"
                                 text: root.controlsModel.volumePercent.toString() + "%"
                                 color: Theme.textStrong
                                 font.pixelSize: Theme.panelFontSize

--- a/config/quickshell/panel/DwmPanel.qml
+++ b/config/quickshell/panel/DwmPanel.qml
@@ -267,16 +267,27 @@ PanelWindow {
 
                     PanelPill {
                         visible: root.controlCenterModel.showVolumeWidget
-                        Layout.preferredWidth: Theme.compactWidgetSize
+                        Layout.preferredWidth: volumeRow.implicitWidth + Theme.compactWidgetHorizontalPadding * 2
                         Layout.preferredHeight: Theme.compactWidgetSize
                         active: root.controlsModel.visible
                         hovered: controlsMouse.containsMouse
 
-                        IconText {
+                        RowLayout {
+                            id: volumeRow
                             anchors.centerIn: parent
-                            text: root.controlsModel.volumeMuted ? "󰝟" : "󰕾"
-                            color: Theme.textStrong
-                            font.pixelSize: Math.round((Theme.panelFontSize + 1) * 1.5)
+                            spacing: Theme.compactSpacing
+
+                            IconText {
+                                text: root.controlsModel.volumeMuted ? "󰝟" : "󰕾"
+                                color: Theme.textStrong
+                                font.pixelSize: Math.round((Theme.panelFontSize + 1) * 1.5)
+                            }
+
+                            UiText {
+                                text: root.controlsModel.volumePercent.toString() + "%"
+                                color: Theme.textStrong
+                                font.pixelSize: Theme.panelFontSize
+                            }
                         }
 
                         MouseArea {

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -437,6 +437,7 @@ if grep -Fq 'color: Theme.transparent' "$repo/config/quickshell/panel/DwmPanel.q
 fi
 grep -Fq 'root.controlsModel.volumeUp();' "$repo/config/quickshell/panel/DwmPanel.qml"
 grep -Fq 'root.controlsModel.volumeDown();' "$repo/config/quickshell/panel/DwmPanel.qml"
+grep -Fq 'root.controlsModel.volumePercent.toString() + "%"' "$repo/config/quickshell/panel/DwmPanel.qml"
 grep -Fq 'trimmed !== "AC"' "$repo/config/quickshell/state/DwmState.qml"
 grep -Fq 'root.powerMenuModel.open("controlcenter")' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
 grep -Fq 'powerMenuModel.anchorSource === "controlcenter"' "$repo/config/quickshell/power/PowerMenuWindow.qml"

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -437,6 +437,7 @@ if grep -Fq 'color: Theme.transparent' "$repo/config/quickshell/panel/DwmPanel.q
 fi
 grep -Fq 'root.controlsModel.volumeUp();' "$repo/config/quickshell/panel/DwmPanel.qml"
 grep -Fq 'root.controlsModel.volumeDown();' "$repo/config/quickshell/panel/DwmPanel.qml"
+grep -Fq 'visible: root.controlsModel.volumeText !== "VOL unavailable"' "$repo/config/quickshell/panel/DwmPanel.qml"
 grep -Fq 'root.controlsModel.volumePercent.toString() + "%"' "$repo/config/quickshell/panel/DwmPanel.qml"
 grep -Fq 'trimmed !== "AC"' "$repo/config/quickshell/state/DwmState.qml"
 grep -Fq 'root.powerMenuModel.open("controlcenter")' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"


### PR DESCRIPTION
## Summary

- show the live volume percentage beside the panel audio icon
- size the audio pill from its icon-and-label content
- add a focused regression assertion for the percentage binding

## Why

The panel exposed audio controls through the speaker icon but required opening the control center or tooltip to see the current level. Showing the percentage makes the current volume visible at a glance while preserving the existing click, mute-icon, and wheel behavior.

## Validation

- `make check`
- `make check-quickshell-controlcenter`
- `/home/titus/github/titus-ai/.agents/skills/quickshell/scripts/quickshell-qmllint --root config/quickshell`
- `shellcheck tests/test-quickshell-controlcenter.sh`
- `shfmt -d tests/test-quickshell-controlcenter.sh`
- `make check-quickshell-health-xvfb`
- `git diff --check`

## Manual testing

- deployed with `make install-user`
- confirmed the installed panel QML matches the branch
- restarted the managed shell with `dwm-quickshell-controlcenter action restart-quickshell`
- inspected the live X11 panel at 1920x1080 and confirmed the speaker icon displays the current `100%` value beside it

The local CodeRabbit CLI was unavailable, so no local CodeRabbit review was run.