### PR TITLE
Fix Quickshell surface stacking and panel mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,11 @@ versions from `config.mk`.
 
 ### Fixed
 
-- Keep Quickshell notifications, control popups, and tooltips above managed
-  client windows when dwm restacks the X11 session.
+- Keep Quickshell notifications and panel-transient control popups above normal
+  client windows while preserving true fullscreen applications above every
+  shell surface through one centralized X11 stacking pass.
+- Map Quickshell panels even when their geometry is reconciled before dwm
+  receives the initial map request.
 - Keep tray context menus above managed windows, start a single tray-owning
   Flameshot daemon with a sanitized X11 environment, and default to its native
   X11 capture backend when no explicit backend preference is configured.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@ versions from `config.mk`.
 
 - Keep Quickshell notifications and panel-transient control popups above normal
   client windows while preserving true fullscreen applications above every
-  shell surface through one centralized X11 stacking pass.
+  shell surface through one centralized X11 stacking pass, returning input
+  focus to fullscreen when a hidden panel popup requests it.
 - Map Quickshell panels even when their geometry is reconciled before dwm
   receives the initial map request.
 - Keep tray context menus above managed windows, start a single tray-owning

--- a/config/window-rules.toml
+++ b/config/window-rules.toml
@@ -32,13 +32,10 @@ rules = [
   { title="Event Tester",   noswallow=1  },
 
   # ── floating ─────────────────────────────────────────────────────────────
-  # Quickshell dock windows are handled as the managed top bar and keep the
-  # reserved 30px gap. FloatingWindow surfaces expose titles but no WM_CLASS.
+  # Quickshell dock windows are handled as managed top bars. Panel-anchored
+  # PopupWindow surfaces are override-redirect transients and are stacked by
+  # dwm directly. Managed FloatingWindow surfaces still use their titles.
   { title="dwm launcher",             isfloating=1, alwaysontop=1 },
-  { title="dwm power menu",           isfloating=1, alwaysontop=1 },
-  { title="dwm controls",             isfloating=1, alwaysontop=1 },
-  { title="dwm network",              isfloating=1, alwaysontop=1 },
-  { title="dwm control center",       isfloating=1, alwaysontop=1 },
   { title="dwm control center utility", isfloating=1, alwaysontop=1 },
   { title="dwm system health",        isfloating=1, alwaysontop=1 },
   { title="dwm settings",             isfloating=1, alwaysontop=1 },

--- a/config/window-rules.toml
+++ b/config/window-rules.toml
@@ -36,6 +36,7 @@ rules = [
   # PopupWindow surfaces are override-redirect transients and are stacked by
   # dwm directly. Managed FloatingWindow surfaces still use their titles.
   { title="dwm launcher",             isfloating=1, alwaysontop=1 },
+  { title="dwm network password",     isfloating=1, alwaysontop=1 },
   { title="dwm control center utility", isfloating=1, alwaysontop=1 },
   { title="dwm system health",        isfloating=1, alwaysontop=1 },
   { title="dwm settings",             isfloating=1, alwaysontop=1 },

--- a/dwm.c
+++ b/dwm.c
@@ -217,6 +217,7 @@ static void grabbuttons(Client *c, int focused);
 static void grabkeys(void);
 static void incnmaster(const Arg *arg);
 static int isaltbar(Window win, XWindowAttributes *wa);
+static int istransientforbar(Window win);
 static int isdescprocess(pid_t p, pid_t c);
 static void killclient(const Arg *arg);
 static void manage(Window w, XWindowAttributes *wa);
@@ -239,8 +240,8 @@ static int resizetiledmouse(const Arg *arg);
 static int isvisiblefullscreen(Client *c);
 static int monitorhasfullscreen(Monitor *m);
 static void raisefullscreenclients(Client *c);
-static void raisealwaysontop(Monitor *m);
 static void raisealwaysontopclients(Client *c);
+static void restackprioritywindows(void);
 static void restack(Monitor *m);
 static int sendevent(Client *c, Atom proto);
 static void sendmon(Client *c, Monitor *m);
@@ -1918,14 +1919,15 @@ manage(Window w, XWindowAttributes *wa)
 void
 managealtbar(Window win, XWindowAttributes *wa)
 {
+	int changed;
 	Monitor *m;
 	if (!(m = recttomon(wa->x, wa->y, wa->width, wa->height)))
 		return;
 
-	if (!updatealtbar(m, win, wa))
-		return;
+	changed = updatealtbar(m, win, wa);
 
-	arrange(m);
+	if (changed)
+		arrange(m);
 	XSelectInput(dpy, win, EnterWindowMask|FocusChangeMask|PropertyChangeMask|StructureNotifyMask|ExposureMask);
 	XMoveResizeWindow(dpy, win, wa->x, wa->y, wa->width, wa->height);
 	XRaiseWindow(dpy, win);
@@ -1947,6 +1949,18 @@ isaltbar(Window win, XWindowAttributes *wa)
 
 	wtype = getwinatomprop(win, netatom[NetWMWindowType]);
 	return wtype == netatom[NetWMWindowTypeDock];
+}
+
+int
+istransientforbar(Window win)
+{
+	Window trans;
+	XWindowAttributes wa;
+
+	return XGetTransientForHint(dpy, win, &trans)
+		&& XGetWindowAttributes(dpy, trans, &wa)
+		&& !wa.override_redirect
+		&& isaltbar(trans, &wa);
 }
 
 void
@@ -1983,6 +1997,7 @@ mapnotify(XEvent *e)
 	XMapEvent *ev = &e->xmap;
 
 	trackoverridewindow(ev->window);
+	restackprioritywindows();
 }
 
 void
@@ -2321,20 +2336,16 @@ void
 propertynotify(XEvent *e)
 {
 	Client *c;
-	Monitor *m;
 	OverrideWindow *ow;
 	Window trans;
 	XPropertyEvent *ev = &e->xproperty;
-	XWindowAttributes wa;
 
 	for (ow = overridewindows; ow && ow->win != ev->window; ow = ow->next);
 	if (ow && (ev->atom == netatom[NetWMState]
-	    || ev->atom == netatom[NetWMWindowType])) {
+	    || ev->atom == netatom[NetWMWindowType]
+	    || ev->atom == XA_WM_TRANSIENT_FOR)) {
 		updateoverridewindow(ev->window);
-		m = XGetWindowAttributes(dpy, ev->window, &wa)
-			? recttomon(wa.x, wa.y, wa.width, wa.height) : selmon;
-		if (m)
-			restack(m);
+		restackprioritywindows();
 	}
 	if ((ev->window == root) && (ev->atom == XA_WM_NAME)) {
 		updatestatus();
@@ -2360,7 +2371,7 @@ propertynotify(XEvent *e)
 			updatetitle(c);
 			if (applytitlerules(c)) {
 				arrange(c->mon);
-				raisealwaysontop(c->mon);
+				restackprioritywindows();
 			}
 			if (c == c->mon->sel)
 				drawbar(c->mon);
@@ -2604,7 +2615,7 @@ restack(Monitor *m)
 
 	drawbar(m);
 	if (!m->sel) {
-		raisealwaysontop(m);
+		restackprioritywindows();
 		return;
 	}
 	if (m->sel->isfloating || !m->lt[m->sellt]->arrange)
@@ -2618,7 +2629,7 @@ restack(Monitor *m)
 				wc.sibling = c->win;
 			}
 	}
-	raisealwaysontop(m);
+	restackprioritywindows();
 	XSync(dpy, False);
 	while (XCheckMaskEvent(dpy, EnterWindowMask, &ev));
 }
@@ -2651,22 +2662,25 @@ raisefullscreenclients(Client *c)
 }
 
 void
-raisealwaysontop(Monitor *m)
+restackprioritywindows(void)
 {
+	Monitor *m;
 	OverrideWindow *ow;
 
-	if (monitorhasfullscreen(m)) {
-		raisefullscreenclients(m->stack);
-	} else {
+	for (m = mons; m; m = m->next)
 		raisealwaysontopclients(m->stack);
-		if (m->barwin)
-			XRaiseWindow(dpy, m->barwin);
-		if (m->traywin)
-			XRaiseWindow(dpy, m->traywin);
-	}
+	for (m = mons; m; m = m->next)
+		if (!monitorhasfullscreen(m)) {
+			if (m->barwin)
+				XRaiseWindow(dpy, m->barwin);
+			if (m->traywin)
+				XRaiseWindow(dpy, m->traywin);
+		}
 	for (ow = overridewindows; ow; ow = ow->next)
 		if (ow->raise)
 			XRaiseWindow(dpy, ow->win);
+	for (m = mons; m; m = m->next)
+		raisefullscreenclients(m->stack);
 }
 
 void
@@ -4714,17 +4728,22 @@ updatebarpos(Monitor *m)
 static int
 updatealtbar(Monitor *m, Window win, XWindowAttributes *wa)
 {
+	int changed, newbh, newtopbar;
+
 	if (!m || !wa)
 		return 0;
 	if (wa->override_redirect)
 		return 0;
 
+	newtopbar = wa->y < m->my + m->mh / 2;
+	newbh = wa->height > 0 ? wa->height : bh;
+	changed = m->barwin != win || m->topbar != newtopbar || m->bh != newbh;
 	m->barwin = win;
-	m->topbar = wa->y < m->my + m->mh / 2;
-	m->bh = wa->height > 0 ? wa->height : bh;
+	m->topbar = newtopbar;
+	m->bh = newbh;
 	bh = m->bh;
 	updatebarpos(m);
-	return 1;
+	return changed;
 }
 
 void
@@ -5063,7 +5082,8 @@ updateoverridewindow(Window win)
 		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypeDropdownMenu])
 		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypeCombo])
 		|| atomlistcontains(types, ntypes, netatom[NetWMWindowTypeDnd])
-		|| atomlistcontains(types, ntypes, kdewindowtypeoverride);
+		|| atomlistcontains(types, ntypes, kdewindowtypeoverride)
+		|| istransientforbar(win);
 }
 
 void

--- a/dwm.c
+++ b/dwm.c
@@ -203,6 +203,7 @@ static Monitor *dirtomon(int dir);
 static void drawbar(Monitor *m);
 static void drawbars(void);
 static void focus(Client *c);
+static int focusfullscreenforoverride(Window win);
 static void focusmon(const Arg *arg);
 static void focusstack(const Arg *arg);
 static pid_t getparentprocess(pid_t p);
@@ -1375,12 +1376,39 @@ focus(Client *c)
 	drawbars();
 }
 
+int
+focusfullscreenforoverride(Window win)
+{
+	Client *c;
+	Monitor *m;
+	OverrideWindow *ow;
+	Window trans;
+
+	for (ow = overridewindows; ow && ow->win != win; ow = ow->next);
+	if (!ow || !ow->raise || !XGetTransientForHint(dpy, win, &trans))
+		return 0;
+	for (m = mons; m && m->barwin != trans; m = m->next);
+	if (!m || !monitorhasfullscreen(m))
+		return 0;
+	for (c = m->stack; c && !isvisiblefullscreen(c); c = c->snext);
+	if (!c)
+		return 0;
+	focus(c);
+	return 1;
+}
+
 /* there are some broken focus acquiring clients needing extra handling */
 void
 focusin(XEvent *e)
 {
+	OverrideWindow *ow;
 	XFocusChangeEvent *ev = &e->xfocus;
 
+	for (ow = overridewindows; ow && ow->win != ev->window; ow = ow->next);
+	if (ow) {
+		focusfullscreenforoverride(ev->window);
+		return;
+	}
 	if (selmon->sel && ev->window != selmon->sel->win)
 		setfocus(selmon->sel);
 }
@@ -2664,9 +2692,14 @@ raisefullscreenclients(Client *c)
 void
 restackprioritywindows(void)
 {
+	int revert;
 	Monitor *m;
 	OverrideWindow *ow;
+	Window focused;
 
+	/* Raise order is the priority contract: always-on-top clients, bars and
+	 * trays, override popups, then real fullscreen clients above all shell
+	 * surfaces. */
 	for (m = mons; m; m = m->next)
 		raisealwaysontopclients(m->stack);
 	for (m = mons; m; m = m->next)
@@ -2681,6 +2714,8 @@ restackprioritywindows(void)
 			XRaiseWindow(dpy, ow->win);
 	for (m = mons; m; m = m->next)
 		raisefullscreenclients(m->stack);
+	if (XGetInputFocus(dpy, &focused, &revert))
+		focusfullscreenforoverride(focused);
 }
 
 void
@@ -3228,8 +3263,10 @@ setfullscreen(Client *c, int fullscreen)
 	 */
 	if (!c->isfullscreen)
 		while (XCheckMaskEvent(dpy, EnterWindowMask, &ev));
-	if (actualfullscreenchanged)
+	if (actualfullscreenchanged) {
 		updatefullscreenmonitors();
+		restackprioritywindows();
+	}
 }
 
 Layout *last_layout;
@@ -4637,7 +4674,8 @@ trackoverridewindow(Window win)
 		ow->win = win;
 		for (tail = &overridewindows; *tail; tail = &(*tail)->next);
 		*tail = ow;
-		XSelectInput(dpy, win, wa.your_event_mask | PropertyChangeMask);
+		XSelectInput(dpy, win,
+			wa.your_event_mask | FocusChangeMask | PropertyChangeMask);
 	}
 	updateoverridewindow(win);
 }

--- a/dwm.c
+++ b/dwm.c
@@ -1405,10 +1405,9 @@ focusin(XEvent *e)
 	XFocusChangeEvent *ev = &e->xfocus;
 
 	for (ow = overridewindows; ow && ow->win != ev->window; ow = ow->next);
-	if (ow) {
-		focusfullscreenforoverride(ev->window);
+	if (ow && (focusfullscreenforoverride(ev->window)
+	    || istransientforbar(ev->window)))
 		return;
-	}
 	if (selmon->sel && ev->window != selmon->sel->win)
 		setfocus(selmon->sel);
 }

--- a/tests/test-monitor-tag-switching.sh
+++ b/tests/test-monitor-tag-switching.sh
@@ -150,7 +150,8 @@ map_notify_body=$(sed -n '/^mapnotify(XEvent \*e)/,/^}$/p' "$repo_dir/dwm.c")
 printf '%s\n' "$map_notify_body" | grep -q 'trackoverridewindow(ev->window);'
 printf '%s\n' "$map_notify_body" | grep -q 'restackprioritywindows();'
 focus_in_body=$(sed -n '/^focusin(XEvent \*e)/,/^}$/p' "$repo_dir/dwm.c")
-printf '%s\n' "$focus_in_body" | grep -q 'focusfullscreenforoverride(ev->window);'
+printf '%s\n' "$focus_in_body" | grep -q 'focusfullscreenforoverride(ev->window)'
+printf '%s\n' "$focus_in_body" | grep -q 'istransientforbar(ev->window)'
 track_override_body=$(sed -n '/^trackoverridewindow(Window win)/,/^}$/p' "$repo_dir/dwm.c")
 printf '%s\n' "$track_override_body" | grep -q 'FocusChangeMask'
 tagmon_body=$(sed -n '/^tagmon(const Arg \*arg)/,/^}$/p' "$repo_dir/dwm.c")

--- a/tests/test-monitor-tag-switching.sh
+++ b/tests/test-monitor-tag-switching.sh
@@ -93,6 +93,12 @@ manage_alt_bar_body=$(sed -n '/^managealtbar(Window win, XWindowAttributes \*wa)
 printf '%s\n' "$manage_alt_bar_body" | grep -q 'changed = updatealtbar(m, win, wa);'
 printf '%s\n' "$manage_alt_bar_body" | grep -q 'if (changed)'
 printf '%s\n' "$manage_alt_bar_body" | grep -q 'XMapWindow(dpy, win);'
+changed_arrange_block=$(printf '%s\n' "$manage_alt_bar_body" |
+	sed -n '/if (changed)/,/arrange(m);/p')
+if printf '%s\n' "$changed_arrange_block" | grep -q 'XMapWindow'; then
+	printf '%s\n' "XMapWindow must remain outside the changed-geometry branch." >&2
+	exit 1
+fi
 grep -q 'ewmh_replace_root_cardinal(dwmtagupdateatom, data, 1)' "$repo_dir/dwm.c"
 grep -q 'm->barwin, m->wx, m->by, m->ww, m->bh' "$repo_dir/dwm.c"
 grep -q 'selmon->barwin, selmon->wx, selmon->by, selmon->ww, selmon->bh' "$repo_dir/dwm.c"
@@ -115,6 +121,7 @@ printf '%s\n' "$priority_body" | grep -q 'raisealwaysontopclients(m->stack)'
 printf '%s\n' "$priority_body" | grep -q '!monitorhasfullscreen(m)'
 printf '%s\n' "$priority_body" | grep -q 'ow->raise'
 printf '%s\n' "$priority_body" | grep -q 'raisefullscreenclients(m->stack)'
+printf '%s\n' "$priority_body" | grep -q 'focusfullscreenforoverride(focused)'
 override_line=$(printf '%s\n' "$priority_body" |
 	grep -n 'for (ow = overridewindows' | cut -d: -f1)
 fullscreen_line=$(printf '%s\n' "$priority_body" |
@@ -142,6 +149,10 @@ printf '%s\n' "$transient_bar_body" | grep -q 'isaltbar(trans, &wa)'
 map_notify_body=$(sed -n '/^mapnotify(XEvent \*e)/,/^}$/p' "$repo_dir/dwm.c")
 printf '%s\n' "$map_notify_body" | grep -q 'trackoverridewindow(ev->window);'
 printf '%s\n' "$map_notify_body" | grep -q 'restackprioritywindows();'
+focus_in_body=$(sed -n '/^focusin(XEvent \*e)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$focus_in_body" | grep -q 'focusfullscreenforoverride(ev->window);'
+track_override_body=$(sed -n '/^trackoverridewindow(Window win)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$track_override_body" | grep -q 'FocusChangeMask'
 tagmon_body=$(sed -n '/^tagmon(const Arg \*arg)/,/^}$/p' "$repo_dir/dwm.c")
 printf '%s\n' "$tagmon_body" | grep -q 'c->isfullscreen = 1;'
 printf '%s\n' "$tagmon_body" | grep -q 'updatefullscreenmonitors();'

--- a/tests/test-monitor-tag-switching.sh
+++ b/tests/test-monitor-tag-switching.sh
@@ -86,6 +86,13 @@ printf '%s\n' "$scan_alt_bars_body" | grep -q 'knownbars\[j\] == wins\[i\]'
 printf '%s\n' "$scan_alt_bars_body" | grep -q 'INTERSECT(wa.x, wa.y, wa.width, wa.height, m) <= 0'
 printf '%s\n' "$scan_alt_bars_body" | grep -q 'm = oldm;'
 printf '%s\n' "$scan_alt_bars_body" | grep -q 'updatealtbar(m, wins\[i\], &wa);'
+update_alt_bar_body=$(sed -n '/^updatealtbar(Monitor \*m, Window win, XWindowAttributes \*wa)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$update_alt_bar_body" | grep -q 'changed = m->barwin != win'
+printf '%s\n' "$update_alt_bar_body" | grep -q 'return changed;'
+manage_alt_bar_body=$(sed -n '/^managealtbar(Window win, XWindowAttributes \*wa)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$manage_alt_bar_body" | grep -q 'changed = updatealtbar(m, win, wa);'
+printf '%s\n' "$manage_alt_bar_body" | grep -q 'if (changed)'
+printf '%s\n' "$manage_alt_bar_body" | grep -q 'XMapWindow(dpy, win);'
 grep -q 'ewmh_replace_root_cardinal(dwmtagupdateatom, data, 1)' "$repo_dir/dwm.c"
 grep -q 'm->barwin, m->wx, m->by, m->ww, m->bh' "$repo_dir/dwm.c"
 grep -q 'selmon->barwin, selmon->wx, selmon->by, selmon->ww, selmon->bh' "$repo_dir/dwm.c"
@@ -103,9 +110,16 @@ fullscreen_monitors_body=$(sed -n '/^updatefullscreenmonitors(void)/,/^}$/p' "$r
 printf '%s\n' "$fullscreen_monitors_body" | grep -q 'monitorhasfullscreen(m)'
 printf '%s\n' "$fullscreen_monitors_body" | grep -q 'getmonlogicalindex(m)'
 printf '%s\n' "$fullscreen_monitors_body" | grep -q 'dwmfullscreenmonitorsatom'
-raise_always_body=$(sed -n '/^raisealwaysontop(Monitor \*m)/,/^}$/p' "$repo_dir/dwm.c")
-printf '%s\n' "$raise_always_body" | grep -q 'monitorhasfullscreen(m)'
-printf '%s\n' "$raise_always_body" | grep -q 'raisefullscreenclients(m->stack)'
+priority_body=$(sed -n '/^restackprioritywindows(void)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$priority_body" | grep -q 'raisealwaysontopclients(m->stack)'
+printf '%s\n' "$priority_body" | grep -q '!monitorhasfullscreen(m)'
+printf '%s\n' "$priority_body" | grep -q 'ow->raise'
+printf '%s\n' "$priority_body" | grep -q 'raisefullscreenclients(m->stack)'
+override_line=$(printf '%s\n' "$priority_body" |
+	grep -n 'for (ow = overridewindows' | cut -d: -f1)
+fullscreen_line=$(printf '%s\n' "$priority_body" |
+	grep -n 'raisefullscreenclients(m->stack)' | cut -d: -f1)
+test "$override_line" -lt "$fullscreen_line"
 raise_fullscreen_clients_body=$(sed -n '/^raisefullscreenclients(Client \*c)/,/^}$/p' "$repo_dir/dwm.c")
 printf '%s\n' "$raise_fullscreen_clients_body" | grep -q 'raisefullscreenclients(c->snext);'
 printf '%s\n' "$raise_fullscreen_clients_body" | grep -q 'isvisiblefullscreen(c)'
@@ -113,12 +127,21 @@ property_notify_body=$(sed -n '/^propertynotify(XEvent \*e)/,/^}$/p' "$repo_dir/
 override_property_block=$(printf '%s\n' "$property_notify_body" |
 	sed -n '/for (ow = overridewindows/,/if ((ev->window == root)/p')
 printf '%s\n' "$override_property_block" | grep -q 'updateoverridewindow(ev->window);'
-printf '%s\n' "$override_property_block" | grep -q 'restack(m);'
+printf '%s\n' "$override_property_block" | grep -q 'XA_WM_TRANSIENT_FOR'
+printf '%s\n' "$override_property_block" | grep -q 'restackprioritywindows();'
 update_override_line=$(printf '%s\n' "$override_property_block" |
 	grep -n 'updateoverridewindow(ev->window);' | cut -d: -f1)
 restack_override_line=$(printf '%s\n' "$override_property_block" |
-	grep -n 'restack(m);' | cut -d: -f1)
+	grep -n 'restackprioritywindows();' | cut -d: -f1)
 test "$update_override_line" -lt "$restack_override_line"
+update_override_body=$(sed -n '/^updateoverridewindow(Window win)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$update_override_body" | grep -q 'istransientforbar(win)'
+transient_bar_body=$(sed -n '/^istransientforbar(Window win)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$transient_bar_body" | grep -q 'XGetTransientForHint'
+printf '%s\n' "$transient_bar_body" | grep -q 'isaltbar(trans, &wa)'
+map_notify_body=$(sed -n '/^mapnotify(XEvent \*e)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$map_notify_body" | grep -q 'trackoverridewindow(ev->window);'
+printf '%s\n' "$map_notify_body" | grep -q 'restackprioritywindows();'
 tagmon_body=$(sed -n '/^tagmon(const Arg \*arg)/,/^}$/p' "$repo_dir/dwm.c")
 printf '%s\n' "$tagmon_body" | grep -q 'c->isfullscreen = 1;'
 printf '%s\n' "$tagmon_body" | grep -q 'updatefullscreenmonitors();'

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -366,6 +366,8 @@ grep -Fq 'enabled: !root.networkModel.wifiPasswordPromptVisible' "$repo/config/q
 grep -Fq 'grabFocus: !networkModel.wifiPasswordPromptVisible' "$repo/config/quickshell/network/NetworkWindow.qml"
 grep -Fq 'FloatingWindow {' "$repo/config/quickshell/network/NetworkWindow.qml"
 grep -Fq 'title: "dwm network password"' "$repo/config/quickshell/network/NetworkWindow.qml"
+grep -Fq '{ title="dwm network password",     isfloating=1, alwaysontop=1 }' \
+	"$repo/config/window-rules.toml"
 grep -Fq 'screen: root.panelWindow ? root.panelWindow.screen : null' "$repo/config/quickshell/network/NetworkWindow.qml"
 grep -Fq 'model: Quickshell.screens' "$repo/config/quickshell/shell.qml"
 grep -Fq 'screen: modelData' "$repo/config/quickshell/shell.qml"

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -236,6 +236,8 @@ main(int argc, char **argv)
 	int initial_many_states = 0;
 	int override_redirect = 0;
 	int panel = 0;
+	int preconfigure_panel = 0;
+	Window transient_for = None;
 	const char *popup_state = NULL;
 	const char *popup_type = NULL;
 	int swallow_terminal = 0;
@@ -256,6 +258,18 @@ main(int argc, char **argv)
 			return 3;
 		}
 		printf("override_redirect=%d\n", attributes.override_redirect);
+		XCloseDisplay(dpy);
+		return 0;
+	}
+	if (argc == 3 && strcmp(argv[1], "map-state") == 0) {
+		XWindowAttributes attributes;
+
+		win = strtoul(argv[2], NULL, 0);
+		if (!XGetWindowAttributes(dpy, win, &attributes)) {
+			XCloseDisplay(dpy);
+			return 3;
+		}
+		printf("%d\n", attributes.map_state);
 		XCloseDisplay(dpy);
 		return 0;
 	}
@@ -321,9 +335,13 @@ main(int argc, char **argv)
 	else if (argc == 2 && strcmp(argv[1], "initial-many-states") == 0)
 		initial_many_states = 1;
 	else if (argc == 2 && strcmp(argv[1], "panel") == 0)
-		panel = 1;
+		panel = preconfigure_panel = 1;
 	else if (argc == 2 && strcmp(argv[1], "override") == 0)
 		override_redirect = 1;
+	else if (argc == 3 && strcmp(argv[1], "override-transient") == 0) {
+		override_redirect = 1;
+		transient_for = strtoul(argv[2], NULL, 0);
+	}
 	else if (argc == 2 && strcmp(argv[1], "override-tooltip") == 0) {
 		override_redirect = 1;
 		popup_type = "_NET_WM_WINDOW_TYPE_TOOLTIP";
@@ -368,8 +386,8 @@ main(int argc, char **argv)
 		swallow_terminal = 1;
 
 	win = XCreateSimpleWindow(dpy, DefaultRootWindow(dpy),
-		panel ? 0 : 20, panel ? 0 : 20,
-		panel ? 1024 : 320, panel ? 24 : 180,
+		panel ? 1 : 20, panel ? 1 : 20,
+		panel ? 1 : 320, panel ? 1 : 180,
 		0, 0, WhitePixel(dpy, DefaultScreen(dpy)));
 	if (override_redirect) {
 		XSetWindowAttributes attributes = { .override_redirect = True };
@@ -407,6 +425,8 @@ main(int argc, char **argv)
 		XChangeProperty(dpy, win, XInternAtom(dpy, "_NET_WM_STATE", False),
 			XA_ATOM, 32, PropModeReplace, (unsigned char *)&state, 1);
 	}
+	if (transient_for != None)
+		XSetTransientForHint(dpy, win, transient_for);
 	if (initial_many_states) {
 		Atom states[65];
 		char name[64];
@@ -431,6 +451,11 @@ main(int argc, char **argv)
 	wm_delete = XInternAtom(dpy, "WM_DELETE_WINDOW", False);
 	XSetWMProtocols(dpy, win, &wm_delete, 1);
 	XSelectInput(dpy, win, StructureNotifyMask);
+	if (preconfigure_panel) {
+		XMoveResizeWindow(dpy, win, 0, 0, 1024, 24);
+		XFlush(dpy);
+		usleep(100000);
+	}
 	XMapWindow(dpy, win);
 	XFlush(dpy);
 
@@ -720,7 +745,7 @@ while [ "$i" -lt 100 ] && [ ! -s "$work/stack-window-id" ]; do
 done
 stack_win=$(cat "$work/stack-window-id")
 [ -n "$stack_win" ]
-wait_for_top_window "$stack_win"
+wait_for_top_window "$above_win"
 DISPLAY=$display xdotool key Super+t
 wait_for_top_window "$above_win"
 
@@ -830,6 +855,7 @@ done
 panel_win=$(cat "$work/panel-window-id")
 [ -n "$panel_win" ]
 DISPLAY=$display xprop -root _NET_CLIENT_LIST | grep -q "$panel_win"
+[ "$(DISPLAY=$display "$work/xclient" map-state "$panel_win")" = 2 ]
 
 DISPLAY=$display xdotool key Super+Shift+y
 wait_for_window_state "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
@@ -841,12 +867,33 @@ DISPLAY=$display xdotool key Super+Shift+y
 wait_for_window_state_absent "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
 wait_for_fullscreen_monitors ''
 
+DISPLAY=$display "$work/xclient" override-transient "$panel_win" \
+	>"$work/popup-panel-transient-window-id" \
+	2>"$work/popup-panel-transient-client.log" &
+popup_client_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ ! -s "$work/popup-panel-transient-window-id" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+popup_win=$(cat "$work/popup-panel-transient-window-id")
+[ -n "$popup_win" ]
+[ "$(DISPLAY=$display "$work/xclient" attributes "$popup_win")" = "override_redirect=1" ]
+DISPLAY=$display xprop -id "$popup_win" WM_TRANSIENT_FOR | grep -q "$panel_win"
+wait_for_window_above "$popup_win" "$above_win"
+wait_for_window_above "$popup_win" "$fullscreen_win"
+
 DISPLAY=$display "$work/xclient" fullscreen "$fullscreen_win"
 wait_for_window_state "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
 wait_for_fullscreen_monitors 0
+wait_for_window_above "$fullscreen_win" "$popup_win"
 
 DISPLAY=$display xdotool key Super+t
 wait_for_top_window "$fullscreen_win"
+wait_for_window_above "$fullscreen_win" "$popup_win"
+kill "$popup_client_pid"
+wait "$popup_client_pid" 2>/dev/null || true
+popup_client_pid=
 DISPLAY=$display xdotool key Super+2
 wait_for_current_desktop 1
 wait_for_fullscreen_monitors ''

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -829,6 +829,8 @@ for popup_marker in tooltip kde notification menu popup-menu dropdown-menu combo
 	DISPLAY=$display xprop -id "$popup_win" "$popup_property" |
 		grep -q "$popup_atom"
 	wait_for_top_window "$popup_win"
+	DISPLAY=$display xdotool windowfocus "$popup_win"
+	wait_for_input_focus "$above_win"
 	DISPLAY=$display xdotool key Super+t
 	wait_for_top_window "$popup_win"
 	kill "$popup_client_pid"

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -172,6 +172,21 @@ wait_for_active_window() {
 	return 1
 }
 
+wait_for_input_focus() {
+	expected_win=$(printf '%d' "$1")
+	i=0
+	while [ "$i" -lt 100 ]; do
+		focused=$(DISPLAY=$display xdotool getwindowfocus 2>/dev/null || true)
+		if [ "$focused" = "$expected_win" ]; then
+			return 0
+		fi
+		i=$((i + 1))
+		sleep 0.05
+	done
+	printf '%s\n' "window $1 did not receive input focus" >&2
+	return 1
+}
+
 wait_for_client_window() {
 	expected_win=$1
 	i=0
@@ -882,15 +897,20 @@ popup_win=$(cat "$work/popup-panel-transient-window-id")
 DISPLAY=$display xprop -id "$popup_win" WM_TRANSIENT_FOR | grep -q "$panel_win"
 wait_for_window_above "$popup_win" "$above_win"
 wait_for_window_above "$popup_win" "$fullscreen_win"
+DISPLAY=$display xdotool windowfocus "$popup_win"
+wait_for_input_focus "$popup_win"
 
 DISPLAY=$display "$work/xclient" fullscreen "$fullscreen_win"
 wait_for_window_state "$fullscreen_win" _NET_WM_STATE_FULLSCREEN
 wait_for_fullscreen_monitors 0
 wait_for_window_above "$fullscreen_win" "$popup_win"
+wait_for_input_focus "$fullscreen_win"
 
 DISPLAY=$display xdotool key Super+t
 wait_for_top_window "$fullscreen_win"
 wait_for_window_above "$fullscreen_win" "$popup_win"
+DISPLAY=$display xdotool windowfocus "$popup_win"
+wait_for_input_focus "$fullscreen_win"
 kill "$popup_client_pid"
 wait "$popup_client_pid" 2>/dev/null || true
 popup_client_pid=


### PR DESCRIPTION
## Summary

- centralize dwm stacking for always-on-top clients, Quickshell panels and panel-transient override-redirect popups
- keep real fullscreen clients above every shell surface while allowing Quickshell controls and notifications above normal clients
- map Quickshell panels even when `ConfigureNotify` reconciles their geometry before the initial `MapRequest`
- remove obsolete title rules for panel-anchored `PopupWindow` surfaces
- extend Xvfb coverage for popup/fullscreen ordering and the preconfigured-panel map race

## Root cause

The multi-monitor panel reconciliation path could record a new dock window during `ConfigureNotify`. When its later `MapRequest` arrived, `managealtbar()` treated the unchanged panel assignment as a reason to return early, so the panel remained `IsUnMapped` even though Quickshell was running and the window had the correct geometry.

Popup stacking was also split across per-monitor restacks and title-based window rules. Quickshell's X11 panel popups are override-redirect transients, so they need to be recognized from their transient relationship to a dock and handled by one global priority pass.

## Validation

- `make clean`
- `make`
- `make check`
- `tests/test-monitor-tag-switching.sh`
- `tests/test-xvfb-runtime.sh`
- `shellcheck tests/test-xvfb-runtime.sh tests/test-monitor-tag-switching.sh`
- `shfmt -d tests/test-xvfb-runtime.sh tests/test-monitor-tag-switching.sh`
- `git diff --check origin/main...HEAD`
- CodeRabbit CLI review of all changed files: zero findings

## Manual verification

On Fedora 44 in the live X11 session with HDMI-0 at 1920x1080 and DP-0 at 2560x1440:

- confirmed Quickshell was running with two correctly positioned dock windows
- reproduced one panel as `IsUnMapped` while the other was viewable
- restored the panel without logging out and verified both windows were `IsViewable`
- captured the primary panel window and confirmed its contents rendered normally
- installed the corrected dwm binary at `/usr/local/bin/dwm`

The active dwm process was not restarted because doing so would terminate the current LightDM session. The deterministic Xvfb regression configures the panel before its map request and verifies `map_state == IsViewable` against the corrected binary.