### PR TITLE
Fix popup stacking and Flameshot X11 capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,8 @@ versions from `config.mk`.
 - Keep Quickshell notifications, control popups, and tooltips above managed
   client windows when dwm restacks the X11 session.
 - Keep tray context menus above managed windows, start a single tray-owning
-  Flameshot daemon, and use its native X11 capture backend when portal capture
-  is unavailable in the dwm session.
+  Flameshot daemon with a sanitized X11 environment, and default to its native
+  X11 capture backend when no explicit backend preference is configured.
 - Keep `install-herdr --dry-run` side-effect free, have `install.sh` skip
   unsupported automatic ARMv7 installs, and warn when a preserved legacy
   terminal hotkey bypasses Herdr.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ versions from `config.mk`.
 
 - Keep Quickshell notifications, control popups, and tooltips above managed
   client windows when dwm restacks the X11 session.
+- Keep tray context menus above managed windows, start a single tray-owning
+  Flameshot daemon, and use its native X11 capture backend when portal capture
+  is unavailable in the dwm session.
 - Keep `install-herdr --dry-run` side-effect free, have `install.sh` skip
   unsupported automatic ARMv7 installs, and warn when a preserved legacy
   terminal hotkey bypasses Herdr.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ versions from `config.mk`.
 
 ### Fixed
 
+- Keep Quickshell notifications, control popups, and tooltips above managed
+  client windows when dwm restacks the X11 session.
 - Keep `install-herdr --dry-run` side-effect free, have `install.sh` skip
   unsupported automatic ARMv7 installs, and warn when a preserved legacy
   terminal hotkey bypasses Herdr.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ versions from `config.mk`.
 - Keep tray context menus above managed windows, start a single tray-owning
   Flameshot daemon with a sanitized X11 environment, and default to its native
   X11 capture backend when no explicit backend preference is configured.
+- Keep the Quickshell bar above normal desktop windows while allowing true
+  fullscreen applications to cover it without panel redraw flashes.
 - Keep `install-herdr --dry-run` side-effect free, have `install.sh` skip
   unsupported automatic ARMv7 installs, and warn when a preserved legacy
   terminal hotkey bypasses Herdr.

--- a/config/quickshell/panel/DwmPanel.qml
+++ b/config/quickshell/panel/DwmPanel.qml
@@ -41,7 +41,8 @@ PanelWindow {
     implicitHeight: Theme.panelHeight
     color: Theme.barBackground
     exclusiveZone: Theme.panelHeight
-    aboveWindows: true
+    aboveWindows: root.state.fullscreenWorkspaces.indexOf(
+        root.state.currentWorkspaceForScreen(root.screen)) === -1
 
     anchors {
         top: true

--- a/config/quickshell/panel/DwmPanel.qml
+++ b/config/quickshell/panel/DwmPanel.qml
@@ -41,8 +41,8 @@ PanelWindow {
     implicitHeight: Theme.panelHeight
     color: Theme.barBackground
     exclusiveZone: Theme.panelHeight
-    aboveWindows: root.state.fullscreenWorkspaces.indexOf(
-        root.state.currentWorkspaceForScreen(root.screen)) === -1
+    aboveWindows: root.state.fullscreenMonitorIndexes.indexOf(
+        root.state.screenIndex(root.screen)) === -1
 
     anchors {
         top: true

--- a/config/quickshell/state/DwmState.qml
+++ b/config/quickshell/state/DwmState.qml
@@ -8,6 +8,7 @@ Scope {
     property var monitorWorkspaceRows: []
     property var workspaceNames: ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     property var occupiedWorkspaces: []
+    property var fullscreenWorkspaces: []
     property var runningApps: []
     property string activeWindowTitle: "Desktop"
     property string activeWindowClass: "application-x-executable"
@@ -52,6 +53,10 @@ Scope {
                 root.workspaceNames = value.length > 0 ? value.split("|") : [];
             } else if (key === "occupied") {
                 root.occupiedWorkspaces = value.length > 0 ? value.split("|").map(function(workspace) {
+                    return parseInt(workspace, 10);
+                }) : [];
+            } else if (key === "fullscreen") {
+                root.fullscreenWorkspaces = value.length > 0 ? value.split("|").map(function(workspace) {
                     return parseInt(workspace, 10);
                 }) : [];
             } else if (key === "apps") {

--- a/config/quickshell/state/DwmState.qml
+++ b/config/quickshell/state/DwmState.qml
@@ -8,7 +8,7 @@ Scope {
     property var monitorWorkspaceRows: []
     property var workspaceNames: ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     property var occupiedWorkspaces: []
-    property var fullscreenWorkspaces: []
+    property var fullscreenMonitorIndexes: []
     property var runningApps: []
     property string activeWindowTitle: "Desktop"
     property string activeWindowClass: "application-x-executable"
@@ -55,9 +55,9 @@ Scope {
                 root.occupiedWorkspaces = value.length > 0 ? value.split("|").map(function(workspace) {
                     return parseInt(workspace, 10);
                 }) : [];
-            } else if (key === "fullscreen") {
-                root.fullscreenWorkspaces = value.length > 0 ? value.split("|").map(function(workspace) {
-                    return parseInt(workspace, 10);
+            } else if (key === "fullscreen_monitors") {
+                root.fullscreenMonitorIndexes = value.length > 0 ? value.split("|").map(function(monitor) {
+                    return parseInt(monitor, 10);
                 }) : [];
             } else if (key === "apps") {
                 root.runningApps = value.length > 0 ? value.split("|").map(function(app) {

--- a/dwm.c
+++ b/dwm.c
@@ -271,7 +271,7 @@ static int updatealtbar(Monitor *m, Window win, XWindowAttributes *wa);
 static void updatebarpos(Monitor *m);
 static void updatebars(void);
 static void updateclientlist(void);
-static void updatefullscreendesktops(void);
+static void updatefullscreenmonitors(void);
 static int updategeom(void);
 static void updateoverridewindow(Window win);
 static void updatenumlockmask(void);
@@ -406,7 +406,7 @@ static xcb_connection_t *xcon;
 static Window *clientlistcache;
 static unsigned long clientlistcachelen;
 static int clientlistcachevalid;
-static Atom dwmfullscreendesktopsatom, dwmtagupdateatom;
+static Atom dwmfullscreenmonitorsatom, dwmtagupdateatom;
 static unsigned long tagupdatesequence;
 
 /* External dock integration */
@@ -3064,7 +3064,7 @@ setclientdesktop(Client *c)
     }
     
 	ewmh_replace_window_cardinal(c->win, netatom[NetWMDesktop], data, 1);
-	updatefullscreendesktops();
+	updatefullscreenmonitors();
 	data[0] = ++tagupdatesequence;
 	ewmh_replace_root_cardinal(dwmtagupdateatom, data, 1);
 }
@@ -3177,7 +3177,7 @@ setfullscreen(Client *c, int fullscreen)
 	if (!c->isfullscreen)
 		while (XCheckMaskEvent(dpy, EnterWindowMask, &ev));
 	if (actualfullscreenchanged)
-		updatefullscreendesktops();
+		updatefullscreenmonitors();
 }
 
 Layout *last_layout;
@@ -3991,7 +3991,7 @@ setup(void)
 	netatom[NetDesktopNames] = XInternAtom(dpy, "_NET_DESKTOP_NAMES", False);
 	netatom[NetWMDesktop] = XInternAtom(dpy, "_NET_WM_DESKTOP", False);
 	netatom[NetDwmMonitorDesktops] = XInternAtom(dpy, "_DWM_MONITOR_DESKTOPS", False);
-	dwmfullscreendesktopsatom = XInternAtom(dpy, "_DWM_FULLSCREEN_DESKTOPS", False);
+	dwmfullscreenmonitorsatom = XInternAtom(dpy, "_DWM_FULLSCREEN_MONITORS", False);
 	dwmtagupdateatom = XInternAtom(dpy, "DWM_TAG_UPDATE", False);
 	/* init cursors */
 	cursor[CurNormal] = drw_cur_create(drw, XC_left_ptr);
@@ -4237,6 +4237,7 @@ tagmon(const Arg *arg)
 		c->isfullscreen = 0;
 		sendmon(c, dirtomon(arg->i));
 		c->isfullscreen = 1;
+		updatefullscreenmonitors();
 		if (c->fakefullscreen != 1) {
 			resizeclient(c, c->mon->mx, c->mon->my, c->mon->mw, c->mon->mh);
 			XRaiseWindow(dpy, c->win);
@@ -4732,31 +4733,34 @@ updateclientlist(void)
 	clientlistcache = clients;
 	clientlistcachelen = count;
 	clientlistcachevalid = 1;
-	updatefullscreendesktops();
+	updatefullscreenmonitors();
 }
 
 void
-updatefullscreendesktops(void)
+updatefullscreenmonitors(void)
 {
 	Client *c;
 	Monitor *m;
-	long desktops[TAGSLENGTH];
-	unsigned int count = 0, i, j;
+	long *monitors;
+	int logicalindex;
+	unsigned int count = 0;
 
 	for (m = mons; m; m = m->next)
+		count++;
+	monitors = count ? ecalloc(count, sizeof(*monitors)) : NULL;
+	count = 0;
+	for (m = mons; m; m = m->next)
 		for (c = m->clients; c; c = c->next) {
-			if (!c->isfullscreen || c->fakefullscreen == 1)
+			if (!c->isfullscreen || c->fakefullscreen == 1 || !ISVISIBLE(c))
 				continue;
-			for (i = 0; i < TAGSLENGTH; i++) {
-				if (!(c->tags & 1U << i))
-					continue;
-				for (j = 0; j < count && desktops[j] != (long)i; j++);
-				if (j == count)
-					desktops[count++] = i;
-			}
+			logicalindex = getmonlogicalindex(m);
+			if (logicalindex >= 0)
+				monitors[count++] = logicalindex;
+			break;
 		}
-	XChangeProperty(dpy, root, dwmfullscreendesktopsatom, XA_CARDINAL, 32,
-		PropModeReplace, (unsigned char *)desktops, count);
+	XChangeProperty(dpy, root, dwmfullscreenmonitorsatom, XA_CARDINAL, 32,
+		PropModeReplace, (unsigned char *)monitors, count);
+	free(monitors);
 }
 
 void
@@ -4800,6 +4804,7 @@ updatecurrentdesktop(void)
 	XChangeProperty(dpy, root, netatom[NetDwmMonitorDesktops], XA_INTEGER, 32,
 		PropModeReplace, (unsigned char *)monitor_desktops, count * 5);
 	free(monitor_desktops);
+	updatefullscreenmonitors();
 }
 
 #if SHOWWINICON

--- a/dwm.c
+++ b/dwm.c
@@ -81,6 +81,7 @@ enum { SchemeNorm, SchemeSel }; /* color schemes */
 enum { NetSupported, NetWMName, NetWMState, NetWMCheck,
        NetWMFullscreen, NetWMAbove, NetWMStaysOnTop, NetActiveWindow, NetWMWindowType, NetWMIcon,
        NetWMWindowTypeDialog, NetWMWindowTypeDock, NetWMWindowTypeTooltip, NetWMWindowTypeNotification,
+       NetWMWindowTypeMenu, NetWMWindowTypePopupMenu, NetWMWindowTypeDropdownMenu,
        NetClientList, NetDesktopNames, NetDesktopViewport, NetNumberOfDesktops, NetCurrentDesktop,
        NetWMDesktop, NetDwmMonitorDesktops, NetLast }; /* EWMH atoms */
 enum { WMProtocols, WMDelete, WMState, WMTakeFocus, WMLast }; /* default atoms */
@@ -3967,6 +3968,9 @@ setup(void)
 	netatom[NetWMWindowTypeDock] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DOCK", False);
 	netatom[NetWMWindowTypeTooltip] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_TOOLTIP", False);
 	netatom[NetWMWindowTypeNotification] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_NOTIFICATION", False);
+	netatom[NetWMWindowTypeMenu] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_MENU", False);
+	netatom[NetWMWindowTypePopupMenu] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_POPUP_MENU", False);
+	netatom[NetWMWindowTypeDropdownMenu] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DROPDOWN_MENU", False);
 	kdewindowtypeoverride = XInternAtom(dpy, "_KDE_NET_WM_WINDOW_TYPE_OVERRIDE", False);
 	netatom[NetClientList] = XInternAtom(dpy, "_NET_CLIENT_LIST", False);
 	netatom[NetDesktopViewport] = XInternAtom(dpy, "_NET_DESKTOP_VIEWPORT", False);
@@ -4974,6 +4978,9 @@ updateoverridewindow(Window win)
 		|| atomlistcontains(states, nstates, netatom[NetWMStaysOnTop])
 		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypeTooltip])
 		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypeNotification])
+		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypeMenu])
+		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypePopupMenu])
+		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypeDropdownMenu])
 		|| atomlistcontains(types, ntypes, kdewindowtypeoverride);
 }
 

--- a/dwm.c
+++ b/dwm.c
@@ -80,7 +80,9 @@ enum { CurResizeBR, CurResizeBL, CurResizeTR, CurResizeTL, CurNormal, CurResize,
 enum { SchemeNorm, SchemeSel }; /* color schemes */
 enum { NetSupported, NetWMName, NetWMState, NetWMCheck,
        NetWMFullscreen, NetWMAbove, NetWMStaysOnTop, NetActiveWindow, NetWMWindowType, NetWMIcon,
-       NetWMWindowTypeDialog, NetWMWindowTypeDock, NetClientList, NetDesktopNames, NetDesktopViewport, NetNumberOfDesktops, NetCurrentDesktop, NetWMDesktop, NetDwmMonitorDesktops, NetLast }; /* EWMH atoms */
+       NetWMWindowTypeDialog, NetWMWindowTypeDock, NetWMWindowTypeTooltip, NetWMWindowTypeNotification,
+       NetClientList, NetDesktopNames, NetDesktopViewport, NetNumberOfDesktops, NetCurrentDesktop,
+       NetWMDesktop, NetDwmMonitorDesktops, NetLast }; /* EWMH atoms */
 enum { WMProtocols, WMDelete, WMState, WMTakeFocus, WMLast }; /* default atoms */
 enum { ClkTagBar, ClkLtSymbol, ClkStatusText, ClkWinTitle,
        ClkClientWin, ClkRootWin, ClkLast }; /* clicks */
@@ -198,6 +200,7 @@ static pid_t getparentprocess(pid_t p);
 static int getrootptr(int *x, int *y);
 static int atomlistcontains(const Atom *atoms, unsigned long nitems, Atom atom);
 static unsigned long getatomproplist(Client *c, Atom prop, Atom *atoms, unsigned long maxitems, int *truncated);
+static unsigned long getwinatomproplist(Window win, Atom prop, Atom *atoms, unsigned long maxitems, int *truncated);
 static long getstate(Window w);
 static pid_t getstatusbarpid();
 static int gettextprop(Window w, Atom atom, char *text, unsigned int size);
@@ -225,6 +228,7 @@ static void resizemouse(const Arg *arg);
 static int resizetiledmouse(const Arg *arg);
 static void raisealwaysontop(Monitor *m);
 static void raisealwaysontopclients(Client *c);
+static void raiseoverridepopups(void);
 static void restack(Monitor *m);
 static int sendevent(Client *c, Atom proto);
 static void sendmon(Client *c, Monitor *m);
@@ -376,7 +380,7 @@ static void (*handler[LASTEvent]) (XEvent *) = {
 	[PropertyNotify] = propertynotify,
 	[UnmapNotify] = unmapnotify
 };
-static Atom wmatom[WMLast], netatom[NetLast];
+static Atom kdewindowtypeoverride, wmatom[WMLast], netatom[NetLast];
 static int running = 1;
 static Cur *cursor[CurLast];
 static Clr **scheme;
@@ -1442,6 +1446,12 @@ atomlistcontains(const Atom *atoms, unsigned long nitems, Atom atom)
 unsigned long
 getatomproplist(Client *c, Atom prop, Atom *atoms, unsigned long maxitems, int *truncated)
 {
+	return getwinatomproplist(c->win, prop, atoms, maxitems, truncated);
+}
+
+unsigned long
+getwinatomproplist(Window win, Atom prop, Atom *atoms, unsigned long maxitems, int *truncated)
+{
 	int format;
 	unsigned long extra, nitems = 0;
 	unsigned char *data = NULL;
@@ -1449,7 +1459,7 @@ getatomproplist(Client *c, Atom prop, Atom *atoms, unsigned long maxitems, int *
 
 	if (truncated)
 		*truncated = 0;
-	if (XGetWindowProperty(dpy, c->win, prop, 0L, maxitems, False, XA_ATOM,
+	if (XGetWindowProperty(dpy, win, prop, 0L, maxitems, False, XA_ATOM,
 	    &actual, &format, &nitems, &extra, &data) != Success)
 		return 0;
 	if (actual != XA_ATOM || format != 32) {
@@ -2548,8 +2558,10 @@ restack(Monitor *m)
 	XWindowChanges wc;
 
 	drawbar(m);
-	if (!m->sel)
+	if (!m->sel) {
+		raiseoverridepopups();
 		return;
+	}
 	if (m->sel->isfloating || !m->lt[m->sellt]->arrange)
 		XRaiseWindow(dpy, m->sel->win);
 	if (m->lt[m->sellt]->arrange) {
@@ -2562,6 +2574,7 @@ restack(Monitor *m)
 			}
 	}
 	raisealwaysontop(m);
+	raiseoverridepopups();
 	XSync(dpy, False);
 	while (XCheckMaskEvent(dpy, EnterWindowMask, &ev));
 }
@@ -2584,6 +2597,38 @@ raisealwaysontopclients(Client *c)
 	raisealwaysontopclients(c->snext);
 	if ((c->alwaysontop || c->ewmhabove) && ISVISIBLE(c))
 		XRaiseWindow(dpy, c->win);
+}
+
+void
+raiseoverridepopups(void)
+{
+	Atom states[NET_WM_STATE_MAX], types[NET_WM_STATE_MAX];
+	Window parent, root_return, *wins = NULL;
+	XWindowAttributes wa;
+	unsigned int i, nwins;
+	unsigned long nstates, ntypes;
+
+	if (!XQueryTree(dpy, root, &root_return, &parent, &wins, &nwins))
+		return;
+	/* These windows bypass normal management, so restore their declared
+	 * popup/above layer after managed clients have been restacked. */
+	for (i = 0; i < nwins; i++) {
+		if (!XGetWindowAttributes(dpy, wins[i], &wa)
+		    || !wa.override_redirect || wa.map_state != IsViewable)
+			continue;
+		nstates = getwinatomproplist(wins[i], netatom[NetWMState],
+			states, LENGTH(states), NULL);
+		ntypes = getwinatomproplist(wins[i], netatom[NetWMWindowType],
+			types, LENGTH(types), NULL);
+		if (atomlistcontains(states, nstates, netatom[NetWMAbove])
+		    || atomlistcontains(states, nstates, netatom[NetWMStaysOnTop])
+		    || atomlistcontains(types, ntypes, netatom[NetWMWindowTypeTooltip])
+		    || atomlistcontains(types, ntypes, netatom[NetWMWindowTypeNotification])
+		    || atomlistcontains(types, ntypes, kdewindowtypeoverride))
+			XRaiseWindow(dpy, wins[i]);
+	}
+	if (wins)
+		XFree(wins);
 }
 
 void
@@ -3911,6 +3956,9 @@ setup(void)
 	netatom[NetWMWindowType] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE", False);
 	netatom[NetWMWindowTypeDialog] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DIALOG", False);
 	netatom[NetWMWindowTypeDock] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DOCK", False);
+	netatom[NetWMWindowTypeTooltip] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_TOOLTIP", False);
+	netatom[NetWMWindowTypeNotification] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_NOTIFICATION", False);
+	kdewindowtypeoverride = XInternAtom(dpy, "_KDE_NET_WM_WINDOW_TYPE_OVERRIDE", False);
 	netatom[NetClientList] = XInternAtom(dpy, "_NET_CLIENT_LIST", False);
 	netatom[NetDesktopViewport] = XInternAtom(dpy, "_NET_DESKTOP_VIEWPORT", False);
 	netatom[NetNumberOfDesktops] = XInternAtom(dpy, "_NET_NUMBER_OF_DESKTOPS", False);

--- a/dwm.c
+++ b/dwm.c
@@ -82,6 +82,7 @@ enum { NetSupported, NetWMName, NetWMState, NetWMCheck,
        NetWMFullscreen, NetWMAbove, NetWMStaysOnTop, NetActiveWindow, NetWMWindowType, NetWMIcon,
        NetWMWindowTypeDialog, NetWMWindowTypeDock, NetWMWindowTypeTooltip, NetWMWindowTypeNotification,
        NetWMWindowTypeMenu, NetWMWindowTypePopupMenu, NetWMWindowTypeDropdownMenu,
+       NetWMWindowTypeCombo,
        NetClientList, NetDesktopNames, NetDesktopViewport, NetNumberOfDesktops, NetCurrentDesktop,
        NetWMDesktop, NetDwmMonitorDesktops, NetLast }; /* EWMH atoms */
 enum { WMProtocols, WMDelete, WMState, WMTakeFocus, WMLast }; /* default atoms */
@@ -3983,6 +3984,7 @@ setup(void)
 	netatom[NetWMWindowTypeMenu] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_MENU", False);
 	netatom[NetWMWindowTypePopupMenu] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_POPUP_MENU", False);
 	netatom[NetWMWindowTypeDropdownMenu] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DROPDOWN_MENU", False);
+	netatom[NetWMWindowTypeCombo] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_COMBO", False);
 	kdewindowtypeoverride = XInternAtom(dpy, "_KDE_NET_WM_WINDOW_TYPE_OVERRIDE", False);
 	netatom[NetClientList] = XInternAtom(dpy, "_NET_CLIENT_LIST", False);
 	netatom[NetDesktopViewport] = XInternAtom(dpy, "_NET_DESKTOP_VIEWPORT", False);
@@ -5024,6 +5026,7 @@ updateoverridewindow(Window win)
 		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypeMenu])
 		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypePopupMenu])
 		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypeDropdownMenu])
+		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypeCombo])
 		|| atomlistcontains(types, ntypes, kdewindowtypeoverride);
 }
 
@@ -5512,6 +5515,8 @@ reconcilemonitortags(void)
 		m->showbar = m->pertag->showbars[m->pertag->curtag];
 		updatebarpos(m);
 	}
+	if (dwmfullscreenmonitorsatom != None)
+		updatefullscreenmonitors();
 }
 
 int

--- a/dwm.c
+++ b/dwm.c
@@ -4569,7 +4569,7 @@ trackoverridewindow(Window win)
 		ow->win = win;
 		for (tail = &overridewindows; *tail; tail = &(*tail)->next);
 		*tail = ow;
-		XSelectInput(dpy, win, PropertyChangeMask);
+		XSelectInput(dpy, win, wa.your_event_mask | PropertyChangeMask);
 	}
 	updateoverridewindow(win);
 }

--- a/dwm.c
+++ b/dwm.c
@@ -271,6 +271,7 @@ static int updatealtbar(Monitor *m, Window win, XWindowAttributes *wa);
 static void updatebarpos(Monitor *m);
 static void updatebars(void);
 static void updateclientlist(void);
+static void updatefullscreendesktops(void);
 static int updategeom(void);
 static void updateoverridewindow(Window win);
 static void updatenumlockmask(void);
@@ -405,7 +406,7 @@ static xcb_connection_t *xcon;
 static Window *clientlistcache;
 static unsigned long clientlistcachelen;
 static int clientlistcachevalid;
-static Atom dwmtagupdateatom;
+static Atom dwmfullscreendesktopsatom, dwmtagupdateatom;
 static unsigned long tagupdatesequence;
 
 /* External dock integration */
@@ -2618,8 +2619,13 @@ raisealwaysontop(Monitor *m)
 
 	if (m->sel && m->sel->isfullscreen && m->sel->fakefullscreen != 1) {
 		XRaiseWindow(dpy, m->sel->win);
-	} else
+	} else {
 		raisealwaysontopclients(m->stack);
+		if (m->barwin)
+			XRaiseWindow(dpy, m->barwin);
+		if (m->traywin)
+			XRaiseWindow(dpy, m->traywin);
+	}
 	for (ow = overridewindows; ow; ow = ow->next)
 		if (ow->raise)
 			XRaiseWindow(dpy, ow->win);
@@ -3058,6 +3064,7 @@ setclientdesktop(Client *c)
     }
     
 	ewmh_replace_window_cardinal(c->win, netatom[NetWMDesktop], data, 1);
+	updatefullscreendesktops();
 	data[0] = ++tagupdatesequence;
 	ewmh_replace_root_cardinal(dwmtagupdateatom, data, 1);
 }
@@ -3107,7 +3114,8 @@ void
 setfullscreen(Client *c, int fullscreen)
 {
 	XEvent ev;
-	int savestate = 0, restorestate = 0;
+	int actualfullscreenchanged, savestate = 0, restorestate = 0;
+	int wasactualfullscreen = c->isfullscreen && c->fakefullscreen != 1;
 
 	if ((c->fakefullscreen == 0 && fullscreen && !c->isfullscreen) // normal fullscreen
 			|| (c->fakefullscreen == 2 && fullscreen)) // fake fullscreen --> actual fullscreen
@@ -3133,6 +3141,8 @@ setfullscreen(Client *c, int fullscreen)
 	}
 
 	c->isfullscreen = fullscreen;
+	actualfullscreenchanged = wasactualfullscreen
+		!= (c->isfullscreen && c->fakefullscreen != 1);
 
 	/* Some clients, e.g. firefox, will send a client message informing the window manager
 	 * that it is going into fullscreen after receiving the above signal. This has the side
@@ -3166,6 +3176,8 @@ setfullscreen(Client *c, int fullscreen)
 	 */
 	if (!c->isfullscreen)
 		while (XCheckMaskEvent(dpy, EnterWindowMask, &ev));
+	if (actualfullscreenchanged)
+		updatefullscreendesktops();
 }
 
 Layout *last_layout;
@@ -3979,6 +3991,7 @@ setup(void)
 	netatom[NetDesktopNames] = XInternAtom(dpy, "_NET_DESKTOP_NAMES", False);
 	netatom[NetWMDesktop] = XInternAtom(dpy, "_NET_WM_DESKTOP", False);
 	netatom[NetDwmMonitorDesktops] = XInternAtom(dpy, "_DWM_MONITOR_DESKTOPS", False);
+	dwmfullscreendesktopsatom = XInternAtom(dpy, "_DWM_FULLSCREEN_DESKTOPS", False);
 	dwmtagupdateatom = XInternAtom(dpy, "DWM_TAG_UPDATE", False);
 	/* init cursors */
 	cursor[CurNormal] = drw_cur_create(drw, XC_left_ptr);
@@ -4719,6 +4732,31 @@ updateclientlist(void)
 	clientlistcache = clients;
 	clientlistcachelen = count;
 	clientlistcachevalid = 1;
+	updatefullscreendesktops();
+}
+
+void
+updatefullscreendesktops(void)
+{
+	Client *c;
+	Monitor *m;
+	long desktops[TAGSLENGTH];
+	unsigned int count = 0, i, j;
+
+	for (m = mons; m; m = m->next)
+		for (c = m->clients; c; c = c->next) {
+			if (!c->isfullscreen || c->fakefullscreen == 1)
+				continue;
+			for (i = 0; i < TAGSLENGTH; i++) {
+				if (!(c->tags & 1U << i))
+					continue;
+				for (j = 0; j < count && desktops[j] != (long)i; j++);
+				if (j == count)
+					desktops[count++] = i;
+			}
+		}
+	XChangeProperty(dpy, root, dwmfullscreendesktopsatom, XA_CARDINAL, 32,
+		PropModeReplace, (unsigned char *)desktops, count);
 }
 
 void

--- a/dwm.c
+++ b/dwm.c
@@ -82,7 +82,7 @@ enum { NetSupported, NetWMName, NetWMState, NetWMCheck,
        NetWMFullscreen, NetWMAbove, NetWMStaysOnTop, NetActiveWindow, NetWMWindowType, NetWMIcon,
        NetWMWindowTypeDialog, NetWMWindowTypeDock, NetWMWindowTypeTooltip, NetWMWindowTypeNotification,
        NetWMWindowTypeMenu, NetWMWindowTypePopupMenu, NetWMWindowTypeDropdownMenu,
-       NetWMWindowTypeCombo,
+       NetWMWindowTypeCombo, NetWMWindowTypeDnd,
        NetClientList, NetDesktopNames, NetDesktopViewport, NetNumberOfDesktops, NetCurrentDesktop,
        NetWMDesktop, NetDwmMonitorDesktops, NetLast }; /* EWMH atoms */
 enum { WMProtocols, WMDelete, WMState, WMTakeFocus, WMLast }; /* default atoms */
@@ -3985,6 +3985,7 @@ setup(void)
 	netatom[NetWMWindowTypePopupMenu] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_POPUP_MENU", False);
 	netatom[NetWMWindowTypeDropdownMenu] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DROPDOWN_MENU", False);
 	netatom[NetWMWindowTypeCombo] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_COMBO", False);
+	netatom[NetWMWindowTypeDnd] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DND", False);
 	kdewindowtypeoverride = XInternAtom(dpy, "_KDE_NET_WM_WINDOW_TYPE_OVERRIDE", False);
 	netatom[NetClientList] = XInternAtom(dpy, "_NET_CLIENT_LIST", False);
 	netatom[NetDesktopViewport] = XInternAtom(dpy, "_NET_DESKTOP_VIEWPORT", False);
@@ -5027,6 +5028,7 @@ updateoverridewindow(Window win)
 		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypePopupMenu])
 		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypeDropdownMenu])
 		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypeCombo])
+		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypeDnd])
 		|| atomlistcontains(types, ntypes, kdewindowtypeoverride);
 }
 

--- a/dwm.c
+++ b/dwm.c
@@ -104,6 +104,7 @@ typedef struct {
 
 typedef struct Monitor Monitor;
 typedef struct Client Client;
+typedef struct OverrideWindow OverrideWindow;
 struct Client {
 	char name[256];
 	float mina, maxa;
@@ -125,6 +126,12 @@ struct Client {
 	Window win;
 	unsigned int icw, ich;
 	Picture icon;
+};
+
+struct OverrideWindow {
+	Window win;
+	int raise;
+	OverrideWindow *next;
 };
 
 typedef struct {
@@ -211,6 +218,7 @@ static int isaltbar(Window win, XWindowAttributes *wa);
 static int isdescprocess(pid_t p, pid_t c);
 static void killclient(const Arg *arg);
 static void manage(Window w, XWindowAttributes *wa);
+static void mapnotify(XEvent *e);
 static void monocle(Monitor *m);
 static void movemouse(const Arg *arg);
 static void movestack(const Arg *arg);
@@ -228,7 +236,6 @@ static void resizemouse(const Arg *arg);
 static int resizetiledmouse(const Arg *arg);
 static void raisealwaysontop(Monitor *m);
 static void raisealwaysontopclients(Client *c);
-static void raiseoverridepopups(void);
 static void restack(Monitor *m);
 static int sendevent(Client *c, Atom proto);
 static void sendmon(Client *c, Monitor *m);
@@ -254,14 +261,17 @@ static void togglefakefullscreen(const Arg *arg);
 static void togglefloating(const Arg *arg);
 static void toggletag(const Arg *arg);
 static void toggleview(const Arg *arg);
+static void trackoverridewindow(Window win);
 static void unfocus(Client *c, int setfocus);
 static void unmanage(Client *c, int destroyed);
+static void untrackoverridewindow(Window win);
 static void unswallow(Client *c);
 static int updatealtbar(Monitor *m, Window win, XWindowAttributes *wa);
 static void updatebarpos(Monitor *m);
 static void updatebars(void);
 static void updateclientlist(void);
 static int updategeom(void);
+static void updateoverridewindow(Window win);
 static void updatenumlockmask(void);
 static void updatesizehints(Client *c);
 static void updatestatus(void);
@@ -375,6 +385,7 @@ static void (*handler[LASTEvent]) (XEvent *) = {
 	[FocusIn] = focusin,
 	[KeyPress] = keypress,
 	[MappingNotify] = mappingnotify,
+	[MapNotify] = mapnotify,
 	[MapRequest] = maprequest,
 	[MotionNotify] = motionnotify,
 	[PropertyNotify] = propertynotify,
@@ -387,6 +398,7 @@ static Clr **scheme;
 static Display *dpy;
 static Drw *drw;
 static Monitor *mons, *selmon;
+static OverrideWindow *overridewindows;
 static Window root, wmcheckwin;
 static xcb_connection_t *xcon;
 static Window *clientlistcache;
@@ -824,6 +836,7 @@ void
 cleanup(void)
 {
 	Monitor *m;
+	OverrideWindow *ow;
 	Layout foo = { "", NULL };
 	size_t i;
 
@@ -834,6 +847,11 @@ cleanup(void)
 	XUngrabKey(dpy, AnyKey, AnyModifier, root);
 	while (mons)
 		cleanupmon(mons);
+	while (overridewindows) {
+		ow = overridewindows;
+		overridewindows = overridewindows->next;
+		free(ow);
+	}
 	for (i = 0; i < CurLast; i++)
 		drw_cur_free(drw, cursor[i]);
 	for (i = 0; i < 2; i++)
@@ -1161,6 +1179,7 @@ destroynotify(XEvent *e)
 	Monitor *m;
 	XDestroyWindowEvent *ev = &e->xdestroywindow;
 
+	untrackoverridewindow(ev->window);
 	if ((c = wintoclient(ev->window)))
 		unmanage(c, 1);
 	else if ((c = swallowingclient(ev->window)))
@@ -1953,6 +1972,14 @@ mappingnotify(XEvent *e)
 }
 
 void
+mapnotify(XEvent *e)
+{
+	XMapEvent *ev = &e->xmap;
+
+	trackoverridewindow(ev->window);
+}
+
+void
 maprequest(XEvent *e)
 {
 	static XWindowAttributes wa;
@@ -2288,9 +2315,14 @@ void
 propertynotify(XEvent *e)
 {
 	Client *c;
+	OverrideWindow *ow;
 	Window trans;
 	XPropertyEvent *ev = &e->xproperty;
 
+	for (ow = overridewindows; ow && ow->win != ev->window; ow = ow->next);
+	if (ow && (ev->atom == netatom[NetWMState]
+	    || ev->atom == netatom[NetWMWindowType]))
+		updateoverridewindow(ev->window);
 	if ((ev->window == root) && (ev->atom == XA_WM_NAME)) {
 		updatestatus();
 	} else if (ev->state == PropertyDelete) {
@@ -2559,7 +2591,7 @@ restack(Monitor *m)
 
 	drawbar(m);
 	if (!m->sel) {
-		raiseoverridepopups();
+		raisealwaysontop(m);
 		return;
 	}
 	if (m->sel->isfloating || !m->lt[m->sellt]->arrange)
@@ -2574,7 +2606,6 @@ restack(Monitor *m)
 			}
 	}
 	raisealwaysontop(m);
-	raiseoverridepopups();
 	XSync(dpy, False);
 	while (XCheckMaskEvent(dpy, EnterWindowMask, &ev));
 }
@@ -2582,11 +2613,15 @@ restack(Monitor *m)
 void
 raisealwaysontop(Monitor *m)
 {
+	OverrideWindow *ow;
+
 	if (m->sel && m->sel->isfullscreen && m->sel->fakefullscreen != 1) {
 		XRaiseWindow(dpy, m->sel->win);
-		return;
-	}
-	raisealwaysontopclients(m->stack);
+	} else
+		raisealwaysontopclients(m->stack);
+	for (ow = overridewindows; ow; ow = ow->next)
+		if (ow->raise)
+			XRaiseWindow(dpy, ow->win);
 }
 
 void
@@ -2597,38 +2632,6 @@ raisealwaysontopclients(Client *c)
 	raisealwaysontopclients(c->snext);
 	if ((c->alwaysontop || c->ewmhabove) && ISVISIBLE(c))
 		XRaiseWindow(dpy, c->win);
-}
-
-void
-raiseoverridepopups(void)
-{
-	Atom states[NET_WM_STATE_MAX], types[NET_WM_STATE_MAX];
-	Window parent, root_return, *wins = NULL;
-	XWindowAttributes wa;
-	unsigned int i, nwins;
-	unsigned long nstates, ntypes;
-
-	if (!XQueryTree(dpy, root, &root_return, &parent, &wins, &nwins))
-		return;
-	/* These windows bypass normal management, so restore their declared
-	 * popup/above layer after managed clients have been restacked. */
-	for (i = 0; i < nwins; i++) {
-		if (!XGetWindowAttributes(dpy, wins[i], &wa)
-		    || !wa.override_redirect || wa.map_state != IsViewable)
-			continue;
-		nstates = getwinatomproplist(wins[i], netatom[NetWMState],
-			states, LENGTH(states), NULL);
-		ntypes = getwinatomproplist(wins[i], netatom[NetWMWindowType],
-			types, LENGTH(types), NULL);
-		if (atomlistcontains(states, nstates, netatom[NetWMAbove])
-		    || atomlistcontains(states, nstates, netatom[NetWMStaysOnTop])
-		    || atomlistcontains(types, ntypes, netatom[NetWMWindowTypeTooltip])
-		    || atomlistcontains(types, ntypes, netatom[NetWMWindowTypeNotification])
-		    || atomlistcontains(types, ntypes, kdewindowtypeoverride))
-			XRaiseWindow(dpy, wins[i]);
-	}
-	if (wins)
-		XFree(wins);
 }
 
 void
@@ -2830,8 +2833,14 @@ scan(void)
 
 	if (XQueryTree(dpy, root, &d1, &d2, &wins, &num)) {
 		for (i = 0; i < num; i++) {
-			if (!XGetWindowAttributes(dpy, wins[i], &wa)
-			|| wa.override_redirect || XGetTransientForHint(dpy, wins[i], &d1))
+			if (!XGetWindowAttributes(dpy, wins[i], &wa))
+				continue;
+			if (wa.override_redirect) {
+				if (wa.map_state == IsViewable)
+					trackoverridewindow(wins[i]);
+				continue;
+			}
+			if (XGetTransientForHint(dpy, wins[i], &d1))
 				continue;
 			if (isaltbar(wins[i], &wa))
 				managealtbar(wins[i], &wa);
@@ -4528,6 +4537,7 @@ unmapnotify(XEvent *e)
 	Monitor *m;
 	XUnmapEvent *ev = &e->xunmap;
 
+	untrackoverridewindow(ev->window);
 	if ((c = wintoclient(ev->window))) {
 		if (ev->send_event)
 			setclientstate(c, WithdrawnState);
@@ -4537,6 +4547,41 @@ unmapnotify(XEvent *e)
 		unmanagealtbar(ev->window);
 	else if (m && m->traywin == ev->window)
 		unmanagetray(ev->window);
+}
+
+void
+trackoverridewindow(Window win)
+{
+	OverrideWindow *ow;
+	OverrideWindow **tail;
+	XWindowAttributes wa;
+
+	if (!XGetWindowAttributes(dpy, win, &wa)
+	    || !wa.override_redirect || wa.map_state != IsViewable)
+		return;
+	for (ow = overridewindows; ow && ow->win != win; ow = ow->next);
+	if (!ow) {
+		ow = ecalloc(1, sizeof(*ow));
+		ow->win = win;
+		for (tail = &overridewindows; *tail; tail = &(*tail)->next);
+		*tail = ow;
+		XSelectInput(dpy, win, PropertyChangeMask);
+	}
+	updateoverridewindow(win);
+}
+
+void
+untrackoverridewindow(Window win)
+{
+	OverrideWindow **ow;
+
+	for (ow = &overridewindows; *ow && (*ow)->win != win; ow = &(*ow)->next);
+	if (*ow) {
+		OverrideWindow *removed = *ow;
+
+		*ow = removed->next;
+		free(removed);
+	}
 }
 
 void
@@ -4909,6 +4954,27 @@ updatewindowtype(Client *c)
 		|| atomlistcontains(states, nstates, netatom[NetWMStaysOnTop]);
 	if (wtype == netatom[NetWMWindowTypeDialog])
 		c->isfloating = 1;
+}
+
+void
+updateoverridewindow(Window win)
+{
+	Atom states[NET_WM_STATE_MAX], types[NET_WM_STATE_MAX];
+	OverrideWindow *ow;
+	unsigned long nstates, ntypes;
+
+	for (ow = overridewindows; ow && ow->win != win; ow = ow->next);
+	if (!ow)
+		return;
+	nstates = getwinatomproplist(win, netatom[NetWMState],
+		states, LENGTH(states), NULL);
+	ntypes = getwinatomproplist(win, netatom[NetWMWindowType],
+		types, LENGTH(types), NULL);
+	ow->raise = atomlistcontains(states, nstates, netatom[NetWMAbove])
+		|| atomlistcontains(states, nstates, netatom[NetWMStaysOnTop])
+		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypeTooltip])
+		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypeNotification])
+		|| atomlistcontains(types, ntypes, kdewindowtypeoverride);
 }
 
 void

--- a/scripts/autostart.sh
+++ b/scripts/autostart.sh
@@ -117,12 +117,22 @@ if ! command -v "$screenshot_helper" >/dev/null 2>&1; then
 	*/*) screenshot_helper=${0%/*}/dwm-screenshot ;;
 	esac
 fi
-if [ -x "$screenshot_helper" ] || command -v "$screenshot_helper" >/dev/null 2>&1; then
-	"$screenshot_helper" setup >/dev/null 2>&1 || true
-fi
 # Starting it explicitly avoids racing D-Bus activation against
 # StatusNotifier registration.
-start_detached_once flameshot flameshot
+if command -v flameshot >/dev/null 2>&1; then
+	if [ -x "$screenshot_helper" ] ||
+		command -v "$screenshot_helper" >/dev/null 2>&1; then
+		if "$screenshot_helper" setup >/dev/null; then
+			start_detached_once flameshot flameshot
+		else
+			printf '%s\n' \
+				"autostart: failed to configure Flameshot's X11 backend; not starting Flameshot" >&2
+		fi
+	else
+		printf '%s\n' \
+			"autostart: dwm-screenshot helper not found; not starting Flameshot" >&2
+	fi
+fi
 
 xdg_autostart_started=0
 

--- a/scripts/autostart.sh
+++ b/scripts/autostart.sh
@@ -75,18 +75,26 @@ esac
 XDG_CURRENT_DESKTOP=$desktop_tokens
 export XDG_CURRENT_DESKTOP
 export DESKTOP_SESSION="${DESKTOP_SESSION:-dwm}"
-export XDG_SESSION_TYPE="${XDG_SESSION_TYPE:-x11}"
+export XDG_SESSION_TYPE=x11
+export QT_QPA_PLATFORM=xcb
+unset WAYLAND_DISPLAY
 
-IMPORT_ENV="DISPLAY XAUTHORITY XDG_CURRENT_DESKTOP DESKTOP_SESSION XDG_SESSION_TYPE QT_QPA_PLATFORMTHEME XCURSOR_THEME XCURSOR_SIZE"
+IMPORT_ENV="DISPLAY XAUTHORITY XDG_CURRENT_DESKTOP DESKTOP_SESSION XDG_SESSION_TYPE QT_QPA_PLATFORM QT_QPA_PLATFORMTHEME XCURSOR_THEME XCURSOR_SIZE"
 
 # Export display and theme env to systemd/dbus in parallel (both are IPC round-trips).
 if command -v systemctl >/dev/null 2>&1; then
-	# shellcheck disable=SC2086
-	systemctl --user import-environment $IMPORT_ENV &
+	{
+		systemctl --user unset-environment WAYLAND_DISPLAY
+		# shellcheck disable=SC2086
+		systemctl --user import-environment $IMPORT_ENV
+	} &
 fi
 if command -v dbus-update-activation-environment >/dev/null 2>&1; then
-	# shellcheck disable=SC2086
-	dbus-update-activation-environment --systemd $IMPORT_ENV 2>/dev/null &
+	{
+		dbus-update-activation-environment WAYLAND_DISPLAY=
+		# shellcheck disable=SC2086
+		dbus-update-activation-environment --systemd $IMPORT_ENV
+	} 2>/dev/null &
 fi
 wait
 

--- a/scripts/autostart.sh
+++ b/scripts/autostart.sh
@@ -109,6 +109,21 @@ if [ -f "$QUICKSHELL_CONFIG" ]; then
 	fi
 fi
 
+# Configure native X11 capture before the tray menu can request a screenshot,
+# then keep one tray-owning daemon ready before screenshot hotkeys run.
+screenshot_helper=dwm-screenshot
+if ! command -v "$screenshot_helper" >/dev/null 2>&1; then
+	case $0 in
+	*/*) screenshot_helper=${0%/*}/dwm-screenshot ;;
+	esac
+fi
+if [ -x "$screenshot_helper" ] || command -v "$screenshot_helper" >/dev/null 2>&1; then
+	"$screenshot_helper" setup >/dev/null 2>&1 || true
+fi
+# Starting it explicitly avoids racing D-Bus activation against
+# StatusNotifier registration.
+start_detached_once flameshot flameshot
+
 xdg_autostart_started=0
 
 # Activate user graphical-session.target through the wm shim so portal services

--- a/scripts/autostart.sh
+++ b/scripts/autostart.sh
@@ -79,21 +79,23 @@ export XDG_SESSION_TYPE=x11
 export QT_QPA_PLATFORM=xcb
 unset WAYLAND_DISPLAY
 
-IMPORT_ENV="DISPLAY XAUTHORITY XDG_CURRENT_DESKTOP DESKTOP_SESSION XDG_SESSION_TYPE QT_QPA_PLATFORM QT_QPA_PLATFORMTHEME XCURSOR_THEME XCURSOR_SIZE"
-
 # Export display and theme env to systemd/dbus in parallel (both are IPC round-trips).
 if command -v systemctl >/dev/null 2>&1; then
 	{
 		systemctl --user unset-environment WAYLAND_DISPLAY
-		# shellcheck disable=SC2086
-		systemctl --user import-environment $IMPORT_ENV
+		systemctl --user import-environment \
+			DISPLAY XAUTHORITY XDG_CURRENT_DESKTOP DESKTOP_SESSION \
+			XDG_SESSION_TYPE QT_QPA_PLATFORM QT_QPA_PLATFORMTHEME \
+			XCURSOR_THEME XCURSOR_SIZE
 	} &
 fi
 if command -v dbus-update-activation-environment >/dev/null 2>&1; then
 	{
 		dbus-update-activation-environment WAYLAND_DISPLAY=
-		# shellcheck disable=SC2086
-		dbus-update-activation-environment --systemd $IMPORT_ENV
+		dbus-update-activation-environment --systemd \
+			DISPLAY XAUTHORITY XDG_CURRENT_DESKTOP DESKTOP_SESSION \
+			XDG_SESSION_TYPE QT_QPA_PLATFORM QT_QPA_PLATFORMTHEME \
+			XCURSOR_THEME XCURSOR_SIZE
 	} 2>/dev/null &
 fi
 wait
@@ -125,14 +127,11 @@ if ! command -v "$screenshot_helper" >/dev/null 2>&1; then
 	*/*) screenshot_helper=${0%/*}/dwm-screenshot ;;
 	esac
 fi
-# Starting it explicitly avoids racing D-Bus activation against
-# StatusNotifier registration.
+# The helper serializes daemon startup with theme-driven restarts.
 if command -v flameshot >/dev/null 2>&1; then
 	if [ -x "$screenshot_helper" ] ||
 		command -v "$screenshot_helper" >/dev/null 2>&1; then
-		if "$screenshot_helper" setup >/dev/null; then
-			start_detached_once flameshot flameshot
-		else
+		if ! "$screenshot_helper" daemon >/dev/null; then
 			printf '%s\n' \
 				"autostart: failed to configure Flameshot's X11 backend; not starting Flameshot" >&2
 		fi

--- a/scripts/dwm-quickshell-state
+++ b/scripts/dwm-quickshell-state
@@ -80,8 +80,8 @@ occupied_workspaces() {
 		paste -sd '|' -
 }
 
-fullscreen_workspaces() {
-	root_property_value _DWM_FULLSCREEN_DESKTOPS |
+fullscreen_monitors() {
+	root_property_value _DWM_FULLSCREEN_MONITORS |
 		tr ',' '\n' |
 		awk '$1 ~ /^[0-9]+$/ { print $1 }' |
 		sort -nu |
@@ -157,7 +157,7 @@ show_state() {
 	class=${class:-application-x-executable}
 	status=$(root_status)
 	occupied=$(occupied_workspaces)
-	fullscreen=$(fullscreen_workspaces)
+	fullscreen_monitors=$(fullscreen_monitors)
 	apps=$(running_apps)
 	monitor_desktops=$(
 		root_property_value _DWM_MONITOR_DESKTOPS |
@@ -170,7 +170,7 @@ show_state() {
 	printf 'count=%s\n' "$count"
 	printf 'names=%s\n' "$names"
 	printf 'occupied=%s\n' "$occupied"
-	printf 'fullscreen=%s\n' "$fullscreen"
+	printf 'fullscreen_monitors=%s\n' "$fullscreen_monitors"
 	printf 'apps=%s\n' "$apps"
 	printf 'active_window=%s\n' "$window_id"
 	printf 'title=%s\n' "$title"
@@ -191,7 +191,7 @@ watch_state() {
 			_NET_DESKTOP_NAMES \
 			_NET_ACTIVE_WINDOW \
 			_NET_CLIENT_LIST \
-			_DWM_FULLSCREEN_DESKTOPS \
+			_DWM_FULLSCREEN_MONITORS \
 			WM_NAME 2>/dev/null
 	else
 		xprop -root -spy \
@@ -201,7 +201,7 @@ watch_state() {
 			_NET_DESKTOP_NAMES \
 			_NET_ACTIVE_WINDOW \
 			_NET_CLIENT_LIST \
-			_DWM_FULLSCREEN_DESKTOPS \
+			_DWM_FULLSCREEN_MONITORS \
 			WM_NAME 2>/dev/null
 	fi |
 		while IFS= read -r _event; do

--- a/scripts/dwm-quickshell-state
+++ b/scripts/dwm-quickshell-state
@@ -80,6 +80,14 @@ occupied_workspaces() {
 		paste -sd '|' -
 }
 
+fullscreen_workspaces() {
+	root_property_value _DWM_FULLSCREEN_DESKTOPS |
+		tr ',' '\n' |
+		awk '$1 ~ /^[0-9]+$/ { print $1 }' |
+		sort -nu |
+		paste -sd '|' -
+}
+
 running_apps() {
 	seen='|'
 	root_property_value _NET_CLIENT_LIST |
@@ -149,6 +157,7 @@ show_state() {
 	class=${class:-application-x-executable}
 	status=$(root_status)
 	occupied=$(occupied_workspaces)
+	fullscreen=$(fullscreen_workspaces)
 	apps=$(running_apps)
 	monitor_desktops=$(
 		root_property_value _DWM_MONITOR_DESKTOPS |
@@ -161,6 +170,7 @@ show_state() {
 	printf 'count=%s\n' "$count"
 	printf 'names=%s\n' "$names"
 	printf 'occupied=%s\n' "$occupied"
+	printf 'fullscreen=%s\n' "$fullscreen"
 	printf 'apps=%s\n' "$apps"
 	printf 'active_window=%s\n' "$window_id"
 	printf 'title=%s\n' "$title"
@@ -181,6 +191,7 @@ watch_state() {
 			_NET_DESKTOP_NAMES \
 			_NET_ACTIVE_WINDOW \
 			_NET_CLIENT_LIST \
+			_DWM_FULLSCREEN_DESKTOPS \
 			WM_NAME 2>/dev/null
 	else
 		xprop -root -spy \
@@ -190,6 +201,7 @@ watch_state() {
 			_NET_DESKTOP_NAMES \
 			_NET_ACTIVE_WINDOW \
 			_NET_CLIENT_LIST \
+			_DWM_FULLSCREEN_DESKTOPS \
 			WM_NAME 2>/dev/null
 	fi |
 		while IFS= read -r _event; do

--- a/scripts/dwm-screenshot
+++ b/scripts/dwm-screenshot
@@ -138,6 +138,7 @@ flameshot_daemon_pids() {
 	local pid user_id=$1
 
 	while IFS= read -r pid; do
+		process_is_alive "$pid" || continue
 		[[ -r "/proc/$pid/environ" ]] || continue
 		if awk -v expected_display="DISPLAY=$DISPLAY" '
 			BEGIN { RS = "\0" }
@@ -149,6 +150,17 @@ flameshot_daemon_pids() {
 			printf '%s\n' "$pid"
 		fi
 	done < <(pgrep -u "$user_id" -x flameshot 2>/dev/null || true)
+}
+
+process_is_alive() {
+	local pid=$1 state
+
+	state=$(ps -o stat= -p "$pid" 2>/dev/null || true)
+	state=${state//[[:space:]]/}
+	case "$state" in
+	Z* | X*) return 1 ;;
+	esac
+	kill -0 "$pid" 2>/dev/null
 }
 
 manage_daemon() {
@@ -183,7 +195,7 @@ manage_daemon() {
 		while :; do
 			alive=0
 			for pid in "${all_pids[@]}"; do
-				if kill -0 "$pid" 2>/dev/null; then
+				if process_is_alive "$pid"; then
 					alive=1
 					break
 				fi

--- a/scripts/dwm-screenshot
+++ b/scripts/dwm-screenshot
@@ -11,6 +11,23 @@
 
 set -euo pipefail
 
+acquire_flameshot_lock() {
+	local lock_dir
+
+	if ! command -v flock >/dev/null 2>&1; then
+		printf 'dwm-screenshot: flock is required to manage Flameshot\n' >&2
+		return 1
+	fi
+
+	lock_dir="${XDG_RUNTIME_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}}/dwm-titus"
+	mkdir -p "$lock_dir"
+	exec {flameshot_lock_fd}>"$lock_dir/flameshot.lock"
+	if ! flock -w 5 "$flameshot_lock_fd"; then
+		printf 'dwm-screenshot: timed out waiting for the Flameshot lock\n' >&2
+		return 1
+	fi
+}
+
 sync_activation_environment() {
 	local -a activation_vars=(DISPLAY XDG_SESSION_TYPE QT_QPA_PLATFORM)
 
@@ -172,21 +189,8 @@ process_is_alive() {
 }
 
 manage_daemon() {
-	local action=$1 alive attempt lock_dir lock_fd pid user_id
+	local action=$1 alive attempt pid user_id
 	local -a all_pids daemon_pids
-
-	if ! command -v flock >/dev/null 2>&1; then
-		printf 'dwm-screenshot: flock is required to manage the Flameshot daemon\n' >&2
-		return 1
-	fi
-
-	lock_dir="${XDG_RUNTIME_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}}/dwm-titus"
-	mkdir -p "$lock_dir"
-	exec {lock_fd}>"$lock_dir/flameshot.lock"
-	if ! flock -w 5 "$lock_fd"; then
-		printf 'dwm-screenshot: timed out waiting for the Flameshot daemon lock\n' >&2
-		return 1
-	fi
 
 	user_id=$(id -u)
 	mapfile -t all_pids < <(pgrep -u "$user_id" -x flameshot 2>/dev/null || true)
@@ -225,7 +229,7 @@ manage_daemon() {
 
 	if command -v setsid >/dev/null 2>&1; then
 		(
-			exec {lock_fd}>&-
+			exec {flameshot_lock_fd}>&-
 			exec setsid -f env -u WAYLAND_DISPLAY \
 				XDG_SESSION_TYPE=x11 \
 				QT_QPA_PLATFORM=xcb \
@@ -233,7 +237,7 @@ manage_daemon() {
 		) >/dev/null 2>&1
 	else
 		(
-			exec {lock_fd}>&-
+			exec {flameshot_lock_fd}>&-
 			exec env -u WAYLAND_DISPLAY \
 				XDG_SESSION_TYPE=x11 \
 				QT_QPA_PLATFORM=xcb \
@@ -260,6 +264,7 @@ if ! command -v flameshot >/dev/null 2>&1; then
 fi
 
 sync_activation_environment
+acquire_flameshot_lock
 ensure_x11_capture_backend
 
 ACTION="${1:-gui}"
@@ -281,12 +286,15 @@ mkdir -p "$SCREENSHOT_DIR"
 
 case "$ACTION" in
 full)
+	exec {flameshot_lock_fd}>&-
 	exec flameshot full -p "$SCREENSHOT_DIR"
 	;;
 gui)
+	exec {flameshot_lock_fd}>&-
 	exec flameshot gui -p "$SCREENSHOT_DIR"
 	;;
 clip)
+	exec {flameshot_lock_fd}>&-
 	exec flameshot gui --clipboard
 	;;
 *)

--- a/scripts/dwm-screenshot
+++ b/scripts/dwm-screenshot
@@ -67,7 +67,7 @@ ensure_x11_capture_backend() {
 	fi
 
 	temp_file=$(mktemp "$config_file.tmp.XXXXXX")
-	awk '
+	if ! awk '
 		BEGIN {
 			in_general = 0
 			found_general = 0
@@ -106,8 +106,15 @@ ensure_x11_capture_backend() {
 				print "useX11LegacyScreenshot=true"
 			}
 		}
-	' "$config_file" >"$temp_file"
-	mv "$temp_file" "$config_file"
+	' "$config_file" >"$temp_file"; then
+		rm -f "$temp_file"
+		return 1
+	fi
+	if ! cat "$temp_file" >"$config_file"; then
+		rm -f "$temp_file"
+		return 1
+	fi
+	rm -f "$temp_file"
 }
 
 if ! command -v flameshot >/dev/null 2>&1; then

--- a/scripts/dwm-screenshot
+++ b/scripts/dwm-screenshot
@@ -134,8 +134,26 @@ ensure_x11_capture_backend() {
 	rm -f -- "$backup_file" "$temp_file"
 }
 
+flameshot_daemon_pids() {
+	local pid user_id=$1
+
+	while IFS= read -r pid; do
+		[[ -r "/proc/$pid/environ" ]] || continue
+		if awk -v expected_display="DISPLAY=$DISPLAY" '
+			BEGIN { RS = "\0" }
+			$0 == expected_display { display = 1 }
+			$0 == "XDG_SESSION_TYPE=x11" { session = 1 }
+			$0 == "QT_QPA_PLATFORM=xcb" { platform = 1 }
+			END { exit !(display && session && platform) }
+		' "/proc/$pid/environ"; then
+			printf '%s\n' "$pid"
+		fi
+	done < <(pgrep -u "$user_id" -x flameshot 2>/dev/null || true)
+}
+
 manage_daemon() {
-	local action=$1 attempt lock_dir lock_fd user_id
+	local action=$1 alive attempt lock_dir lock_fd pid user_id
+	local -a all_pids daemon_pids
 
 	if ! command -v flock >/dev/null 2>&1; then
 		printf 'dwm-screenshot: flock is required to manage the Flameshot daemon\n' >&2
@@ -151,10 +169,26 @@ manage_daemon() {
 	fi
 
 	user_id=$(id -u)
-	if [[ "$action" == restart-daemon ]]; then
-		pkill -u "$user_id" -x flameshot 2>/dev/null || true
+	mapfile -t all_pids < <(pgrep -u "$user_id" -x flameshot 2>/dev/null || true)
+	mapfile -t daemon_pids < <(flameshot_daemon_pids "$user_id")
+	if [[ "$action" == daemon ]] && ((${#daemon_pids[@]})); then
+		return 0
+	fi
+
+	# Flameshot is a per-user singleton on the session bus. Replace any stale
+	# daemon from another display so this managed X11 session owns it.
+	if ((${#all_pids[@]})); then
+		kill "${all_pids[@]}" 2>/dev/null || true
 		attempt=0
-		while pgrep -u "$user_id" -x flameshot >/dev/null 2>&1; do
+		while :; do
+			alive=0
+			for pid in "${all_pids[@]}"; do
+				if kill -0 "$pid" 2>/dev/null; then
+					alive=1
+					break
+				fi
+			done
+			((alive)) || break
 			((attempt += 1))
 			if ((attempt >= 100)); then
 				printf 'dwm-screenshot: timed out waiting for Flameshot to exit\n' >&2
@@ -164,24 +198,33 @@ manage_daemon() {
 		done
 	fi
 
-	if pgrep -u "$user_id" -x flameshot >/dev/null 2>&1; then
+	mapfile -t daemon_pids < <(flameshot_daemon_pids "$user_id")
+	if ((${#daemon_pids[@]})); then
 		return 0
 	fi
 
 	if command -v setsid >/dev/null 2>&1; then
-		setsid -f env -u WAYLAND_DISPLAY \
-			XDG_SESSION_TYPE=x11 \
-			QT_QPA_PLATFORM=xcb \
-			flameshot >/dev/null 2>&1
+		(
+			exec {lock_fd}>&-
+			exec setsid -f env -u WAYLAND_DISPLAY \
+				XDG_SESSION_TYPE=x11 \
+				QT_QPA_PLATFORM=xcb \
+				flameshot
+		) >/dev/null 2>&1
 	else
-		env -u WAYLAND_DISPLAY \
-			XDG_SESSION_TYPE=x11 \
-			QT_QPA_PLATFORM=xcb \
-			flameshot >/dev/null 2>&1 &
+		(
+			exec {lock_fd}>&-
+			exec env -u WAYLAND_DISPLAY \
+				XDG_SESSION_TYPE=x11 \
+				QT_QPA_PLATFORM=xcb \
+				flameshot
+		) >/dev/null 2>&1 &
 	fi
 
 	attempt=0
-	until pgrep -u "$user_id" -x flameshot >/dev/null 2>&1; do
+	while :; do
+		mapfile -t daemon_pids < <(flameshot_daemon_pids "$user_id")
+		((${#daemon_pids[@]})) && break
 		((attempt += 1))
 		if ((attempt >= 100)); then
 			printf 'dwm-screenshot: timed out waiting for Flameshot to start\n' >&2

--- a/scripts/dwm-screenshot
+++ b/scripts/dwm-screenshot
@@ -140,12 +140,20 @@ flameshot_daemon_pids() {
 	while IFS= read -r pid; do
 		process_is_alive "$pid" || continue
 		[[ -r "/proc/$pid/environ" ]] || continue
-		if awk -v expected_display="DISPLAY=$DISPLAY" '
+		if awk \
+			-v expected_display="DISPLAY=$DISPLAY" \
+			-v expected_bus="${DBUS_SESSION_BUS_ADDRESS:+DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS}" '
 			BEGIN { RS = "\0" }
 			$0 == expected_display { display = 1 }
 			$0 == "XDG_SESSION_TYPE=x11" { session = 1 }
 			$0 == "QT_QPA_PLATFORM=xcb" { platform = 1 }
-			END { exit !(display && session && platform) }
+			index($0, "DBUS_SESSION_BUS_ADDRESS=") == 1 { bus_present = 1 }
+			$0 == expected_bus { bus = 1 }
+			END {
+				if (expected_bus == "")
+					bus = !bus_present
+				exit !(display && session && platform && bus)
+			}
 		' "/proc/$pid/environ"; then
 			printf '%s\n' "$pid"
 		fi
@@ -188,7 +196,7 @@ manage_daemon() {
 	fi
 
 	# Flameshot is a per-user singleton on the session bus. Replace any stale
-	# daemon from another display so this managed X11 session owns it.
+	# daemon from another display or bus so this managed X11 session owns it.
 	if ((${#all_pids[@]})); then
 		kill "${all_pids[@]}" 2>/dev/null || true
 		attempt=0

--- a/scripts/dwm-screenshot
+++ b/scripts/dwm-screenshot
@@ -134,6 +134,63 @@ ensure_x11_capture_backend() {
 	rm -f -- "$backup_file" "$temp_file"
 }
 
+manage_daemon() {
+	local action=$1 attempt lock_dir lock_fd user_id
+
+	if ! command -v flock >/dev/null 2>&1; then
+		printf 'dwm-screenshot: flock is required to manage the Flameshot daemon\n' >&2
+		return 1
+	fi
+
+	lock_dir="${XDG_RUNTIME_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}}/dwm-titus"
+	mkdir -p "$lock_dir"
+	exec {lock_fd}>"$lock_dir/flameshot.lock"
+	if ! flock -w 5 "$lock_fd"; then
+		printf 'dwm-screenshot: timed out waiting for the Flameshot daemon lock\n' >&2
+		return 1
+	fi
+
+	user_id=$(id -u)
+	if [[ "$action" == restart-daemon ]]; then
+		pkill -u "$user_id" -x flameshot 2>/dev/null || true
+		attempt=0
+		while pgrep -u "$user_id" -x flameshot >/dev/null 2>&1; do
+			((attempt += 1))
+			if ((attempt >= 100)); then
+				printf 'dwm-screenshot: timed out waiting for Flameshot to exit\n' >&2
+				return 1
+			fi
+			sleep 0.05
+		done
+	fi
+
+	if pgrep -u "$user_id" -x flameshot >/dev/null 2>&1; then
+		return 0
+	fi
+
+	if command -v setsid >/dev/null 2>&1; then
+		setsid -f env -u WAYLAND_DISPLAY \
+			XDG_SESSION_TYPE=x11 \
+			QT_QPA_PLATFORM=xcb \
+			flameshot >/dev/null 2>&1
+	else
+		env -u WAYLAND_DISPLAY \
+			XDG_SESSION_TYPE=x11 \
+			QT_QPA_PLATFORM=xcb \
+			flameshot >/dev/null 2>&1 &
+	fi
+
+	attempt=0
+	until pgrep -u "$user_id" -x flameshot >/dev/null 2>&1; do
+		((attempt += 1))
+		if ((attempt >= 100)); then
+			printf 'dwm-screenshot: timed out waiting for Flameshot to start\n' >&2
+			return 1
+		fi
+		sleep 0.05
+	done
+}
+
 if ! command -v flameshot >/dev/null 2>&1; then
 	printf 'dwm-screenshot: flameshot is not installed\n' >&2
 	exit 127
@@ -145,6 +202,10 @@ ensure_x11_capture_backend
 ACTION="${1:-gui}"
 if [[ "$ACTION" == setup ]]; then
 	exit 0
+fi
+if [[ "$ACTION" == daemon || "$ACTION" == restart-daemon ]]; then
+	manage_daemon "$ACTION"
+	exit
 fi
 
 SCREENSHOT_DIR=""
@@ -166,7 +227,7 @@ clip)
 	exec flameshot gui --clipboard
 	;;
 *)
-	printf 'Usage: %s {full|gui|clip}\n' "$0" >&2
+	printf 'Usage: %s {full|gui|clip|setup|daemon|restart-daemon}\n' "$0" >&2
 	exit 1
 	;;
 esac

--- a/scripts/dwm-screenshot
+++ b/scripts/dwm-screenshot
@@ -44,7 +44,7 @@ sync_activation_environment() {
 }
 
 ensure_x11_capture_backend() {
-	local config_dir config_file temp_file
+	local backup_file config_dir config_file target_file temp_file
 
 	config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/flameshot"
 	config_file="$config_dir/flameshot.ini"
@@ -107,14 +107,31 @@ ensure_x11_capture_backend() {
 			}
 		}
 	' "$config_file" >"$temp_file"; then
-		rm -f "$temp_file"
+		rm -f -- "$temp_file"
 		return 1
 	fi
-	if ! cat "$temp_file" >"$config_file"; then
-		rm -f "$temp_file"
+
+	if ! target_file=$(readlink -f -- "$config_file"); then
+		rm -f -- "$temp_file"
 		return 1
 	fi
-	rm -f "$temp_file"
+	if ! backup_file=$(mktemp "$target_file.backup.XXXXXX"); then
+		rm -f -- "$temp_file"
+		return 1
+	fi
+	if ! cat "$target_file" >"$backup_file"; then
+		rm -f -- "$backup_file" "$temp_file"
+		return 1
+	fi
+	if ! cat "$temp_file" >"$target_file"; then
+		if ! cat "$backup_file" >"$target_file"; then
+			printf 'dwm-screenshot: failed to restore %s after an update error\n' \
+				"$config_file" >&2
+		fi
+		rm -f -- "$backup_file" "$temp_file"
+		return 1
+	fi
+	rm -f -- "$backup_file" "$temp_file"
 }
 
 if ! command -v flameshot >/dev/null 2>&1; then

--- a/scripts/dwm-screenshot
+++ b/scripts/dwm-screenshot
@@ -43,12 +43,85 @@ sync_activation_environment() {
 	fi
 }
 
+ensure_x11_capture_backend() {
+	local config_dir config_file temp_file
+
+	config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/flameshot"
+	config_file="$config_dir/flameshot.ini"
+	mkdir -p "$config_dir"
+
+	if [[ ! -f "$config_file" ]]; then
+		printf '[General]\nuseX11LegacyScreenshot=true\n' >"$config_file"
+		return
+	fi
+	if awk '
+		/^\[General\][[:space:]]*$/ { in_general = 1; next }
+		/^\[[^]]+\][[:space:]]*$/ { in_general = 0 }
+		in_general &&
+			/^useX11LegacyScreenshot[[:space:]]*=[[:space:]]*true[[:space:]]*$/ {
+			found = 1
+		}
+		END { exit !found }
+	' "$config_file"; then
+		return
+	fi
+
+	temp_file=$(mktemp "$config_file.tmp.XXXXXX")
+	awk '
+		BEGIN {
+			in_general = 0
+			found_general = 0
+			wrote_setting = 0
+		}
+		/^\[General\][[:space:]]*$/ {
+			in_general = 1
+			found_general = 1
+			print
+			next
+		}
+		/^\[[^]]+\][[:space:]]*$/ {
+			if (in_general && !wrote_setting) {
+				print "useX11LegacyScreenshot=true"
+				wrote_setting = 1
+			}
+			in_general = 0
+			print
+			next
+		}
+		in_general &&
+			/^useX11LegacyScreenshot[[:space:]]*=/ {
+			if (!wrote_setting) {
+				print "useX11LegacyScreenshot=true"
+				wrote_setting = 1
+			}
+			next
+		}
+		{ print }
+		END {
+			if (in_general && !wrote_setting)
+				print "useX11LegacyScreenshot=true"
+			else if (!found_general) {
+				print ""
+				print "[General]"
+				print "useX11LegacyScreenshot=true"
+			}
+		}
+	' "$config_file" >"$temp_file"
+	mv "$temp_file" "$config_file"
+}
+
 if ! command -v flameshot >/dev/null 2>&1; then
 	printf 'dwm-screenshot: flameshot is not installed\n' >&2
 	exit 127
 fi
 
 sync_activation_environment
+ensure_x11_capture_backend
+
+ACTION="${1:-gui}"
+if [[ "$ACTION" == setup ]]; then
+	exit 0
+fi
 
 SCREENSHOT_DIR=""
 if command -v xdg-user-dir >/dev/null 2>&1; then
@@ -57,8 +130,6 @@ if command -v xdg-user-dir >/dev/null 2>&1; then
 fi
 SCREENSHOT_DIR="${SCREENSHOT_DIR:-$HOME/Pictures/Screenshots}"
 mkdir -p "$SCREENSHOT_DIR"
-
-ACTION="${1:-gui}"
 
 case "$ACTION" in
 full)

--- a/scripts/dwm-screenshot
+++ b/scripts/dwm-screenshot
@@ -58,7 +58,7 @@ ensure_x11_capture_backend() {
 		/^\[General\][[:space:]]*$/ { in_general = 1; next }
 		/^\[[^]]+\][[:space:]]*$/ { in_general = 0 }
 		in_general &&
-			/^useX11LegacyScreenshot[[:space:]]*=[[:space:]]*true[[:space:]]*$/ {
+			/^useX11LegacyScreenshot[[:space:]]*=[[:space:]]*(true|false)[[:space:]]*$/ {
 			found = 1
 		}
 		END { exit !found }

--- a/scripts/theme-apply.sh
+++ b/scripts/theme-apply.sh
@@ -331,9 +331,26 @@ fi
 
 # Restart flameshot so its tray icon picks up the new theme
 if pgrep -x flameshot &>/dev/null; then
-	pkill -x flameshot 2>/dev/null || true
-	sleep 0.3
-	QT_QPA_PLATFORMTHEME="$QT_PLATFORM_THEME" flameshot &
+	screenshot_helper=dwm-screenshot
+	if ! command -v "$screenshot_helper" >/dev/null 2>&1; then
+		case $0 in
+		*/*) screenshot_helper=${0%/*}/dwm-screenshot ;;
+		esac
+	fi
+
+	if { [[ -x "$screenshot_helper" ]] ||
+		command -v "$screenshot_helper" >/dev/null 2>&1; } &&
+		"$screenshot_helper" setup >/dev/null; then
+		pkill -x flameshot 2>/dev/null || true
+		sleep 0.3
+		env -u WAYLAND_DISPLAY \
+			XDG_SESSION_TYPE=x11 \
+			QT_QPA_PLATFORM=xcb \
+			QT_QPA_PLATFORMTHEME="$QT_PLATFORM_THEME" \
+			flameshot &
+	else
+		echo "theme-apply: failed to configure Flameshot's X11 backend; keeping the current daemon" >&2
+	fi
 fi
 
 echo "theme-apply: applied theme '$THEME_NAME'"

--- a/scripts/theme-apply.sh
+++ b/scripts/theme-apply.sh
@@ -330,7 +330,7 @@ if command -v dbus-update-activation-environment &>/dev/null; then
 fi
 
 # Restart flameshot so its tray icon picks up the new theme
-if pgrep -x flameshot &>/dev/null; then
+if pgrep -u "$(id -u)" -x flameshot &>/dev/null; then
 	screenshot_helper=dwm-screenshot
 	if ! command -v "$screenshot_helper" >/dev/null 2>&1; then
 		case $0 in
@@ -340,16 +340,11 @@ if pgrep -x flameshot &>/dev/null; then
 
 	if { [[ -x "$screenshot_helper" ]] ||
 		command -v "$screenshot_helper" >/dev/null 2>&1; } &&
-		"$screenshot_helper" setup >/dev/null; then
-		pkill -x flameshot 2>/dev/null || true
-		sleep 0.3
-		env -u WAYLAND_DISPLAY \
-			XDG_SESSION_TYPE=x11 \
-			QT_QPA_PLATFORM=xcb \
-			QT_QPA_PLATFORMTHEME="$QT_PLATFORM_THEME" \
-			flameshot &
+		QT_QPA_PLATFORMTHEME="$QT_PLATFORM_THEME" \
+			"$screenshot_helper" restart-daemon >/dev/null; then
+		:
 	else
-		echo "theme-apply: failed to configure Flameshot's X11 backend; keeping the current daemon" >&2
+		echo "theme-apply: Flameshot X11 restart failed" >&2
 	fi
 fi
 

--- a/tests/test-autostart.sh
+++ b/tests/test-autostart.sh
@@ -17,6 +17,13 @@ count=0
 count=$((count + 1))
 printf '%s\n' "$count" >"$count_file"
 : >"${TEST_STATE:?}/$name.running"
+if [ "$name" = flameshot ]; then
+	printf '%s|%s|%s\n' \
+		"${XDG_SESSION_TYPE:-}" \
+		"${QT_QPA_PLATFORM:-}" \
+		"${WAYLAND_DISPLAY:-}" \
+		>"${TEST_STATE:?}/flameshot.env"
+fi
 EOF
 	chmod +x "$work/bin/$name"
 }
@@ -135,17 +142,23 @@ run_duplicate_case() {
 			XDG_RUNTIME_DIR="$runtime" dbus-run-session -- env \
 				DISPLAY=:99 \
 				HOME="$home" \
+				QT_QPA_PLATFORM=wayland \
 				TEST_STATE="$state" \
 				PATH="$work/bin:/usr/bin:/bin" \
+				WAYLAND_DISPLAY=wayland-0 \
 				XDG_CONFIG_HOME="$home/.config" \
+				XDG_SESSION_TYPE=wayland \
 				DWM_AUTOSTART_NO_SETSID=1 \
 				sh "$repo_dir/scripts/autostart.sh"
 		else
 			DISPLAY=:99 \
 				HOME=$home \
+				QT_QPA_PLATFORM=wayland \
 				TEST_STATE=$state \
 				PATH="$work/bin:/usr/bin:/bin" \
+				WAYLAND_DISPLAY=wayland-0 \
 				XDG_CONFIG_HOME="$home/.config" \
+				XDG_SESSION_TYPE=wayland \
 				DWM_AUTOSTART_NO_SETSID=1 \
 				sh "$repo_dir/scripts/autostart.sh"
 		fi
@@ -162,6 +175,7 @@ run_duplicate_case() {
 	done
 	grep -Fqx 'useX11LegacyScreenshot=true' \
 		"$home/.config/flameshot/flameshot.ini"
+	grep -Fqx 'x11|xcb|' "$state/flameshot.env"
 	test ! -e "$state/light-locker.count"
 	test ! -e "$state/dex.count"
 	test ! -e "$state/dex-autostart.count"

--- a/tests/test-autostart.sh
+++ b/tests/test-autostart.sh
@@ -195,7 +195,13 @@ run_duplicate_case() {
 	done
 
 	for name in feh flameshot picom dwm-lock-watch quickshell; do
-		test "$(cat "$state/$name.count")" -eq 1
+		expected=1
+		# Each startx fixture invocation has a fresh session bus, so the
+		# surviving Flameshot daemon must be replaced for the second bus.
+		if [ "$mode" = startx ] && [ "$name" = flameshot ]; then
+			expected=2
+		fi
+		test "$(cat "$state/$name.count")" -eq "$expected"
 	done
 	grep -Fqx 'useX11LegacyScreenshot=true' \
 		"$home/.config/flameshot/flameshot.ini"

--- a/tests/test-autostart.sh
+++ b/tests/test-autostart.sh
@@ -4,7 +4,14 @@ set -eu
 
 repo_dir=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
 work=$(mktemp -d)
-trap 'rm -rf "$work"' EXIT HUP INT TERM
+cleanup() {
+	for pid_file in "$work"/*/state/flameshot.pid; do
+		[ -f "$pid_file" ] || continue
+		kill "$(cat "$pid_file")" 2>/dev/null || true
+	done
+	rm -rf "$work"
+}
+trap cleanup EXIT HUP INT TERM
 
 make_mock_command() {
 	name=$1
@@ -23,6 +30,15 @@ if [ "$name" = flameshot ]; then
 		"${QT_QPA_PLATFORM:-}" \
 		"${WAYLAND_DISPLAY:-}" \
 		>"${TEST_STATE:?}/flameshot.env"
+	printf '%s\n' "$$" >"${TEST_STATE:?}/flameshot.pid"
+	cleanup() {
+		rm -f "${TEST_STATE:?}/flameshot.pid"
+	}
+	trap 'cleanup; exit 0' TERM INT
+	trap cleanup EXIT
+	while :; do
+		sleep 1
+	done
 fi
 EOF
 	chmod +x "$work/bin/$name"
@@ -60,6 +76,13 @@ while [ "$#" -gt 0 ]; do
 	shift
 done
 [ -n "$name" ] || exit 1
+if [ "$name" = flameshot ]; then
+	test -f "${TEST_STATE:?}/flameshot.pid" || exit 1
+	pid=$(cat "${TEST_STATE:?}/flameshot.pid")
+	kill -0 "$pid" 2>/dev/null || exit 1
+	printf '%s\n' "$pid"
+	exit 0
+fi
 test -f "${TEST_STATE:?}/$name.running"
 EOF
 
@@ -98,7 +121,7 @@ cat >"$work/bin/setsid" <<'EOF'
 if [ "$1" = "-f" ]; then
 	shift
 fi
-exec "$@"
+"$@" &
 EOF
 
 chmod +x "$work/bin/"*

--- a/tests/test-autostart.sh
+++ b/tests/test-autostart.sh
@@ -218,10 +218,34 @@ run_missing_optional_case() {
 		/bin/sh "$repo_dir/scripts/autostart.sh"
 }
 
+run_flameshot_setup_failure_case() {
+	home="$work/flameshot-failure/home"
+	state="$work/flameshot-failure/state"
+	config_path="$home/not-a-directory"
+	mkdir -p "$home" "$state"
+	: >"$config_path"
+	: >"$state/polkit-mate-authentication-agent-1.running"
+
+	DISPLAY=:99 \
+		HOME=$home \
+		TEST_STATE=$state \
+		TEST_SYSTEMD_START_FAIL=1 \
+		PATH="$work/bin:/usr/bin:/bin" \
+		XDG_CONFIG_HOME=$config_path \
+		DWM_AUTOSTART_NO_SETSID=1 \
+		sh "$repo_dir/scripts/autostart.sh" \
+		2>"$state/autostart.err"
+
+	test ! -e "$state/flameshot.count"
+	grep -Fq "failed to configure Flameshot's X11 backend" \
+		"$state/autostart.err"
+}
+
 run_duplicate_case display-manager
 run_duplicate_case startx
 run_dex_fallback_case
 run_missing_optional_case
+run_flameshot_setup_failure_case
 
 if grep -q '^WantedBy=default.target$' \
 	"$repo_dir/config/systemd/user/wm-graphical-session.service"; then

--- a/tests/test-autostart.sh
+++ b/tests/test-autostart.sh
@@ -96,7 +96,7 @@ EOF
 
 chmod +x "$work/bin/"*
 
-for name in feh picom dwm-status dwm-lock-watch light-locker dex dex-autostart; do
+for name in feh flameshot picom dwm-status dwm-lock-watch light-locker dex dex-autostart; do
 	make_mock_command "$name"
 done
 
@@ -133,6 +133,7 @@ run_duplicate_case() {
 	for _ in 1 2; do
 		if [ "$mode" = startx ]; then
 			XDG_RUNTIME_DIR="$runtime" dbus-run-session -- env \
+				DISPLAY=:99 \
 				HOME="$home" \
 				TEST_STATE="$state" \
 				PATH="$work/bin:/usr/bin:/bin" \
@@ -140,7 +141,8 @@ run_duplicate_case() {
 				DWM_AUTOSTART_NO_SETSID=1 \
 				sh "$repo_dir/scripts/autostart.sh"
 		else
-			HOME=$home \
+			DISPLAY=:99 \
+				HOME=$home \
 				TEST_STATE=$state \
 				PATH="$work/bin:/usr/bin:/bin" \
 				XDG_CONFIG_HOME="$home/.config" \
@@ -152,11 +154,14 @@ run_duplicate_case() {
 		wait_for_marker "$state/dwm-status.running"
 		wait_for_marker "$state/dwm-lock-watch.running"
 		wait_for_marker "$state/quickshell.running"
+		wait_for_marker "$state/flameshot.running"
 	done
 
-	for name in feh picom dwm-lock-watch quickshell; do
+	for name in feh flameshot picom dwm-lock-watch quickshell; do
 		test "$(cat "$state/$name.count")" -eq 1
 	done
+	grep -Fqx 'useX11LegacyScreenshot=true' \
+		"$home/.config/flameshot/flameshot.ini"
 	test ! -e "$state/light-locker.count"
 	test ! -e "$state/dex.count"
 	test ! -e "$state/dex-autostart.count"

--- a/tests/test-autostart.sh
+++ b/tests/test-autostart.sh
@@ -158,6 +158,7 @@ run_duplicate_case() {
 				PATH="$work/bin:/usr/bin:/bin" \
 				WAYLAND_DISPLAY=wayland-0 \
 				XDG_CONFIG_HOME="$home/.config" \
+				XDG_RUNTIME_DIR="$runtime" \
 				XDG_SESSION_TYPE=wayland \
 				DWM_AUTOSTART_NO_SETSID=1 \
 				sh "$repo_dir/scripts/autostart.sh"
@@ -246,6 +247,7 @@ run_flameshot_setup_failure_case() {
 		TEST_SYSTEMD_START_FAIL=1 \
 		PATH="$work/bin:/usr/bin:/bin" \
 		XDG_CONFIG_HOME=$config_path \
+		XDG_RUNTIME_DIR="$work/flameshot-failure/runtime" \
 		DWM_AUTOSTART_NO_SETSID=1 \
 		sh "$repo_dir/scripts/autostart.sh" \
 		2>"$state/autostart.err"

--- a/tests/test-dwm-screenshot.sh
+++ b/tests/test-dwm-screenshot.sh
@@ -10,7 +10,6 @@ mkdir -p "$work/bin" "$work/home/.config/flameshot" "$work/home/Pictures"
 cat >"$work/home/flameshot-target.ini" <<'EOF'
 [General]
 showHelp=false
-useX11LegacyScreenshot=false
 
 [Shortcuts]
 TYPE_COPY=Ctrl+C
@@ -79,6 +78,27 @@ env -u WAYLAND_DISPLAY \
 	"$repo_dir/scripts/dwm-screenshot" setup
 if grep -q '^flameshot:' "$log"; then
 	printf '%s\n' "Flameshot setup must not start a capture" >&2
+	exit 1
+fi
+
+mkdir -p "$work/explicit/.config/flameshot"
+cat >"$work/explicit/.config/flameshot/flameshot.ini" <<'EOF'
+[General]
+useX11LegacyScreenshot=false
+EOF
+env -u WAYLAND_DISPLAY \
+	DISPLAY=:99 \
+	XDG_SESSION_TYPE=x11 \
+	XDG_CONFIG_HOME="$work/explicit/.config" \
+	HOME="$work/explicit" \
+	PATH="$work/bin:/usr/bin:/bin" \
+	TEST_LOG="$log" \
+	"$repo_dir/scripts/dwm-screenshot" setup
+grep -Fqx 'useX11LegacyScreenshot=false' \
+	"$work/explicit/.config/flameshot/flameshot.ini"
+if grep -Fqx 'useX11LegacyScreenshot=true' \
+	"$work/explicit/.config/flameshot/flameshot.ini"; then
+	printf '%s\n' "Flameshot setup must preserve an explicit backend preference" >&2
 	exit 1
 fi
 

--- a/tests/test-dwm-screenshot.sh
+++ b/tests/test-dwm-screenshot.sh
@@ -5,7 +5,16 @@ repo_dir=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT HUP INT TERM
 
-mkdir -p "$work/bin" "$work/home/Pictures"
+mkdir -p "$work/bin" "$work/home/.config/flameshot" "$work/home/Pictures"
+
+cat >"$work/home/.config/flameshot/flameshot.ini" <<'EOF'
+[General]
+showHelp=false
+useX11LegacyScreenshot=false
+
+[Shortcuts]
+TYPE_COPY=Ctrl+C
+EOF
 
 cat >"$work/bin/systemctl" <<'EOF'
 #!/bin/sh
@@ -34,6 +43,7 @@ env -u XDG_CURRENT_DESKTOP -u WAYLAND_DISPLAY \
 	DISPLAY=:99 \
 	XAUTHORITY="$work/Xauthority" \
 	XDG_SESSION_TYPE=x11 \
+	XDG_CONFIG_HOME="$work/home/.config" \
 	HOME="$work/home" \
 	PATH="$work/bin:/usr/bin:/bin" \
 	TEST_LOG="$log" \
@@ -44,6 +54,24 @@ grep -Fqx 'systemctl:--user import-environment DISPLAY XDG_SESSION_TYPE QT_QPA_P
 grep -Fqx 'dbus:WAYLAND_DISPLAY=' "$log"
 grep -Fqx 'dbus:--systemd DISPLAY XDG_SESSION_TYPE QT_QPA_PLATFORM XAUTHORITY' "$log"
 grep -Fqx 'flameshot:gui --clipboard' "$log"
+grep -Fqx 'useX11LegacyScreenshot=true' \
+	"$work/home/.config/flameshot/flameshot.ini"
+grep -Fqx 'showHelp=false' "$work/home/.config/flameshot/flameshot.ini"
+grep -Fqx 'TYPE_COPY=Ctrl+C' "$work/home/.config/flameshot/flameshot.ini"
 test -d "$work/home/Pictures/Screenshots"
 
-printf '%s\n' "Flameshot environment and clipboard command: PASS"
+: >"$log"
+env -u WAYLAND_DISPLAY \
+	DISPLAY=:99 \
+	XDG_SESSION_TYPE=x11 \
+	XDG_CONFIG_HOME="$work/home/.config" \
+	HOME="$work/home" \
+	PATH="$work/bin:/usr/bin:/bin" \
+	TEST_LOG="$log" \
+	"$repo_dir/scripts/dwm-screenshot" setup
+if grep -q '^flameshot:' "$log"; then
+	printf '%s\n' "Flameshot setup must not start a capture" >&2
+	exit 1
+fi
+
+printf '%s\n' "Flameshot X11 backend, environment, and clipboard command: PASS"

--- a/tests/test-dwm-screenshot.sh
+++ b/tests/test-dwm-screenshot.sh
@@ -102,4 +102,77 @@ if grep -Fqx 'useX11LegacyScreenshot=true' \
 	exit 1
 fi
 
+theme_bin=$work/theme-bin
+theme_home=$work/theme-home
+mkdir -p "$theme_bin" "$theme_home/.config/dwm-titus"
+cp "$repo_dir/config/themes.toml" \
+	"$theme_home/.config/dwm-titus/themes.toml"
+
+cat >"$theme_bin/pgrep" <<'EOF'
+#!/bin/sh
+test "$1" = "-x" && test "$2" = "flameshot"
+EOF
+
+cat >"$theme_bin/pkill" <<'EOF'
+#!/bin/sh
+printf 'pkill:%s\n' "$*" >>"${TEST_LOG:?}"
+EOF
+
+cat >"$theme_bin/dwm-screenshot" <<'EOF'
+#!/bin/sh
+printf 'dwm-screenshot:%s\n' "$*" >>"${TEST_LOG:?}"
+test "${TEST_SETUP_FAIL:-0}" != "1"
+EOF
+
+cat >"$theme_bin/flameshot" <<'EOF'
+#!/bin/sh
+printf 'flameshot-env:%s:%s:%s:%s\n' \
+	"${WAYLAND_DISPLAY-unset}" \
+	"${XDG_SESSION_TYPE-unset}" \
+	"${QT_QPA_PLATFORM-unset}" \
+	"${QT_QPA_PLATFORMTHEME-unset}" >>"${TEST_LOG:?}"
+EOF
+
+for command_name in dbus-update-activation-environment gsettings qt6ct \
+	sleep systemctl xfconf-query xrdb; do
+	cat >"$theme_bin/$command_name" <<'EOF'
+#!/bin/sh
+:
+EOF
+done
+chmod +x "$theme_bin/"*
+
+: >"$log"
+DISPLAY=:99 \
+	WAYLAND_DISPLAY=wayland-0 \
+	XDG_SESSION_TYPE=wayland \
+	QT_QPA_PLATFORM=wayland \
+	XDG_CONFIG_HOME="$theme_home/.config" \
+	HOME="$theme_home" \
+	PATH="$theme_bin:/usr/bin:/bin" \
+	TEST_LOG="$log" \
+	"$repo_dir/scripts/theme-apply.sh"
+
+grep -Fqx 'dwm-screenshot:setup' "$log"
+grep -Fqx 'pkill:-x flameshot' "$log"
+grep -Fqx 'flameshot-env:unset:x11:xcb:qt6ct' "$log"
+
+: >"$log"
+DISPLAY=:99 \
+	WAYLAND_DISPLAY=wayland-0 \
+	XDG_SESSION_TYPE=wayland \
+	QT_QPA_PLATFORM=wayland \
+	XDG_CONFIG_HOME="$theme_home/.config" \
+	HOME="$theme_home" \
+	PATH="$theme_bin:/usr/bin:/bin" \
+	TEST_LOG="$log" \
+	TEST_SETUP_FAIL=1 \
+	"$repo_dir/scripts/theme-apply.sh" 2>/dev/null
+
+grep -Fqx 'dwm-screenshot:setup' "$log"
+if grep -Eq '^(pkill|flameshot-env):' "$log"; then
+	printf '%s\n' "Theme reload must keep Flameshot running when X11 setup fails" >&2
+	exit 1
+fi
+
 printf '%s\n' "Flameshot X11 backend, environment, and clipboard command: PASS"

--- a/tests/test-dwm-screenshot.sh
+++ b/tests/test-dwm-screenshot.sh
@@ -234,11 +234,12 @@ test ! -f "${DAEMON_STATE:?}/count" ||
 count=$(cat "${DAEMON_STATE:?}/count")
 count=$((count + 1))
 printf '%s\n' "$count" >"${DAEMON_STATE:?}/count"
-printf 'daemon-env:%s:%s:%s:%s\n' \
+printf 'daemon-env:%s:%s:%s:%s:%s\n' \
 	"${DISPLAY-unset}" \
 	"${WAYLAND_DISPLAY-unset}" \
 	"${XDG_SESSION_TYPE-unset}" \
-	"${QT_QPA_PLATFORM-unset}" >>"${TEST_LOG:?}"
+	"${QT_QPA_PLATFORM-unset}" \
+	"${DBUS_SESSION_BUS_ADDRESS-unset}" >>"${TEST_LOG:?}"
 for descriptor in /proc/$$/fd/*; do
 	case $(readlink "$descriptor" 2>/dev/null || true) in
 	*/flameshot.lock)
@@ -254,6 +255,7 @@ EOF
 chmod +x "$daemon_bin/"*
 
 : >"$log"
+test_bus=${DBUS_SESSION_BUS_ADDRESS-unset}
 DISPLAY=:98 \
 	WAYLAND_DISPLAY=wayland-0 \
 	XDG_SESSION_TYPE=wayland \
@@ -267,7 +269,7 @@ DISPLAY=:98 \
 	"$repo_dir/scripts/dwm-screenshot" daemon
 
 test "$(cat "$daemon_state/count")" -eq 1
-grep -Fqx 'daemon-env::98:unset:x11:xcb' "$log"
+grep -Fqx "daemon-env::98:unset:x11:xcb:$test_bus" "$log"
 
 DISPLAY=:99 \
 	WAYLAND_DISPLAY=wayland-0 \
@@ -281,7 +283,7 @@ DISPLAY=:99 \
 	TEST_LOG="$log" \
 	"$repo_dir/scripts/dwm-screenshot" daemon
 test "$(cat "$daemon_state/count")" -eq 2
-grep -Fqx 'daemon-env::99:unset:x11:xcb' "$log"
+grep -Fqx "daemon-env::99:unset:x11:xcb:$test_bus" "$log"
 test "$(find "$daemon_state" -name 'pid.*' -type f | wc -l)" -eq 1
 
 DISPLAY=:99 \
@@ -349,6 +351,32 @@ kill -KILL "$zombie_mock_pid"
 wait "$zombie_mock_pid" 2>/dev/null || true
 rm -f "$daemon_state/pid.$zombie_mock_pid"
 zombie_mock_pid=
+
+replacement_bus="unix:path=$work/replacement-bus"
+DISPLAY=:99 \
+	XDG_SESSION_TYPE=x11 \
+	DBUS_SESSION_BUS_ADDRESS="$replacement_bus" \
+	XDG_CONFIG_HOME="$daemon_home/.config" \
+	XDG_RUNTIME_DIR="$daemon_home/runtime" \
+	HOME="$daemon_home" \
+	PATH="$daemon_bin:$work/bin:/usr/bin:/bin" \
+	DAEMON_STATE="$daemon_state" \
+	TEST_LOG="$log" \
+	"$repo_dir/scripts/dwm-screenshot" daemon
+test "$(cat "$daemon_state/count")" -eq 6
+grep -Fqx "daemon-env::99:unset:x11:xcb:$replacement_bus" "$log"
+
+DISPLAY=:99 \
+	XDG_SESSION_TYPE=x11 \
+	DBUS_SESSION_BUS_ADDRESS="$replacement_bus" \
+	XDG_CONFIG_HOME="$daemon_home/.config" \
+	XDG_RUNTIME_DIR="$daemon_home/runtime" \
+	HOME="$daemon_home" \
+	PATH="$daemon_bin:$work/bin:/usr/bin:/bin" \
+	DAEMON_STATE="$daemon_state" \
+	TEST_LOG="$log" \
+	"$repo_dir/scripts/dwm-screenshot" daemon
+test "$(cat "$daemon_state/count")" -eq 6
 
 theme_bin=$work/theme-bin
 theme_home=$work/theme-home

--- a/tests/test-dwm-screenshot.sh
+++ b/tests/test-dwm-screenshot.sh
@@ -212,10 +212,9 @@ trap cleanup EXIT
 
 count=0
 test ! -f "${DAEMON_STATE:?}/count" ||
-	count=$(cat "${DAEMON_STATE:?}/count")
+count=$(cat "${DAEMON_STATE:?}/count")
 count=$((count + 1))
 printf '%s\n' "$count" >"${DAEMON_STATE:?}/count"
-printf '%s\n' "$$" >"$pid_file"
 printf 'daemon-env:%s:%s:%s:%s\n' \
 	"${DISPLAY-unset}" \
 	"${WAYLAND_DISPLAY-unset}" \
@@ -228,6 +227,7 @@ for descriptor in /proc/$$/fd/*; do
 		;;
 	esac
 done
+printf '%s\n' "$$" >"$pid_file"
 while :; do
 	sleep 0.1
 done

--- a/tests/test-dwm-screenshot.sh
+++ b/tests/test-dwm-screenshot.sh
@@ -3,7 +3,14 @@ set -eu
 
 repo_dir=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
 work=$(mktemp -d)
-trap 'rm -rf "$work"' EXIT HUP INT TERM
+cleanup() {
+	for pid_file in "$work"/daemon-state/pid.*; do
+		[ -f "$pid_file" ] || continue
+		kill "$(cat "$pid_file")" 2>/dev/null || true
+	done
+	rm -rf "$work"
+}
+trap cleanup EXIT HUP INT TERM
 
 mkdir -p "$work/bin" "$work/home/.config/flameshot" "$work/home/Pictures"
 
@@ -175,13 +182,15 @@ while [ "$#" -gt 0 ]; do
 	shift
 done
 test "$name" = flameshot
-test -f "${DAEMON_STATE:?}/running"
-EOF
-
-cat >"$daemon_bin/pkill" <<'EOF'
-#!/bin/sh
-printf 'pkill:%s\n' "$*" >>"${TEST_LOG:?}"
-rm -f "${DAEMON_STATE:?}/running"
+for pid_file in "${DAEMON_STATE:?}"/pid.*; do
+	test -f "$pid_file" || continue
+	pid=$(cat "$pid_file")
+	if kill -0 "$pid" 2>/dev/null; then
+		printf '%s\n' "$pid"
+	else
+		rm -f "$pid_file"
+	fi
+done
 EOF
 
 cat >"$daemon_bin/setsid" <<'EOF'
@@ -189,26 +198,44 @@ cat >"$daemon_bin/setsid" <<'EOF'
 if [ "${1:-}" = "-f" ]; then
 	shift
 fi
-exec "$@"
+"$@" &
 EOF
 
 cat >"$daemon_bin/flameshot" <<'EOF'
 #!/bin/sh
+pid_file="${DAEMON_STATE:?}/pid.$$"
+cleanup() {
+	rm -f "$pid_file"
+}
+trap 'cleanup; exit 0' TERM INT
+trap cleanup EXIT
+
 count=0
 test ! -f "${DAEMON_STATE:?}/count" ||
 	count=$(cat "${DAEMON_STATE:?}/count")
 count=$((count + 1))
 printf '%s\n' "$count" >"${DAEMON_STATE:?}/count"
-printf 'daemon-env:%s:%s:%s\n' \
+printf '%s\n' "$$" >"$pid_file"
+printf 'daemon-env:%s:%s:%s:%s\n' \
+	"${DISPLAY-unset}" \
 	"${WAYLAND_DISPLAY-unset}" \
 	"${XDG_SESSION_TYPE-unset}" \
 	"${QT_QPA_PLATFORM-unset}" >>"${TEST_LOG:?}"
-: >"${DAEMON_STATE:?}/running"
+for descriptor in /proc/$$/fd/*; do
+	case $(readlink "$descriptor" 2>/dev/null || true) in
+	*/flameshot.lock)
+		printf 'inherited-lock:%s\n' "$descriptor" >>"${TEST_LOG:?}"
+		;;
+	esac
+done
+while :; do
+	sleep 0.1
+done
 EOF
 chmod +x "$daemon_bin/"*
 
 : >"$log"
-DISPLAY=:99 \
+DISPLAY=:98 \
 	WAYLAND_DISPLAY=wayland-0 \
 	XDG_SESSION_TYPE=wayland \
 	QT_QPA_PLATFORM=wayland \
@@ -221,7 +248,22 @@ DISPLAY=:99 \
 	"$repo_dir/scripts/dwm-screenshot" daemon
 
 test "$(cat "$daemon_state/count")" -eq 1
-grep -Fqx 'daemon-env:unset:x11:xcb' "$log"
+grep -Fqx 'daemon-env::98:unset:x11:xcb' "$log"
+
+DISPLAY=:99 \
+	WAYLAND_DISPLAY=wayland-0 \
+	XDG_SESSION_TYPE=wayland \
+	QT_QPA_PLATFORM=wayland \
+	XDG_CONFIG_HOME="$daemon_home/.config" \
+	XDG_RUNTIME_DIR="$daemon_home/runtime" \
+	HOME="$daemon_home" \
+	PATH="$daemon_bin:$work/bin:/usr/bin:/bin" \
+	DAEMON_STATE="$daemon_state" \
+	TEST_LOG="$log" \
+	"$repo_dir/scripts/dwm-screenshot" daemon
+test "$(cat "$daemon_state/count")" -eq 2
+grep -Fqx 'daemon-env::99:unset:x11:xcb' "$log"
+test "$(find "$daemon_state" -name 'pid.*' -type f | wc -l)" -eq 1
 
 DISPLAY=:99 \
 	XDG_SESSION_TYPE=x11 \
@@ -232,7 +274,7 @@ DISPLAY=:99 \
 	DAEMON_STATE="$daemon_state" \
 	TEST_LOG="$log" \
 	"$repo_dir/scripts/dwm-screenshot" daemon
-test "$(cat "$daemon_state/count")" -eq 1
+test "$(cat "$daemon_state/count")" -eq 2
 
 DISPLAY=:99 \
 	XDG_SESSION_TYPE=x11 \
@@ -243,8 +285,12 @@ DISPLAY=:99 \
 	DAEMON_STATE="$daemon_state" \
 	TEST_LOG="$log" \
 	"$repo_dir/scripts/dwm-screenshot" restart-daemon
-test "$(cat "$daemon_state/count")" -eq 2
-grep -Fqx 'pkill:-u 1000 -x flameshot' "$log"
+test "$(cat "$daemon_state/count")" -eq 3
+test "$(find "$daemon_state" -name 'pid.*' -type f | wc -l)" -eq 1
+if grep -q '^inherited-lock:' "$log"; then
+	printf '%s\n' "Flameshot daemon inherited the serialization lock" >&2
+	exit 1
+fi
 
 theme_bin=$work/theme-bin
 theme_home=$work/theme-home

--- a/tests/test-dwm-screenshot.sh
+++ b/tests/test-dwm-screenshot.sh
@@ -155,6 +155,81 @@ cmp "$failure_home/flameshot-expected.ini" \
 test -L "$failure_home/.config/flameshot/flameshot.ini"
 test "$(stat -Lc %i "$failure_home/flameshot-target.ini")" = "$failure_inode"
 
+concurrent_bin=$work/concurrent-bin
+concurrent_home=$work/concurrent-home
+concurrent_state=$work/concurrent-state
+mkdir -p "$concurrent_bin" "$concurrent_home/.config/flameshot" \
+	"$concurrent_home/runtime" "$concurrent_state"
+cat >"$concurrent_home/.config/flameshot/flameshot.ini" <<'EOF'
+[General]
+showHelp=false
+
+[Shortcuts]
+TYPE_COPY=Ctrl+C
+EOF
+
+cat >"$concurrent_bin/cat" <<'EOF'
+#!/bin/sh
+case ${1:-} in
+*.tmp.*)
+	if (
+		set -C
+		: >"${CONCURRENCY_STATE:?}/writer-entered"
+	) 2>/dev/null; then
+		while [ ! -f "${CONCURRENCY_STATE:?}/release-writer" ]; do
+			sleep 0.01
+		done
+	else
+		: >"${CONCURRENCY_STATE:?}/second-writer-entered"
+	fi
+	;;
+esac
+exec /usr/bin/cat "$@"
+EOF
+chmod +x "$concurrent_bin/cat"
+
+env -u WAYLAND_DISPLAY \
+	DISPLAY=:99 \
+	XDG_SESSION_TYPE=x11 \
+	XDG_CONFIG_HOME="$concurrent_home/.config" \
+	XDG_RUNTIME_DIR="$concurrent_home/runtime" \
+	HOME="$concurrent_home" \
+	PATH="$concurrent_bin:$work/bin:/usr/bin:/bin" \
+	CONCURRENCY_STATE="$concurrent_state" \
+	TEST_LOG="$log" \
+	"$repo_dir/scripts/dwm-screenshot" setup &
+first_setup_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ ! -f "$concurrent_state/writer-entered" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+test -f "$concurrent_state/writer-entered"
+
+env -u WAYLAND_DISPLAY \
+	DISPLAY=:99 \
+	XDG_SESSION_TYPE=x11 \
+	XDG_CONFIG_HOME="$concurrent_home/.config" \
+	XDG_RUNTIME_DIR="$concurrent_home/runtime" \
+	HOME="$concurrent_home" \
+	PATH="$concurrent_bin:$work/bin:/usr/bin:/bin" \
+	CONCURRENCY_STATE="$concurrent_state" \
+	TEST_LOG="$log" \
+	"$repo_dir/scripts/dwm-screenshot" setup &
+second_setup_pid=$!
+sleep 0.2
+test ! -e "$concurrent_state/second-writer-entered"
+: >"$concurrent_state/release-writer"
+wait "$first_setup_pid"
+wait "$second_setup_pid"
+test ! -e "$concurrent_state/second-writer-entered"
+grep -Fqx 'useX11LegacyScreenshot=true' \
+	"$concurrent_home/.config/flameshot/flameshot.ini"
+grep -Fqx 'showHelp=false' \
+	"$concurrent_home/.config/flameshot/flameshot.ini"
+grep -Fqx 'TYPE_COPY=Ctrl+C' \
+	"$concurrent_home/.config/flameshot/flameshot.ini"
+
 daemon_bin=$work/daemon-bin
 daemon_home=$work/daemon-home
 daemon_state=$work/daemon-state

--- a/tests/test-dwm-screenshot.sh
+++ b/tests/test-dwm-screenshot.sh
@@ -7,7 +7,7 @@ trap 'rm -rf "$work"' EXIT HUP INT TERM
 
 mkdir -p "$work/bin" "$work/home/.config/flameshot" "$work/home/Pictures"
 
-cat >"$work/home/.config/flameshot/flameshot.ini" <<'EOF'
+cat >"$work/home/flameshot-target.ini" <<'EOF'
 [General]
 showHelp=false
 useX11LegacyScreenshot=false
@@ -15,6 +15,11 @@ useX11LegacyScreenshot=false
 [Shortcuts]
 TYPE_COPY=Ctrl+C
 EOF
+chmod 640 "$work/home/flameshot-target.ini"
+ln -s "$work/home/flameshot-target.ini" \
+	"$work/home/.config/flameshot/flameshot.ini"
+config_inode=$(stat -Lc %i "$work/home/flameshot-target.ini")
+config_mode=$(stat -Lc %a "$work/home/flameshot-target.ini")
 
 cat >"$work/bin/systemctl" <<'EOF'
 #!/bin/sh
@@ -58,6 +63,9 @@ grep -Fqx 'useX11LegacyScreenshot=true' \
 	"$work/home/.config/flameshot/flameshot.ini"
 grep -Fqx 'showHelp=false' "$work/home/.config/flameshot/flameshot.ini"
 grep -Fqx 'TYPE_COPY=Ctrl+C' "$work/home/.config/flameshot/flameshot.ini"
+test -L "$work/home/.config/flameshot/flameshot.ini"
+test "$(stat -Lc %i "$work/home/flameshot-target.ini")" = "$config_inode"
+test "$(stat -Lc %a "$work/home/flameshot-target.ini")" = "$config_mode"
 test -d "$work/home/Pictures/Screenshots"
 
 : >"$log"

--- a/tests/test-dwm-screenshot.sh
+++ b/tests/test-dwm-screenshot.sh
@@ -146,6 +146,106 @@ cmp "$failure_home/flameshot-expected.ini" \
 test -L "$failure_home/.config/flameshot/flameshot.ini"
 test "$(stat -Lc %i "$failure_home/flameshot-target.ini")" = "$failure_inode"
 
+daemon_bin=$work/daemon-bin
+daemon_home=$work/daemon-home
+daemon_state=$work/daemon-state
+mkdir -p "$daemon_bin" "$daemon_home" "$daemon_state"
+
+cat >"$daemon_bin/id" <<'EOF'
+#!/bin/sh
+printf '%s\n' 1000
+EOF
+
+cat >"$daemon_bin/flock" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+
+cat >"$daemon_bin/pgrep" <<'EOF'
+#!/bin/sh
+name=
+while [ "$#" -gt 0 ]; do
+	case $1 in
+	-x)
+		shift
+		name=${1:-}
+		break
+		;;
+	esac
+	shift
+done
+test "$name" = flameshot
+test -f "${DAEMON_STATE:?}/running"
+EOF
+
+cat >"$daemon_bin/pkill" <<'EOF'
+#!/bin/sh
+printf 'pkill:%s\n' "$*" >>"${TEST_LOG:?}"
+rm -f "${DAEMON_STATE:?}/running"
+EOF
+
+cat >"$daemon_bin/setsid" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = "-f" ]; then
+	shift
+fi
+exec "$@"
+EOF
+
+cat >"$daemon_bin/flameshot" <<'EOF'
+#!/bin/sh
+count=0
+test ! -f "${DAEMON_STATE:?}/count" ||
+	count=$(cat "${DAEMON_STATE:?}/count")
+count=$((count + 1))
+printf '%s\n' "$count" >"${DAEMON_STATE:?}/count"
+printf 'daemon-env:%s:%s:%s\n' \
+	"${WAYLAND_DISPLAY-unset}" \
+	"${XDG_SESSION_TYPE-unset}" \
+	"${QT_QPA_PLATFORM-unset}" >>"${TEST_LOG:?}"
+: >"${DAEMON_STATE:?}/running"
+EOF
+chmod +x "$daemon_bin/"*
+
+: >"$log"
+DISPLAY=:99 \
+	WAYLAND_DISPLAY=wayland-0 \
+	XDG_SESSION_TYPE=wayland \
+	QT_QPA_PLATFORM=wayland \
+	XDG_CONFIG_HOME="$daemon_home/.config" \
+	XDG_RUNTIME_DIR="$daemon_home/runtime" \
+	HOME="$daemon_home" \
+	PATH="$daemon_bin:$work/bin:/usr/bin:/bin" \
+	DAEMON_STATE="$daemon_state" \
+	TEST_LOG="$log" \
+	"$repo_dir/scripts/dwm-screenshot" daemon
+
+test "$(cat "$daemon_state/count")" -eq 1
+grep -Fqx 'daemon-env:unset:x11:xcb' "$log"
+
+DISPLAY=:99 \
+	XDG_SESSION_TYPE=x11 \
+	XDG_CONFIG_HOME="$daemon_home/.config" \
+	XDG_RUNTIME_DIR="$daemon_home/runtime" \
+	HOME="$daemon_home" \
+	PATH="$daemon_bin:$work/bin:/usr/bin:/bin" \
+	DAEMON_STATE="$daemon_state" \
+	TEST_LOG="$log" \
+	"$repo_dir/scripts/dwm-screenshot" daemon
+test "$(cat "$daemon_state/count")" -eq 1
+
+DISPLAY=:99 \
+	XDG_SESSION_TYPE=x11 \
+	XDG_CONFIG_HOME="$daemon_home/.config" \
+	XDG_RUNTIME_DIR="$daemon_home/runtime" \
+	HOME="$daemon_home" \
+	PATH="$daemon_bin:$work/bin:/usr/bin:/bin" \
+	DAEMON_STATE="$daemon_state" \
+	TEST_LOG="$log" \
+	"$repo_dir/scripts/dwm-screenshot" restart-daemon
+test "$(cat "$daemon_state/count")" -eq 2
+grep -Fqx 'pkill:-u 1000 -x flameshot' "$log"
+
 theme_bin=$work/theme-bin
 theme_home=$work/theme-home
 mkdir -p "$theme_bin" "$theme_home/.config/dwm-titus"
@@ -154,31 +254,18 @@ cp "$repo_dir/config/themes.toml" \
 
 cat >"$theme_bin/pgrep" <<'EOF'
 #!/bin/sh
-test "$1" = "-x" && test "$2" = "flameshot"
-EOF
-
-cat >"$theme_bin/pkill" <<'EOF'
-#!/bin/sh
-printf 'pkill:%s\n' "$*" >>"${TEST_LOG:?}"
+test "$1" = "-u" && test "$3" = "-x" && test "$4" = "flameshot"
 EOF
 
 cat >"$theme_bin/dwm-screenshot" <<'EOF'
 #!/bin/sh
-printf 'dwm-screenshot:%s\n' "$*" >>"${TEST_LOG:?}"
+printf 'dwm-screenshot:%s:%s\n' \
+	"$*" "${QT_QPA_PLATFORMTHEME-unset}" >>"${TEST_LOG:?}"
 test "${TEST_SETUP_FAIL:-0}" != "1"
 EOF
 
-cat >"$theme_bin/flameshot" <<'EOF'
-#!/bin/sh
-printf 'flameshot-env:%s:%s:%s:%s\n' \
-	"${WAYLAND_DISPLAY-unset}" \
-	"${XDG_SESSION_TYPE-unset}" \
-	"${QT_QPA_PLATFORM-unset}" \
-	"${QT_QPA_PLATFORMTHEME-unset}" >>"${TEST_LOG:?}"
-EOF
-
 for command_name in dbus-update-activation-environment gsettings qt6ct \
-	sleep systemctl xfconf-query xrdb; do
+	systemctl xfconf-query xrdb; do
 	cat >"$theme_bin/$command_name" <<'EOF'
 #!/bin/sh
 :
@@ -197,9 +284,7 @@ DISPLAY=:99 \
 	TEST_LOG="$log" \
 	"$repo_dir/scripts/theme-apply.sh"
 
-grep -Fqx 'dwm-screenshot:setup' "$log"
-grep -Fqx 'pkill:-x flameshot' "$log"
-grep -Fqx 'flameshot-env:unset:x11:xcb:qt6ct' "$log"
+grep -Fqx 'dwm-screenshot:restart-daemon:qt6ct' "$log"
 
 : >"$log"
 DISPLAY=:99 \
@@ -213,10 +298,6 @@ DISPLAY=:99 \
 	TEST_SETUP_FAIL=1 \
 	"$repo_dir/scripts/theme-apply.sh" 2>/dev/null
 
-grep -Fqx 'dwm-screenshot:setup' "$log"
-if grep -Eq '^(pkill|flameshot-env):' "$log"; then
-	printf '%s\n' "Theme reload must keep Flameshot running when X11 setup fails" >&2
-	exit 1
-fi
+grep -Fqx 'dwm-screenshot:restart-daemon:qt6ct' "$log"
 
 printf '%s\n' "Flameshot X11 backend, environment, and clipboard command: PASS"

--- a/tests/test-dwm-screenshot.sh
+++ b/tests/test-dwm-screenshot.sh
@@ -102,6 +102,50 @@ if grep -Fqx 'useX11LegacyScreenshot=true' \
 	exit 1
 fi
 
+failure_home=$work/failure
+failure_bin=$work/failure-bin
+mkdir -p "$failure_home/.config/flameshot" "$failure_bin"
+cat >"$failure_home/flameshot-target.ini" <<'EOF'
+[General]
+showHelp=false
+
+[Shortcuts]
+TYPE_COPY=Ctrl+C
+EOF
+cp "$failure_home/flameshot-target.ini" \
+	"$failure_home/flameshot-expected.ini"
+ln -s "$failure_home/flameshot-target.ini" \
+	"$failure_home/.config/flameshot/flameshot.ini"
+failure_inode=$(stat -Lc %i "$failure_home/flameshot-target.ini")
+
+cat >"$failure_bin/cat" <<'EOF'
+#!/bin/sh
+case ${1:-} in
+*.tmp.*)
+	printf '%s\n' "partial update"
+	exit 1
+	;;
+esac
+exec /usr/bin/cat "$@"
+EOF
+chmod +x "$failure_bin/cat"
+
+if env -u WAYLAND_DISPLAY \
+	DISPLAY=:99 \
+	XDG_SESSION_TYPE=x11 \
+	XDG_CONFIG_HOME="$failure_home/.config" \
+	HOME="$failure_home" \
+	PATH="$failure_bin:$work/bin:/usr/bin:/bin" \
+	TEST_LOG="$log" \
+	"$repo_dir/scripts/dwm-screenshot" setup; then
+	printf '%s\n' "Flameshot setup must report an in-place update failure" >&2
+	exit 1
+fi
+cmp "$failure_home/flameshot-expected.ini" \
+	"$failure_home/.config/flameshot/flameshot.ini"
+test -L "$failure_home/.config/flameshot/flameshot.ini"
+test "$(stat -Lc %i "$failure_home/flameshot-target.ini")" = "$failure_inode"
+
 theme_bin=$work/theme-bin
 theme_home=$work/theme-home
 mkdir -p "$theme_bin" "$theme_home/.config/dwm-titus"

--- a/tests/test-dwm-screenshot.sh
+++ b/tests/test-dwm-screenshot.sh
@@ -6,8 +6,10 @@ work=$(mktemp -d)
 cleanup() {
 	for pid_file in "$work"/daemon-state/pid.*; do
 		[ -f "$pid_file" ] || continue
-		kill "$(cat "$pid_file")" 2>/dev/null || true
+		kill -KILL "$(cat "$pid_file")" 2>/dev/null || true
 	done
+	[ -z "${zombie_mock_pid:-}" ] ||
+		kill -KILL "$zombie_mock_pid" 2>/dev/null || true
 	rm -rf "$work"
 }
 trap cleanup EXIT HUP INT TERM
@@ -201,13 +203,30 @@ fi
 "$@" &
 EOF
 
+cat >"$daemon_bin/ps" <<'EOF'
+#!/bin/sh
+last=
+for arg; do
+	last=$arg
+done
+if [ -n "${TEST_ZOMBIE_PID:-}" ] && [ "$last" = "$TEST_ZOMBIE_PID" ]; then
+	printf 'Z\n'
+	exit 0
+fi
+exec /usr/bin/ps "$@"
+EOF
+
 cat >"$daemon_bin/flameshot" <<'EOF'
 #!/bin/sh
 pid_file="${DAEMON_STATE:?}/pid.$$"
 cleanup() {
 	rm -f "$pid_file"
 }
-trap 'cleanup; exit 0' TERM INT
+if [ "${TEST_IGNORE_TERM:-0}" = 1 ]; then
+	trap '' TERM
+else
+	trap 'cleanup; exit 0' TERM INT
+fi
 trap cleanup EXIT
 
 count=0
@@ -291,6 +310,45 @@ if grep -q '^inherited-lock:' "$log"; then
 	printf '%s\n' "Flameshot daemon inherited the serialization lock" >&2
 	exit 1
 fi
+
+for pid_file in "$daemon_state"/pid.*; do
+	[ -f "$pid_file" ] || continue
+	daemon_pid=$(cat "$pid_file")
+	kill "$daemon_pid"
+	wait "$daemon_pid" 2>/dev/null || true
+done
+
+DISPLAY=:99 \
+	XDG_SESSION_TYPE=x11 \
+	QT_QPA_PLATFORM=xcb \
+	DAEMON_STATE="$daemon_state" \
+	TEST_LOG="$log" \
+	TEST_IGNORE_TERM=1 \
+	"$daemon_bin/flameshot" &
+zombie_mock_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ ! -f "$daemon_state/pid.$zombie_mock_pid" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+test -f "$daemon_state/pid.$zombie_mock_pid"
+
+DISPLAY=:99 \
+	XDG_SESSION_TYPE=x11 \
+	XDG_CONFIG_HOME="$daemon_home/.config" \
+	XDG_RUNTIME_DIR="$daemon_home/runtime" \
+	HOME="$daemon_home" \
+	PATH="$daemon_bin:$work/bin:/usr/bin:/bin" \
+	DAEMON_STATE="$daemon_state" \
+	TEST_LOG="$log" \
+	TEST_ZOMBIE_PID="$zombie_mock_pid" \
+	"$repo_dir/scripts/dwm-screenshot" daemon
+test "$(cat "$daemon_state/count")" -eq 5
+test -f "$daemon_state/pid.$zombie_mock_pid"
+kill -KILL "$zombie_mock_pid"
+wait "$zombie_mock_pid" 2>/dev/null || true
+rm -f "$daemon_state/pid.$zombie_mock_pid"
+zombie_mock_pid=
 
 theme_bin=$work/theme-bin
 theme_home=$work/theme-home

--- a/tests/test-monitor-tag-switching.sh
+++ b/tests/test-monitor-tag-switching.sh
@@ -92,19 +92,24 @@ grep -q 'selmon->barwin, selmon->wx, selmon->by, selmon->ww, selmon->bh' "$repo_
 set_fullscreen_body=$(sed -n '/^setfullscreen(Client \*c, int fullscreen)/,/^}$/p' "$repo_dir/dwm.c")
 printf '%s\n' "$set_fullscreen_body" | grep -q 'actualfullscreenchanged'
 printf '%s\n' "$set_fullscreen_body" | grep -q 'wasactualfullscreen'
-printf '%s\n' "$set_fullscreen_body" | grep -q 'updatefullscreendesktops();'
-fullscreen_desktops_body=$(sed -n '/^updatefullscreendesktops(void)/,/^}$/p' "$repo_dir/dwm.c")
-printf '%s\n' "$fullscreen_desktops_body" | grep -q 'c->fakefullscreen == 1'
-printf '%s\n' "$fullscreen_desktops_body" | grep -q 'dwmfullscreendesktopsatom'
-grep -q 'XInternAtom(dpy, "_DWM_FULLSCREEN_DESKTOPS", False)' "$repo_dir/dwm.c"
+printf '%s\n' "$set_fullscreen_body" | grep -q 'updatefullscreenmonitors();'
+fullscreen_monitors_body=$(sed -n '/^updatefullscreenmonitors(void)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$fullscreen_monitors_body" | grep -q 'c->fakefullscreen == 1'
+printf '%s\n' "$fullscreen_monitors_body" | grep -q '!ISVISIBLE(c)'
+printf '%s\n' "$fullscreen_monitors_body" | grep -q 'getmonlogicalindex(m)'
+printf '%s\n' "$fullscreen_monitors_body" | grep -q 'dwmfullscreenmonitorsatom'
+tagmon_body=$(sed -n '/^tagmon(const Arg \*arg)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$tagmon_body" | grep -q 'c->isfullscreen = 1;'
+printf '%s\n' "$tagmon_body" | grep -q 'updatefullscreenmonitors();'
+grep -q 'XInternAtom(dpy, "_DWM_FULLSCREEN_MONITORS", False)' "$repo_dir/dwm.c"
 
 mkdir -p "$work/bin"
 cat >"$work/bin/xprop" <<'SH'
 #!/bin/sh
 case $* in
-*"_DWM_FULLSCREEN_DESKTOPS"*)
-	if [ "${DWM_TEST_FULLSCREEN_DESKTOPS+x}" = x ]; then
-		printf '_DWM_FULLSCREEN_DESKTOPS(CARDINAL) = %s\n' "$DWM_TEST_FULLSCREEN_DESKTOPS"
+*"_DWM_FULLSCREEN_MONITORS"*)
+	if [ "${DWM_TEST_FULLSCREEN_MONITORS+x}" = x ]; then
+		printf '_DWM_FULLSCREEN_MONITORS(CARDINAL) = %s\n' "$DWM_TEST_FULLSCREEN_MONITORS"
 	else
 		exit 1
 	fi
@@ -131,12 +136,12 @@ exit 1
 SH
 chmod +x "$work/bin/xprop" "$work/bin/xdotool"
 
-DWM_TEST_FULLSCREEN_DESKTOPS='0, 4' \
+DWM_TEST_FULLSCREEN_MONITORS='0, 1' \
 	DWM_TEST_MONITOR_DESKTOPS='2560, 0, 2560, 1440, 0, 0, 0, 2560, 1440, 4' \
 	PATH="$work/bin:$PATH" \
 	"$repo_dir/scripts/dwm-quickshell-state" state >"$work/state.out"
 grep -Fqx 'monitor_desktops=2560,0,2560,1440,0,0,0,2560,1440,4' "$work/state.out"
-grep -Fqx 'fullscreen=0|4' "$work/state.out"
+grep -Fqx 'fullscreen_monitors=0|1' "$work/state.out"
 
 PATH="$work/bin:$PATH" \
 	"$repo_dir/scripts/dwm-quickshell-state" state >"$work/fallback.out"

--- a/tests/test-monitor-tag-switching.sh
+++ b/tests/test-monitor-tag-switching.sh
@@ -89,11 +89,26 @@ printf '%s\n' "$scan_alt_bars_body" | grep -q 'updatealtbar(m, wins\[i\], &wa);'
 grep -q 'ewmh_replace_root_cardinal(dwmtagupdateatom, data, 1)' "$repo_dir/dwm.c"
 grep -q 'm->barwin, m->wx, m->by, m->ww, m->bh' "$repo_dir/dwm.c"
 grep -q 'selmon->barwin, selmon->wx, selmon->by, selmon->ww, selmon->bh' "$repo_dir/dwm.c"
+set_fullscreen_body=$(sed -n '/^setfullscreen(Client \*c, int fullscreen)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$set_fullscreen_body" | grep -q 'actualfullscreenchanged'
+printf '%s\n' "$set_fullscreen_body" | grep -q 'wasactualfullscreen'
+printf '%s\n' "$set_fullscreen_body" | grep -q 'updatefullscreendesktops();'
+fullscreen_desktops_body=$(sed -n '/^updatefullscreendesktops(void)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$fullscreen_desktops_body" | grep -q 'c->fakefullscreen == 1'
+printf '%s\n' "$fullscreen_desktops_body" | grep -q 'dwmfullscreendesktopsatom'
+grep -q 'XInternAtom(dpy, "_DWM_FULLSCREEN_DESKTOPS", False)' "$repo_dir/dwm.c"
 
 mkdir -p "$work/bin"
 cat >"$work/bin/xprop" <<'SH'
 #!/bin/sh
 case $* in
+*"_DWM_FULLSCREEN_DESKTOPS"*)
+	if [ "${DWM_TEST_FULLSCREEN_DESKTOPS+x}" = x ]; then
+		printf '_DWM_FULLSCREEN_DESKTOPS(CARDINAL) = %s\n' "$DWM_TEST_FULLSCREEN_DESKTOPS"
+	else
+		exit 1
+	fi
+	;;
 *"_DWM_MONITOR_DESKTOPS"*)
 	if [ "${DWM_TEST_MONITOR_DESKTOPS+x}" = x ]; then
 		printf '_DWM_MONITOR_DESKTOPS(CARDINAL) = %s\n' "$DWM_TEST_MONITOR_DESKTOPS"
@@ -116,9 +131,12 @@ exit 1
 SH
 chmod +x "$work/bin/xprop" "$work/bin/xdotool"
 
-DWM_TEST_MONITOR_DESKTOPS='2560, 0, 2560, 1440, 0, 0, 0, 2560, 1440, 4' PATH="$work/bin:$PATH" \
+DWM_TEST_FULLSCREEN_DESKTOPS='0, 4' \
+	DWM_TEST_MONITOR_DESKTOPS='2560, 0, 2560, 1440, 0, 0, 0, 2560, 1440, 4' \
+	PATH="$work/bin:$PATH" \
 	"$repo_dir/scripts/dwm-quickshell-state" state >"$work/state.out"
 grep -Fqx 'monitor_desktops=2560,0,2560,1440,0,0,0,2560,1440,4' "$work/state.out"
+grep -Fqx 'fullscreen=0|4' "$work/state.out"
 
 PATH="$work/bin:$PATH" \
 	"$repo_dir/scripts/dwm-quickshell-state" state >"$work/fallback.out"

--- a/tests/test-monitor-tag-switching.sh
+++ b/tests/test-monitor-tag-switching.sh
@@ -101,7 +101,11 @@ printf '%s\n' "$fullscreen_monitors_body" | grep -q 'dwmfullscreenmonitorsatom'
 tagmon_body=$(sed -n '/^tagmon(const Arg \*arg)/,/^}$/p' "$repo_dir/dwm.c")
 printf '%s\n' "$tagmon_body" | grep -q 'c->isfullscreen = 1;'
 printf '%s\n' "$tagmon_body" | grep -q 'updatefullscreenmonitors();'
+reconcile_body=$(sed -n '/^reconcilemonitortags(void)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$reconcile_body" | grep -q 'dwmfullscreenmonitorsatom != None'
+printf '%s\n' "$reconcile_body" | grep -q 'updatefullscreenmonitors();'
 grep -q 'XInternAtom(dpy, "_DWM_FULLSCREEN_MONITORS", False)' "$repo_dir/dwm.c"
+grep -q 'XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_COMBO", False)' "$repo_dir/dwm.c"
 
 mkdir -p "$work/bin"
 cat >"$work/bin/xprop" <<'SH'

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -461,13 +461,13 @@ grep -Fq 'visible: root.state.batteryAvailable' "$repo/config/quickshell/panel/D
 grep -Fq 'root.batteryAvailable = true;' "$repo/config/quickshell/state/DwmState.qml"
 grep -Fq 'trimmed.indexOf("BAT ") === 0' "$repo/config/quickshell/state/DwmState.qml"
 grep -Fq 'color: Theme.barBackground' "$repo/config/quickshell/panel/DwmPanel.qml"
-grep -Fq 'aboveWindows: root.state.fullscreenWorkspaces.indexOf(' \
+grep -Fq 'aboveWindows: root.state.fullscreenMonitorIndexes.indexOf(' \
 	"$repo/config/quickshell/panel/DwmPanel.qml"
-grep -Fq 'root.state.currentWorkspaceForScreen(root.screen)) === -1' \
+grep -Fq 'root.state.screenIndex(root.screen)) === -1' \
 	"$repo/config/quickshell/panel/DwmPanel.qml"
-grep -Fq 'property var fullscreenWorkspaces: []' \
+grep -Fq 'property var fullscreenMonitorIndexes: []' \
 	"$repo/config/quickshell/state/DwmState.qml"
-grep -Fq 'key === "fullscreen"' "$repo/config/quickshell/state/DwmState.qml"
+grep -Fq 'key === "fullscreen_monitors"' "$repo/config/quickshell/state/DwmState.qml"
 if grep -Fq 'color: Theme.transparent' "$repo/config/quickshell/panel/DwmPanel.qml"; then
 	exit 1
 fi

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -461,6 +461,13 @@ grep -Fq 'visible: root.state.batteryAvailable' "$repo/config/quickshell/panel/D
 grep -Fq 'root.batteryAvailable = true;' "$repo/config/quickshell/state/DwmState.qml"
 grep -Fq 'trimmed.indexOf("BAT ") === 0' "$repo/config/quickshell/state/DwmState.qml"
 grep -Fq 'color: Theme.barBackground' "$repo/config/quickshell/panel/DwmPanel.qml"
+grep -Fq 'aboveWindows: root.state.fullscreenWorkspaces.indexOf(' \
+	"$repo/config/quickshell/panel/DwmPanel.qml"
+grep -Fq 'root.state.currentWorkspaceForScreen(root.screen)) === -1' \
+	"$repo/config/quickshell/panel/DwmPanel.qml"
+grep -Fq 'property var fullscreenWorkspaces: []' \
+	"$repo/config/quickshell/state/DwmState.qml"
+grep -Fq 'key === "fullscreen"' "$repo/config/quickshell/state/DwmState.qml"
 if grep -Fq 'color: Theme.transparent' "$repo/config/quickshell/panel/DwmPanel.qml"; then
 	exit 1
 fi

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -74,6 +74,23 @@ wait_for_monitor_desktops() {
 	return 1
 }
 
+wait_for_fullscreen_desktops() {
+	expected=$1
+	i=0
+	while [ "$i" -lt 100 ]; do
+		desktops=$(DISPLAY=$display xprop -root _DWM_FULLSCREEN_DESKTOPS 2>/dev/null |
+			sed -n 's/^[^=]*=[[:space:]]*//p' |
+			tr -d '[:space:]')
+		if [ "$desktops" = "$expected" ]; then
+			return 0
+		fi
+		i=$((i + 1))
+		sleep 0.05
+	done
+	printf '%s\n' "fullscreen desktops did not become ${expected:-empty}" >&2
+	return 1
+}
+
 wait_for_window_state() {
 	win=$1
 	needle=$2
@@ -441,8 +458,10 @@ dwm_pid=$!
 wait_for_root_property _NET_SUPPORTED
 wait_for_root_property _NET_NUMBER_OF_DESKTOPS
 wait_for_root_property _DWM_MONITOR_DESKTOPS
+wait_for_root_property _DWM_FULLSCREEN_DESKTOPS
 wait_for_current_desktop 0
 wait_for_monitor_desktops 0,0,1024,768,0
+wait_for_fullscreen_desktops ''
 DISPLAY=$display xprop -root _NET_SUPPORTED | grep -q _NET_WM_STATE_ABOVE
 DISPLAY=$display xprop -root _NET_SUPPORTED | grep -q _NET_WM_STATE_STAYS_ON_TOP
 
@@ -728,18 +747,22 @@ fullscreen_win=$(cat "$work/fullscreen-window-id")
 wait_for_active_window "$fullscreen_win"
 DISPLAY=$display xdotool key Super+Shift+y
 wait_for_window_state "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
+wait_for_fullscreen_desktops ''
 DISPLAY=$display xdotool windowraise "$stack_win"
 DISPLAY=$display xdotool key Super+t
 wait_for_top_window "$above_win"
 DISPLAY=$display xdotool key Super+Shift+y
 wait_for_window_state_absent "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
+wait_for_fullscreen_desktops ''
 
 DISPLAY=$display "$work/xclient" fullscreen "$fullscreen_win"
 wait_for_window_state "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
+wait_for_fullscreen_desktops 0
 DISPLAY=$display xdotool key Super+t
 wait_for_top_window "$fullscreen_win"
 DISPLAY=$display "$work/xclient" state "$fullscreen_win" 0 _NET_WM_STATE_FULLSCREEN
 wait_for_window_state_absent "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
+wait_for_fullscreen_desktops ''
 kill "$fullscreen_client_pid"
 wait "$fullscreen_client_pid" 2>/dev/null || true
 fullscreen_client_pid=

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -74,20 +74,20 @@ wait_for_monitor_desktops() {
 	return 1
 }
 
-wait_for_fullscreen_desktops() {
+wait_for_fullscreen_monitors() {
 	expected=$1
 	i=0
 	while [ "$i" -lt 100 ]; do
-		desktops=$(DISPLAY=$display xprop -root _DWM_FULLSCREEN_DESKTOPS 2>/dev/null |
+		monitors=$(DISPLAY=$display xprop -root _DWM_FULLSCREEN_MONITORS 2>/dev/null |
 			sed -n 's/^[^=]*=[[:space:]]*//p' |
 			tr -d '[:space:]')
-		if [ "$desktops" = "$expected" ]; then
+		if [ "$monitors" = "$expected" ]; then
 			return 0
 		fi
 		i=$((i + 1))
 		sleep 0.05
 	done
-	printf '%s\n' "fullscreen desktops did not become ${expected:-empty}" >&2
+	printf '%s\n' "fullscreen monitors did not become ${expected:-empty}" >&2
 	return 1
 }
 
@@ -458,10 +458,10 @@ dwm_pid=$!
 wait_for_root_property _NET_SUPPORTED
 wait_for_root_property _NET_NUMBER_OF_DESKTOPS
 wait_for_root_property _DWM_MONITOR_DESKTOPS
-wait_for_root_property _DWM_FULLSCREEN_DESKTOPS
+wait_for_root_property _DWM_FULLSCREEN_MONITORS
 wait_for_current_desktop 0
 wait_for_monitor_desktops 0,0,1024,768,0
-wait_for_fullscreen_desktops ''
+wait_for_fullscreen_monitors ''
 DISPLAY=$display xprop -root _NET_SUPPORTED | grep -q _NET_WM_STATE_ABOVE
 DISPLAY=$display xprop -root _NET_SUPPORTED | grep -q _NET_WM_STATE_STAYS_ON_TOP
 
@@ -484,7 +484,9 @@ wait_for_monitor_desktops 0,0,1024,768,1
 
 printf '%s\n' \
 	'keys = [' \
+	'  { mod="SUPER", key="0", desc="Xvfb all tags", func="view", ui=511 },' \
 	'  { mod="SUPER", key="1", desc="Xvfb tag 1", func="view", ui=1 },' \
+	'  { mod="SUPER", key="2", desc="Xvfb tag 2", func="view", ui=2 },' \
 	'  { mod="SUPER", key="m", desc="Xvfb fullscreen", func="fullscreen" },' \
 	'  { mod="SUPER", key="o", desc="Xvfb monocle", func="setlayout", layout_idx=2 },' \
 	'  { mod="SUPER", key="t", desc="Xvfb tile", func="setlayout", layout_idx=0 },' \
@@ -747,22 +749,30 @@ fullscreen_win=$(cat "$work/fullscreen-window-id")
 wait_for_active_window "$fullscreen_win"
 DISPLAY=$display xdotool key Super+Shift+y
 wait_for_window_state "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
-wait_for_fullscreen_desktops ''
+wait_for_fullscreen_monitors ''
 DISPLAY=$display xdotool windowraise "$stack_win"
 DISPLAY=$display xdotool key Super+t
 wait_for_top_window "$above_win"
 DISPLAY=$display xdotool key Super+Shift+y
 wait_for_window_state_absent "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
-wait_for_fullscreen_desktops ''
+wait_for_fullscreen_monitors ''
 
 DISPLAY=$display "$work/xclient" fullscreen "$fullscreen_win"
 wait_for_window_state "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
-wait_for_fullscreen_desktops 0
+wait_for_fullscreen_monitors 0
 DISPLAY=$display xdotool key Super+t
 wait_for_top_window "$fullscreen_win"
+DISPLAY=$display xdotool key Super+2
+wait_for_current_desktop 1
+wait_for_fullscreen_monitors ''
+DISPLAY=$display xdotool key Super+0
+wait_for_fullscreen_monitors 0
+DISPLAY=$display xdotool key Super+1
+wait_for_current_desktop 0
+wait_for_fullscreen_monitors 0
 DISPLAY=$display "$work/xclient" state "$fullscreen_win" 0 _NET_WM_STATE_FULLSCREEN
 wait_for_window_state_absent "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
-wait_for_fullscreen_desktops ''
+wait_for_fullscreen_monitors ''
 kill "$fullscreen_client_pid"
 wait "$fullscreen_client_pid" 2>/dev/null || true
 fullscreen_client_pid=

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -201,7 +201,8 @@ main(int argc, char **argv)
 	int initial_above = 0;
 	int initial_many_states = 0;
 	int override_redirect = 0;
-	int popup_override = 0;
+	const char *popup_state = NULL;
+	const char *popup_type = NULL;
 	int swallow_terminal = 0;
 	pid_t child_pid = -1;
 
@@ -260,9 +261,25 @@ main(int argc, char **argv)
 		initial_many_states = 1;
 	else if (argc == 2 && strcmp(argv[1], "override") == 0)
 		override_redirect = 1;
-	else if (argc == 2 && strcmp(argv[1], "override-popup") == 0) {
+	else if (argc == 2 && strcmp(argv[1], "override-tooltip") == 0) {
 		override_redirect = 1;
-		popup_override = 1;
+		popup_type = "_NET_WM_WINDOW_TYPE_TOOLTIP";
+	}
+	else if (argc == 2 && strcmp(argv[1], "override-kde") == 0) {
+		override_redirect = 1;
+		popup_type = "_KDE_NET_WM_WINDOW_TYPE_OVERRIDE";
+	}
+	else if (argc == 2 && strcmp(argv[1], "override-notification") == 0) {
+		override_redirect = 1;
+		popup_type = "_NET_WM_WINDOW_TYPE_NOTIFICATION";
+	}
+	else if (argc == 2 && strcmp(argv[1], "override-above") == 0) {
+		override_redirect = 1;
+		popup_state = "_NET_WM_STATE_ABOVE";
+	}
+	else if (argc == 2 && strcmp(argv[1], "override-stays-on-top") == 0) {
+		override_redirect = 1;
+		popup_state = "_NET_WM_STATE_STAYS_ON_TOP";
 	}
 	else if (argc == 2 && strcmp(argv[1], "swallow-terminal") == 0)
 		swallow_terminal = 1;
@@ -292,14 +309,17 @@ main(int argc, char **argv)
 		XChangeProperty(dpy, win, net_wm_icon, XA_CARDINAL, 32,
 			PropModeReplace, (unsigned char *)icon, 3);
 	}
-	if (popup_override) {
-		Atom types[3];
+	if (popup_type) {
+		Atom type = XInternAtom(dpy, popup_type, False);
 
-		types[0] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_TOOLTIP", False);
-		types[1] = XInternAtom(dpy, "_KDE_NET_WM_WINDOW_TYPE_OVERRIDE", False);
-		types[2] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_NORMAL", False);
 		XChangeProperty(dpy, win, XInternAtom(dpy, "_NET_WM_WINDOW_TYPE", False),
-			XA_ATOM, 32, PropModeReplace, (unsigned char *)types, 3);
+			XA_ATOM, 32, PropModeReplace, (unsigned char *)&type, 1);
+	}
+	if (popup_state) {
+		Atom state = XInternAtom(dpy, popup_state, False);
+
+		XChangeProperty(dpy, win, XInternAtom(dpy, "_NET_WM_STATE", False),
+			XA_ATOM, 32, PropModeReplace, (unsigned char *)&state, 1);
 	}
 	if (initial_many_states) {
 		Atom states[65];
@@ -614,24 +634,50 @@ wait_for_top_window "$stack_win"
 DISPLAY=$display xdotool key Super+t
 wait_for_top_window "$above_win"
 
-DISPLAY=$display "$work/xclient" override-popup >"$work/popup-window-id" 2>"$work/popup-client.log" &
-popup_client_pid=$!
-i=0
-while [ "$i" -lt 100 ] && [ ! -s "$work/popup-window-id" ]; do
-	i=$((i + 1))
-	sleep 0.05
+for popup_marker in tooltip kde notification above stays-on-top; do
+	DISPLAY=$display "$work/xclient" "override-$popup_marker" \
+		>"$work/popup-$popup_marker-window-id" \
+		2>"$work/popup-$popup_marker-client.log" &
+	popup_client_pid=$!
+	i=0
+	while [ "$i" -lt 100 ] && [ ! -s "$work/popup-$popup_marker-window-id" ]; do
+		i=$((i + 1))
+		sleep 0.05
+	done
+	popup_win=$(cat "$work/popup-$popup_marker-window-id")
+	[ -n "$popup_win" ]
+	[ "$(DISPLAY=$display "$work/xclient" attributes "$popup_win")" = "override_redirect=1" ]
+	case $popup_marker in
+	tooltip)
+		popup_atom=_NET_WM_WINDOW_TYPE_TOOLTIP
+		popup_property=_NET_WM_WINDOW_TYPE
+		;;
+	kde)
+		popup_atom=_KDE_NET_WM_WINDOW_TYPE_OVERRIDE
+		popup_property=_NET_WM_WINDOW_TYPE
+		;;
+	notification)
+		popup_atom=_NET_WM_WINDOW_TYPE_NOTIFICATION
+		popup_property=_NET_WM_WINDOW_TYPE
+		;;
+	above)
+		popup_atom=_NET_WM_STATE_ABOVE
+		popup_property=_NET_WM_STATE
+		;;
+	stays-on-top)
+		popup_atom=_NET_WM_STATE_STAYS_ON_TOP
+		popup_property=_NET_WM_STATE
+		;;
+	esac
+	DISPLAY=$display xprop -id "$popup_win" "$popup_property" |
+		grep -q "$popup_atom"
+	wait_for_top_window "$popup_win"
+	DISPLAY=$display xdotool key Super+t
+	wait_for_top_window "$popup_win"
+	kill "$popup_client_pid"
+	wait "$popup_client_pid" 2>/dev/null || true
+	popup_client_pid=
 done
-popup_win=$(cat "$work/popup-window-id")
-[ -n "$popup_win" ]
-[ "$(DISPLAY=$display "$work/xclient" attributes "$popup_win")" = "override_redirect=1" ]
-DISPLAY=$display xprop -id "$popup_win" _NET_WM_WINDOW_TYPE |
-	grep -q _KDE_NET_WM_WINDOW_TYPE_OVERRIDE
-wait_for_top_window "$popup_win"
-DISPLAY=$display xdotool key Super+t
-wait_for_top_window "$popup_win"
-kill "$popup_client_pid"
-wait "$popup_client_pid" 2>/dev/null || true
-popup_client_pid=
 
 DISPLAY=$display "$work/xclient" state "$above_win" 0 _NET_WM_STATE_STAYS_ON_TOP
 wait_for_window_state_absent "$above_win" _NET_WM_STATE_STAYS_ON_TOP

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -308,6 +308,10 @@ main(int argc, char **argv)
 		override_redirect = 1;
 		popup_type = "_NET_WM_WINDOW_TYPE_COMBO";
 	}
+	else if (argc == 2 && strcmp(argv[1], "override-dnd") == 0) {
+		override_redirect = 1;
+		popup_type = "_NET_WM_WINDOW_TYPE_DND";
+	}
 	else if (argc == 2 && strcmp(argv[1], "override-above") == 0) {
 		override_redirect = 1;
 		popup_state = "_NET_WM_STATE_ABOVE";
@@ -673,7 +677,7 @@ wait_for_top_window "$stack_win"
 DISPLAY=$display xdotool key Super+t
 wait_for_top_window "$above_win"
 
-for popup_marker in tooltip kde notification menu popup-menu dropdown-menu combo above stays-on-top; do
+for popup_marker in tooltip kde notification menu popup-menu dropdown-menu combo dnd above stays-on-top; do
 	DISPLAY=$display "$work/xclient" "override-$popup_marker" \
 		>"$work/popup-$popup_marker-window-id" \
 		2>"$work/popup-$popup_marker-client.log" &
@@ -713,6 +717,10 @@ for popup_marker in tooltip kde notification menu popup-menu dropdown-menu combo
 		;;
 	combo)
 		popup_atom=_NET_WM_WINDOW_TYPE_COMBO
+		popup_property=_NET_WM_WINDOW_TYPE
+		;;
+	dnd)
+		popup_atom=_NET_WM_WINDOW_TYPE_DND
 		popup_property=_NET_WM_WINDOW_TYPE
 		;;
 	above)

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -157,7 +157,7 @@ require_cmd Xvfb awk cc pkg-config xdotool xprop sed grep tail
 pkg-config --exists x11
 
 work=$(mktemp -d)
-trap 'set +e; [ -n "${swallow_client_pid:-}" ] && kill "$swallow_client_pid" 2>/dev/null; [ -n "${many_state_client_pid:-}" ] && kill "$many_state_client_pid" 2>/dev/null; [ -n "${fullscreen_client_pid:-}" ] && kill "$fullscreen_client_pid" 2>/dev/null; [ -n "${second_above_client_pid:-}" ] && kill "$second_above_client_pid" 2>/dev/null; [ -n "${stack_client_pid:-}" ] && kill "$stack_client_pid" 2>/dev/null; [ -n "${above_client_pid:-}" ] && kill "$above_client_pid" 2>/dev/null; [ -n "${second_client_pid:-}" ] && kill "$second_client_pid" 2>/dev/null; [ -n "${client_pid:-}" ] && kill "$client_pid" 2>/dev/null; [ -n "${dwm_pid:-}" ] && kill "$dwm_pid" 2>/dev/null; [ -n "${xvfb_pid:-}" ] && kill "$xvfb_pid" 2>/dev/null; rm -rf "$work"' EXIT HUP INT TERM
+trap 'set +e; [ -n "${swallow_client_pid:-}" ] && kill "$swallow_client_pid" 2>/dev/null; [ -n "${many_state_client_pid:-}" ] && kill "$many_state_client_pid" 2>/dev/null; [ -n "${fullscreen_client_pid:-}" ] && kill "$fullscreen_client_pid" 2>/dev/null; [ -n "${popup_client_pid:-}" ] && kill "$popup_client_pid" 2>/dev/null; [ -n "${second_above_client_pid:-}" ] && kill "$second_above_client_pid" 2>/dev/null; [ -n "${stack_client_pid:-}" ] && kill "$stack_client_pid" 2>/dev/null; [ -n "${above_client_pid:-}" ] && kill "$above_client_pid" 2>/dev/null; [ -n "${second_client_pid:-}" ] && kill "$second_client_pid" 2>/dev/null; [ -n "${client_pid:-}" ] && kill "$client_pid" 2>/dev/null; [ -n "${dwm_pid:-}" ] && kill "$dwm_pid" 2>/dev/null; [ -n "${xvfb_pid:-}" ] && kill "$xvfb_pid" 2>/dev/null; rm -rf "$work"' EXIT HUP INT TERM
 
 home="$work/home"
 mkdir -p "$home/.config/dwm-titus" "$home/.local/share/dwm-titus/config"
@@ -201,6 +201,7 @@ main(int argc, char **argv)
 	int initial_above = 0;
 	int initial_many_states = 0;
 	int override_redirect = 0;
+	int popup_override = 0;
 	int swallow_terminal = 0;
 	pid_t child_pid = -1;
 
@@ -210,6 +211,18 @@ main(int argc, char **argv)
 	dpy = XOpenDisplay(NULL);
 	if (!dpy)
 		return 2;
+	if (argc == 3 && strcmp(argv[1], "attributes") == 0) {
+		XWindowAttributes attributes;
+
+		win = strtoul(argv[2], NULL, 0);
+		if (!XGetWindowAttributes(dpy, win, &attributes)) {
+			XCloseDisplay(dpy);
+			return 3;
+		}
+		printf("override_redirect=%d\n", attributes.override_redirect);
+		XCloseDisplay(dpy);
+		return 0;
+	}
 	if ((argc == 3 && strcmp(argv[1], "fullscreen") == 0)
 	|| (argc == 5 && strcmp(argv[1], "state") == 0)) {
 		XEvent ev;
@@ -247,6 +260,10 @@ main(int argc, char **argv)
 		initial_many_states = 1;
 	else if (argc == 2 && strcmp(argv[1], "override") == 0)
 		override_redirect = 1;
+	else if (argc == 2 && strcmp(argv[1], "override-popup") == 0) {
+		override_redirect = 1;
+		popup_override = 1;
+	}
 	else if (argc == 2 && strcmp(argv[1], "swallow-terminal") == 0)
 		swallow_terminal = 1;
 
@@ -274,6 +291,15 @@ main(int argc, char **argv)
 		Atom net_wm_icon = XInternAtom(dpy, "_NET_WM_ICON", False);
 		XChangeProperty(dpy, win, net_wm_icon, XA_CARDINAL, 32,
 			PropModeReplace, (unsigned char *)icon, 3);
+	}
+	if (popup_override) {
+		Atom types[3];
+
+		types[0] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_TOOLTIP", False);
+		types[1] = XInternAtom(dpy, "_KDE_NET_WM_WINDOW_TYPE_OVERRIDE", False);
+		types[2] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_NORMAL", False);
+		XChangeProperty(dpy, win, XInternAtom(dpy, "_NET_WM_WINDOW_TYPE", False),
+			XA_ATOM, 32, PropModeReplace, (unsigned char *)types, 3);
 	}
 	if (initial_many_states) {
 		Atom states[65];
@@ -587,6 +613,25 @@ stack_win=$(cat "$work/stack-window-id")
 wait_for_top_window "$stack_win"
 DISPLAY=$display xdotool key Super+t
 wait_for_top_window "$above_win"
+
+DISPLAY=$display "$work/xclient" override-popup >"$work/popup-window-id" 2>"$work/popup-client.log" &
+popup_client_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ ! -s "$work/popup-window-id" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+popup_win=$(cat "$work/popup-window-id")
+[ -n "$popup_win" ]
+[ "$(DISPLAY=$display "$work/xclient" attributes "$popup_win")" = "override_redirect=1" ]
+DISPLAY=$display xprop -id "$popup_win" _NET_WM_WINDOW_TYPE |
+	grep -q _KDE_NET_WM_WINDOW_TYPE_OVERRIDE
+wait_for_top_window "$popup_win"
+DISPLAY=$display xdotool key Super+t
+wait_for_top_window "$popup_win"
+kill "$popup_client_pid"
+wait "$popup_client_pid" 2>/dev/null || true
+popup_client_pid=
 
 DISPLAY=$display "$work/xclient" state "$above_win" 0 _NET_WM_STATE_STAYS_ON_TOP
 wait_for_window_state_absent "$above_win" _NET_WM_STATE_STAYS_ON_TOP

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -273,6 +273,18 @@ main(int argc, char **argv)
 		override_redirect = 1;
 		popup_type = "_NET_WM_WINDOW_TYPE_NOTIFICATION";
 	}
+	else if (argc == 2 && strcmp(argv[1], "override-menu") == 0) {
+		override_redirect = 1;
+		popup_type = "_NET_WM_WINDOW_TYPE_MENU";
+	}
+	else if (argc == 2 && strcmp(argv[1], "override-popup-menu") == 0) {
+		override_redirect = 1;
+		popup_type = "_NET_WM_WINDOW_TYPE_POPUP_MENU";
+	}
+	else if (argc == 2 && strcmp(argv[1], "override-dropdown-menu") == 0) {
+		override_redirect = 1;
+		popup_type = "_NET_WM_WINDOW_TYPE_DROPDOWN_MENU";
+	}
 	else if (argc == 2 && strcmp(argv[1], "override-above") == 0) {
 		override_redirect = 1;
 		popup_state = "_NET_WM_STATE_ABOVE";
@@ -634,7 +646,7 @@ wait_for_top_window "$stack_win"
 DISPLAY=$display xdotool key Super+t
 wait_for_top_window "$above_win"
 
-for popup_marker in tooltip kde notification above stays-on-top; do
+for popup_marker in tooltip kde notification menu popup-menu dropdown-menu above stays-on-top; do
 	DISPLAY=$display "$work/xclient" "override-$popup_marker" \
 		>"$work/popup-$popup_marker-window-id" \
 		2>"$work/popup-$popup_marker-client.log" &
@@ -658,6 +670,18 @@ for popup_marker in tooltip kde notification above stays-on-top; do
 		;;
 	notification)
 		popup_atom=_NET_WM_WINDOW_TYPE_NOTIFICATION
+		popup_property=_NET_WM_WINDOW_TYPE
+		;;
+	menu)
+		popup_atom=_NET_WM_WINDOW_TYPE_MENU
+		popup_property=_NET_WM_WINDOW_TYPE
+		;;
+	popup-menu)
+		popup_atom=_NET_WM_WINDOW_TYPE_POPUP_MENU
+		popup_property=_NET_WM_WINDOW_TYPE
+		;;
+	dropdown-menu)
+		popup_atom=_NET_WM_WINDOW_TYPE_DROPDOWN_MENU
 		popup_property=_NET_WM_WINDOW_TYPE
 		;;
 	above)

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -78,10 +78,12 @@ wait_for_fullscreen_monitors() {
 	expected=$1
 	i=0
 	while [ "$i" -lt 100 ]; do
-		monitors=$(DISPLAY=$display xprop -root _DWM_FULLSCREEN_MONITORS 2>/dev/null |
+		property=$(DISPLAY=$display xprop -root _DWM_FULLSCREEN_MONITORS 2>/dev/null || true)
+		monitors=$(printf '%s\n' "$property" |
 			sed -n 's/^[^=]*=[[:space:]]*//p' |
 			tr -d '[:space:]')
-		if [ "$monitors" = "$expected" ]; then
+		if printf '%s\n' "$property" | grep -Fq '_DWM_FULLSCREEN_MONITORS(' &&
+			[ "$monitors" = "$expected" ]; then
 			return 0
 		fi
 		i=$((i + 1))
@@ -301,6 +303,10 @@ main(int argc, char **argv)
 	else if (argc == 2 && strcmp(argv[1], "override-dropdown-menu") == 0) {
 		override_redirect = 1;
 		popup_type = "_NET_WM_WINDOW_TYPE_DROPDOWN_MENU";
+	}
+	else if (argc == 2 && strcmp(argv[1], "override-combo") == 0) {
+		override_redirect = 1;
+		popup_type = "_NET_WM_WINDOW_TYPE_COMBO";
 	}
 	else if (argc == 2 && strcmp(argv[1], "override-above") == 0) {
 		override_redirect = 1;
@@ -667,7 +673,7 @@ wait_for_top_window "$stack_win"
 DISPLAY=$display xdotool key Super+t
 wait_for_top_window "$above_win"
 
-for popup_marker in tooltip kde notification menu popup-menu dropdown-menu above stays-on-top; do
+for popup_marker in tooltip kde notification menu popup-menu dropdown-menu combo above stays-on-top; do
 	DISPLAY=$display "$work/xclient" "override-$popup_marker" \
 		>"$work/popup-$popup_marker-window-id" \
 		2>"$work/popup-$popup_marker-client.log" &
@@ -703,6 +709,10 @@ for popup_marker in tooltip kde notification menu popup-menu dropdown-menu above
 		;;
 	dropdown-menu)
 		popup_atom=_NET_WM_WINDOW_TYPE_DROPDOWN_MENU
+		popup_property=_NET_WM_WINDOW_TYPE
+		;;
+	combo)
+		popup_atom=_NET_WM_WINDOW_TYPE_COMBO
 		popup_property=_NET_WM_WINDOW_TYPE
 		;;
 	above)


### PR DESCRIPTION
## Summary

- keep Quickshell notifications, control surfaces, tray menus, and tooltips above managed X11 clients after dwm restacks
- cache qualifying override-redirect metadata from map, property, unmap, and destroy events so the hot restack path performs raises only
- let each Quickshell bar yield only on monitors currently showing a true fullscreen client, while remaining above normal windows, hidden fullscreen clients, and fake fullscreen
- start one X-display and D-Bus-session scoped, tray-owning Flameshot daemon with a sanitized X11 environment and native X11 capture backend

## Root cause

Quickshell popups bypass normal dwm client management, so a later managed-client restack could cover them. The initial fix queried every root child during each restack; review correctly identified those synchronous X round trips as inappropriate for a latency-sensitive path, so popup state is now cached from X events.

The Quickshell panel also permanently requested ABOVE/STAYS_ON_TOP, allowing a panel redraw to jump over a true fullscreen client. dwm now publishes the logical monitor indexes currently displaying actual fullscreen clients, excluding fake and hidden fullscreen clients, and each panel binds its stacking policy to its monitor.

Flameshot 14 defaults to the desktop Screenshot portal even on X11. The GTK portal available in this minimal dwm session does not expose that interface, leaving area capture blocked in freeDesktopPortal() until its timeout. The wrapper enables the supported native X11 backend and serializes autostart, D-Bus activation recovery, and theme reloads through one daemon lock. Reuse requires matching X display, X11/XCB environment, and D-Bus session address; terminal zombies are ignored. Setup failures are reported and existing config symlinks and metadata are preserved.

## Validation

- make check
- make check-xvfb-runtime
- make check-screenshot
- make check-session-guards
- make check-shell
- make check-format
- nested X11 verifies independent tooltip, notification, KDE override, ABOVE, and STAYS_ON_TOP stacking markers
- nested X11 verifies fake fullscreen, hidden true fullscreen, show-all-tags true fullscreen, and restored single-tag transitions
- monitor-move source guard verifies fullscreen state is republished after tagmon restores the moved client
- live managed Quickshell restart remained on x11,:0 and normal bars retained ABOVE/STAYS_ON_TOP
- live Fedora X11 Flameshot area selector mapped at full monitor geometry, then cancelled cleanly with status 2
- regression coverage verifies config metadata and rollback, stale-Wayland replacement, zombie handling, same-display D-Bus-session replacement, and same-session reuse

## Manual testing note

The active dwm process was intentionally not restarted to preserve the live desktop session. The new dwm stacking and fullscreen-monitor property behavior is covered in nested X11 and will activate at the next normal dwm login. Quickshell and Flameshot were validated live without restarting dwm.