### PR TITLE
Complete Phase 2 display qualification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ versions from `config.mk`.
   symlink, structured-input, and authorization-denial coverage.
 - Fedora hardware, nested-X11, and Debian/Arch/Fedora container validation for
   the Phase 2 provider, packaging, recovery, and privilege contracts.
+- NVIDIA ForceFullCompositionPipeline capability discovery and safe persistent
+  defaults, with unsupported drivers left unchanged and incompatible forced-on
+  requests rejected.
 
 ### Changed
 
@@ -29,6 +32,10 @@ versions from `config.mk`.
 
 ### Fixed
 
+- Match generated Xorg OutputClass rules against the DRM driver name, including
+  mapping virtio PCI devices to `virtio_gpu`, so saved display layouts survive
+  a real Xorg restart. Associate NVIDIA RandR names through per-display driver
+  targets so additional DRM providers do not hide supported anti-tearing.
 - Remove Quickshell notification cards when their sender closes the underlying
   notification, and dismiss overflow notifications instead of retaining hidden
   objects that can accumulate during a long session.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ The installer also provides `dwm-settings-display` and its root-owned
 discovery and previews require `xrandr`; hotplug watching requires `udevadm`;
 only persistent Xorg install and rollback require `pkexec`. Named profiles live
 under the `display-profiles/` directory in the XDG path above.
+Run `dwm-display-setup detect`, then `dwm-display-setup`, for a guided wizard
+that detects outputs and configures modes, positions, rotation, and the primary
+display with a reversible preview. Persistent generation selects compatible
+TearFree or NVIDIA Full Composition Pipeline behavior automatically; pass
+`--force-full-composition-pipeline off` to disable the NVIDIA default.
 The adjacent `dwm-settings-input` provider uses `xinput`, `setxkbmap` for
 keyboard settings, and `udevadm` for stable device identity and hotplug events.
 Kept values are stored in `input-settings.conf` in the same XDG directory;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,8 +99,9 @@ Make common monitor and input changes available from the Settings application.
   natural scrolling, tap-to-click, and device-specific input controls where the
   X11 driver exposes them.
 - Clear reporting when a driver or device does not support a requested setting.
-- Default to TearFree and Full Composition Pipeline where the driver supports
-  it, with a fallback to the existing dwm behavior.
+- Default to TearFree or Full Composition Pipeline where the driver supports
+  it, selecting the compatible option and falling back to existing dwm
+  behavior.
 
 ### Exit Criteria
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,7 +83,7 @@ application without changing existing desktop behavior.
 
 ## Phase 2: Displays and Input
 
-Status: Implementation in progress (2026-08-15); release qualification pending
+Status: Complete (2026-08-15)
 
 ### Objective
 
@@ -99,8 +99,8 @@ Make common monitor and input changes available from the Settings application.
   natural scrolling, tap-to-click, and device-specific input controls where the
   X11 driver exposes them.
 - Clear reporting when a driver or device does not support a requested setting.
-- Default to TearFree and Full Composition Pipeline where the driver supports it, with a
-  fallback to the existing dwm behavior.
+- Default to TearFree and Full Composition Pipeline where the driver supports
+  it, with a fallback to the existing dwm behavior.
 
 ### Exit Criteria
 
@@ -128,14 +128,26 @@ Make common monitor and input changes available from the Settings application.
   availability in the qualification environment. Package mapping and shell
   fixtures pass, but a complete Rocky install is not claimed.
 - Named profile persistence, generated managed-fragment install/backup/rollback,
-  and idempotent input startup apply are automated. A real logout/login with
-  the generated Xorg fragment was not performed because it would terminate the
-  active qualification workspace; that remains a release-session check.
-- NVIDIA ForceFullCompositionPipeline support remains outstanding, so Phase 2
-  is not complete or NVIDIA-qualified even where the other display and input
-  outcomes are ready.
+  and idempotent input startup apply are automated. In a Fedora 44 UEFI VM,
+  root-owned mode-0644 generated fragments preserved both a non-default
+  single-output mode and a two-output 1024x768 plus 800x600 layout across real
+  LightDM/Xorg restarts. Xorg logs confirmed that the managed OutputClass and
+  both monitor sections were applied.
+- The restart qualification exposed and fixed a driver-matching defect: the
+  generated OutputClass now maps the virtio PCI bus driver to Xorg's
+  `virtio_gpu` DRM driver name.
+- On representative NVIDIA hardware, both active outputs reported
+  ForceFullCompositionPipeline availability and the active NVIDIA MetaMode
+  confirmed it enabled. Generated persistence enables the NVIDIA option by
+  default, leaves unsupported drivers unchanged, and rejects an explicit
+  forced-on request on incompatible drivers.
+- No physical touchpad was available, and complete Rocky Linux 9 runtime and
+  real secondary-platform X11 sessions remain unqualified. These limitations
+  do not affect the Fedora Phase 2 exit criteria.
 
 ## Phase 3: Connectivity and Audio
+
+Status: Ready to start (2026-08-15)
 
 ### Objective
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -691,11 +691,12 @@ In a real or nested X11 session:
 
 The existing desktop provides dwm, a managed Quickshell panel and launcher,
 notifications, quick controls, power actions, network and Bluetooth surfaces,
-display helpers, a system-health dashboard, and the unified read-only Settings
-foundation. Settings currently discovers provider capabilities and reports
-available, partial, restricted, unavailable, and unsupported state. It does not
-yet provide the full settings mutation surface in Section 5.10; those outcomes
-are sequenced in `ROADMAP.md` and the active phase is defined in `TASKS.md`.
+display helpers, a system-health dashboard, and the unified Settings platform.
+Settings now includes the completed Phase 2 display and input mutation surface
+with preview, rollback, persistence, and capability reporting. It does not yet
+provide the remaining settings mutation surface in Section 5.10; those
+outcomes are sequenced in `ROADMAP.md`, and Phase 3 connectivity and audio work
+is defined in `TASKS.md`.
 
 The installer contains Debian-, Arch-, and Fedora/RHEL-family package mappings.
 The build uses `pkg-config`, supports staged installation with `DESTDIR`, and

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,119 +1,151 @@
 # Active Project Tasks
 
 `SPEC.md` is the product contract and `ROADMAP.md` defines phase order. This
-file contains implementation work only for the active roadmap phase. Phase 1
+file contains implementation work only for the active roadmap phase. Phase 2
 completion evidence is recorded in `ROADMAP.md`, `CHANGELOG.md`, and
 `docs/SETTINGS-PLATFORM.md`.
 
-## Active Phase: Displays and Input
+## Active Phase: Connectivity and Audio
 
-### DISP-001: Display Provider Contract
+### CONN-001: Connectivity Provider Contract
 
-- [x] Add a versioned display provider for connected outputs, modes, refresh
-  rates, positions, rotations, primary state, profiles, and persistence state.
-- [x] Reuse `dwm-display-profile` and `dwm-display-setup` parsing and validation
-  instead of duplicating RandR or Xorg policy in QML.
-- [x] Report unsupported driver properties and missing X11 state explicitly.
-
-Acceptance:
-
-- Discovery is machine-readable and bounded, with fixtures for single-monitor,
-  multi-monitor, disconnected-output, malformed-output, and unavailable cases.
-- Opening and closing the Displays section starts and stops only section-owned
-  watches and helper processes.
-- Discovery performs no mutation and requires no authorization.
-
-### DISP-002: Display Layout and Preview
-
-- [x] Add Settings controls for resolution, refresh rate, position, rotation,
-  primary output, output enablement, and saved profiles.
-- [x] Generate a complete proposed layout and validate it before live apply.
-- [x] Add explicit preview, Keep, Revert, timeout, and automatic rollback
-  states using the Phase 1 application contract.
+- [ ] Define versioned machine-readable records for network, VPN, Bluetooth,
+  and provider availability without parsing human-oriented status output.
+- [ ] Define required fields for a protocol-version header and each record;
+  consumers reject a missing or incompatible major version, reject records
+  missing required fields, and ignore documented trailing fields and unknown
+  record types for append-only compatibility.
+- [ ] Reuse the existing NetworkManager and BlueZ helpers where their output,
+  lifecycle, and failure contracts are already suitable.
+- [ ] Separate read-only state, user-session actions, delegated authorization,
+  and unsupported capabilities in provider and QML state.
 
 Acceptance:
 
-- Every preview captures the previous complete layout before applying changes.
-- Rejection, timeout, Settings close, or apply failure restores the previous
-  live layout and reports rollback success or failure.
-- Keyboard and mouse users can recover without relying on the changed output.
+- Opening and closing Network or Bluetooth starts and stops only section-owned
+  watches, scans, and helper processes.
+- Missing services, adapters, or commands fail only the owning section and do
+  not break the Settings shell or core desktop session.
+- Provider fixtures cover available, unavailable, restricted, malformed, and
+  action-failure records.
 
-### DISP-003: Persistent Display Profiles
+### NET-001: Network and VPN Workflows
 
-- [x] Save named user profiles under the existing XDG display-profile path.
-- [x] Define and implement a narrow installed-helper operation for persistent
-  managed Xorg fragment install and rollback.
-- [x] Add confirmation, ownership, permission, backup, and polkit-denial tests.
-
-Acceptance:
-
-- Repository, XDG, home-directory, symlinked, or writable helper copies cannot
-  be elevated.
-- The helper accepts validated structured display data only, never arbitrary
-  paths, commands, or Xorg text.
-- Persistent install creates an isolated managed fragment and recoverable
-  backup without replacing unrelated Xorg configuration.
-
-### INPUT-001: Input Device Provider
-
-- [x] Discover keyboards, pointers, touchpads, and relevant X11/libinput
-  properties by stable device ID.
-- [x] Map layout, repeat, modifier, speed, acceleration, natural scrolling,
-  tap-to-click, and other supported properties without assuming every driver
-  exposes them.
-- [x] Report unsupported properties per device.
+- [ ] Add Ethernet, Wi-Fi, saved connection, active connection, and VPN status
+  to Settings using NetworkManager-owned interfaces.
+- [ ] Add scan, saved-profile activation, Wi-Fi connection, disconnect, and
+  forget actions with explicit progress and failure states. Bound scans to 10
+  seconds, activation and connection to 90 seconds, and disconnect or forget
+  to 15 seconds; cancellation terminates the owning helper, cleans temporary
+  state, and performs no automatic retry.
+- [ ] Delegate advanced, hidden, enterprise, and VPN editing to a trusted
+  NetworkManager tool when the workflow is not safely owned by Settings.
 
 Acceptance:
 
-- Device and property output is machine-readable and handles names containing
-  whitespace or punctuation safely.
-- Hotplug updates are event-driven where X11 provides a usable event source;
-  any fallback is bounded and documented.
-- Missing devices or drivers do not break Displays or other Settings sections.
+- Secrets reach the fixed NetworkManager helper only over its stdin and a
+  caller-owned mode-0600 temporary `nmcli --passwd-file`. The helper authorizes
+  only the invoking user, redacts diagnostics, and removes the file on success,
+  failure, cancellation, timeout, or signal. Secrets never appear in argv,
+  logs, provider records, or persistent QML state.
+- Authentication cancellation and service loss leave readable state available
+  and do not report the requested action as successful.
+- Existing panel network state and Settings converge after each change without
+  overlapping polling or duplicate long-lived monitors.
 
-### INPUT-002: Input Changes and Recovery
+### BT-001: Bluetooth Workflows
 
-- [x] Add per-device Settings controls only for properties reported by the
-  provider.
-- [x] Apply session changes to the selected stable device ID and define the
-  persistence format and startup application path.
-- [x] Add reset, invalid-value, disconnected-device, and partial-failure
-  behavior.
-
-Acceptance:
-
-- A change cannot affect a different device because names or enumeration order
-  changed.
-- Keyboard changes preserve a documented recovery path that does not require
-  the changed layout or modifier.
-- Re-running startup application is idempotent and preserves unrelated user
-  configuration.
-
-### DI-VALIDATE: Phase 2 Validation
-
-- [x] Run focused shell, QML, helper, and nested-X11 tests for display and input
-  providers and interactions.
-- [x] Validate single- and multi-monitor previews, profile persistence, and
-  rollback in a real Fedora X11 session.
-- [ ] Validate the generated Xorg fragment through a real logout/login session.
-- [ ] Implement and validate NVIDIA ForceFullCompositionPipeline with a safe
-  fallback for unsupported drivers.
-- [x] Validate available input controls on representative keyboard, pointer,
-  and touchpad hardware and record absent hardware.
-- [x] Run the full repository validation and record secondary-platform gaps.
+- [ ] Add adapter power, bounded discovery, known-device, paired, trusted, and
+  connected state using BlueZ-owned interfaces.
+- [ ] Add pair, trust, connect, disconnect, and remove actions with per-device
+  progress and attributed failures.
+- [ ] Carry one validated canonical device address or stable BlueZ object path
+  through every request, progress record, completion callback, and error.
+- [ ] Report adapter, daemon, hardware, and operation support separately.
 
 Acceptance:
 
-- Every Phase 2 exit criterion maps to passing automated evidence or a named
+- Discovery stops on section close, timeout, or shell exit and cannot leave a
+  background scan running indefinitely.
+- A failed, cancelled, or late operation re-resolves and mutates only its stable
+  identity; it cannot target a name, enumeration position, or another device.
+- Real adapter/device tests cover pairing recovery and service unavailability;
+  absent hardware is recorded rather than described as verified.
+
+### AUDIO-001: PipeWire and WirePlumber Provider
+
+- [ ] Define event-driven output, input, stream, volume, mute, default-device,
+  and microphone-visibility records using PipeWire/WirePlumber-compatible
+  interfaces.
+- [ ] Reuse native Quickshell PipeWire signals where stable and provide one
+  documented bounded fallback when native state is unavailable.
+- [ ] Start one fallback subscription only after native initialization fails or
+  disconnects within three seconds. Increment a source generation on every
+  transition, ignore events from older generations, terminate the fallback on
+  section close or native recovery, and hand new snapshots back to native state
+  without overlapping subscriptions.
+- [ ] Keep audio and media provider failures independent.
+
+Acceptance:
+
+- Settings adds no audio polling timer and starts no overlapping subscription
+  process while a native or shared event source is active.
+- Device removal, default changes, service restart, and malformed fallback
+  output degrade cleanly without stale success state.
+- Provider fixtures cover multiple sinks, sources, applications, and no-audio
+  environments.
+
+### AUDIO-002: Audio Controls and Panel Synchronization
+
+- [ ] Add output and input selection, volume, mute, per-application stream, and
+  microphone controls only when reported by the provider.
+- [ ] Make one root-scoped audio service model authoritative for the panel and
+  Settings. Tag mutations with an origin and monotonic generation, reject stale
+  generations, and suppress echoed events at their originating surface so both
+  consumers converge without feedback loops.
+- [ ] Add bounded value validation, partial-failure reporting, and reset or
+  recovery behavior for disappearing devices and streams.
+
+Acceptance:
+
+- Common output, input, mute, volume, and application-stream workflows no
+  longer require a terminal on the qualified Fedora session.
+- A Settings action updates the panel and an external PipeWire change updates
+  Settings without reopening either surface.
+- Service unavailability and authorization cancellation do not hide readable
+  state or affect unrelated sections.
+
+### CA-VALIDATE: Phase 3 Validation
+
+- [ ] Run focused shell, QML, provider, helper, and nested-X11 tests for all
+  connectivity and audio interactions.
+- [ ] Exercise NetworkManager workflows with a real Fedora Ethernet or Wi-Fi
+  connection, including cancellation and service-unavailable recovery.
+- [ ] Exercise BlueZ workflows with a real adapter and device, or record the
+  exact hardware path that remains unqualified.
+- [ ] Exercise PipeWire/WirePlumber outputs, inputs, application streams, and
+  microphone state in a real Fedora session.
+- [ ] Verify closed Settings sections leave no scans, duplicate subscriptions,
+  or overlapping commands. Compare a 30-second closed baseline with a
+  30-second sample after opening and closing each section; the mean Quickshell
+  CPU delta must be no more than 0.5 percentage points of one CPU.
+- [ ] Run the full repository validation and record secondary-platform gaps.
+
+Acceptance:
+
+- Every Phase 3 exit criterion maps to passing automated evidence or a named
   manual check with release, hardware, session, and limitation details.
+- Common network, Bluetooth, and audio workflows work without a terminal on the
+  qualified Fedora session, fail safely, and remain synchronized with panel
+  controls.
 - No phase is described as hardware- or platform-verified when its required
   environment was not tested.
 
 ## Phase Completion
 
-When all Phase 2 acceptance criteria pass:
+When all Phase 3 acceptance criteria pass:
 
 1. Record delivered behavior and validation in `CHANGELOG.md`.
-2. Update the Phase 2 status and limitations in `ROADMAP.md`.
-3. Replace this file's active task set with Phase 3 tasks.
+2. Update the Phase 3 status and limitations in `ROADMAP.md`.
+3. Replace this file's active task set with Phase 4 tasks.
 4. Preserve incomplete or deferred work as explicit roadmap limitations.

--- a/config/quickshell/settings/DisplaySettingsPane.qml
+++ b/config/quickshell/settings/DisplaySettingsPane.qml
@@ -88,7 +88,14 @@ Flickable {
                     RowLayout {
                         Layout.fillWidth: true
                         Text { Layout.fillWidth: true; text: outputCard.modelData.name; color: Theme.textStrong; font.family: Theme.fontFamily; font.bold: true }
-                        Text { text: outputCard.modelData.tearfree === "available" ? "TearFree available" : "TearFree unsupported"; color: Theme.textMuted; font.family: Theme.fontFamily; font.pixelSize: Theme.tinyFontSize }
+                        Text {
+                            text: outputCard.modelData.fullCompositionPipeline === "available"
+                                ? "NVIDIA full composition on persistent install"
+                                : (outputCard.modelData.tearfree === "available" ? "TearFree available" : "Anti-tearing unsupported")
+                            color: Theme.textMuted
+                            font.family: Theme.fontFamily
+                            font.pixelSize: Theme.tinyFontSize
+                        }
                         ShellButton { label: outputCard.modelData.enabled ? "Enabled" : "Disabled"; onActivated: root.settingsModel.updateDisplay(outputCard.index, "enabled", !outputCard.modelData.enabled) }
                         ShellButton { label: outputCard.modelData.primary ? "Primary" : "Make primary"; enabled: outputCard.modelData.enabled; onActivated: root.settingsModel.updateDisplay(outputCard.index, "primary", true) }
                     }

--- a/config/quickshell/settings/SettingsModel.qml
+++ b/config/quickshell/settings/SettingsModel.qml
@@ -110,7 +110,8 @@ Scope {
                     "name": fields[1], "enabled": fields[2] === "1",
                     "primary": fields[3] === "1", "mode": fields[4],
                     "rate": "", "x": Number(fields[5]), "y": Number(fields[6]),
-                    "rotation": fields[7], "tearfree": fields[8]
+                    "rotation": fields[7], "tearfree": fields[8],
+                    "fullCompositionPipeline": fields.length >= 10 ? fields[9] : "unsupported"
                 });
             } else if (fields[0] === "mode" && fields.length >= 6) {
                 modes.push({

--- a/docs/SETTINGS-CAPABILITIES.md
+++ b/docs/SETTINGS-CAPABILITIES.md
@@ -36,7 +36,7 @@ provider work still required.
 
 | Section | Current owner and state source | Current mutation path | Class coverage | Failure and fallback | Validation |
 | --- | --- | --- | --- | --- | --- |
-| Displays | `dwm-settings-display` over `dwm-display-setup` and RandR state from `xrandr` | Complete timed RandR preview, named profiles, and allowlisted managed-fragment install/rollback | Read-only, user-session, privileged | Malformed or missing RandR fails only Displays; unsupported drivers report TearFree unavailable; persistence is restricted without the installed helper and polkit | `make check-display-setup check-settings check-quickshell-settings-xvfb`; real multi-monitor preview/rollback |
+| Displays | `dwm-settings-display` over `dwm-display-setup` and RandR state from `xrandr` | Complete timed RandR preview, named profiles, and allowlisted managed-fragment install/rollback | Read-only, user-session, privileged | Malformed or missing RandR fails only Displays; unsupported drivers report anti-tearing unavailable; persistence is restricted without the installed helper and polkit | `make check-display-setup check-settings check-quickshell-settings-xvfb`; real multi-monitor preview/rollback and Xorg restart |
 | Input | `dwm-settings-input` over XInput/libinput, `setxkbmap`, and udev hotplug events | Timed per-device preview, reset, XDG persistence, idempotent session-start apply, and debounced hotplug replay | Read-only, user-session | Unsupported properties are reported per stable device; disconnects are skipped without affecting other devices or sections | `make check-settings check-quickshell-settings-xvfb`; representative real keyboard/pointer checks |
 | Network and VPN | `dwm-quickshell-network` over NetworkManager's `nmcli`; event stream from `nmcli monitor` | NetworkManager connection activation/deactivation; `nm-connection-editor` for advanced flows | Read-only, delegated | `NET unavailable` when NetworkManager or `nmcli` is absent; hide the editor action when unavailable | `make check-quickshell-network`; NetworkManager runtime exercise |
 | Bluetooth | `dwm-quickshell-controls` over `bluetoothctl` and the BlueZ daemon | BlueZ power, scan, pair/trust/connect, and disconnect operations | Read-only, delegated | `BT unavailable` when BlueZ tooling or an adapter is absent | `make check-quickshell-controls`; real adapter/device check |
@@ -70,7 +70,7 @@ action.
 | Operations | Owner and state/mutation path | Class | Failure and safety behavior |
 | --- | --- | --- | --- |
 | Profile directory/list/current/template | `dwm-display-profile`; XDG profile files and `xrandr --query` | Read-only | Missing profiles produce an empty list; missing RandR is an actionable error. |
-| Detect outputs/modes/drivers/TearFree; show status | `dwm-display-setup detect` and `status` | Read-only | Driver-specific features are reported only when detected. |
+| Detect outputs, modes, drivers, TearFree, and NVIDIA Full Composition Pipeline; show status | `dwm-display-setup detect`, `capabilities`, and `status` | Read-only | Driver-specific features are reported only when the kernel and Xorg drivers are compatible. |
 | Generate an Xorg fragment | `dwm-display-setup generate PROFILE` | Read-only | Parses and validates an allowlisted profile grammar without installing it. |
 | Apply a saved profile | `dwm-display-profile apply PROFILE` invokes `xrandr` with validated output names/options | User-session | Reject invalid profiles and disconnected outputs; failure leaves persistence unchanged. |
 | Timed live preview | `dwm-display-setup preview PROFILE` captures the current RandR layout before apply | User-session | Reverts after timeout or rejection; reports rollback failure explicitly. |
@@ -146,7 +146,7 @@ duplicate distro-specific lists.
 | Provider capability | Fedora path | Secondary-platform behavior |
 | --- | --- | --- |
 | Quickshell Settings frontend | `rhel:desktop` supplies Quickshell on Fedora | Arch maps Quickshell in `arch:desktop`. The Debian map does not currently supply it, so the Settings UI is unsupported there unless a compatible Quickshell is installed separately; core dwm remains usable. |
-| X11 display state | `rhel:x11` supplies the RandR/X11 tools | `arch:x11` and `debian:x11` supply family equivalents. TearFree remains driver-dependent everywhere. |
+| X11 display state | `rhel:x11` supplies the RandR/X11 tools | `arch:x11` and `debian:x11` supply family equivalents. TearFree and the NVIDIA Full Composition Pipeline remain driver-dependent everywhere. |
 | NetworkManager | `rhel:desktop-optional`; enabled by the Fedora image | Arch and Debian optional profiles provide NetworkManager. Without it, the provider reports unavailable and other sections continue. |
 | BlueZ | `rhel:desktop` plus the Fedora image service/package set | Arch and Debian desktop profiles provide their BlueZ equivalents. Adapter absence is a runtime unsupported state. |
 | PipeWire/WirePlumber and controls | `rhel:desktop`; included by the Fedora image | Arch and Debian desktop profiles provide family equivalents. Helpers fall back between supported session commands. |

--- a/docs/SETTINGS-PLATFORM.md
+++ b/docs/SETTINGS-PLATFORM.md
@@ -209,11 +209,12 @@ Evidence recorded on 2026-07-21:
 
 `dwm-settings-display` and `dwm-settings-input` use append-only, version 1,
 tab-separated protocols. Display records describe outputs, modes, current and
-preferred rates, rotation, primary state, TearFree capability, profiles, and
-persistence. Input records describe stable devices, supported settings, and
-device-scoped unsupported settings. Tabs and line breaks in external names are
-sanitized. QML passes complete structured argv to fixed helper actions and
-does not implement RandR, Xorg, XInput, or libinput policy.
+preferred rates, rotation, primary state, TearFree and NVIDIA Full Composition
+Pipeline capability, profiles, and persistence. Input records describe stable
+devices, supported settings, and device-scoped unsupported settings. Tabs and
+line breaks in external names are sanitized. QML passes complete structured
+argv to fixed helper actions and does not implement RandR, Xorg, XInput, or
+libinput policy.
 
 Both sections own event-driven udev discovery watches only while active. A
 separate session input watcher debounces add/change events and reapplies saved
@@ -259,9 +260,17 @@ Evidence recorded on 2026-08-15:
   package source in the qualification environment; its package map and shell
   fixtures are covered, but the complete Rocky install path is not claimed.
 - Generated display persistence, backup, rollback, and input startup reapply
-  are automated. A real Xorg logout/login using the generated fragment remains
-  a release-session check because performing it would terminate the active
-  qualification workspace.
-- NVIDIA ForceFullCompositionPipeline remains unimplemented and unqualified;
-  the current Phase 2 evidence covers RandR layout handling and supported
-  TearFree properties only.
+  are automated. A disposable Fedora 44 UEFI VM with LightDM verified a
+  root-owned mode-0644 managed fragment through real Xorg restarts. A
+  non-default single-output mode persisted, followed by a two-output
+  1024x768 plus 800x600 layout. The Xorg log confirmed the managed OutputClass
+  and both monitor sections were applied after restart.
+- That restart test exposed and fixed a virtio driver-name mismatch: generated
+  OutputClass rules use Xorg's `virtio_gpu` DRM name instead of the
+  `virtio-pci` bus driver name.
+- An NVIDIA GeForce RTX 4070 SUPER using driver 610.43.03 reported the NVIDIA
+  fallback available on both active outputs. The active MetaMode confirmed
+  ForceFullCompositionPipeline enabled, and generated persistence emits the
+  documented NVIDIA option only for a compatible NVIDIA kernel and Xorg
+  driver. Unsupported drivers remain unchanged; explicitly forcing the option
+  on an incompatible driver fails before installation.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -102,8 +102,11 @@ For persistent Xorg configuration, run `dwm-display-setup`. The interactive
 wizard detects connected outputs and their exact advertised timings, then asks
 for resolution, refresh rate, rotation, absolute position, and the primary
 display. It checks whether the active Xorg driver exposes compatible TearFree
-support and offers to enable it only when supported. The proposed layout is
-applied as a live preview and automatically restored unless it is confirmed.
+support or the NVIDIA Full Composition Pipeline and enables only the compatible
+default. The proposed layout is applied as a live preview and automatically
+restored unless it is confirmed. Advanced calls may pass
+`--force-full-composition-pipeline off` to disable the NVIDIA default; forcing
+it on with an incompatible kernel or Xorg driver is rejected.
 
 Accepted layouts are installed as the isolated managed fragment
 `/etc/X11/xorg.conf.d/90-dwm-titus-display.conf`; existing Xorg files are not

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -88,6 +88,10 @@ as `Alacritty`, which is already covered by the terminal swallowing rules.
   `/etc/X11/xorg.conf.d/90-dwm-titus-display.conf` if Xorg cannot start.
 - TearFree is enabled only when the active Xorg driver exposes a compatible
   option or RandR property. Unsupported drivers are left unchanged.
+- NVIDIA Full Composition Pipeline is enabled in generated persistence only
+  when both the kernel and Xorg drivers are NVIDIA. Run
+  `dwm-display-setup capabilities` to inspect the detected fallback before
+  saving a layout.
 - Display layout profiles: run `dwm-display-profile dir` and
   `dwm-display-profile template` to create optional `xrandr` profiles
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -89,7 +89,8 @@ as `Alacritty`, which is already covered by the terminal swallowing rules.
 - TearFree is enabled only when the active Xorg driver exposes a compatible
   option or RandR property. Unsupported drivers are left unchanged.
 - NVIDIA Full Composition Pipeline is enabled in generated persistence only
-  when both the kernel and Xorg drivers are NVIDIA. Run
+  when the relevant output uses the NVIDIA kernel driver and an NVIDIA Xorg
+  provider is available, including supported hybrid configurations. Run
   `dwm-display-setup capabilities` to inspect the detected fallback before
   saving a layout.
 - Display layout profiles: run `dwm-display-profile dir` and

--- a/scripts/dwm-display-setup
+++ b/scripts/dwm-display-setup
@@ -221,12 +221,16 @@ output_kernel_driver() {
 		driver=$(driver_name_from_link "$driver_link")
 		exact_detected[$driver]=1
 	done
-	if ((${#exact_detected[@]} == 1)); then
-		printf '%s\n' "${!exact_detected[@]}"
+	if nvidia_owns_output "$output"; then
+		printf '%s\n' nvidia
 		return
 	fi
 	if driver=$(output_driver_by_edid "$output"); then
 		printf '%s\n' "$driver"
+		return
+	fi
+	if ((${#exact_detected[@]} == 1)); then
+		printf '%s\n' "${!exact_detected[@]}"
 		return
 	fi
 	# RandR appends a provider suffix when an offload/sink provider exports an
@@ -247,10 +251,6 @@ output_kernel_driver() {
 			printf '%s\n' "${!provider_detected[@]}"
 			return
 		fi
-	fi
-	if nvidia_owns_output "$output"; then
-		printf '%s\n' nvidia
-		return
 	fi
 	# Proprietary drivers do not always use the same connector numbering for
 	# RandR and DRM sysfs. If exactly one DRM driver owns connected outputs,

--- a/scripts/dwm-display-setup
+++ b/scripts/dwm-display-setup
@@ -145,22 +145,33 @@ driver_name_from_link() {
 	esac
 }
 
-nvidia_owns_output() {
+nvidia_output_ownership() {
 	local output=$1
 	local attribute
 
-	xorg_uses_driver nvidia || return 1
-	command -v nvidia-settings >/dev/null 2>&1 || return 1
+	if ! xorg_uses_driver nvidia; then
+		printf '%s\n' not-present
+		return
+	fi
+	if ! command -v nvidia-settings >/dev/null 2>&1; then
+		printf '%s\n' unavailable
+		return
+	fi
 	# NVIDIA RandR names do not necessarily match DRM connector names. Query a
 	# read-only per-display target so multi-provider sessions can associate the
 	# RandR output without treating another connected DRM card as NVIDIA.
 	for attribute in CurrentDithering DigitalVibrance; do
 		if nvidia-settings --terse \
 			--query "[dpy:$output]/$attribute" >/dev/null 2>&1; then
-			return 0
+			printf '%s\n' owned
+			return
 		fi
 	done
-	return 1
+	if nvidia-settings --terse --query gpus >/dev/null 2>&1; then
+		printf '%s\n' not-owned
+	else
+		printf '%s\n' unavailable
+	fi
 }
 
 output_edid_hex() {
@@ -205,7 +216,7 @@ output_driver_by_edid() {
 
 output_kernel_driver() {
 	local output=$1
-	local connector card driver driver_link provider_output
+	local connector card driver driver_link provider_output nvidia_ownership
 	local -A detected=() exact_detected=() provider_detected=()
 
 	if [[ -n ${DWM_KERNEL_DRIVER:-} ]]; then
@@ -221,7 +232,8 @@ output_kernel_driver() {
 		driver=$(driver_name_from_link "$driver_link")
 		exact_detected[$driver]=1
 	done
-	if nvidia_owns_output "$output"; then
+	nvidia_ownership=$(nvidia_output_ownership "$output")
+	if [[ $nvidia_ownership == owned ]]; then
 		printf '%s\n' nvidia
 		return
 	fi
@@ -229,8 +241,24 @@ output_kernel_driver() {
 		printf '%s\n' "$driver"
 		return
 	fi
+	for connector in "$drm_root"/card*-*; do
+		[[ -e $connector/status ]] || continue
+		[[ $(<"$connector/status") == connected ]] || continue
+		card=${connector##*/}
+		card=${card%%-*}
+		driver_link="$drm_root/$card/device/driver"
+		[[ -L $driver_link ]] || continue
+		driver=$(driver_name_from_link "$driver_link")
+		detected[$driver]=1
+	done
 	if ((${#exact_detected[@]} == 1)); then
-		printf '%s\n' "${!exact_detected[@]}"
+		driver=${!exact_detected[*]}
+		if [[ $nvidia_ownership == unavailable && $driver != nvidia &&
+			-n ${detected[nvidia]+present} ]]; then
+			printf '%s\n' unknown
+		else
+			printf '%s\n' "$driver"
+		fi
 		return
 	fi
 	# RandR appends a provider suffix when an offload/sink provider exports an
@@ -248,23 +276,19 @@ output_kernel_driver() {
 			provider_detected[$driver]=1
 		done
 		if ((${#provider_detected[@]} == 1)); then
-			printf '%s\n' "${!provider_detected[@]}"
+			driver=${!provider_detected[*]}
+			if [[ $nvidia_ownership == unavailable && $driver != nvidia &&
+				-n ${detected[nvidia]+present} ]]; then
+				printf '%s\n' unknown
+			else
+				printf '%s\n' "$driver"
+			fi
 			return
 		fi
 	fi
 	# Proprietary drivers do not always use the same connector numbering for
 	# RandR and DRM sysfs. If exactly one DRM driver owns connected outputs,
 	# that driver is an unambiguous fallback.
-	for connector in "$drm_root"/card*-*; do
-		[[ -e $connector/status ]] || continue
-		[[ $(<"$connector/status") == connected ]] || continue
-		card=${connector##*/}
-		card=${card%%-*}
-		driver_link="$drm_root/$card/device/driver"
-		[[ -L $driver_link ]] || continue
-		driver=$(driver_name_from_link "$driver_link")
-		detected[$driver]=1
-	done
 	if ((${#detected[@]} == 1)); then
 		printf '%s\n' "${!detected[@]}"
 		return

--- a/scripts/dwm-display-setup
+++ b/scripts/dwm-display-setup
@@ -295,6 +295,21 @@ xorg_driver_for_kernel() {
 	esac
 }
 
+xorg_match_driver_for_kernel() {
+	local kernel_driver=$1
+
+	case $kernel_driver in
+	nvidia)
+		# Xorg OutputClass matches the NVIDIA DRM platform driver, while the
+		# display driver loaded by the class remains the nvidia DDX.
+		printf '%s\n' nvidia-drm
+		;;
+	*)
+		printf '%s\n' "$kernel_driver"
+		;;
+	esac
+}
+
 output_has_tearfree_property() {
 	local output=$1
 	awk -v output="$output" '
@@ -721,6 +736,7 @@ generate_config() {
 	local -A output_drivers=()
 	local driver
 	local xorg_driver
+	local match_driver
 
 	if resolved_tearfree; then
 		tearfree_enabled=1
@@ -739,9 +755,10 @@ generate_config() {
 		printf '%s\n' '# Exact timings are copied from the active X server for the selected outputs.'
 		for driver in "${!output_drivers[@]}"; do
 			xorg_driver=$(xorg_driver_for_kernel "$driver")
+			match_driver=$(xorg_match_driver_for_kernel "$driver")
 			printf '\nSection "OutputClass"\n'
 			printf '\tIdentifier "dwm-titus-display-map-%s"\n' "$driver"
-			printf '\tMatchDriver "%s"\n' "$driver"
+			printf '\tMatchDriver "%s"\n' "$match_driver"
 			printf '\tDriver "%s"\n' "$xorg_driver"
 			for index in "${!cfg_outputs[@]}"; do
 				[[ ${cfg_kernel_drivers[$index]} == "$driver" ]] || continue

--- a/scripts/dwm-display-setup
+++ b/scripts/dwm-display-setup
@@ -5,6 +5,7 @@ config_path="${DWM_XORG_CONFIG:-/etc/X11/xorg.conf.d/90-dwm-titus-display.conf}"
 main_config="${DWM_XORG_MAIN_CONFIG:-/etc/X11/xorg.conf}"
 drm_root="${DWM_DRM_SYSFS_ROOT:-/sys/class/drm}"
 tearfree_policy=auto
+full_composition_pipeline_policy=auto
 preview=true
 assume_yes=false
 confirm_seconds=15
@@ -33,6 +34,7 @@ Usage:
   dwm-display-setup
   dwm-display-setup wizard [options]
   dwm-display-setup detect
+  dwm-display-setup capabilities
   dwm-display-setup capture
   dwm-display-setup validate <profile>
   dwm-display-setup apply <profile>
@@ -46,6 +48,7 @@ Commands:
   wizard             Interactively choose modes, positions, rotations, primary
                      display, and TearFree. This is the default command.
   detect             Show connected outputs, modes, drivers, and TearFree.
+  capabilities       Print machine-readable anti-tearing capabilities.
   capture            Print the current complete RandR layout as a profile.
   validate PROFILE   Validate a complete profile with xrandr --dryrun.
   apply PROFILE      Apply a validated complete profile to this X11 session.
@@ -58,6 +61,8 @@ Commands:
 Options:
   --config PATH      Managed Xorg fragment path.
   --tearfree POLICY  auto, on, or off. Default: auto.
+  --force-full-composition-pipeline POLICY
+                     auto, on, or off. Default: auto.
   --no-preview       Install without changing the current live layout.
   --timeout SECONDS  Preview confirmation timeout. Default: 15.
   --yes              Accept install/rollback prompts and keep a successful
@@ -125,10 +130,83 @@ output_is_connected() {
 	awk -v output="$output" '$1 == output && $2 == "connected" { found = 1 } END { exit !found }' "$query_file"
 }
 
+driver_name_from_link() {
+	local driver_link=$1
+	local driver
+
+	driver=$(basename "$(readlink -f "$driver_link")")
+	case $driver in
+	# Virtio's PCI transport owns the device symlink, while the DRM driver
+	# name used by Xorg OutputClass matching is virtio_gpu.
+	virtio-pci | virtio_pci) printf '%s\n' virtio_gpu ;;
+	# VKMS devices use the generic faux bus but expose the vkms DRM driver.
+	faux_driver) printf '%s\n' vkms ;;
+	*) printf '%s\n' "$driver" ;;
+	esac
+}
+
+nvidia_owns_output() {
+	local output=$1
+	local attribute
+
+	xorg_uses_driver nvidia || return 1
+	command -v nvidia-settings >/dev/null 2>&1 || return 1
+	# NVIDIA RandR names do not necessarily match DRM connector names. Query a
+	# read-only per-display target so multi-provider sessions can associate the
+	# RandR output without treating another connected DRM card as NVIDIA.
+	for attribute in CurrentDithering DigitalVibrance; do
+		if nvidia-settings --terse \
+			--query "[dpy:$output]/$attribute" >/dev/null 2>&1; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+output_edid_hex() {
+	local output=$1
+
+	awk -v output="$output" '
+		$1 == output && ($2 == "connected" || $2 == "disconnected") {
+			in_output = 1
+			next
+		}
+		/^[^[:space:]]/ { in_output = 0; in_edid = 0 }
+		in_output && $1 == "EDID:" { in_edid = 1; next }
+		in_edid && $1 ~ /^[[:xdigit:]]+$/ { printf "%s", tolower($1); next }
+		in_edid { exit }
+	' "$properties_file"
+}
+
+output_driver_by_edid() {
+	local output=$1
+	local wanted connector card driver driver_link actual
+	local -A detected=()
+
+	wanted=$(output_edid_hex "$output")
+	[[ -n $wanted ]] || return 1
+	for connector in "$drm_root"/card*-*; do
+		[[ -r $connector/edid ]] || continue
+		actual=$(od -An -v -tx1 "$connector/edid" | tr -d '[:space:]')
+		[[ -n $actual && $actual == "$wanted" ]] || continue
+		card=${connector##*/}
+		card=${card%%-*}
+		driver_link="$drm_root/$card/device/driver"
+		[[ -L $driver_link ]] || continue
+		driver=$(driver_name_from_link "$driver_link")
+		detected[$driver]=1
+	done
+	if ((${#detected[@]} == 1)); then
+		printf '%s\n' "${!detected[@]}"
+		return 0
+	fi
+	return 1
+}
+
 output_kernel_driver() {
 	local output=$1
-	local connector card driver driver_link
-	local -A detected=()
+	local connector card driver driver_link provider_output
+	local -A detected=() provider_detected=()
 
 	if [[ -n ${DWM_KERNEL_DRIVER:-} ]]; then
 		printf '%s\n' "$DWM_KERNEL_DRIVER"
@@ -140,10 +218,37 @@ output_kernel_driver() {
 		card=${card%%-*}
 		driver_link="$drm_root/$card/device/driver"
 		if [[ -L $driver_link ]]; then
-			basename "$(readlink -f "$driver_link")"
+			driver_name_from_link "$driver_link"
 			return
 		fi
 	done
+	if driver=$(output_driver_by_edid "$output"); then
+		printf '%s\n' "$driver"
+		return
+	fi
+	# RandR appends a provider suffix when an offload/sink provider exports an
+	# output whose name would otherwise collide. Retry the underlying connector
+	# name only when it resolves to one DRM driver.
+	provider_output=${output%-*}
+	if [[ $provider_output != "$output" && $provider_output == *-* ]]; then
+		for connector in "$drm_root"/card*-"$provider_output"; do
+			[[ -e $connector/status ]] || continue
+			card=${connector##*/}
+			card=${card%%-*}
+			driver_link="$drm_root/$card/device/driver"
+			[[ -L $driver_link ]] || continue
+			driver=$(driver_name_from_link "$driver_link")
+			provider_detected[$driver]=1
+		done
+		if ((${#provider_detected[@]} == 1)); then
+			printf '%s\n' "${!provider_detected[@]}"
+			return
+		fi
+	fi
+	if nvidia_owns_output "$output"; then
+		printf '%s\n' nvidia
+		return
+	fi
 	# Proprietary drivers do not always use the same connector numbering for
 	# RandR and DRM sysfs. If exactly one DRM driver owns connected outputs,
 	# that driver is an unambiguous fallback.
@@ -154,7 +259,7 @@ output_kernel_driver() {
 		card=${card%%-*}
 		driver_link="$drm_root/$card/device/driver"
 		[[ -L $driver_link ]] || continue
-		driver=$(basename "$(readlink -f "$driver_link")")
+		driver=$(driver_name_from_link "$driver_link")
 		detected[$driver]=1
 	done
 	if ((${#detected[@]} == 1)); then
@@ -246,6 +351,38 @@ current_xorg_driver() {
 	printf '%s\n' unknown
 }
 
+xorg_uses_driver() {
+	local driver=$1 display_number candidate override
+
+	if [[ -n ${DWM_XORG_DRIVERS:-} ]]; then
+		override=${DWM_XORG_DRIVERS//,/ }
+		for candidate in $override; do
+			[[ $candidate == "$driver" ]] && return 0
+		done
+		return 1
+	fi
+	if [[ -n ${DWM_XORG_DRIVER:-} ]]; then
+		[[ $DWM_XORG_DRIVER == "$driver" ]]
+		return
+	fi
+	display_number=${DISPLAY#:}
+	display_number=${display_number%%.*}
+	for candidate in \
+		"/var/log/Xorg.${display_number}.log" \
+		"$HOME/.local/share/xorg/Xorg.${display_number}.log"; do
+		[[ -r $candidate ]] || continue
+		case $driver in
+		nvidia)
+			grep -Eq 'NVIDIA\(([0-9]+|G[0-9]+)\):' "$candidate" && return 0
+			;;
+		*)
+			[[ $(current_xorg_driver) == "$driver" ]] && return 0
+			;;
+		esac
+	done
+	return 1
+}
+
 output_tearfree_compatible() {
 	local index=$1
 	local driver=${cfg_kernel_drivers[$index]}
@@ -263,6 +400,31 @@ output_tearfree_compatible() {
 		return 0
 		;;
 	esac
+	return 1
+}
+
+driver_full_composition_pipeline_compatible() {
+	local kernel_driver=$1
+
+	[[ $kernel_driver == nvidia ]] || return 1
+	xorg_uses_driver nvidia
+}
+
+output_full_composition_pipeline_compatible() {
+	local index=$1
+
+	[[ ${cfg_enabled[$index]} == 1 ]] || return 1
+	driver_full_composition_pipeline_compatible "${cfg_kernel_drivers[$index]}"
+}
+
+full_composition_pipeline_compatible() {
+	local index
+
+	for index in "${!cfg_outputs[@]}"; do
+		if output_full_composition_pipeline_compatible "$index"; then
+			return 0
+		fi
+	done
 	return 1
 }
 
@@ -525,12 +687,33 @@ resolved_tearfree() {
 	esac
 }
 
+resolved_full_composition_pipeline() {
+	case $full_composition_pipeline_policy in
+	off)
+		return 1
+		;;
+	auto)
+		full_composition_pipeline_compatible
+		;;
+	on)
+		if ! full_composition_pipeline_compatible; then
+			die "ForceFullCompositionPipeline was requested, but the active outputs do not use the NVIDIA Xorg driver"
+		fi
+		return 0
+		;;
+	*)
+		die "invalid ForceFullCompositionPipeline policy: $full_composition_pipeline_policy"
+		;;
+	esac
+}
+
 generate_config() {
 	local destination=$1
 	local index output identifier mode_name timing
 	local clock hdisplay hstart hend htotal vdisplay vstart vend vtotal flags hsync rate
 	local hlow hhigh vlow vhigh
 	local tearfree_enabled=0
+	local full_composition_pipeline_enabled=0
 	local -A tearfree_drivers=()
 	local -A output_drivers=()
 	local driver
@@ -538,6 +721,9 @@ generate_config() {
 
 	if resolved_tearfree; then
 		tearfree_enabled=1
+	fi
+	if resolved_full_composition_pipeline; then
+		full_composition_pipeline_enabled=1
 	fi
 	for index in "${!cfg_outputs[@]}"; do
 		driver=${cfg_kernel_drivers[$index]}
@@ -560,6 +746,10 @@ generate_config() {
 				identifier="dwm-titus-$output"
 				printf '\tOption "Monitor-%s" "%s"\n' "$output" "$identifier"
 			done
+			if [[ $full_composition_pipeline_enabled == 1 ]] &&
+				driver_full_composition_pipeline_compatible "$driver"; then
+				printf '\tOption "ForceFullCompositionPipeline" "true"\n'
+			fi
 			printf 'EndSection\n'
 		done
 
@@ -892,7 +1082,7 @@ list_output_modes() {
 }
 
 detect_displays() {
-	local output default driver tearfree xorg_driver
+	local output default driver tearfree full_composition_pipeline xorg_driver
 
 	load_display_data
 	if ! connected_outputs | grep -q .; then
@@ -915,11 +1105,45 @@ detect_displays() {
 				;;
 			esac
 		fi
-		printf '\n%s  default=%s  kernel-driver=%s  TearFree=%s\n' \
-			"$output" "${default/|/@}" "$driver" "$tearfree"
+		if driver_full_composition_pipeline_compatible "$driver"; then
+			full_composition_pipeline=supported-xorg-option
+		else
+			full_composition_pipeline=unsupported
+		fi
+		printf '\n%s  default=%s  kernel-driver=%s  TearFree=%s  ForceFullCompositionPipeline=%s\n' \
+			"$output" "${default/|/@}" "$driver" "$tearfree" "$full_composition_pipeline"
 		list_output_modes "$output" | sed 's/^/  /'
 	done < <(connected_outputs)
 	printf '\nActive Xorg driver: %s\n' "$xorg_driver"
+}
+
+display_capabilities() {
+	local output driver tearfree full_composition_pipeline xorg_driver
+
+	load_display_data
+	if ! connected_outputs | grep -q .; then
+		die "no connected X11 outputs were detected"
+	fi
+	xorg_driver=$(current_xorg_driver)
+	printf 'display-capability-protocol\t1\n'
+	while IFS= read -r output; do
+		driver=$(output_kernel_driver "$output")
+		if output_has_tearfree_property "$output"; then
+			tearfree=available
+		else
+			case "$xorg_driver:$driver" in
+			amdgpu:amdgpu | intel:i915) tearfree=available ;;
+			*) tearfree=unsupported ;;
+			esac
+		fi
+		if driver_full_composition_pipeline_compatible "$driver"; then
+			full_composition_pipeline=available
+		else
+			full_composition_pipeline=unsupported
+		fi
+		printf 'output\t%s\t%s\t%s\n' \
+			"$output" "$tearfree" "$full_composition_pipeline"
+	done < <(connected_outputs)
 }
 
 prompt_yes_no() {
@@ -1061,7 +1285,7 @@ main() {
 	trap cleanup EXIT HUP INT TERM
 	if (($# > 0)); then
 		case $1 in
-		wizard | detect | capture | validate | apply | generate | preview | install | status | rollback)
+		wizard | detect | capabilities | capture | validate | apply | generate | preview | install | status | rollback)
 			command=$1
 			shift
 			;;
@@ -1090,6 +1314,15 @@ main() {
 			;;
 		--tearfree=*)
 			tearfree_policy=${1#*=}
+			shift
+			;;
+		--force-full-composition-pipeline)
+			(($# >= 2)) || die "--force-full-composition-pipeline requires auto, on, or off"
+			full_composition_pipeline_policy=$2
+			shift 2
+			;;
+		--force-full-composition-pipeline=*)
+			full_composition_pipeline_policy=${1#*=}
 			shift
 			;;
 		--timeout)
@@ -1124,12 +1357,20 @@ main() {
 	done
 
 	case $tearfree_policy in auto | on | off) ;; *) die "invalid TearFree policy: $tearfree_policy" ;; esac
+	case $full_composition_pipeline_policy in
+	auto | on | off) ;;
+	*) die "invalid ForceFullCompositionPipeline policy: $full_composition_pipeline_policy" ;;
+	esac
 	[[ $confirm_seconds =~ ^[1-9][0-9]*$ ]] || die "preview timeout must be a positive integer"
 
 	case $command in
 	detect)
 		((${#positional[@]} == 0)) || die "detect takes no profile"
 		detect_displays
+		;;
+	capabilities)
+		((${#positional[@]} == 0)) || die "capabilities takes no profile"
+		display_capabilities
 		;;
 	capture)
 		((${#positional[@]} == 0)) || die "capture takes no profile"

--- a/scripts/dwm-display-setup
+++ b/scripts/dwm-display-setup
@@ -206,7 +206,7 @@ output_driver_by_edid() {
 output_kernel_driver() {
 	local output=$1
 	local connector card driver driver_link provider_output
-	local -A detected=() provider_detected=()
+	local -A detected=() exact_detected=() provider_detected=()
 
 	if [[ -n ${DWM_KERNEL_DRIVER:-} ]]; then
 		printf '%s\n' "$DWM_KERNEL_DRIVER"
@@ -217,11 +217,14 @@ output_kernel_driver() {
 		card=${connector##*/}
 		card=${card%%-*}
 		driver_link="$drm_root/$card/device/driver"
-		if [[ -L $driver_link ]]; then
-			driver_name_from_link "$driver_link"
-			return
-		fi
+		[[ -L $driver_link ]] || continue
+		driver=$(driver_name_from_link "$driver_link")
+		exact_detected[$driver]=1
 	done
+	if ((${#exact_detected[@]} == 1)); then
+		printf '%s\n' "${!exact_detected[@]}"
+		return
+	fi
 	if driver=$(output_driver_by_edid "$output"); then
 		printf '%s\n' "$driver"
 		return

--- a/scripts/dwm-settings-display
+++ b/scripts/dwm-settings-display
@@ -133,18 +133,24 @@ profile_is_complete() {
 }
 
 discover() {
-	local query properties profile
+	local query properties capabilities profile
 	command -v xrandr >/dev/null 2>&1 || die "xrandr is unavailable"
 	[[ -n ${DISPLAY:-} ]] || die "DISPLAY is not set"
 	query=$(mktemp)
 	properties=$(mktemp)
-	trap 'rm -f "$query" "$properties"' RETURN
+	capabilities=$(mktemp)
+	trap 'rm -f "$query" "$properties" "$capabilities"' RETURN
 	xrandr --query >"$query"
 	grep -q '^Screen [0-9][0-9]*:' "$query" || die "xrandr returned malformed display state"
 	grep -Eq '^[A-Za-z0-9_.:+-]+ connected([[:space:]]|$)' "$query" || die "xrandr reported no connected outputs"
 	xrandr --prop >"$properties" 2>/dev/null || : >"$properties"
+	if ! "$setup_helper" capabilities >"$capabilities" 2>/dev/null; then
+		printf 'display-capability-protocol\t1\n' >"$capabilities"
+	fi
+	grep -Fqx $'display-capability-protocol\t1' "$capabilities" ||
+		die "display setup returned an unsupported capability protocol"
 	printf 'display-protocol\t1\n'
-	awk -v props="$properties" '
+	awk -v props="$properties" -v capabilities="$capabilities" '
 		function yes(value) { return value ? "1" : "0" }
 		$2 == "connected" {
 			output = $1; primary = 0; enabled = 0; mode = ""; x = 0; y = 0; rotation = "normal"; geometry_index = 0
@@ -166,7 +172,17 @@ discover() {
 				else if (in_output && property_line ~ /^[[:space:]]*TearFree:/) tearfree = "available"
 			}
 			close(props)
-			printf "output\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", output, enabled, primary, mode, x, y, rotation, tearfree
+			full_composition_pipeline = "unsupported"
+			while ((getline capability_line < capabilities) > 0) {
+				split(capability_line, capability_fields, "\t")
+				if (capability_fields[1] == "output" && capability_fields[2] == output) {
+					tearfree = capability_fields[3]
+					full_composition_pipeline = capability_fields[4]
+					break
+				}
+			}
+			close(capabilities)
+			printf "output\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", output, enabled, primary, mode, x, y, rotation, tearfree, full_composition_pipeline
 			current_output = output
 			next
 		}

--- a/scripts/dwm-settings-display-root
+++ b/scripts/dwm-settings-display-root
@@ -99,7 +99,8 @@ install)
 	done
 	[[ ! -e $main_config ]] ||
 		die "existing $main_config may conflict; migrate or remove it before installing a managed display profile"
-	run_setup "$display" "$xauthority" install "$profile" --no-preview --yes --tearfree auto
+	run_setup "$display" "$xauthority" install "$profile" --no-preview --yes \
+		--tearfree auto --force-full-composition-pipeline auto
 	;;
 rollback)
 	[[ $# == 1 ]] || die "rollback takes no arguments"

--- a/tests/test-dwm-display-setup.sh
+++ b/tests/test-dwm-display-setup.sh
@@ -186,6 +186,11 @@ for output in ${TEST_NVIDIA_OUTPUTS:-}; do
 		;;
 	esac
 done
+if [ "${TEST_NVIDIA_SETTINGS_UNAVAILABLE:-0}" != 1 ] &&
+	[ "$*" = "--terse --query gpus" ]; then
+	printf '%s\n' '1 GPU'
+	exit 0
+fi
 exit 1
 EOF
 chmod +x "$work/bin/nvidia-settings"
@@ -396,6 +401,14 @@ env "${env_common[@]}" DWM_KERNEL_DRIVER= \
 	"$BASH_BIN" "$HELPER" detect >"$work/detect-mismatched-nvidia"
 grep -Fq 'DP-1  default=  kernel-driver=nvidia' \
 	"$work/detect-mismatched-nvidia"
+env "${env_common[@]}" DWM_KERNEL_DRIVER= \
+	DWM_DRM_SYSFS_ROOT="$work/drm-mismatched" \
+	DWM_XORG_DRIVERS='modesetting nvidia' TEST_NVIDIA_SETTINGS_UNAVAILABLE=1 \
+	TEST_QUERY="$work/query-exact-collision" \
+	TEST_PROPERTIES="$work/properties-unsupported" \
+	"$BASH_BIN" "$HELPER" detect >"$work/detect-mismatched-unavailable"
+grep -Fq 'DP-1  default=  kernel-driver=unknown' \
+	"$work/detect-mismatched-unavailable"
 
 mkdir -p "$work/drm/card1-DP-1" "$work/drm/card1/device" \
 	"$work/sys/drivers/nvidia"

--- a/tests/test-dwm-display-setup.sh
+++ b/tests/test-dwm-display-setup.sh
@@ -38,6 +38,11 @@ Screen 0: minimum 320 x 200, current 1024 x 768, maximum 16384 x 16384
 DP-1-1 connected (normal left inverted right x axis y axis)
 EOF
 
+cat >"$work/query-exact-collision" <<'EOF'
+Screen 0: minimum 320 x 200, current 1024 x 768, maximum 16384 x 16384
+DP-1 connected (normal left inverted right x axis y axis)
+EOF
+
 cat >"$work/query-rotated" <<'EOF'
 Screen 0: minimum 320 x 200, current 1920 x 3640, maximum 16384 x 16384
 HDMI-1 connected primary 1920x1080+0+0 (normal left inverted right x axis y axis) 527mm x 296mm
@@ -122,6 +127,12 @@ EOF
 
 cat >"$work/properties-provider-collision" <<'EOF'
 DP-1-1 connected (normal left inverted right x axis y axis)
+	EDID:
+		aabbccdd
+EOF
+
+cat >"$work/properties-exact-collision" <<'EOF'
+DP-1 connected (normal left inverted right x axis y axis)
 	EDID:
 		aabbccdd
 EOF
@@ -360,6 +371,13 @@ env "${env_common[@]}" DWM_KERNEL_DRIVER= \
 	"$BASH_BIN" "$HELPER" detect >"$work/detect-provider-collision"
 grep -Fq 'DP-1-1  default=  kernel-driver=nvidia' \
 	"$work/detect-provider-collision"
+env "${env_common[@]}" DWM_KERNEL_DRIVER= \
+	DWM_DRM_SYSFS_ROOT="$work/drm-collision" DWM_XORG_DRIVER=nvidia \
+	TEST_QUERY="$work/query-exact-collision" \
+	TEST_PROPERTIES="$work/properties-exact-collision" \
+	"$BASH_BIN" "$HELPER" detect >"$work/detect-exact-collision"
+grep -Fq 'DP-1  default=  kernel-driver=nvidia' \
+	"$work/detect-exact-collision"
 
 mkdir -p "$work/drm/card1-DP-1" "$work/drm/card1/device" \
 	"$work/sys/drivers/nvidia"

--- a/tests/test-dwm-display-setup.sh
+++ b/tests/test-dwm-display-setup.sh
@@ -379,6 +379,22 @@ env "${env_common[@]}" DWM_KERNEL_DRIVER= \
 grep -Fq 'DP-1  default=  kernel-driver=nvidia' \
 	"$work/detect-exact-collision"
 
+mkdir -p "$work/drm-mismatched/card0-DP-1" \
+	"$work/drm-mismatched/card0/device" "$work/drm-mismatched/card1-DP-2" \
+	"$work/drm-mismatched/card1/device"
+printf '%s\n' connected >"$work/drm-mismatched/card0-DP-1/status"
+printf '%s\n' connected >"$work/drm-mismatched/card1-DP-2/status"
+printf '\252\273\314\335' >"$work/drm-mismatched/card0-DP-1/edid"
+ln -s "$work/sys/drivers/amdgpu" "$work/drm-mismatched/card0/device/driver"
+ln -s "$work/sys/drivers/nvidia" "$work/drm-mismatched/card1/device/driver"
+env "${env_common[@]}" DWM_KERNEL_DRIVER= \
+	DWM_DRM_SYSFS_ROOT="$work/drm-mismatched" DWM_XORG_DRIVER=nvidia \
+	TEST_NVIDIA_OUTPUTS=DP-1 TEST_QUERY="$work/query-exact-collision" \
+	TEST_PROPERTIES="$work/properties-exact-collision" \
+	"$BASH_BIN" "$HELPER" detect >"$work/detect-mismatched-nvidia"
+grep -Fq 'DP-1  default=  kernel-driver=nvidia' \
+	"$work/detect-mismatched-nvidia"
+
 mkdir -p "$work/drm/card1-DP-1" "$work/drm/card1/device" \
 	"$work/sys/drivers/nvidia"
 printf '%s\n' connected >"$work/drm/card1-DP-1/status"

--- a/tests/test-dwm-display-setup.sh
+++ b/tests/test-dwm-display-setup.sh
@@ -311,10 +311,12 @@ env "${env_common[@]}" TEST_PROPERTIES="$work/properties-unsupported" \
 	>"$work/generated-nvidia-hybrid.conf"
 grep -Fq 'Option "ForceFullCompositionPipeline" "true"' \
 	"$work/generated-nvidia-hybrid.conf"
+grep -Fq 'MatchDriver "nvidia-drm"' "$work/generated-nvidia-hybrid.conf"
+grep -Fq 'Driver "nvidia"' "$work/generated-nvidia-hybrid.conf"
 env "${env_common[@]}" TEST_PROPERTIES="$work/properties-unsupported" \
 	DWM_KERNEL_DRIVER=nvidia DWM_XORG_DRIVER=nvidia \
 	"$BASH_BIN" "$HELPER" generate "$work/profile-60.conf" >"$work/generated-nvidia.conf"
-grep -Fq 'MatchDriver "nvidia"' "$work/generated-nvidia.conf"
+grep -Fq 'MatchDriver "nvidia-drm"' "$work/generated-nvidia.conf"
 grep -Fq 'Driver "nvidia"' "$work/generated-nvidia.conf"
 grep -Fq 'Option "ForceFullCompositionPipeline" "true"' "$work/generated-nvidia.conf"
 if grep -Fq 'Option "TearFree" "true"' "$work/generated-nvidia.conf"; then
@@ -403,7 +405,7 @@ env "${env_common[@]}" DWM_KERNEL_DRIVER= DWM_DRM_SYSFS_ROOT="$work/drm" \
 	DWM_XORG_DRIVER=nvidia TEST_NVIDIA_OUTPUTS='HDMI-1 DP-1 DP-2' \
 	"$BASH_BIN" "$HELPER" generate "$work/profile-60.conf" \
 	>"$work/generated-multi-provider-nvidia.conf"
-grep -Fq 'MatchDriver "nvidia"' "$work/generated-multi-provider-nvidia.conf"
+grep -Fq 'MatchDriver "nvidia-drm"' "$work/generated-multi-provider-nvidia.conf"
 grep -Fq 'Option "ForceFullCompositionPipeline" "true"' \
 	"$work/generated-multi-provider-nvidia.conf"
 if grep -Fq 'MatchDriver "unknown"' "$work/generated-multi-provider-nvidia.conf"; then

--- a/tests/test-dwm-display-setup.sh
+++ b/tests/test-dwm-display-setup.sh
@@ -28,6 +28,16 @@ HDMI-1 connected primary 1920x1080+0+0 (normal left inverted right x axis y axis
    1920x1080     60.00*+
 EOF
 
+cat >"$work/query-provider-suffix" <<'EOF'
+Screen 0: minimum 320 x 200, current 1024 x 768, maximum 16384 x 16384
+Virtual-1-1 connected (normal left inverted right x axis y axis)
+EOF
+
+cat >"$work/query-provider-collision" <<'EOF'
+Screen 0: minimum 320 x 200, current 1024 x 768, maximum 16384 x 16384
+DP-1-1 connected (normal left inverted right x axis y axis)
+EOF
+
 cat >"$work/query-rotated" <<'EOF'
 Screen 0: minimum 320 x 200, current 1920 x 3640, maximum 16384 x 16384
 HDMI-1 connected primary 1920x1080+0+0 (normal left inverted right x axis y axis) 527mm x 296mm
@@ -110,6 +120,12 @@ DP-1 connected 2560x1440+1920+0 (normal left inverted right x axis y axis)
 DP-2 connected (normal left inverted right x axis y axis)
 EOF
 
+cat >"$work/properties-provider-collision" <<'EOF'
+DP-1-1 connected (normal left inverted right x axis y axis)
+	EDID:
+		aabbccdd
+EOF
+
 cat >"$work/bin/xrandr" <<'EOF'
 #!/bin/sh
 case ${1:-} in
@@ -124,6 +140,7 @@ case ${1:-} in
 	cat "$TEST_VERBOSE"
 	;;
 --prop)
+	[ "${TEST_PROPERTIES_UNAVAILABLE:-0}" != 1 ] || exit 1
 	cat "$TEST_PROPERTIES"
 	;;
 *)
@@ -147,6 +164,20 @@ case ${1:-} in
 esac
 EOF
 chmod +x "$work/bin/xrandr"
+
+cat >"$work/bin/nvidia-settings" <<'EOF'
+#!/bin/sh
+for output in ${TEST_NVIDIA_OUTPUTS:-}; do
+	case " $* " in
+	*"[dpy:$output]/"*)
+		printf '%s\n' 0
+		exit 0
+		;;
+	esac
+done
+exit 1
+EOF
+chmod +x "$work/bin/nvidia-settings"
 
 cat >"$work/profile-60.conf" <<'EOF'
 HDMI-1 --primary --mode 1920x1080 --rate 60 --pos 0x0 --rotate normal
@@ -177,6 +208,11 @@ env_common=(
 env "${env_common[@]}" "$BASH_BIN" "$HELPER" detect >"$work/detect"
 grep -Fq 'HDMI-1  default=1920x1080@60.00' "$work/detect"
 grep -Fq 'TearFree=supported' "$work/detect"
+grep -Fq 'ForceFullCompositionPipeline=unsupported' "$work/detect"
+
+env "${env_common[@]}" "$BASH_BIN" "$HELPER" capabilities >"$work/capabilities"
+grep -Fqx $'display-capability-protocol\t1' "$work/capabilities"
+grep -Fqx $'output\tHDMI-1\tavailable\tunsupported' "$work/capabilities"
 
 env "${env_common[@]}" "$BASH_BIN" "$HELPER" capture >"$work/captured.conf"
 grep -Fq 'HDMI-1 --primary --mode 1920x1080 --rate 60.00 --pos 0x0 --rotate normal' "$work/captured.conf"
@@ -242,6 +278,105 @@ if env "${env_common[@]}" TEST_PROPERTIES="$work/properties-unsupported" \
 fi
 grep -Fq 'no compatible interface' "$work/tearfree-error"
 
+env "${env_common[@]}" TEST_PROPERTIES="$work/properties-unsupported" \
+	DWM_KERNEL_DRIVER=nvidia DWM_XORG_DRIVER=nvidia \
+	"$BASH_BIN" "$HELPER" capabilities >"$work/capabilities-nvidia"
+grep -Fqx $'output\tHDMI-1\tunsupported\tavailable' "$work/capabilities-nvidia"
+env "${env_common[@]}" TEST_PROPERTIES="$work/properties-unsupported" \
+	DWM_KERNEL_DRIVER=nvidia DWM_XORG_DRIVER=modesetting \
+	"$BASH_BIN" "$HELPER" capabilities >"$work/capabilities-nvidia-modesetting"
+grep -Fqx $'output\tHDMI-1\tunsupported\tunsupported' \
+	"$work/capabilities-nvidia-modesetting"
+env "${env_common[@]}" TEST_PROPERTIES="$work/properties-unsupported" \
+	DWM_KERNEL_DRIVER=nvidia DWM_XORG_DRIVER=modesetting \
+	DWM_XORG_DRIVERS='modesetting nvidia' TEST_NVIDIA_OUTPUTS='HDMI-1 DP-1 DP-2' \
+	"$BASH_BIN" "$HELPER" capabilities >"$work/capabilities-nvidia-hybrid"
+grep -Fqx $'output\tHDMI-1\tunsupported\tavailable' \
+	"$work/capabilities-nvidia-hybrid"
+env "${env_common[@]}" TEST_PROPERTIES="$work/properties-unsupported" \
+	DWM_KERNEL_DRIVER=nvidia DWM_XORG_DRIVER=modesetting \
+	DWM_XORG_DRIVERS='modesetting nvidia' TEST_NVIDIA_OUTPUTS='HDMI-1 DP-1 DP-2' \
+	"$BASH_BIN" "$HELPER" generate "$work/profile-60.conf" \
+	>"$work/generated-nvidia-hybrid.conf"
+grep -Fq 'Option "ForceFullCompositionPipeline" "true"' \
+	"$work/generated-nvidia-hybrid.conf"
+env "${env_common[@]}" TEST_PROPERTIES="$work/properties-unsupported" \
+	DWM_KERNEL_DRIVER=nvidia DWM_XORG_DRIVER=nvidia \
+	"$BASH_BIN" "$HELPER" generate "$work/profile-60.conf" >"$work/generated-nvidia.conf"
+grep -Fq 'MatchDriver "nvidia"' "$work/generated-nvidia.conf"
+grep -Fq 'Driver "nvidia"' "$work/generated-nvidia.conf"
+grep -Fq 'Option "ForceFullCompositionPipeline" "true"' "$work/generated-nvidia.conf"
+if grep -Fq 'Option "TearFree" "true"' "$work/generated-nvidia.conf"; then
+	printf '%s\n' 'TearFree was emitted for the NVIDIA Xorg driver' >&2
+	exit 1
+fi
+env "${env_common[@]}" TEST_PROPERTIES="$work/properties-unsupported" \
+	DWM_KERNEL_DRIVER=nvidia DWM_XORG_DRIVER=nvidia \
+	"$BASH_BIN" "$HELPER" generate "$work/profile-60.conf" \
+	--force-full-composition-pipeline off >"$work/generated-nvidia-disabled.conf"
+if grep -Fq 'Option "ForceFullCompositionPipeline" "true"' \
+	"$work/generated-nvidia-disabled.conf"; then
+	printf '%s\n' 'disabled ForceFullCompositionPipeline was emitted' >&2
+	exit 1
+fi
+if env "${env_common[@]}" TEST_PROPERTIES="$work/properties-unsupported" \
+	DWM_KERNEL_DRIVER=xe DWM_XORG_DRIVER=modesetting \
+	"$BASH_BIN" "$HELPER" generate "$work/profile-60.conf" \
+	--force-full-composition-pipeline on 2>"$work/full-composition-error"; then
+	printf '%s\n' 'forced unsupported ForceFullCompositionPipeline was accepted' >&2
+	exit 1
+fi
+grep -Fq 'do not use the NVIDIA Xorg driver' "$work/full-composition-error"
+
+mkdir -p "$work/drm/card0-Virtual-1" "$work/drm/card0/device" \
+	"$work/sys/drivers/virtio-pci"
+printf '%s\n' connected >"$work/drm/card0-Virtual-1/status"
+ln -s "$work/sys/drivers/virtio-pci" "$work/drm/card0/device/driver"
+env "${env_common[@]}" DWM_KERNEL_DRIVER= DWM_DRM_SYSFS_ROOT="$work/drm" \
+	DWM_XORG_DRIVER=modesetting "$BASH_BIN" "$HELPER" generate \
+	"$work/profile-60.conf" >"$work/generated-module-driver.conf"
+grep -Fq 'MatchDriver "virtio_gpu"' "$work/generated-module-driver.conf"
+grep -Fq 'Driver "modesetting"' "$work/generated-module-driver.conf"
+env "${env_common[@]}" DWM_KERNEL_DRIVER= DWM_DRM_SYSFS_ROOT="$work/drm" \
+	DWM_XORG_DRIVER=modesetting TEST_QUERY="$work/query-provider-suffix" \
+	"$BASH_BIN" "$HELPER" detect >"$work/detect-provider-suffix"
+grep -Fq 'Virtual-1-1  default=  kernel-driver=virtio_gpu' \
+	"$work/detect-provider-suffix"
+
+mkdir -p "$work/drm-collision/card0-DP-1" \
+	"$work/drm-collision/card0/device" "$work/drm-collision/card1-DP-1" \
+	"$work/drm-collision/card1/device" "$work/sys/drivers/amdgpu" \
+	"$work/sys/drivers/nvidia"
+printf '%s\n' connected >"$work/drm-collision/card0-DP-1/status"
+printf '%s\n' connected >"$work/drm-collision/card1-DP-1/status"
+printf '\001\002\003\004' >"$work/drm-collision/card0-DP-1/edid"
+printf '\252\273\314\335' >"$work/drm-collision/card1-DP-1/edid"
+ln -s "$work/sys/drivers/amdgpu" "$work/drm-collision/card0/device/driver"
+ln -s "$work/sys/drivers/nvidia" "$work/drm-collision/card1/device/driver"
+env "${env_common[@]}" DWM_KERNEL_DRIVER= \
+	DWM_DRM_SYSFS_ROOT="$work/drm-collision" DWM_XORG_DRIVER=nvidia \
+	TEST_QUERY="$work/query-provider-collision" \
+	TEST_PROPERTIES="$work/properties-provider-collision" \
+	"$BASH_BIN" "$HELPER" detect >"$work/detect-provider-collision"
+grep -Fq 'DP-1-1  default=  kernel-driver=nvidia' \
+	"$work/detect-provider-collision"
+
+mkdir -p "$work/drm/card1-DP-1" "$work/drm/card1/device" \
+	"$work/sys/drivers/nvidia"
+printf '%s\n' connected >"$work/drm/card1-DP-1/status"
+ln -s "$work/sys/drivers/nvidia" "$work/drm/card1/device/driver"
+env "${env_common[@]}" DWM_KERNEL_DRIVER= DWM_DRM_SYSFS_ROOT="$work/drm" \
+	DWM_XORG_DRIVER=nvidia TEST_NVIDIA_OUTPUTS='HDMI-1 DP-1 DP-2' \
+	"$BASH_BIN" "$HELPER" generate "$work/profile-60.conf" \
+	>"$work/generated-multi-provider-nvidia.conf"
+grep -Fq 'MatchDriver "nvidia"' "$work/generated-multi-provider-nvidia.conf"
+grep -Fq 'Option "ForceFullCompositionPipeline" "true"' \
+	"$work/generated-multi-provider-nvidia.conf"
+if grep -Fq 'MatchDriver "unknown"' "$work/generated-multi-provider-nvidia.conf"; then
+	printf '%s\n' 'NVIDIA RandR outputs were ambiguous in a multi-provider session' >&2
+	exit 1
+fi
+
 rm -f "$work/xrandr.log"
 env "${env_common[@]}" "$BASH_BIN" "$HELPER" preview \
 	"$work/profile-60.conf" --yes >/dev/null
@@ -288,9 +423,13 @@ DP-1 --mode 2560x1440 --rate 60
 EOF
 env "${settings_env[@]}" "$BASH_BIN" "$SETTINGS_HELPER" discover >"$work/settings-discover"
 grep -Fqx 'display-protocol	1' "$work/settings-discover"
-grep -Fqx 'output	HDMI-1	1	1	1920x1080	0	0	normal	available' "$work/settings-discover"
-grep -Fqx 'output	DP-2	0	0		0	0	normal	unsupported' "$work/settings-discover"
+grep -Fqx 'output	HDMI-1	1	1	1920x1080	0	0	normal	available	unsupported' "$work/settings-discover"
+grep -Fqx 'output	DP-2	0	0		0	0	normal	available	unsupported' "$work/settings-discover"
 grep -Fq $'profile-unsupported\tlegacy.conf\tLegacy profile omits complete' "$work/settings-discover"
+env "${settings_env[@]}" TEST_PROPERTIES_UNAVAILABLE=1 \
+	"$BASH_BIN" "$SETTINGS_HELPER" discover >"$work/settings-properties-unavailable"
+grep -Fqx $'output\tHDMI-1\t1\t1\t1920x1080\t0\t0\tnormal\tunsupported\tunsupported' \
+	"$work/settings-properties-unavailable"
 if env "${settings_env[@]}" "$BASH_BIN" "$SETTINGS_HELPER" preview-profile legacy-test 5 legacy \
 	2>"$work/legacy-preview.err"; then
 	printf 'incomplete legacy display profile was accepted\n' >&2
@@ -411,4 +550,4 @@ fi
 grep -Fq 'previous layout was restored' "$work/settings-failure.err"
 grep -Fq -- '--output DP-1 --mode 2560x1440 --rate 60.00 --pos 1920x0 --rotate normal' "$work/xrandr.log"
 
-printf '%s\n' 'Display detection, Xorg generation, TearFree, preview, install, and rollback: PASS'
+printf '%s\n' 'Display detection, Xorg generation, anti-tearing policy, preview, install, and rollback: PASS'

--- a/tests/test-settings.sh
+++ b/tests/test-settings.sh
@@ -58,8 +58,13 @@ printf '%s\n' "$fedora_output" | grep -Fqx \
 	'capability	displays	randr	Display discovery	available	read-only	xrandr	RandR display state is available'
 printf '%s\n' "$fedora_output" | grep -Fqx \
 	'capability	displays	display-changes	Display changes	available	user-session	dwm-settings-display	Validated layout previews, rollback, and user profiles are available'
-printf '%s\n' "$fedora_output" | grep -Fqx \
-	'capability	displays	display-persistence	Persistent display profiles	restricted	privileged	dwm-settings-display-root	Live previews remain available; install the trusted root helper for persistence'
+if ! printf '%s\n' "$fedora_output" | grep -Fqx \
+	'capability	displays	display-persistence	Persistent display profiles	available	privileged	dwm-settings-display-root	Managed Xorg install and rollback are available through polkit' &&
+	! printf '%s\n' "$fedora_output" | grep -Fqx \
+		'capability	displays	display-persistence	Persistent display profiles	restricted	privileged	dwm-settings-display-root	Live previews remain available; install the trusted root helper for persistence'; then
+	printf '%s\n' 'unexpected display-persistence capability state' >&2
+	exit 1
+fi
 printf '%s\n' "$fedora_output" | grep -Fqx \
 	'capability	input	input-devices	Input devices	available	user-session	dwm-settings-input	Stable device discovery, preview, reset, and persistence are available'
 printf '%s\n' "$fedora_output" | grep -Fqx \
@@ -158,8 +163,14 @@ grep -Fq 'root.settingsModel.displayPersistenceAvailable' "$repo/config/quickshe
 grep -Fq 'root.settingsModel.displayUnsupportedProfiles' "$repo/config/quickshell/settings/DisplaySettingsPane.qml"
 grep -Fq 'if (!visible) root.confirmation = "";' \
 	"$repo/config/quickshell/settings/DisplaySettingsPane.qml"
-grep -Fq -- '--no-preview --yes --tearfree auto' \
+grep -Fq -- '--no-preview --yes' \
 	"$repo/scripts/dwm-settings-display-root"
+grep -Fq -- '--tearfree auto --force-full-composition-pipeline auto' \
+	"$repo/scripts/dwm-settings-display-root"
+grep -Fq 'fields.length >= 10 ? fields[9] : "unsupported"' \
+	"$repo/config/quickshell/settings/SettingsModel.qml"
+grep -Fq 'NVIDIA full composition on persistent install' \
+	"$repo/config/quickshell/settings/DisplaySettingsPane.qml"
 grep -Fq 'migrate or remove it before installing a managed display profile' \
 	"$repo/scripts/dwm-settings-display-root"
 grep -Fq 'watch-apply' "$repo/scripts/autostart.sh"


### PR DESCRIPTION
## Summary

- qualify persistent single- and multi-output layouts through real Fedora Xorg restarts
- add safe NVIDIA ForceFullCompositionPipeline discovery and persistent defaults, including hybrid-provider handling
- correct DRM-to-Xorg driver mapping and preserve display discovery when optional capability probing fails
- close Phase 2 in the roadmap and replace the active task set with the Phase 3 connectivity and audio plan

## Validation

- `make check`
- `mdbook build docs`
- `mdbook test docs`
- ShellCheck and shfmt on changed shell files
- `codex review --uncommitted` review/fix loop
- CodeRabbit CLI final review: zero findings
- Fedora 44 UEFI VM, LightDM, real Xorg restarts:
  - non-default 1024x768 single-output persistence
  - two-output 1024x768 + 800x600 persistence
  - root-owned mode-0644 managed fragment and Xorg log confirmation
- Fedora 44 X11 host with GeForce RTX 4070 SUPER / NVIDIA 610.43.03:
  - both physical outputs report Full Composition Pipeline available
  - active MetaMode confirms ForceFullCompositionPipeline enabled

## Recorded limitations

- no physical touchpad was available
- complete Rocky Linux 9 runtime and real secondary-platform X11 sessions remain unqualified
- the qualification host has an existing `/etc/X11/xorg.conf`, so the managed fragment was not installed over it
