### PR TITLE
Fix late popup restacking edge cases

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -238,6 +238,7 @@ static void resizemouse(const Arg *arg);
 static int resizetiledmouse(const Arg *arg);
 static int isvisiblefullscreen(Client *c);
 static int monitorhasfullscreen(Monitor *m);
+static void raisefullscreenclients(Client *c);
 static void raisealwaysontop(Monitor *m);
 static void raisealwaysontopclients(Client *c);
 static void restack(Monitor *m);
@@ -2640,15 +2641,22 @@ monitorhasfullscreen(Monitor *m)
 }
 
 void
+raisefullscreenclients(Client *c)
+{
+	if (!c)
+		return;
+	raisefullscreenclients(c->snext);
+	if (isvisiblefullscreen(c))
+		XRaiseWindow(dpy, c->win);
+}
+
+void
 raisealwaysontop(Monitor *m)
 {
-	Client *c;
 	OverrideWindow *ow;
 
 	if (monitorhasfullscreen(m)) {
-		for (c = m->stack; c; c = c->snext)
-			if (isvisiblefullscreen(c))
-				XRaiseWindow(dpy, c->win);
+		raisefullscreenclients(m->stack);
 	} else {
 		raisealwaysontopclients(m->stack);
 		if (m->barwin)

--- a/dwm.c
+++ b/dwm.c
@@ -236,6 +236,8 @@ static void resize(Client *c, int x, int y, int w, int h, int interact);
 static void resizeclient(Client *c, int x, int y, int w, int h);
 static void resizemouse(const Arg *arg);
 static int resizetiledmouse(const Arg *arg);
+static int isvisiblefullscreen(Client *c);
+static int monitorhasfullscreen(Monitor *m);
 static void raisealwaysontop(Monitor *m);
 static void raisealwaysontopclients(Client *c);
 static void restack(Monitor *m);
@@ -2318,14 +2320,21 @@ void
 propertynotify(XEvent *e)
 {
 	Client *c;
+	Monitor *m;
 	OverrideWindow *ow;
 	Window trans;
 	XPropertyEvent *ev = &e->xproperty;
+	XWindowAttributes wa;
 
 	for (ow = overridewindows; ow && ow->win != ev->window; ow = ow->next);
 	if (ow && (ev->atom == netatom[NetWMState]
-	    || ev->atom == netatom[NetWMWindowType]))
+	    || ev->atom == netatom[NetWMWindowType])) {
 		updateoverridewindow(ev->window);
+		m = XGetWindowAttributes(dpy, ev->window, &wa)
+			? recttomon(wa.x, wa.y, wa.width, wa.height) : selmon;
+		if (m)
+			restack(m);
+	}
 	if ((ev->window == root) && (ev->atom == XA_WM_NAME)) {
 		updatestatus();
 	} else if (ev->state == PropertyDelete) {
@@ -2613,13 +2622,33 @@ restack(Monitor *m)
 	while (XCheckMaskEvent(dpy, EnterWindowMask, &ev));
 }
 
+int
+isvisiblefullscreen(Client *c)
+{
+	return c->isfullscreen && c->fakefullscreen != 1 && ISVISIBLE(c);
+}
+
+int
+monitorhasfullscreen(Monitor *m)
+{
+	Client *c;
+
+	for (c = m->clients; c; c = c->next)
+		if (isvisiblefullscreen(c))
+			return 1;
+	return 0;
+}
+
 void
 raisealwaysontop(Monitor *m)
 {
+	Client *c;
 	OverrideWindow *ow;
 
-	if (m->sel && m->sel->isfullscreen && m->sel->fakefullscreen != 1) {
-		XRaiseWindow(dpy, m->sel->win);
+	if (monitorhasfullscreen(m)) {
+		for (c = m->stack; c; c = c->snext)
+			if (isvisiblefullscreen(c))
+				XRaiseWindow(dpy, c->win);
 	} else {
 		raisealwaysontopclients(m->stack);
 		if (m->barwin)
@@ -4742,7 +4771,6 @@ updateclientlist(void)
 void
 updatefullscreenmonitors(void)
 {
-	Client *c;
 	Monitor *m;
 	long *monitors;
 	int logicalindex;
@@ -4752,15 +4780,13 @@ updatefullscreenmonitors(void)
 		count++;
 	monitors = count ? ecalloc(count, sizeof(*monitors)) : NULL;
 	count = 0;
-	for (m = mons; m; m = m->next)
-		for (c = m->clients; c; c = c->next) {
-			if (!c->isfullscreen || c->fakefullscreen == 1 || !ISVISIBLE(c))
-				continue;
-			logicalindex = getmonlogicalindex(m);
-			if (logicalindex >= 0)
-				monitors[count++] = logicalindex;
-			break;
-		}
+	for (m = mons; m; m = m->next) {
+		if (!monitorhasfullscreen(m))
+			continue;
+		logicalindex = getmonlogicalindex(m);
+		if (logicalindex >= 0)
+			monitors[count++] = logicalindex;
+	}
 	XChangeProperty(dpy, root, dwmfullscreenmonitorsatom, XA_CARDINAL, 32,
 		PropModeReplace, (unsigned char *)monitors, count);
 	free(monitors);

--- a/scripts/dwm-quickshell-state
+++ b/scripts/dwm-quickshell-state
@@ -186,7 +186,6 @@ watch_state() {
 		xprop -root -spy \
 			DWM_TAG_UPDATE \
 			_DWM_MONITOR_DESKTOPS \
-			_NET_CURRENT_DESKTOP \
 			_NET_NUMBER_OF_DESKTOPS \
 			_NET_DESKTOP_NAMES \
 			_NET_ACTIVE_WINDOW \

--- a/tests/test-monitor-tag-switching.sh
+++ b/tests/test-monitor-tag-switching.sh
@@ -93,11 +93,22 @@ set_fullscreen_body=$(sed -n '/^setfullscreen(Client \*c, int fullscreen)/,/^}$/
 printf '%s\n' "$set_fullscreen_body" | grep -q 'actualfullscreenchanged'
 printf '%s\n' "$set_fullscreen_body" | grep -q 'wasactualfullscreen'
 printf '%s\n' "$set_fullscreen_body" | grep -q 'updatefullscreenmonitors();'
+visible_fullscreen_body=$(sed -n '/^isvisiblefullscreen(Client \*c)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$visible_fullscreen_body" | grep -q 'c->isfullscreen'
+printf '%s\n' "$visible_fullscreen_body" | grep -q 'c->fakefullscreen != 1'
+printf '%s\n' "$visible_fullscreen_body" | grep -q 'ISVISIBLE(c)'
+monitor_has_fullscreen_body=$(sed -n '/^monitorhasfullscreen(Monitor \*m)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$monitor_has_fullscreen_body" | grep -q 'isvisiblefullscreen(c)'
 fullscreen_monitors_body=$(sed -n '/^updatefullscreenmonitors(void)/,/^}$/p' "$repo_dir/dwm.c")
-printf '%s\n' "$fullscreen_monitors_body" | grep -q 'c->fakefullscreen == 1'
-printf '%s\n' "$fullscreen_monitors_body" | grep -q '!ISVISIBLE(c)'
+printf '%s\n' "$fullscreen_monitors_body" | grep -q 'monitorhasfullscreen(m)'
 printf '%s\n' "$fullscreen_monitors_body" | grep -q 'getmonlogicalindex(m)'
 printf '%s\n' "$fullscreen_monitors_body" | grep -q 'dwmfullscreenmonitorsatom'
+raise_always_body=$(sed -n '/^raisealwaysontop(Monitor \*m)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$raise_always_body" | grep -q 'monitorhasfullscreen(m)'
+printf '%s\n' "$raise_always_body" | grep -q 'isvisiblefullscreen(c)'
+property_notify_body=$(sed -n '/^propertynotify(XEvent \*e)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$property_notify_body" | grep -q 'updateoverridewindow(ev->window);'
+printf '%s\n' "$property_notify_body" | grep -q 'restack(m);'
 tagmon_body=$(sed -n '/^tagmon(const Arg \*arg)/,/^}$/p' "$repo_dir/dwm.c")
 printf '%s\n' "$tagmon_body" | grep -q 'c->isfullscreen = 1;'
 printf '%s\n' "$tagmon_body" | grep -q 'updatefullscreenmonitors();'

--- a/tests/test-monitor-tag-switching.sh
+++ b/tests/test-monitor-tag-switching.sh
@@ -105,7 +105,10 @@ printf '%s\n' "$fullscreen_monitors_body" | grep -q 'getmonlogicalindex(m)'
 printf '%s\n' "$fullscreen_monitors_body" | grep -q 'dwmfullscreenmonitorsatom'
 raise_always_body=$(sed -n '/^raisealwaysontop(Monitor \*m)/,/^}$/p' "$repo_dir/dwm.c")
 printf '%s\n' "$raise_always_body" | grep -q 'monitorhasfullscreen(m)'
-printf '%s\n' "$raise_always_body" | grep -q 'isvisiblefullscreen(c)'
+printf '%s\n' "$raise_always_body" | grep -q 'raisefullscreenclients(m->stack)'
+raise_fullscreen_clients_body=$(sed -n '/^raisefullscreenclients(Client \*c)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$raise_fullscreen_clients_body" | grep -q 'raisefullscreenclients(c->snext);'
+printf '%s\n' "$raise_fullscreen_clients_body" | grep -q 'isvisiblefullscreen(c)'
 property_notify_body=$(sed -n '/^propertynotify(XEvent \*e)/,/^}$/p' "$repo_dir/dwm.c")
 printf '%s\n' "$property_notify_body" | grep -q 'updateoverridewindow(ev->window);'
 printf '%s\n' "$property_notify_body" | grep -q 'restack(m);'

--- a/tests/test-monitor-tag-switching.sh
+++ b/tests/test-monitor-tag-switching.sh
@@ -110,8 +110,15 @@ raise_fullscreen_clients_body=$(sed -n '/^raisefullscreenclients(Client \*c)/,/^
 printf '%s\n' "$raise_fullscreen_clients_body" | grep -q 'raisefullscreenclients(c->snext);'
 printf '%s\n' "$raise_fullscreen_clients_body" | grep -q 'isvisiblefullscreen(c)'
 property_notify_body=$(sed -n '/^propertynotify(XEvent \*e)/,/^}$/p' "$repo_dir/dwm.c")
-printf '%s\n' "$property_notify_body" | grep -q 'updateoverridewindow(ev->window);'
-printf '%s\n' "$property_notify_body" | grep -q 'restack(m);'
+override_property_block=$(printf '%s\n' "$property_notify_body" |
+	sed -n '/for (ow = overridewindows/,/if ((ev->window == root)/p')
+printf '%s\n' "$override_property_block" | grep -q 'updateoverridewindow(ev->window);'
+printf '%s\n' "$override_property_block" | grep -q 'restack(m);'
+update_override_line=$(printf '%s\n' "$override_property_block" |
+	grep -n 'updateoverridewindow(ev->window);' | cut -d: -f1)
+restack_override_line=$(printf '%s\n' "$override_property_block" |
+	grep -n 'restack(m);' | cut -d: -f1)
+test "$update_override_line" -lt "$restack_override_line"
 tagmon_body=$(sed -n '/^tagmon(const Arg \*arg)/,/^}$/p' "$repo_dir/dwm.c")
 printf '%s\n' "$tagmon_body" | grep -q 'c->isfullscreen = 1;'
 printf '%s\n' "$tagmon_body" | grep -q 'updatefullscreenmonitors();'

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -141,6 +141,21 @@ wait_for_top_window() {
 	return 1
 }
 
+wait_for_window_above() {
+	expected=$1
+	other=$2
+	i=0
+	while [ "$i" -lt 100 ]; do
+		if [ "$(DISPLAY=$display "$work/xclient" above "$expected" "$other")" = 1 ]; then
+			return 0
+		fi
+		i=$((i + 1))
+		sleep 0.05
+	done
+	printf '%s\n' "window $expected did not move above $other" >&2
+	return 1
+}
+
 wait_for_active_window() {
 	expected_win=$1
 	i=0
@@ -876,7 +891,14 @@ fullscreen_peer_win=$(cat "$work/fullscreen-peer-window-id")
 wait_for_active_window "$fullscreen_peer_win"
 wait_for_fullscreen_monitors 0
 DISPLAY=$display xdotool key Super+t
-[ "$(DISPLAY=$display "$work/xclient" above "$fullscreen_win" "$panel_win")" = 1 ]
+wait_for_window_above "$fullscreen_win" "$panel_win"
+
+DISPLAY=$display "$work/xclient" fullscreen "$fullscreen_peer_win"
+wait_for_window_state "$fullscreen_peer_win" _NET_WM_STATE_FULLSCREEN
+wait_for_fullscreen_monitors 0
+DISPLAY=$display xdotool key Super+t
+wait_for_window_above "$fullscreen_peer_win" "$fullscreen_win"
+wait_for_window_above "$fullscreen_win" "$panel_win"
 kill "$second_client_pid"
 wait "$second_client_pid" 2>/dev/null || true
 second_client_pid=

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -176,7 +176,7 @@ require_cmd Xvfb awk cc pkg-config xdotool xprop sed grep tail
 pkg-config --exists x11
 
 work=$(mktemp -d)
-trap 'set +e; [ -n "${swallow_client_pid:-}" ] && kill "$swallow_client_pid" 2>/dev/null; [ -n "${many_state_client_pid:-}" ] && kill "$many_state_client_pid" 2>/dev/null; [ -n "${fullscreen_client_pid:-}" ] && kill "$fullscreen_client_pid" 2>/dev/null; [ -n "${popup_client_pid:-}" ] && kill "$popup_client_pid" 2>/dev/null; [ -n "${second_above_client_pid:-}" ] && kill "$second_above_client_pid" 2>/dev/null; [ -n "${stack_client_pid:-}" ] && kill "$stack_client_pid" 2>/dev/null; [ -n "${above_client_pid:-}" ] && kill "$above_client_pid" 2>/dev/null; [ -n "${second_client_pid:-}" ] && kill "$second_client_pid" 2>/dev/null; [ -n "${client_pid:-}" ] && kill "$client_pid" 2>/dev/null; [ -n "${dwm_pid:-}" ] && kill "$dwm_pid" 2>/dev/null; [ -n "${xvfb_pid:-}" ] && kill "$xvfb_pid" 2>/dev/null; rm -rf "$work"' EXIT HUP INT TERM
+trap 'set +e; [ -n "${swallow_client_pid:-}" ] && kill "$swallow_client_pid" 2>/dev/null; [ -n "${many_state_client_pid:-}" ] && kill "$many_state_client_pid" 2>/dev/null; [ -n "${fullscreen_client_pid:-}" ] && kill "$fullscreen_client_pid" 2>/dev/null; [ -n "${panel_pid:-}" ] && kill "$panel_pid" 2>/dev/null; [ -n "${popup_client_pid:-}" ] && kill "$popup_client_pid" 2>/dev/null; [ -n "${second_above_client_pid:-}" ] && kill "$second_above_client_pid" 2>/dev/null; [ -n "${stack_client_pid:-}" ] && kill "$stack_client_pid" 2>/dev/null; [ -n "${above_client_pid:-}" ] && kill "$above_client_pid" 2>/dev/null; [ -n "${second_client_pid:-}" ] && kill "$second_client_pid" 2>/dev/null; [ -n "${client_pid:-}" ] && kill "$client_pid" 2>/dev/null; [ -n "${dwm_pid:-}" ] && kill "$dwm_pid" 2>/dev/null; [ -n "${xvfb_pid:-}" ] && kill "$xvfb_pid" 2>/dev/null; rm -rf "$work"' EXIT HUP INT TERM
 
 home="$work/home"
 mkdir -p "$home/.config/dwm-titus" "$home/.local/share/dwm-titus/config"
@@ -220,6 +220,7 @@ main(int argc, char **argv)
 	int initial_above = 0;
 	int initial_many_states = 0;
 	int override_redirect = 0;
+	int panel = 0;
 	const char *popup_state = NULL;
 	const char *popup_type = NULL;
 	int swallow_terminal = 0;
@@ -240,6 +241,32 @@ main(int argc, char **argv)
 			return 3;
 		}
 		printf("override_redirect=%d\n", attributes.override_redirect);
+		XCloseDisplay(dpy);
+		return 0;
+	}
+	if (argc == 4 && strcmp(argv[1], "above") == 0) {
+		Window root_return, parent_return, *children = NULL;
+		Window first = strtoul(argv[2], NULL, 0);
+		Window second = strtoul(argv[3], NULL, 0);
+		unsigned int child_count = 0;
+		int first_index = -1, second_index = -1;
+		unsigned int i;
+
+		if (!XQueryTree(dpy, DefaultRootWindow(dpy), &root_return,
+		    &parent_return, &children, &child_count)) {
+			XCloseDisplay(dpy);
+			return 3;
+		}
+		for (i = 0; i < child_count; i++) {
+			if (children[i] == first)
+				first_index = i;
+			if (children[i] == second)
+				second_index = i;
+		}
+		if (children)
+			XFree(children);
+		printf("%d\n", first_index >= 0 && second_index >= 0
+			&& first_index > second_index);
 		XCloseDisplay(dpy);
 		return 0;
 	}
@@ -278,6 +305,8 @@ main(int argc, char **argv)
 		initial_above = 1;
 	else if (argc == 2 && strcmp(argv[1], "initial-many-states") == 0)
 		initial_many_states = 1;
+	else if (argc == 2 && strcmp(argv[1], "panel") == 0)
+		panel = 1;
 	else if (argc == 2 && strcmp(argv[1], "override") == 0)
 		override_redirect = 1;
 	else if (argc == 2 && strcmp(argv[1], "override-tooltip") == 0) {
@@ -324,7 +353,9 @@ main(int argc, char **argv)
 		swallow_terminal = 1;
 
 	win = XCreateSimpleWindow(dpy, DefaultRootWindow(dpy),
-		20, 20, 320, 180, 0, 0, WhitePixel(dpy, DefaultScreen(dpy)));
+		panel ? 0 : 20, panel ? 0 : 20,
+		panel ? 1024 : 320, panel ? 24 : 180,
+		0, 0, WhitePixel(dpy, DefaultScreen(dpy)));
 	if (override_redirect) {
 		XSetWindowAttributes attributes = { .override_redirect = True };
 
@@ -332,8 +363,9 @@ main(int argc, char **argv)
 	}
 	if (set_hints) {
 		XStoreName(dpy, win, "dwm-xvfb-runtime");
-		classhint.res_name = "dwm-xvfb-runtime";
-		classhint.res_class = swallow_terminal ? "DwmXvfbTerminal" : "DwmXvfbRuntime";
+		classhint.res_name = panel ? "quickshell" : "dwm-xvfb-runtime";
+		classhint.res_class = panel ? "quickshell"
+			: (swallow_terminal ? "DwmXvfbTerminal" : "DwmXvfbRuntime");
 		XSetClassHint(dpy, win, &classhint);
 	}
 	if (swallow_terminal) {
@@ -677,6 +709,13 @@ wait_for_top_window "$stack_win"
 DISPLAY=$display xdotool key Super+t
 wait_for_top_window "$above_win"
 
+DISPLAY=$display xprop -id "$stack_win" \
+	-f _NET_WM_WINDOW_TYPE 32a \
+	-set _NET_WM_WINDOW_TYPE _NET_WM_WINDOW_TYPE_TOOLTIP
+wait_for_top_window "$stack_win"
+DISPLAY=$display xprop -id "$stack_win" -remove _NET_WM_WINDOW_TYPE
+wait_for_top_window "$above_win"
+
 for popup_marker in tooltip kde notification menu popup-menu dropdown-menu combo dnd above stays-on-top; do
 	DISPLAY=$display "$work/xclient" "override-$popup_marker" \
 		>"$work/popup-$popup_marker-window-id" \
@@ -765,6 +804,18 @@ done
 fullscreen_win=$(cat "$work/fullscreen-window-id")
 [ -n "$fullscreen_win" ]
 wait_for_active_window "$fullscreen_win"
+
+DISPLAY=$display "$work/xclient" panel >"$work/panel-window-id" 2>"$work/panel-client.log" &
+panel_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ ! -s "$work/panel-window-id" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+panel_win=$(cat "$work/panel-window-id")
+[ -n "$panel_win" ]
+DISPLAY=$display xprop -root _NET_CLIENT_LIST | grep -q "$panel_win"
+
 DISPLAY=$display xdotool key Super+Shift+y
 wait_for_window_state "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
 wait_for_fullscreen_monitors ''
@@ -778,6 +829,7 @@ wait_for_fullscreen_monitors ''
 DISPLAY=$display "$work/xclient" fullscreen "$fullscreen_win"
 wait_for_window_state "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
 wait_for_fullscreen_monitors 0
+
 DISPLAY=$display xdotool key Super+t
 wait_for_top_window "$fullscreen_win"
 DISPLAY=$display xdotool key Super+2
@@ -788,12 +840,53 @@ wait_for_fullscreen_monitors 0
 DISPLAY=$display xdotool key Super+1
 wait_for_current_desktop 0
 wait_for_fullscreen_monitors 0
+
 DISPLAY=$display "$work/xclient" state "$fullscreen_win" 0 _NET_WM_STATE_FULLSCREEN
 wait_for_window_state_absent "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
 wait_for_fullscreen_monitors ''
 kill "$fullscreen_client_pid"
 wait "$fullscreen_client_pid" 2>/dev/null || true
 fullscreen_client_pid=
+
+DISPLAY=$display "$work/xclient" >"$work/unselected-fullscreen-window-id" \
+	2>"$work/unselected-fullscreen-client.log" &
+fullscreen_client_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ ! -s "$work/unselected-fullscreen-window-id" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+fullscreen_win=$(cat "$work/unselected-fullscreen-window-id")
+[ -n "$fullscreen_win" ]
+wait_for_active_window "$fullscreen_win"
+DISPLAY=$display "$work/xclient" fullscreen "$fullscreen_win"
+wait_for_window_state "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
+wait_for_fullscreen_monitors 0
+
+DISPLAY=$display "$work/xclient" >"$work/fullscreen-peer-window-id" \
+	2>"$work/fullscreen-peer-client.log" &
+second_client_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ ! -s "$work/fullscreen-peer-window-id" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+fullscreen_peer_win=$(cat "$work/fullscreen-peer-window-id")
+[ -n "$fullscreen_peer_win" ]
+wait_for_active_window "$fullscreen_peer_win"
+wait_for_fullscreen_monitors 0
+DISPLAY=$display xdotool key Super+t
+[ "$(DISPLAY=$display "$work/xclient" above "$fullscreen_win" "$panel_win")" = 1 ]
+kill "$second_client_pid"
+wait "$second_client_pid" 2>/dev/null || true
+second_client_pid=
+kill "$fullscreen_client_pid"
+wait "$fullscreen_client_pid" 2>/dev/null || true
+fullscreen_client_pid=
+wait_for_fullscreen_monitors ''
+kill "$panel_pid"
+wait "$panel_pid" 2>/dev/null || true
+panel_pid=
 
 DISPLAY=$display "$work/xclient" initial-many-states >"$work/many-state-window-id" 2>"$work/many-state-client.log" &
 many_state_client_pid=$!


### PR DESCRIPTION
## Summary

- keep every visible true-fullscreen client above the managed panel even when fullscreen loses selection
- share the visible-fullscreen predicate with `_DWM_FULLSCREEN_MONITORS` publication so X11 stacking and Quickshell policy cannot diverge
- restack the affected monitor immediately when an already-mapped override window gains or loses a recognized popup or always-on-top marker
- add nested-X11 coverage for nonselected fullscreen clients, managed panels, and dynamic override metadata changes
- avoid the duplicate `_NET_CURRENT_DESKTOP` watcher refresh when `_DWM_MONITOR_DESKTOPS` is available, while preserving the legacy fallback

## Root cause

PR #138 based the native panel raise decision on `m->sel`, while the Quickshell state property scanned all visible clients. A fullscreen client that remained visible after another client became selected therefore disabled Quickshell's `aboveWindows` policy but could still have the panel raised over it by dwm.

Override-window property notifications also refreshed only the cached raise flag. X does not change stacking when those properties change, so the cached decision did not take effect until an unrelated restack.

## Validation

- `make clean && make`
- `make check-xvfb-runtime`
- `make check-monitor-tags`
- `make check`
- `shellcheck tests/test-monitor-tag-switching.sh tests/test-xvfb-runtime.sh`
- `shfmt -d tests/test-monitor-tag-switching.sh tests/test-xvfb-runtime.sh`
- `git diff --check`
- nested-X11 workspace-switch stress with 12 clients and 80 rapid switches per sample: watcher median overhead reduced from about 0.14 ms to about 0.04 ms per switch

## Manual testing

Nested X11 validates the complete affected behavior. The live dwm process was not restarted because that would disrupt the active desktop session; the fixes activate on the next normal dwm restart/login.

Follow-up to the late Codex review on #138.