### PR TITLE
Fix Fedora XDG directory ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ versions from `config.mk`.
 
 ### Fixed
 
+- Keep Fedora image XDG parents owned by the installer-created user, run the
+  user-scoped install stage without root privileges, preserve existing XDG
+  directory modes, make direct root installs drop privileges for the user
+  stage, and document a narrow v0.6.0 repair.
 - Match generated Xorg OutputClass rules against the DRM driver name, including
   mapping virtio PCI devices to `virtio_gpu`, so saved display layouts survive
   a real Xorg restart. Associate NVIDIA RandR names through per-display driver

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@
 
 include config.mk
 
-USER_HOME ?= $(shell getent passwd $(or $(SUDO_USER),$(USER)) 2>/dev/null | cut -d: -f6)
-OWNER     := $(or $(SUDO_USER),$(USER))
+OWNER ?= $(or $(SUDO_USER),$(USER))
+USER_HOME ?= $(shell getent passwd "${OWNER}" 2>/dev/null | cut -d: -f6)
 XDG_CONFIG_HOME ?= ${USER_HOME}/.config
 XDG_DATA_HOME ?= ${USER_HOME}/.local/share
 DATA_DIR  := ${XDG_DATA_HOME}/dwm-titus
@@ -105,7 +105,26 @@ native:
 
 install: install-system
 	if [ -z "${DESTDIR}" ]; then \
-		$(MAKE) install-user; \
+		if [ "$$(id -u)" -eq 0 ]; then \
+			target_user="${OWNER}"; \
+			if [ -z "$$target_user" ] || [ "$$target_user" = root ]; then \
+				echo "Refusing to install user files as root. Run install-user as the target user." >&2; \
+				exit 1; \
+			fi; \
+			command -v runuser >/dev/null 2>&1 || { \
+				echo "runuser is required to install user files without root privileges." >&2; \
+				exit 1; \
+			}; \
+			target_uid="$$(id -u "$$target_user")"; \
+			runuser -u "$$target_user" -- env -u DBUS_SESSION_BUS_ADDRESS \
+				HOME="${USER_HOME}" XDG_RUNTIME_DIR="/run/user/$$target_uid" \
+				$(MAKE) install-user \
+				USER_HOME="${USER_HOME}" OWNER="$$target_user" \
+				XDG_CONFIG_HOME="${XDG_CONFIG_HOME}" \
+				XDG_DATA_HOME="${XDG_DATA_HOME}"; \
+		else \
+			$(MAKE) install-user; \
+		fi; \
 	else \
 		echo "==> DESTDIR set; skipping user configuration."; \
 	fi

--- a/SPEC.md
+++ b/SPEC.md
@@ -571,6 +571,12 @@ ${XDG_DATA_HOME:-$HOME/.local/share}/dwm-titus/
 System paths must be overridable for packaging and staged installs. User data
 must not be written during a package build using `DESTDIR`.
 
+User-scoped installation runs as the target user. Any default XDG parent
+directory created by the Fedora image or installer must be owned by that user
+and their primary group. Existing XDG parent permissions must be preserved,
+and installation must not recursively change ownership outside project-managed
+directories.
+
 Uninstall must remove only files owned by this project. It must preserve user
 configuration and unrelated application configuration by default.
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -73,6 +73,31 @@ the known legacy `dwm-graphical-session.service` and
 start only after the X11 display environment is available; customized user
 units are disabled from early startup but otherwise preserved.
 
+System files are installed with `sudo`, while configuration and data under the
+user's XDG directories are installed as that user.
+
+If a v0.6.0 Fedora image left the default XDG parents owned by root, first
+verify that none of them is a symbolic link, then repair only those parents and
+rerun the installer:
+
+```bash
+xdg_parents=()
+for path in "$HOME/.local" "$HOME/.local/share" "$HOME/.config"; do
+    test ! -L "$path" || {
+        printf 'Refusing symbolic link: %s\n' "$path" >&2
+        exit 1
+    }
+    test -e "$path" || continue
+    test -d "$path" || { printf 'Refusing non-directory: %s\n' "$path" >&2; exit 1; }
+    xdg_parents+=("$path")
+done
+((${#xdg_parents[@]} == 0)) || sudo chown "$(id -u):$(id -g)" -- "${xdg_parents[@]}"
+./install.sh
+```
+
+This repair is intentionally non-recursive so it does not change unrelated
+user files.
+
 Recommended and full profiles install Herdr as the default interactive
 workspace inside Alacritty. The repository downloads the official
 `https://herdr.dev/install.sh` into an isolated staging directory and verifies

--- a/dwm-fedora-nvidia.ks
+++ b/dwm-fedora-nvidia.ks
@@ -177,7 +177,19 @@ target_home=$(getent passwd "$target_user" | cut -d: -f6)
 target_group=$(id -gn "$target_user")
 target_repo_dir="$target_home/.local/share/dwm-titus"
 
-install -d -m 0755 "$target_home/.local/share"
+for xdg_dir in \
+	"$target_home/.local" \
+	"$target_home/.local/share" \
+	"$target_home/.config"; do
+	if [ -e "$xdg_dir" ] || [ -L "$xdg_dir" ]; then
+		if [ ! -d "$xdg_dir" ]; then
+			echo "User XDG path exists but is not a directory: $xdg_dir" >&2
+			exit 1
+		fi
+		continue
+	fi
+	install -d -o "$target_user" -g "$target_group" -m 0755 "$xdg_dir"
+done
 rm -rf "$target_repo_dir"
 cp -a "$repo_dir" "$target_repo_dir"
 chown -R "$target_user:$target_group" "$target_repo_dir"

--- a/dwm-fedora.ks
+++ b/dwm-fedora.ks
@@ -168,7 +168,19 @@ target_home=$(getent passwd "$target_user" | cut -d: -f6)
 target_group=$(id -gn "$target_user")
 target_repo_dir="$target_home/.local/share/dwm-titus"
 
-install -d -m 0755 "$target_home/.local/share"
+for xdg_dir in \
+	"$target_home/.local" \
+	"$target_home/.local/share" \
+	"$target_home/.config"; do
+	if [ -e "$xdg_dir" ] || [ -L "$xdg_dir" ]; then
+		if [ ! -d "$xdg_dir" ]; then
+			echo "User XDG path exists but is not a directory: $xdg_dir" >&2
+			exit 1
+		fi
+		continue
+	fi
+	install -d -o "$target_user" -g "$target_group" -m 0755 "$xdg_dir"
+done
 rm -rf "$target_repo_dir"
 cp -a "$repo_dir" "$target_repo_dir"
 chown -R "$target_user:$target_group" "$target_repo_dir"

--- a/install.sh
+++ b/install.sh
@@ -881,10 +881,13 @@ fi
 cd "$REPO_DIR"
 make clean
 make
-sudo make install \
+sudo make install-system \
 	USER_HOME="$HOME" \
 	OWNER="$(id -un)" \
-	DATADIR="/usr/share" \
+	DATADIR="/usr/share"
+make install-user \
+	USER_HOME="$HOME" \
+	OWNER="$(id -un)" \
 	XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}" \
 	XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 if [[ $HERDR_READY == true ]]; then

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -170,7 +170,7 @@ echo "Session Setup:"
 if [ -f /usr/share/xsessions/dwm.desktop ]; then
 	printf "  ${GREEN}✓${NC} dwm.desktop in /usr/share/xsessions/\n"
 else
-	printf "  ${YELLOW}○${NC} dwm.desktop not found (run 'sudo make install')\n"
+	printf "  ${YELLOW}○${NC} dwm.desktop not found (run './install.sh')\n"
 fi
 if [ -f "$HOME/.xinitrc" ]; then
 	printf "  ${GREEN}✓${NC} ~/.xinitrc exists\n"
@@ -182,7 +182,7 @@ echo ""
 # ── Summary ─────────────────────────────────────────────
 if [ $MISSING -eq 0 ]; then
 	printf "${GREEN}All dependencies satisfied. Ready to build!${NC}\n"
-	echo "  Run: make && sudo make install"
+	echo "  Run: make && sudo make install-system && make install-user"
 	exit 0
 else
 	printf "${RED}$MISSING missing dependency/dependencies.${NC}\n"

--- a/tests/test-install-preservation.sh
+++ b/tests/test-install-preservation.sh
@@ -11,6 +11,7 @@ XDG_CONFIG_HOME="$TEST_HOME/.config"
 XDG_DATA_HOME="$TEST_HOME/.local/share"
 XDG_CONFIG_DIRS="$WORK_DIR/etc-xdg"
 OWNER="$(id -un)"
+OWNER_GROUP="$(id -gn)"
 
 if grep -Eq 'sudo systemctl enable (NetworkManager|bluetooth)\.service' "$REPO_DIR/install.sh"; then
 	printf 'Optional Arch services are enabled without the non-fatal guard.\n' >&2
@@ -21,6 +22,51 @@ for service in NetworkManager.service bluetooth.service; do
 done
 grep -Fq 'Start LightDM now (optional): sudo systemctl start lightdm.service' \
 	"$REPO_DIR/install.sh"
+grep -Fq "sudo make install-system \\" "$REPO_DIR/install.sh"
+grep -Fq "make install-user \\" "$REPO_DIR/install.sh"
+if grep -Fq "sudo make install \\" "$REPO_DIR/install.sh"; then
+	printf 'Installer still runs the user installation stage as root.\n' >&2
+	exit 1
+fi
+grep -Fq "runuser -u \"\$\$target_user\" -- env -u DBUS_SESSION_BUS_ADDRESS \\" \
+	"$REPO_DIR/Makefile"
+grep -Fq "HOME=\"\${USER_HOME}\" XDG_RUNTIME_DIR=\"/run/user/\$\$target_uid\" \\" \
+	"$REPO_DIR/Makefile"
+grep -Fq "\$(MAKE) install-user " "$REPO_DIR/Makefile"
+grep -Fq 'dwm.desktop not found (run '\''./install.sh'\'')' \
+	"$REPO_DIR/scripts/check-deps.sh"
+grep -Fq 'Run: make && sudo make install-system && make install-user' \
+	"$REPO_DIR/scripts/check-deps.sh"
+if grep -Eq 'sudo make install($|[[:space:]&;])' "$REPO_DIR/scripts/check-deps.sh"; then
+	printf 'Dependency check still recommends a root user-install stage.\n' >&2
+	exit 1
+fi
+if grep -Eq 'sudo chown (-R|--recursive)' "$REPO_DIR/install.sh"; then
+	printf 'Installer uses a broad recursive ownership repair.\n' >&2
+	exit 1
+fi
+
+PROBE_OWNER=$(id -un)
+if getent passwd nobody >/dev/null 2>&1; then
+	PROBE_OWNER=nobody
+fi
+PROBE_HOME=$(getent passwd "$PROBE_OWNER" | cut -d: -f6)
+OWNER_HOME_MAKEFILE="$WORK_DIR/owner-home.mk"
+{
+	printf 'include %s/Makefile\n' "$REPO_DIR"
+	cat <<'EOF'
+print-owner-home:
+	@printf '%s\n' "${USER_HOME}"
+EOF
+} >"$OWNER_HOME_MAKEFILE"
+RESOLVED_OWNER_HOME=$(env -u SUDO_USER -u USER_HOME -u XDG_CONFIG_HOME \
+	-u XDG_DATA_HOME USER=root make -s -C "$REPO_DIR" -f "$OWNER_HOME_MAKEFILE" \
+	print-owner-home OWNER="$PROBE_OWNER")
+test "$RESOLVED_OWNER_HOME" = "$PROBE_HOME"
+EXPLICIT_OWNER_HOME=$(env -u SUDO_USER -u XDG_CONFIG_HOME -u XDG_DATA_HOME \
+	USER=root make -s -C "$REPO_DIR" -f "$OWNER_HOME_MAKEFILE" \
+	print-owner-home OWNER="$PROBE_OWNER" USER_HOME="$WORK_DIR/explicit-home")
+test "$EXPLICIT_OWNER_HOME" = "$WORK_DIR/explicit-home"
 
 cp -a "$REPO_DIR/." "$TEST_REPO/"
 mkdir -p \
@@ -183,7 +229,7 @@ FRESH_HOME="$WORK_DIR/fresh-home"
 FRESH_CONFIG_HOME="$FRESH_HOME/.config"
 FRESH_DATA_HOME="$FRESH_HOME/.local/share"
 FRESH_CONFIG_DIRS="$WORK_DIR/fresh-etc-xdg"
-mkdir -p "$FRESH_CONFIG_DIRS/autostart" "$FRESH_DATA_HOME"
+mkdir -p "$FRESH_CONFIG_DIRS/autostart"
 make -C "$TEST_REPO" install-user \
 	USER_HOME="$FRESH_HOME" \
 	OWNER="$OWNER" \
@@ -193,6 +239,15 @@ make -C "$TEST_REPO" install-user \
 cmp "$TEST_REPO/config/Thunar/uca.xml" "$FRESH_CONFIG_HOME/Thunar/uca.xml"
 grep -Fqx '    <command>alacritty --working-directory %f</command>' \
 	"$FRESH_CONFIG_HOME/Thunar/uca.xml"
+for user_path in \
+	"$FRESH_HOME/.local" \
+	"$FRESH_DATA_HOME" \
+	"$FRESH_CONFIG_HOME" \
+	"$FRESH_CONFIG_HOME/dwm-titus" \
+	"$FRESH_DATA_HOME/dwm-titus"; do
+	test "$(stat -c %U "$user_path")" = "$OWNER"
+	test "$(stat -c %G "$user_path")" = "$OWNER_GROUP"
+done
 
 EMPTY_CONFIG_HOME="$WORK_DIR/empty-config"
 EMPTY_CONFIG_DIRS="$WORK_DIR/empty-etc-xdg"

--- a/tests/test-install-preservation.sh
+++ b/tests/test-install-preservation.sh
@@ -60,7 +60,8 @@ print-owner-home:
 EOF
 } >"$OWNER_HOME_MAKEFILE"
 RESOLVED_OWNER_HOME=$(env -u SUDO_USER -u USER_HOME -u XDG_CONFIG_HOME \
-	-u XDG_DATA_HOME USER=root make -s -C "$REPO_DIR" -f "$OWNER_HOME_MAKEFILE" \
+	-u XDG_DATA_HOME USER=root make -s --no-print-directory -C "$REPO_DIR" \
+	-f "$OWNER_HOME_MAKEFILE" \
 	print-owner-home OWNER="$PROBE_OWNER")
 if [[ $RESOLVED_OWNER_HOME != "$PROBE_HOME" ]]; then
 	printf 'OWNER home resolution mismatch: expected %s, got %s.\n' \
@@ -68,7 +69,7 @@ if [[ $RESOLVED_OWNER_HOME != "$PROBE_HOME" ]]; then
 	exit 1
 fi
 EXPLICIT_OWNER_HOME=$(env -u SUDO_USER -u XDG_CONFIG_HOME -u XDG_DATA_HOME \
-	USER=root make -s -C "$REPO_DIR" -f "$OWNER_HOME_MAKEFILE" \
+	USER=root make -s --no-print-directory -C "$REPO_DIR" -f "$OWNER_HOME_MAKEFILE" \
 	print-owner-home OWNER="$PROBE_OWNER" USER_HOME="$WORK_DIR/explicit-home")
 if [[ $EXPLICIT_OWNER_HOME != "$WORK_DIR/explicit-home" ]]; then
 	printf 'Explicit USER_HOME override mismatch: expected %s, got %s.\n' \

--- a/tests/test-install-preservation.sh
+++ b/tests/test-install-preservation.sh
@@ -47,7 +47,7 @@ if grep -Eq 'sudo chown (-R|--recursive)' "$REPO_DIR/install.sh"; then
 fi
 
 PROBE_OWNER=$(id -un)
-if getent passwd nobody >/dev/null 2>&1; then
+if [[ $PROBE_OWNER == root ]] && getent passwd nobody >/dev/null 2>&1; then
 	PROBE_OWNER=nobody
 fi
 PROBE_HOME=$(getent passwd "$PROBE_OWNER" | cut -d: -f6)
@@ -62,11 +62,19 @@ EOF
 RESOLVED_OWNER_HOME=$(env -u SUDO_USER -u USER_HOME -u XDG_CONFIG_HOME \
 	-u XDG_DATA_HOME USER=root make -s -C "$REPO_DIR" -f "$OWNER_HOME_MAKEFILE" \
 	print-owner-home OWNER="$PROBE_OWNER")
-test "$RESOLVED_OWNER_HOME" = "$PROBE_HOME"
+if [[ $RESOLVED_OWNER_HOME != "$PROBE_HOME" ]]; then
+	printf 'OWNER home resolution mismatch: expected %s, got %s.\n' \
+		"$PROBE_HOME" "$RESOLVED_OWNER_HOME" >&2
+	exit 1
+fi
 EXPLICIT_OWNER_HOME=$(env -u SUDO_USER -u XDG_CONFIG_HOME -u XDG_DATA_HOME \
 	USER=root make -s -C "$REPO_DIR" -f "$OWNER_HOME_MAKEFILE" \
 	print-owner-home OWNER="$PROBE_OWNER" USER_HOME="$WORK_DIR/explicit-home")
-test "$EXPLICIT_OWNER_HOME" = "$WORK_DIR/explicit-home"
+if [[ $EXPLICIT_OWNER_HOME != "$WORK_DIR/explicit-home" ]]; then
+	printf 'Explicit USER_HOME override mismatch: expected %s, got %s.\n' \
+		"$WORK_DIR/explicit-home" "$EXPLICIT_OWNER_HOME" >&2
+	exit 1
+fi
 
 cp -a "$REPO_DIR/." "$TEST_REPO/"
 mkdir -p \

--- a/tests/test-kickstart-variants.sh
+++ b/tests/test-kickstart-variants.sh
@@ -137,6 +137,20 @@ for ks in "$standard_ks" "$nvidia_ks"; do
 	grep -Fq 'case "$(uname -m)" in' "$ks"
 	# shellcheck disable=SC2016
 	grep -Fq 'usermod -aG gamemode "$target_user"' "$ks"
+	grep -Fq "for xdg_dir in \\" "$ks"
+	for xdg_parent in \
+		"\"\$target_home/.local\"" \
+		"\"\$target_home/.local/share\"" \
+		"\"\$target_home/.config\""; do
+		grep -Fq "$xdg_parent" "$ks"
+	done
+	grep -Fq "if [ -e \"\$xdg_dir\" ] || [ -L \"\$xdg_dir\" ]; then" "$ks"
+	grep -Fq "if [ ! -d \"\$xdg_dir\" ]; then" "$ks"
+	grep -Fq "install -d -o \"\$target_user\" -g \"\$target_group\" -m 0755 \"\$xdg_dir\"" "$ks"
+	if grep -Fq "install -d -m 0755 \"\$target_home/.local/share\"" "$ks"; then
+		printf 'Kickstart creates the user data parent without ownership: %s\n' "$ks" >&2
+		exit 1
+	fi
 	if grep -Eq 'systemctl --user (enable|start).*(dwm|wm)-graphical-session' "$ks"; then
 		printf 'Kickstart starts graphical autostart before the first dwm session: %s\n' "$ks" >&2
 		exit 1


### PR DESCRIPTION
## Summary

- create Fedora image XDG parent directories with the installer-created user's ownership while preserving existing modes
- split system and user installation stages so user configuration is never created by root
- keep `sudo make install` compatible by dropping privileges with the target user's home and runtime environment
- document a narrow, non-recursive repair for affected v0.6.0 installations
- add regression coverage for both Kickstart variants, fresh user installs, ownership, and owner-home resolution

## Validation

- `rtk make check`
- focused ShellCheck, shfmt, Kickstart, and install-preservation checks
- isolated direct-root `make install` wrapper test, including ownership and mode preservation
- target-user session-bus handoff test
- Codex review: no actionable defects
- CodeRabbit CLI review: 0 findings

An end-to-end Anaconda installation from a newly built ISO was not run; this change does not claim new image boot/install qualification beyond the focused Kickstart and installer regression coverage above.

Closes #150