### PR TITLE
Fix Fedora install ownership and narrow support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -25,21 +25,19 @@ body:
       required: true
 
   - type: dropdown
-    id: distro_family
+    id: fedora_release
     attributes:
-      label: Distribution family
+      label: Fedora release
       options:
-        - Debian or Ubuntu family
-        - Arch family
-        - Fedora, RHEL, Rocky, or Alma family
-        - Other
+        - Fedora 44
+        - Fedora Rawhide
     validations:
       required: true
 
   - type: input
     id: environment
     attributes:
-      label: Distribution, architecture, and session
+      label: Fedora release, architecture, and session
       placeholder: "Fedora 44, x86_64, X11 via LightDM"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -30,8 +30,8 @@ body:
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives and portability impact
-      description: Explain alternatives and effects on Debian, Arch, and RHEL families.
+      label: Alternatives and Fedora impact
+      description: Explain alternatives and effects on supported Fedora installations.
 
   - type: checkboxes
     id: scope

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,12 +13,12 @@
 
 ## Validation
 
-- [ ] `make clean && make`
-- [ ] `make check`
+- [ ] `scripts/run-tests make clean all`
+- [ ] `scripts/run-tests`
 - [ ] Focused X11, Quickshell, installer, or documentation checks as applicable
 - [ ] `git diff --check`
 
-Tested distributions, architectures, and X11 environments:
+Tested Fedora releases, architectures, and X11 environments:
 
 <!-- List exact coverage and clearly identify anything not tested. -->
 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Trust the container checkout
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Install build and validation dependencies
         run: |
           dnf install -y --setopt=install_weak_deps=False \

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -17,70 +17,72 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    container: fedora:44
+    env:
+      DWM_TEST_TMP_ROOT: /var/tmp/dwm-titus-tests
 
     steps:
+      - name: Install checkout dependency
+        run: dnf install -y --setopt=install_weak_deps=False git
+
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Install build and validation dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential pkg-config shellcheck shfmt python3-venv \
-            xvfb xdotool x11-utils \
-            libx11-dev libxft-dev libxinerama-dev libxrender-dev \
-            libimlib2-dev libx11-xcb-dev libxcb1-dev libxcb-res0-dev \
-            libfontconfig-dev libfreetype-dev
-          python3 -m venv .ci-pykickstart
-          .ci-pykickstart/bin/pip install pykickstart
-          echo "$PWD/.ci-pykickstart/bin" >> "$GITHUB_PATH"
+          dnf install -y --setopt=install_weak_deps=False \
+            gcc make diffutils dbus-daemon \
+            pkgconf-pkg-config ShellCheck shfmt pykickstart \
+            xorg-x11-server-Xvfb xdotool xprop xset \
+            libX11-devel libXft-devel libXinerama-devel libXrender-devel \
+            imlib2-devel libxcb-devel xcb-util-devel \
+            fontconfig-devel freetype-devel
 
       - name: Validate
-        run: make check
+        run: scripts/run-tests
 
       - name: Validate nested X11 runtime
-        run: make check-xvfb-runtime check-monitor-tags
+        run: scripts/run-tests make check-xvfb-runtime check-monitor-tags
 
   clang-build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    container: fedora:44
 
     steps:
+      - name: Install checkout dependency
+        run: dnf install -y --setopt=install_weak_deps=False git
+
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Install Clang and build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            clang pkg-config \
-            libx11-dev libxft-dev libxinerama-dev libxrender-dev \
-            libimlib2-dev libx11-xcb-dev libxcb1-dev libxcb-res0-dev \
-            libfontconfig-dev libfreetype-dev
+          dnf install -y --setopt=install_weak_deps=False \
+            clang make pkgconf-pkg-config \
+            libX11-devel libXft-devel libXinerama-devel libXrender-devel \
+            imlib2-devel libxcb-devel xcb-util-devel \
+            fontconfig-devel freetype-devel
 
       - name: Build with Clang
         run: make clean all CC=clang
 
-  distro-smoke:
+  fedora-smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        family: [debian, arch, rhel]
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
-      - name: Validate ${{ matrix.family }} family
+      - name: Validate Fedora 44
         env:
           CONTAINER_ENGINE: docker
-          DWM_CONTAINER_FAMILIES: ${{ matrix.family }}
-        run: make check-container-smoke
+          DWM_CONTAINER_FEDORA_IMAGE: fedora:44
+        run: scripts/run-tests make check-container-smoke
 
   quickshell-qml:
     runs-on: ubuntu-latest
@@ -88,6 +90,9 @@ jobs:
     container: fedora:44
 
     steps:
+      - name: Install checkout dependency
+        run: dnf install -y --setopt=install_weak_deps=False git
+
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
@@ -96,4 +101,4 @@ jobs:
         run: dnf install -y --setopt=install_weak_deps=False make quickshell qt6-qtdeclarative-devel
 
       - name: Validate Quickshell QML
-        run: make check-quickshell-qml
+        run: scripts/run-tests make check-quickshell-qml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,20 +20,23 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    container: fedora:44
 
     steps:
+      - name: Install checkout dependency
+        run: dnf install -y --setopt=install_weak_deps=False git
+
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Install build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential pkg-config \
-            libx11-dev libxft-dev libxinerama-dev libxrender-dev \
-            libimlib2-dev libx11-xcb-dev libxcb1-dev libxcb-res0-dev \
-            libfontconfig-dev libfreetype-dev
+          dnf install -y --setopt=install_weak_deps=False \
+            gcc make pkgconf-pkg-config \
+            libX11-devel libXft-devel libXinerama-devel libXrender-devel \
+            imlib2-devel libxcb-devel xcb-util-devel \
+            fontconfig-devel freetype-devel
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4.37.4
@@ -42,7 +45,7 @@ jobs:
           build-mode: manual
 
       - name: Build
-        run: make clean all
+        run: scripts/run-tests make clean all
 
       - name: Analyze
         uses: github/codeql-action/analyze@v4.37.4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@
 
 This repository is a Fedora-first X11 desktop environment built around a
 heavily patched fork of suckless dwm and a managed Quickshell shell. The
-primary product is a complete desktop installed from Fedora Server Network
-Install media. The existing Debian-, Arch-, Fedora-, and RHEL-family installer
-remains a supported secondary path for the core desktop experience.
+product is a complete Fedora desktop installed from Fedora Server Network
+Install media or onto an existing Fedora installation. Other distributions
+are outside the supported product and validation contract.
 
 Read `SPEC.md` before making product, portability, installer, dependency, or
 packaging changes. Treat `SPEC.md` as the source of truth for project scope and
@@ -18,32 +18,18 @@ acceptance criteria.
 2. Keep the C window-manager core small, understandable, and dependency-light.
 3. Build a cohesive Fedora desktop without moving desktop policy into the C
    event loop.
-4. Preserve the core install and session contract across the three supported
-   distribution families.
+4. Preserve the Fedora install, image, and session contract.
 5. Keep installation and settings changes safe, repeatable, reversible, and
    explicit.
 6. Prefer focused changes that can be reviewed and tested independently.
 
 ## Supported Platforms
 
-The platform contract has two tiers:
-
-- Primary desktop image: the current documented Fedora Server Network Install
-  release, with separate standard and NVIDIA variants.
-- Secondary existing-system install: these distribution families:
-
-- Debian family: Debian, Ubuntu, Linux Mint, Pop!_OS, and compatible
-  derivatives using `apt`.
-- Arch family: Arch Linux, EndeavourOS, Manjaro, Arch Linux ARM, and compatible
-  derivatives using `pacman`.
-- RHEL family: RHEL, Rocky Linux, AlmaLinux, Fedora, and compatible
-  derivatives using `dnf`.
-
-Do not claim full desktop-environment parity on a secondary platform unless its
-settings providers and runtime behavior were tested there. Core support still
-requires dependency discovery, installation, X session startup, configuration
-deployment, and the core runtime checks in `SPEC.md`; a successful C build is
-not sufficient.
+The supported platform is Fedora Linux. The current documented Fedora Server
+Network Install release is the image base, with separate standard and NVIDIA
+variants. The existing-system installer also supports Fedora. Other
+distributions must fail clearly instead of entering an untested package or
+installation path.
 
 ## Repository Map
 
@@ -55,8 +41,7 @@ not sufficient.
 - `config/`: application configuration and default TOML runtime settings.
 - `scripts/`: session startup, dependency checks, desktop helpers, and
   operational scripts.
-- `install.sh`: supported existing-system installer for all distribution
-  families.
+- `install.sh`: supported existing-system installer for Fedora.
 - `dwm-fedora.ks`, `dwm-fedora-nvidia.ks`: Fedora image installation profiles.
 - `dwm.desktop`: display-manager X session entry.
 - `AGENTS.md`: durable engineering and agent-execution rules.
@@ -108,19 +93,17 @@ not sufficient.
 - Risky changes require preview, confirmation, rollback, or recovery behavior
   appropriate to their impact. Authorization denial must not hide readable
   state.
-- Fedora providers may land first. Secondary platforms must hide or explain
-  unavailable capabilities without breaking the rest of Settings.
+- Unsupported hardware capabilities must be hidden or explained without
+  breaking the rest of Settings.
 
 ## Portability Rules
 
-- Never hardcode one package manager in shared logic. Isolate `apt`, `pacman`,
-  and `dnf` behavior behind clearly named distro-family functions or adapters.
-- Detect the distribution using `/etc/os-release`. Detect package managers only
-  as a fallback or validation step.
-- Map required capabilities to family-specific package names. Do not scatter
-  package-name lists across multiple scripts.
-- Use `pkg-config` for X11 and library discovery where available. Avoid relying
-  on Arch-specific paths or `/usr/X11R6`.
+- Detect Fedora through `/etc/os-release` and reject other distributions
+  before package installation or system changes.
+- Keep Fedora package capability names in the shared dependency map. Do not
+  scatter package-name lists across multiple scripts.
+- Use `pkg-config` for X11 and library discovery where available. Avoid legacy
+  hardcoded paths such as `/usr/X11R6`.
 - Respect `CC`, `CFLAGS`, `CPPFLAGS`, `LDFLAGS`, `PREFIX`, `DESTDIR`,
   `XDG_CONFIG_HOME`, and the invoking user's home directory.
 - Do not assume `/usr/lib` versus `/usr/lib64`. Search known executable paths
@@ -197,9 +180,8 @@ not sufficient.
 
 - Keep the existing C99 style and compile with warnings enabled.
 - Avoid adding a new library dependency unless it materially improves a
-  required feature. Dependencies for the core desktop must remain portable;
-  Fedora-first Settings dependencies must have explicit fallback behavior on
-  secondary platforms.
+  required feature. Required dependencies must be available on supported
+  Fedora releases.
 - Check allocation, file, Xlib/XCB, parser, and process-launch failures.
 - Do not introduce blocking work into the X event loop.
 - Keep Linux-specific functionality, such as inotify, explicit and documented.
@@ -208,37 +190,35 @@ not sufficient.
 
 ## Required Validation
 
-Run the smallest applicable set first, then the full relevant set:
+Run the smallest applicable set first, then the full relevant set through the
+managed test workspace:
 
 ```sh
-make clean
-make
+scripts/run-tests make clean all
+scripts/run-tests
 ```
 
 For shell changes:
 
 ```sh
-shellcheck install.sh install-arm.sh scripts/*.sh
-shfmt -d install.sh install-arm.sh scripts/*.sh
+shellcheck install.sh scripts/*.sh tests/*.sh
+shfmt -d install.sh scripts/*.sh tests/*.sh
 ```
 
 For Quickshell QML changes, run `qmllint` with the explicit Qt/Quickshell QML
 module roots documented in `SPEC.md`, and validate the managed shell in a real
 or nested X11 session before declaring runtime behavior verified.
 
-For installer or portability changes, validate in clean containers or virtual
-machines representing:
-
-- One currently supported Debian or Ubuntu release.
-- One current Arch-family installation.
-- One currently supported Fedora, Rocky Linux, AlmaLinux, or RHEL release.
+For installer or packaging changes, validate in a clean container or virtual
+machine using the supported Fedora release.
 
 At minimum, verify dependency resolution, a clean build, staged installation
 with `DESTDIR`, installed file paths, and script syntax. A real X11 session or
 nested X server is required before declaring runtime behavior fully validated.
 
-If a required platform cannot be tested, state exactly what was not tested and
-do not describe the change as universally verified.
+Use `${DWM_TEST_TMP_ROOT:-$HOME/tmp}` for test workspaces and clear the exact
+run directory after success, failure, or interruption. If a required Fedora
+path cannot be tested, state exactly what was not tested.
 
 For Fedora image changes, follow the complete validation contract in
 [SPEC.md Section 9.4](SPEC.md#94-fedora-image-validation). Static validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,10 @@ versions from `config.mk`.
 ### Fixed
 
 - Keep Fedora image XDG parents owned by the installer-created user, run the
-  user-scoped install stage without root privileges, preserve existing XDG
-  directory modes, make direct root installs drop privileges for the user
-  stage, and document a narrow v0.6.0 repair.
+  user-scoped install stage without root privileges or ownership-changing
+  syscalls, avoid rebuilding user-owned sources during the privileged system
+  stage, preserve existing XDG directory modes, make direct root installs drop
+  privileges for the user stage, and document a narrow v0.6.0 repair.
 - Match generated Xorg OutputClass rules against the DRM driver name, including
   mapping virtio PCI devices to `virtio_gpu`, so saved display layouts survive
   a real Xorg restart. Associate NVIDIA RandR names through per-display driver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ versions from `config.mk`.
 
 ## [Unreleased]
 
-## [0.6.1] - 2026-08-16
+## [0.6.1] - 2026-08-17
 
 ### Added
 
@@ -16,14 +16,17 @@ versions from `config.mk`.
 - A narrow root-owned display helper for confirmed managed Xorg fragment
   installation and rollback, with installed-path, ownership, permission,
   symlink, structured-input, and authorization-denial coverage.
-- Fedora hardware, nested-X11, and Debian/Arch/Fedora container validation for
-  the Phase 2 provider, packaging, recovery, and privilege contracts.
+- Fedora hardware, nested-X11, and Fedora 44 container validation for the
+  Phase 2 provider, packaging, recovery, and privilege contracts.
 - NVIDIA ForceFullCompositionPipeline capability discovery and safe persistent
   defaults, with unsupported drivers left unchanged and incompatible forced-on
   requests rejected.
 
 ### Changed
 
+- Narrow platform support, the installer, package mapping, fixtures, and CI to
+  Fedora only. Tests now run in a disposable workspace below `$HOME/tmp` and
+  remove it after success, failure, or interruption.
 - Thunar's seeded **Open Terminal Here** action now launches Alacritty directly
   instead of entering the Herdr workspace.
 - Replace Flameshot with the X11-native `maim` capture tool. Saved captures use

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,7 @@
 # Contributing
 
 Thanks for helping improve dwm-titus. Changes should preserve the small X11
-window-manager core, existing user workflows, the Fedora-first desktop target,
-and the supported core install on Debian, Arch, Fedora, and RHEL families.
+window-manager core, existing user workflows, and the Fedora desktop target.
 
 ## Before You Start
 
@@ -21,7 +20,7 @@ Install the build dependencies for your distribution, then run:
 ```sh
 make clean
 make
-make check
+scripts/run-tests
 ```
 
 Use `./install.sh --dry-run --non-interactive --profile core` to inspect the
@@ -34,14 +33,14 @@ submitting a pull request.
 
 | Change | Required validation |
 | --- | --- |
-| C or build configuration | `make clean && make`, then `make check` |
-| Shell or installer | `make check-shell check-format` and focused tests |
-| X11 behavior | `make check-xvfb-runtime check-monitor-tags` |
-| Quickshell QML | `make check-quickshell-qml` plus real or nested X11 runtime validation |
+| C or build configuration | `scripts/run-tests make clean all`, then `scripts/run-tests` |
+| Shell or installer | `scripts/run-tests make check-shell check-format` and focused tests |
+| X11 behavior | `scripts/run-tests make check-xvfb-runtime check-monitor-tags` |
+| Quickshell QML | `scripts/run-tests make check-quickshell-qml` plus real or nested X11 runtime validation |
 | Documentation | `mdbook build docs && mdbook test docs` |
-| Installer or package mapping | `make check-container-smoke` |
-| Fedora Kickstart or ISO | `make check-kickstart` plus all evidence required by [SPEC.md Section 9.4](SPEC.md#94-fedora-image-validation) |
-| Release automation | `make release-check` and a dry run of the release helper |
+| Installer or package mapping | `scripts/run-tests make check-container-smoke` |
+| Fedora Kickstart or ISO | `scripts/run-tests make check-kickstart` plus all evidence required by [SPEC.md Section 9.4](SPEC.md#94-fedora-image-validation) |
+| Release automation | `scripts/run-tests make release-check` and a dry run of the release helper |
 
 Container and X11 checks require their documented host tools. If a required
 environment is unavailable, state exactly what was not tested in the pull
@@ -50,7 +49,7 @@ request instead of claiming universal validation.
 ## Change Guidelines
 
 - Preserve the C99 style and avoid new mandatory dependencies unless they are
-  available across all supported families.
+  available on supported Fedora releases.
 - Keep POSIX scripts under `#!/bin/sh`; use Bash only for scripts that need Bash
   features.
 - Preserve existing `config.h`, XDG user configuration, and `.xinitrc` files.

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,11 @@ all: dwm
 .c.o:
 	${CC} ${CPPFLAGS} ${CFLAGS} -c $<
 
-${OBJ}: config.h config.mk
+${OBJ}: config.h config.mk Makefile
+drw.o: drw.h util.h
+dwm.o: drw.h util.h tomlparser.h
+util.o: util.h
+tomlparser.o: tomlparser.h
 
 config.h:
 	cp config.def.h $@
@@ -103,7 +107,18 @@ native:
 	$(MAKE) clean
 	$(MAKE) OPTIMISATIONS="${NATIVE_OPTIMISATIONS}" all
 
-install: install-system
+install:
+	if [ "$$(id -u)" -eq 0 ] && [ -n "${OWNER}" ] && [ "${OWNER}" != root ]; then \
+		test -n "${USER_HOME}" || { echo "USER_HOME could not be determined." >&2; exit 1; }; \
+		command -v runuser >/dev/null 2>&1 || { \
+			echo "runuser is required to build user-owned sources without root privileges." >&2; \
+			exit 1; \
+		}; \
+		runuser -u "${OWNER}" -- env HOME="${USER_HOME}" $(MAKE) all; \
+	else \
+		$(MAKE) all; \
+	fi
+	$(MAKE) install-system
 	if [ -z "${DESTDIR}" ]; then \
 		if [ "$$(id -u)" -eq 0 ]; then \
 			target_user="${OWNER}"; \
@@ -129,7 +144,13 @@ install: install-system
 		echo "==> DESTDIR set; skipping user configuration."; \
 	fi
 
-install-system: all install-cursors
+install-system:
+	@test -x dwm || { echo "dwm is not built. Run make before install-system." >&2; exit 1; }
+	@for input in ${SRC} ${OBJ} drw.h util.h tomlparser.h config.h config.mk Makefile; do \
+		test -e "$$input" || { echo "dwm build input is missing: $$input. Run make before install-system." >&2; exit 1; }; \
+		test ! "$$input" -nt dwm || { echo "dwm is stale. Run make before install-system." >&2; exit 1; }; \
+	done
+	$(MAKE) install-cursors
 	@echo ""
 	@echo "==> Installing system files..."
 	install -Dm755 dwm ${DESTDIR}${PREFIX}/bin/dwm
@@ -161,6 +182,7 @@ install-cursors:
 
 install-user:
 	@test -n "${USER_HOME}" || { echo "USER_HOME could not be determined." >&2; exit 1; }
+	@test "$$(id -u)" -ne 0 || { echo "Refusing to install user files as root. Run install-user as the target user." >&2; exit 1; }
 	@echo "==> Installing user files for ${OWNER}..."
 	if [ ! -e "${USER_HOME}/.xinitrc" ]; then \
 		install -Dm644 scripts/.xinitrc "${USER_HOME}/.xinitrc"; \
@@ -171,7 +193,7 @@ install-user:
 	mkdir -p ${DATA_DIR}
 	if [ "$$(realpath .)" != "$$(realpath ${DATA_DIR})" ]; then \
 		rm -rf "${DATA_DIR}/config" "${DATA_DIR}/scripts"; \
-		cp -a config scripts "${DATA_DIR}/"; \
+		cp -a --no-preserve=ownership config scripts "${DATA_DIR}/"; \
 	fi
 	@echo "==> Seeding application config without overwriting user files..."
 	mkdir -p ${CFG_DIR}
@@ -186,17 +208,17 @@ install-user:
 			continue; \
 		fi; \
 		mkdir -p "$$dst"; \
-		cp -aL -n "$$dir"/. "$$dst"/; \
+		cp -aL -n --no-preserve=ownership "$$dir"/. "$$dst"/; \
 	done
 	@echo "==> Seeding dwm-scoped XDG autostart overrides..."
 	HOME="${USER_HOME}" XDG_CONFIG_HOME="${XDG_CONFIG_HOME}" \
-		XDG_CONFIG_DIRS="${XDG_CONFIG_DIRS}" DWM_INSTALL_OWNER="${OWNER}" \
+		XDG_CONFIG_DIRS="${XDG_CONFIG_DIRS}" \
 		scripts/seed-autostart-overrides.sh
 	@echo "==> Replacing managed Quickshell config..."
 	test -n "${CFG_DIR}"
 	rm -rf "${CFG_DIR}/quickshell"
 	mkdir -p "${CFG_DIR}/quickshell"
-	cp -aL config/quickshell/. "${CFG_DIR}/quickshell"/
+	cp -aL --no-preserve=ownership config/quickshell/. "${CFG_DIR}/quickshell"/
 	@echo "==> Seeding user config (skipping existing files)..."
 	mkdir -p ${CFG_DIR}/dwm-titus
 	test -f ${CFG_DIR}/dwm-titus/hotkeys.toml || install -Dm644 config/hotkeys.toml ${CFG_DIR}/dwm-titus/hotkeys.toml
@@ -238,19 +260,14 @@ install-user:
 		echo "  Preserving existing Meslo font alias file."; \
 	fi
 	fc-cache -f >/dev/null 2>&1 || true
-	@echo "==> Fixing ownership and permissions..."
+	@echo "==> Fixing executable permissions..."
 	find ${DATA_DIR} \( -name '*.sh' -o -name '*.py' \) -print0 | xargs -0 -r chmod +x
 	for dir in config/*/; do \
 		b=$$(basename $$dir); \
 		if [ ! -L "${CFG_DIR}/$$b" ]; then \
 			find "${CFG_DIR}/$$b" \( -name '*.sh' -o -name '*.py' \) -print0 2>/dev/null | xargs -0 -r chmod +x; \
-			chown -R ${OWNER}: "${CFG_DIR}/$$b"; \
 		fi; \
 	done
-	chown -R ${OWNER}: ${CFG_DIR}/fontconfig 2>/dev/null || true
-	chown -R ${OWNER}: ${CFG_DIR}/dwm-titus
-	chown -R ${OWNER}: ${DATA_DIR}
-	if [ -e "${USER_HOME}/.xinitrc" ]; then chown ${OWNER}: "${USER_HOME}/.xinitrc"; fi
 	@echo ""
 	@echo "  dwm installed successfully."
 	@echo "  Log out and select 'dwm', or start with: startx"

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ SYSTEMDUSERDIR ?= ${PREFIX}/lib/systemd/user
 CAPITAINE_DARK_THEME = Capitaine-Cursors
 CAPITAINE_LIGHT_THEME = Capitaine-Cursors-White
 CAPITAINE_LICENSE_DIR = ${DATADIR}/licenses/dwm-titus/capitaine-cursors
+run_managed_test = if [ -n "$${DWM_TEST_WORKSPACE:-}" ] && [ -n "$${DWM_TEST_RUNNER_TOKEN:-}" ] && [ "$${TMPDIR:-}" = "$${DWM_TEST_WORKSPACE}" ] && [ -f "$${DWM_TEST_WORKSPACE}/.runner" ] && [ ! -L "$${DWM_TEST_WORKSPACE}/.runner" ] && [ "$$(cat "$${DWM_TEST_WORKSPACE}/.runner" 2>/dev/null)" = "$${DWM_TEST_RUNNER_TOKEN}" ]; then $(1); else scripts/run-tests $(1); fi
 
 SRC = drw.c dwm.c util.c tomlparser.c
 OBJ = ${SRC:.c=.o}
@@ -37,6 +38,7 @@ INSTALL_COMMANDS = \
 	scripts/dwm-quickshell-controlcenter \
 	scripts/dwm-quickshell-network \
 	scripts/dwm-quickshell-state \
+	scripts/dwm-quickshell-version-check \
 	scripts/dwm-status \
 	scripts/dwm-system-health \
 	scripts/dwm-polkit \
@@ -226,7 +228,7 @@ install-user:
 	test -f ${CFG_DIR}/dwm-titus/window-rules.toml || install -Dm644 config/window-rules.toml ${CFG_DIR}/dwm-titus/window-rules.toml
 	@echo "==> Migrating legacy graphical-session startup..."
 	HOME="${USER_HOME}" XDG_CONFIG_HOME="${XDG_CONFIG_HOME}" scripts/migrate-graphical-session.sh
-	@echo "==> Installing font aliases for cross-distro naming..."
+	@echo "==> Installing Meslo font aliases..."
 	mkdir -p ${CFG_DIR}/fontconfig/conf.d
 	if [ ! -f ${CFG_DIR}/fontconfig/conf.d/50-meslolgs-nerd-font-aliases.conf ]; then \
 		{ \
@@ -304,10 +306,10 @@ release: dwm
 	echo "==> Created ${RELEASE_ARCHIVE}"
 
 check-shell:
-	shellcheck install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/install-herdr scripts/quickshell-qmllint scripts/*.sh tests/*.sh
+	shellcheck install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-quickshell-version-check scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/install-herdr scripts/quickshell-qmllint scripts/run-tests scripts/*.sh tests/*.sh
 
 check-format:
-	shfmt -d install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/install-herdr scripts/quickshell-qmllint scripts/*.sh tests/*.sh
+	shfmt -d install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-quickshell-version-check scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/install-herdr scripts/quickshell-qmllint scripts/run-tests scripts/*.sh tests/*.sh
 
 check-session-guards:
 	tests/test-autostart.sh
@@ -413,6 +415,9 @@ check-kickstart:
 check-fedora-iso-builder:
 	tests/test-fedora-iso-builder.sh
 
+check-fedora-platform:
+	@$(call run_managed_test,tests/test-fedora-platform.sh)
+
 check-install: all
 	@set -eu; \
 	stage="$$(mktemp -d)"; \
@@ -478,7 +483,10 @@ check-install-preservation:
 	tests/test-install-preservation.sh
 
 check-container-smoke:
-	tests/test-container-smoke.sh
+	@$(call run_managed_test,tests/test-container-smoke.sh)
+
+check-test-runner:
+	@$(call run_managed_test,tests/test-run-tests.sh)
 
 release-check: all
 	@set -eu; \
@@ -511,6 +519,7 @@ check:
 	$(MAKE) check-shell
 	$(MAKE) check-format
 	$(MAKE) check-build-config
+	$(MAKE) check-fedora-platform
 	$(MAKE) check-dev-sync-install
 	$(MAKE) check-default-apps
 	$(MAKE) check-diagnostics
@@ -537,13 +546,14 @@ check:
 	$(MAKE) check-install
 	$(MAKE) check-install-manifest
 	$(MAKE) check-install-preservation
+	$(MAKE) check-test-runner
 	$(MAKE) check-lightdm-config
 	$(MAKE) release-check
 
-.PHONY: all check check-build-config check-build-deps check-default-apps check-dev-sync-install \
-	check-container-smoke \
-	check-display-profile check-display-setup check-fedora-iso-builder check-format check-install \
+.PHONY: clean all check check-build-config check-build-deps check-default-apps check-dev-sync-install \
+	check-container-smoke check-test-runner \
+	check-display-profile check-display-setup check-fedora-iso-builder check-fedora-platform check-format check-install \
 	check-herdr-install check-install-manifest check-install-preservation check-kickstart check-lock \
 	check-session-guards check-session-migration check-screenshot check-release-helper check-shell check-diagnostics check-status check-system-health check-settings \
-	check-quickshell-launcher check-quickshell-controls check-quickshell-controlcenter check-quickshell-notifications check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-qml check-lightdm-config check-terminal clean install install-system install-user \
+	check-quickshell-launcher check-quickshell-controls check-quickshell-controlcenter check-quickshell-notifications check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-qml check-lightdm-config check-terminal check-xvfb-runtime install install-system install-user \
 	install-cursors native release release-check uninstall

--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ guided installation, and powerful customization. It is designed for people who
 want a responsive keyboard-first workflow without having to assemble every
 part themselves.
 
-Fedora is the primary desktop image. The existing-system installer also
-supports the core experience on Debian-, Arch-, Fedora-, and RHEL-family
-distributions.
+Fedora is the supported platform. Use either the Fedora desktop image or the
+existing-system installer on Fedora Linux.
 
 ## What You Get
 
@@ -29,7 +28,7 @@ distributions.
 | **Everyday essentials** | A polished panel, application launcher, system tray, Control Center, Settings, notifications, screenshots, audio, brightness, and power controls. |
 | **Easy discovery** | An interactive keybind viewer, guided display setup, built-in diagnostics, and clear unsupported-feature reporting. |
 | **Personal configuration** | Live-reloading hotkeys, themes, and window rules, with local configuration preserved across upgrades. |
-| **Two installation paths** | A ready-to-install Fedora image or an installer for an existing supported Linux system. |
+| **Two installation paths** | A ready-to-install Fedora image or an installer for an existing Fedora system. |
 
 > dwm-titus is an X11 desktop. A Wayland-native session is not currently part
 > of the project scope.
@@ -41,7 +40,7 @@ Choose the path that matches your system:
 | Installation | Best for | What it does |
 | --- | --- | --- |
 | [Fedora ISO](#fedora-iso) | A fresh, dedicated installation | Installs the complete Fedora-first desktop from bootable media. |
-| [Existing system](#existing-system) | A supported Linux installation you already use | Installs dependencies, the desktop session, and the selected feature set while preserving local configuration. |
+| [Existing system](#existing-system) | A Fedora installation you already use | Installs dependencies, the desktop session, and the selected feature set while preserving local configuration. |
 
 For complete requirements and installation details, see the
 [Installation Guide](https://dwm.christitus.com/install.html).
@@ -71,8 +70,9 @@ cd dwm-titus
 ```
 
 The dry run shows the dependency and installation plan before anything changes.
-The installer detects your distribution family, preserves existing personal
-configuration, and installs the managed desktop components.
+The installer requires Fedora, preserves existing personal configuration, and
+installs the managed desktop components. It rejects other distributions before
+making changes.
 
 | Profile | Includes |
 | --- | --- |
@@ -177,10 +177,11 @@ Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) for the
 development workflow and validation requirements, and report security issues
 using [SECURITY.md](SECURITY.md).
 
-The main repository check is:
+The main repository check uses a managed workspace under `$HOME/tmp` and
+removes it when the run finishes:
 
 ```bash
-make check
+scripts/run-tests
 ```
 
 Project requirements and active work are tracked in [SPEC.md](SPEC.md),

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,10 +3,9 @@
 ## Mission
 
 dwm-titus is expanding from an opinionated dwm distribution into a cohesive
-X11 desktop environment. The primary product is a complete Fedora desktop
-installed from the official Fedora Server Network Install ISO. The existing
-installer for Debian, Arch, Fedora, and RHEL-family systems remains supported
-as a secondary path.
+X11 desktop environment. The product is a complete Fedora desktop installed
+from the official Fedora Server Network Install ISO or onto an existing Fedora
+installation.
 
 The desktop keeps dwm as the small window-management core and Quickshell as the
 managed shell and settings layer. New features must preserve existing keybinds,
@@ -15,12 +14,10 @@ when optional components fail.
 
 ## Delivery Model
 
-- Fedora is the first implementation and release-qualification target.
+- Fedora is the only implementation and release-qualification target.
 - Fedora 44 Server Network Install is the current canonical image base.
 - Standard and NVIDIA image variants remain separate.
-- Debian, Arch, and generic RHEL-family installs retain the core desktop
-  contract. New settings capabilities may arrive later on those systems and
-  must report or hide unsupported operations cleanly.
+- Non-Fedora installations are outside the supported product contract.
 - Wayland-native support remains out of scope.
 - The Settings experience will be hybrid: common desktop controls belong in a
   cohesive Quickshell application, while high-risk administration is delegated
@@ -53,13 +50,14 @@ application without changing existing desktop behavior.
 - Event-driven state providers and small, testable helper interfaces.
 - A strict privilege boundary: QML remains unprivileged, privileged operations
   are allowlisted, and every system change requires explicit user intent.
-- Fedora-first packaging and dependency requirements with clean fallbacks on
-  secondary platforms.
+- Fedora packaging and dependency requirements with clean unavailable states
+  for missing hardware or services.
 
 ### Exit Criteria
 
 - The Settings shell opens and navigates without adding idle polling.
-- Read-only capability discovery works on Fedora and degrades cleanly elsewhere.
+- Read-only capability discovery works on Fedora and degrades cleanly when a
+  Fedora service or hardware capability is absent.
 - Privilege, rollback, error, and unsupported-state behavior are documented and
   covered by focused tests.
 - Existing Control Center, launcher, hotkeys, and runtime configuration remain
@@ -77,9 +75,6 @@ application without changing existing desktop behavior.
 - Authorization, helper ownership, confirmation, cancellation, error, preview,
   rollback, packaging, and validation contracts are recorded in
   `docs/SETTINGS-PLATFORM.md`.
-- Arch and generic RHEL package mappings and Debian fallback records were
-  statically validated, but real secondary-platform Settings sessions and real
-  input/display hardware behavior remain Phase 2 qualification work.
 
 ## Phase 2: Displays and Input
 
@@ -122,12 +117,9 @@ Make common monitor and input changes available from the Settings application.
 - Nested X11 at 1280x800 discovered one output and two virtual input devices,
   exercised Displays and Input section lifecycle, closed cleanly, and measured
   0.00 percent Quickshell CPU while closed.
-- Debian 13, current Arch, and Fedora 44 containers resolved the new XInput
-  packages, built the project, validated staged install/uninstall symmetry, and
-  passed the root-helper trust and authorization-denial tests.
-- The full Rocky Linux 9 container smoke remains blocked by package-source
-  availability in the qualification environment. Package mapping and shell
-  fixtures pass, but a complete Rocky install is not claimed.
+- Fedora 44 container validation resolved the XInput packages, built the
+  project, validated staged install/uninstall symmetry, and passed the
+  root-helper trust and authorization-denial tests.
 - Named profile persistence, generated managed-fragment install/backup/rollback,
   and idempotent input startup apply are automated. In a Fedora 44 UEFI VM,
   root-owned mode-0644 generated fragments preserved both a non-default
@@ -142,9 +134,8 @@ Make common monitor and input changes available from the Settings application.
   confirmed it enabled. Generated persistence enables the NVIDIA option by
   default, leaves unsupported drivers unchanged, and rejects an explicit
   forced-on request on incompatible drivers.
-- No physical touchpad was available, and complete Rocky Linux 9 runtime and
-  real secondary-platform X11 sessions remain unqualified. These limitations
-  do not affect the Fedora Phase 2 exit criteria.
+- No physical touchpad was available. This limitation does not affect the
+  Fedora Phase 2 exit criteria.
 
 ## Phase 3: Connectivity and Audio
 
@@ -259,12 +250,11 @@ Deliver a repeatable Fedora-first desktop installation and upgrade experience.
   session with the documented desktop features.
 - Kickstart syntax, package resolution, ISO construction, and first boot are
   recorded for each released image.
-- Unsupported or untested hardware and secondary-platform gaps are stated
-  precisely in release notes.
+- Unsupported or untested Fedora hardware paths are stated precisely in
+  release notes.
 
 ## Future Evaluation
 
-After the Fedora-first phases are stable, evaluate broader feature parity for
-Debian, Arch, and generic RHEL-family systems, additional accessibility work,
+After the Fedora phases are stable, evaluate additional accessibility work,
 sharing and peripheral workflows, and whether a Wayland successor should be a
-separate project. These are not current commitments.
+separate project. Support for other distributions is not a current commitment.

--- a/SPEC.md
+++ b/SPEC.md
@@ -7,11 +7,9 @@ maintained fork of suckless dwm with runtime-configurable hotkeys, themes, and
 window rules, a managed Quickshell shell and Settings layer, and supporting
 desktop services and helpers.
 
-The primary product is a cohesive desktop installed from the official Fedora
-Server Network Install ISO. A supported existing-system installer continues to
-provide the core desktop on Debian-family, Arch-family, Fedora, and generic
-RHEL-family systems without requiring users to translate package names or
-repair distribution-specific paths manually.
+The product is a cohesive Fedora desktop installed from the official Fedora
+Server Network Install ISO or onto an existing Fedora installation. Other
+distributions are outside the supported product and validation contract.
 
 ## 2. Goals
 
@@ -20,15 +18,13 @@ repair distribution-specific paths manually.
 - Provide one cohesive Settings experience for common display, input,
   connectivity, audio, power, appearance, default-application, update, and
   system-information workflows.
-- Build and run the core dwm-titus desktop on supported Debian, Arch, and RHEL
-  distribution families.
+- Build and run the complete dwm-titus desktop on supported Fedora releases.
 - Provide safe, idempotent dependency installation and system integration.
 - Preserve the speed, simplicity, and direct configuration model of dwm.
-- Provide consistent defaults and core behavior across distributions while
-  allowing Fedora-first Settings providers to degrade cleanly elsewhere.
+- Provide consistent defaults and complete Settings behavior on Fedora.
 - Support display-manager login and `startx`.
-- Support common x86_64 and ARM Linux systems where the required X11 libraries
-  are available.
+- Support Fedora x86_64. Fedora aarch64 remains future scope until its installer
+  and desktop runtime complete the release validation contract.
 - Keep user configuration under standard XDG paths and preserve it on upgrade.
 
 ## 3. Non-Goals
@@ -57,31 +53,14 @@ The primary release target is the Fedora desktop image:
 | Variants | Standard and explicitly selected NVIDIA image |
 | Initial release architecture | x86_64 |
 
-The existing-system installer remains a supported secondary path for these
-families:
+Fedora aarch64 is not currently a supported release target. Architecture-aware
+package filtering may remain in shared helpers, but it does not constitute an
+aarch64 support claim without native installer and desktop runtime evidence.
 
-| Family | Package interface | Representative systems |
-| --- | --- | --- |
-| Debian | `apt` / `dpkg` | Debian, Ubuntu, Mint, Pop!_OS |
-| Arch | `pacman` | Arch Linux, EndeavourOS, Manjaro, Arch Linux ARM |
-| RHEL | `dnf` / RPM | RHEL, Rocky Linux, AlmaLinux, Fedora |
-
-A compatible derivative is supported for the core desktop when it:
-
-- Provides the family's standard package interface.
-- Provides X11 and the required development libraries.
-- Uses conventional FHS and XDG paths.
-- Has not reached end of life.
-
-The installer must report the detected distribution ID and family. Unknown
-derivatives may continue through a confirmed compatible-family path, but must
-not be silently misidentified.
-
-Secondary-platform support does not imply immediate parity with every Fedora
-Settings provider. Unsupported capabilities must be hidden or reported clearly
-without breaking the window manager, shell, installer, or other Settings
-sections. Full parity may be claimed only after the provider and runtime checks
-are validated on that platform.
+The existing-system installer supports Fedora and uses `dnf`/RPM. It must
+report the detected distribution and reject every non-Fedora system before
+package installation or system changes. Fedora derivatives, generic RHEL
+systems, and other Linux distributions are not implied to be supported.
 
 ## 5. Functional Requirements
 
@@ -138,7 +117,10 @@ managed shell must create one `PanelWindow` for every active screen so each
 monitor has a bar. The per-screen Quickshell `Variants` design must share its
 state providers and be explicitly profiled to show that it remains near idle.
 
-The managed shell requires Quickshell 0.3.0 or newer. Anchored control popups
+The managed shell requires Quickshell 0.3.0 or Fedora 44's compatible
+`0.2.1^git20260209.dacfa9d` snapshot. That Fedora snapshot contains the
+`PopupWindow.grabFocus` API used by the shell; an unpatched upstream 0.2.1 is
+not sufficient. Anchored control popups
 must close on Escape and on a click outside their visible card under X11.
 Visible shell surfaces must be opaque and follow the active theme selected in
 the user `themes.toml` file.
@@ -164,10 +146,8 @@ the mouse cursor and transfer region captures as raw PNG data to an
 daemon or a GUI-toolkit clipboard owner. Saved captures use JPEG, and a full
 monitor capture targets the monitor under the pointer. The recommended desktop
 profile must install `maim` when it is available and keep the core install
-usable when it is not. On non-Fedora RHEL-family systems, the installer must
-explain how to enable the screenshot hotkeys through EPEL where a compatible
-package exists. `xclip` remains a required runtime package because other shell
-features also use the X11 clipboard.
+usable when it is not. `xclip` remains a required runtime package because
+other shell features also use the X11 clipboard.
 
 ### 5.4 Quickshell Launcher
 
@@ -199,8 +179,9 @@ but X11/EWMH behavior remains the compatibility boundary for this project.
 
 The supported installation flow must:
 
-1. Read `/etc/os-release` and select a Debian, Arch, or RHEL adapter.
-2. Resolve family-specific package names from one maintained dependency map.
+1. Read `/etc/os-release`, require Fedora, and reject unsupported systems
+   before making changes.
+2. Resolve Fedora package names from one maintained dependency map.
 3. Show required and optional packages before installing them.
 4. Install only missing required packages unless the user requests a broader
    desktop setup.
@@ -221,9 +202,17 @@ The supported installation flow must:
     configuration through an isolated managed fragment and backups. When no
     X11 session is available, print the deferred setup command instead.
 
-The installer must not require an AUR helper. On RHEL-family systems it may
-explain when an optional component requires EPEL or another repository, but it
-must not enable third-party repositories without user confirmation.
+The existing-system installer may enable only RPM Fusion nonfree and the
+`christitustech/copr-fedora` COPR, and only for the explicitly requested gaming
+profile. Interactive runs require a direct confirmation; non-interactive runs
+require the explicit `--enable-fedora-gaming-repos` approval flag. It must not
+enable any other third-party repository.
+
+The Fedora Kickstart image profiles separately predeclare the four image
+repository groups required by that product: RPM Fusion, Brave Browser, MWT
+Packages, and `christitustech/copr-fedora`. Their inclusion is validated as
+part of the reviewed ISO profile rather than inferred from existing-system
+installer approval.
 
 A source-checkout update of an existing live installation must use the complete
 supported install path. Updating only the `dwm` executable is not a supported
@@ -291,29 +280,17 @@ Quickshell-aware language server:
   editor language server for this repository because it understands Quickshell
   imports, singletons, types, snippets, and workspace QML components.
 
-The Qt tools are installed from distribution packages:
-
-| Family | Package examples |
-| --- | --- |
-| Debian | `qt6-declarative-dev-tools` |
-| Arch | `qt6-declarative` |
-| RHEL/Fedora | `qt6-qtdeclarative-devel` |
-
-Some distributions install Qt helper binaries outside the default `PATH`, such
-as `/usr/lib/qt6/bin`. Development environments should either add that
-directory to `PATH` or create user/system symlinks for `qmllint` and `qmlls`.
-On Fedora/RHEL-family systems the executable may also be named `qmllint-qt6`.
+Fedora provides the Qt tools through `qt6-qtdeclarative-devel`. Helper binaries
+may live outside the default `PATH`, such as `/usr/lib64/qt6/bin` or
+`/usr/lib/qt6/bin`, and `qmllint` may be named `qmllint-qt6`.
 
 `qmllint` must be run with explicit Qt and Quickshell QML import roots. Without
 those roots it can report false import failures for modules such as
 `Quickshell`, even when the shell runs correctly. Typical roots are:
 
-| Family | Common QML import roots |
-| --- | --- |
-| Debian | `/usr/lib/*/qt6/qml`, `/usr/lib/qt6/qml` |
-| Arch | `/usr/lib/qt6/qml` |
-| RHEL/Fedora | `/usr/lib64/qt6/qml`, `/usr/lib/qt6/qml` |
-| Nix | `${qtdeclarative}/lib/qt-6/qml`, `${quickshell}/lib/qt-6/qml` |
+| Fedora QML import roots |
+| --- |
+| `/usr/lib64/qt6/qml`, `/usr/lib/qt6/qml` |
 
 Language-server environments should expose the same roots:
 
@@ -322,66 +299,37 @@ export QMLLS_BUILD_DIRS="/usr/lib64/qt6/qml:/usr/lib/qt6/qml"
 export QML_IMPORT_PATH="$PWD/config/quickshell"
 ```
 
-The repository uses `import qs.core` for local shared QML helpers under
-`config/quickshell/core/`. Quickshell resolves that module at runtime from the
-configuration root, but stock `qmllint` may require a `qmldir` module map. Use
-a temporary lint-only import tree rather than changing the runtime layout:
+The repository wrapper resolves `qmllint-qt6`, `qmllint`, and the Fedora Qt
+binary paths, discovers the explicit Qt import roots, and creates the temporary
+`qmldir` module map needed for local `qs.*` imports:
 
 ```sh
+scripts/quickshell-qmllint --root config/quickshell
+```
+
+For Fedora x86_64, install the pinned `qml-language-server` v1.7.0 Linux AMD64
+asset only after verifying the repository-pinned SHA-256 checksum:
+
+```sh
+set -eu
+asset=qml-language-server-v1.7.0-linux-amd64.zip
+curl -fL --output "$asset" \
+  "https://github.com/cushycush/qml-language-server/releases/download/v1.7.0/$asset"
+printf '%s  %s\n' \
+  ad6e88b0fffbe5ee03fc9f6502c0103aa047c02c4942c547715283443bf4e946 \
+  "$asset" | sha256sum --check --strict
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
-mkdir -p "$tmp/qs/core"
-ln -s "$PWD/config/quickshell/core/Commands.qml" "$tmp/qs/core/Commands.qml"
-ln -s "$PWD/config/quickshell/core/Icons.qml" "$tmp/qs/core/Icons.qml"
-ln -s "$PWD/config/quickshell/core/Theme.qml" "$tmp/qs/core/Theme.qml"
-ln -s "$PWD/config/quickshell/core/ShellButton.qml" "$tmp/qs/core/ShellButton.qml"
-ln -s "$PWD/config/quickshell/core/ShellSurface.qml" "$tmp/qs/core/ShellSurface.qml"
-ln -s "$PWD/config/quickshell/core/SectionLabel.qml" "$tmp/qs/core/SectionLabel.qml"
-cat >"$tmp/qs/core/qmldir" <<'EOF'
-module qs.core
-singleton Commands 1.0 Commands.qml
-singleton Icons 1.0 Icons.qml
-singleton Theme 1.0 Theme.qml
-ShellButton 1.0 ShellButton.qml
-ShellSurface 1.0 ShellSurface.qml
-SectionLabel 1.0 SectionLabel.qml
-EOF
-
-QMLLS_BUILD_DIRS="/usr/lib64/qt6/qml:/usr/lib/qt6/qml" \
-QML_IMPORT_PATH="$PWD/config/quickshell" \
-qmllint-qt6 \
-  -I /usr/lib64/qt6/qml \
-  -I /usr/lib/qt6/qml \
-  -I "$tmp" \
-  -I config/quickshell \
-  config/quickshell/controls/ControlsModel.qml
+unzip -q "$asset" -d "$tmp"
+printf '%s  %s\n' \
+  928bd00ddb14f00a66f18473c0a492ae7109ee45c02db8bf3f55966229bb863a \
+  "$tmp/qml-language-server-v1.7.0-linux-amd64" | sha256sum --check --strict
+install -Dm0755 "$tmp/qml-language-server-v1.7.0-linux-amd64" \
+  "${HOME}/.local/bin/qml-language-server"
 ```
 
-When using Nix, the same rule applies: include both the Qt declarative QML root
-and the Quickshell QML root in the lint command or `QMLLS_BUILD_DIRS`. This
-matches the known workaround for `qmllint`/`qmlls` not discovering Quickshell
-type declarations automatically.
-
-Install the Quickshell-aware server with one of these supported methods:
-
-```sh
-# Arch-family systems with a working AUR helper
-yay -S qml-language-server-bin
-
-# Nix systems
-nix run github:cushycush/qml-language-server
-
-# Source build on any system with Go 1.26.1 or newer
-git clone https://github.com/cushycush/qml-language-server.git
-cd qml-language-server
-make build
-make install
-```
-
-For non-AUR systems that do not use Nix, install the matching prebuilt release
-archive from `https://github.com/cushycush/qml-language-server/releases` and
-place the binary in a developer `PATH` directory such as
-`${HOME}/.local/bin/qml-language-server` or `/usr/local/bin/qml-language-server`.
+Do not substitute a newer release or a different platform asset without
+updating and independently verifying the checksum committed here.
 
 Editor configuration must prefer `qml-language-server` for this repository's
 QML files. Zed users should install the QML extension for language registration,
@@ -400,21 +348,20 @@ and exercising the relevant IPC targets.
 
 ### 5.8 Dependency Mapping
 
-Package names differ by release and derivative. The maintained dependency map
-must cover the equivalent of these capabilities:
+The maintained Fedora dependency map covers these capabilities:
 
-| Capability | Debian family examples | Arch family examples | RHEL family examples |
-| --- | --- | --- | --- |
-| Compiler and make | `build-essential`, `pkg-config` | `base-devel`, `pkgconf` | Development Tools, `pkgconf-pkg-config` |
-| Xlib development | `libx11-dev` | `libx11` | `libX11-devel` |
-| Xft and fonts | `libxft-dev`, `libfontconfig-dev`, `libfreetype-dev` | `libxft`, `fontconfig`, `freetype2` | `libXft-devel`, `fontconfig-devel`, `freetype-devel` |
-| Xinerama | `libxinerama-dev` | `libxinerama` | `libXinerama-devel` |
-| Xrender | `libxrender-dev` | `libxrender` | `libXrender-devel` |
-| Imlib2 | `libimlib2-dev` | `imlib2` | `imlib2-devel` |
-| XCB | `libx11-xcb-dev`, `libxcb1-dev`, `libxcb-res0-dev` | `libxcb`, `xcb-util` | `libxcb-devel`, `xcb-util-devel` |
+| Capability | Fedora package examples |
+| --- | --- |
+| Compiler and make | `gcc`, `make`, `pkgconf-pkg-config` |
+| Xlib development | `libX11-devel` |
+| Xft and fonts | `libXft-devel`, `fontconfig-devel`, `freetype-devel` |
+| Xinerama | `libXinerama-devel` |
+| Xrender | `libXrender-devel` |
+| Imlib2 | `imlib2-devel` |
+| XCB | `libxcb-devel`, `xcb-util-devel` |
 
-These are capability mappings, not immutable package lists. Package availability
-must be validated against each tested release.
+These are capability mappings, not immutable package lists. Availability must
+be validated against the supported Fedora release.
 
 Runtime dependencies are classified as:
 
@@ -629,8 +576,12 @@ configuration and unrelated application configuration by default.
 
 ## 9. Validation and Acceptance Criteria
 
-A core desktop release is cross-distro ready only when all of the following
-pass. A Fedora desktop image additionally requires the image checks below.
+A release is Fedora-ready only when all of the following pass. A Fedora desktop
+image additionally requires the image checks below.
+
+Automated validation must run through `scripts/run-tests`, which creates a
+unique workspace under `${DWM_TEST_TMP_ROOT:-$HOME/tmp}` and removes that exact
+workspace on success, failure, or interruption.
 
 ### 9.1 Static Validation
 
@@ -639,11 +590,12 @@ pass. A Fedora desktop image additionally requires the image checks below.
 - ShellCheck and shfmt checks, with documented justified exceptions.
 - No generated build artifacts unintentionally included in the change.
 
-### 9.2 Distribution Validation
+### 9.2 Fedora Validation
 
-On at least one current representative of each family:
+On the supported Fedora release:
 
-- Distro detection selects the correct adapter.
+- Distribution detection accepts Fedora and rejects non-Fedora systems before
+  mutation.
 - Required package mapping resolves to installable packages.
 - A clean checkout builds successfully.
 - `make install DESTDIR=<staging-dir>` installs the expected system files
@@ -704,18 +656,14 @@ provide the remaining settings mutation surface in Section 5.10; those
 outcomes are sequenced in `ROADMAP.md`, and Phase 3 connectivity and audio work
 is defined in `TASKS.md`.
 
-The installer contains Debian-, Arch-, and Fedora/RHEL-family package mappings.
+The installer contains a Fedora-only package map and rejects other systems.
 The build uses `pkg-config`, supports staged installation with `DESTDIR`, and
 avoids writing user configuration during package builds. Fedora 44 Server
 Network Install is the current documented image base, while real image and
 hardware validation must continue to be recorded per release.
 
-Arch ARM handling is part of the primary installer; some manual package
-examples remain Arch-specific. Debian package resolution and clean compilation
-have been validated in a Debian 13 container, but a real Debian X11 session has
-not been tested. Complete runtime validation on Debian and non-Fedora RHEL
-derivatives remains required before describing those environments as
-universally verified.
+Debian, Arch, generic RHEL, and other distributions are intentionally outside
+the supported and tested product contract.
 
 ## 11. Definition of Done
 
@@ -724,8 +672,7 @@ A roadmap feature is complete when:
 - Its behavior meets the active roadmap phase and task acceptance criteria.
 - Fedora behavior is implemented and runtime validated, or the change is
   explicitly scoped as preparatory work.
-- Secondary-platform behavior is implemented or exposes a tested clean
-  unsupported state without regressing the core desktop.
+- Non-Fedora installation attempts fail clearly before making changes.
 - Relevant automated and manual validation is recorded.
 - On a development machine running dwm-titus, the checkout has been
   synchronized to the local live installation with

--- a/TASKS.md
+++ b/TASKS.md
@@ -129,7 +129,8 @@ Acceptance:
   or overlapping commands. Compare a 30-second closed baseline with a
   30-second sample after opening and closing each section; the mean Quickshell
   CPU delta must be no more than 0.5 percentage points of one CPU.
-- [ ] Run the full repository validation and record secondary-platform gaps.
+- [ ] Run the full Fedora repository validation and record untested hardware
+  paths.
 
 Acceptance:
 

--- a/config.def.h
+++ b/config.def.h
@@ -14,7 +14,7 @@ static const int topbar             = 1;        /* 0 means bottom bar */
 #define ICONSIZE                      17        /* icon size */
 #define ICONSPACING                   5         /* space between icon and title */
 #define SHOWWINICON                   1         /* 0 means no winicon */
-/* Fonts: Install ttf-meslo-nerd and noto-fonts-emoji from pacman */
+/* Fonts: install.sh downloads MesloLGS Nerd Font and installs google-noto-color-emoji-fonts with dnf. */
 static const char dmenufont[]       = "MesloLGS Nerd Font Mono:size=12";
 /* Fonts for the bar */
 static const char *fonts[]          = { "MesloLGS Nerd Font Mono:size=12:antialias=true:autohint=true", "NotoColorEmoji:pixelsize=14:antialias=true:autohint=true" };

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,18 +7,26 @@ use `make native` for published binaries.
    entries from Unreleased into that version.
 2. Commit and push the release source. The helper refuses dirty worktrees,
    version mismatches, and commits that are unavailable on GitHub.
-3. Run `make check`.
-4. Run `make check-xvfb-runtime check-monitor-tags` in isolated X11.
-5. Run `make check-container-smoke` for the Debian, Arch, and RHEL families.
-6. Run `make check-quickshell-qml` and the managed-shell runtime validation
-   when QML changed.
-7. Run `mdbook build docs && mdbook test docs` when documentation changed.
-8. Run `make release-check` and confirm the artifact is named
+3. Run `scripts/run-tests`.
+4. Run `scripts/run-tests make check-xvfb-runtime check-monitor-tags` in isolated X11.
+5. Run `scripts/run-tests make check-container-smoke` against Fedora 44.
+6. Run `scripts/run-tests make check-quickshell-qml check-quickshell-health-xvfb
+   check-quickshell-settings-xvfb` when QML changed.
+7. Run `scripts/run-tests mdbook build docs` and
+   `scripts/run-tests mdbook test docs` when documentation changed.
+8. Run `scripts/run-tests make release-check` and confirm the artifact is named
    `release/dwm-titus-VERSION.tar.gz`.
-9. Record the tested distributions, architectures, X11 environments, known
+9. Record the tested Fedora release, architectures, X11 environments, known
    limitations, and SHA-256 checksum in the release notes.
 10. Tag the release only after all applicable `SPEC.md` acceptance criteria
     and required GitHub checks pass.
+
+`scripts/run-tests` creates an isolated directory below
+`${DWM_TEST_TMP_ROOT:-$HOME/tmp}` and removes it on success, failure, or
+interruption. Store
+disposable VM disks and installer logs under a separately named directory in
+that same root, then delete that exact directory after qualification. Do not
+use `/tmp` for ISO or VM qualification.
 
 To create the GitHub release and bump to the next minor development version:
 
@@ -56,7 +64,10 @@ scripts/build-dwm-fedora-installer-iso.sh \
   --variant nvidia
 ```
 
-Both spins install the enabled Fedora, RPM Fusion, Brave, and MWT package
-repositories used by this project. The NVIDIA spin additionally enables RPM
-Fusion NVIDIA driver packages, blacklists Nouveau, and sets NVIDIA DRM
-modesetting for first boot.
+Both Kickstart profiles share the Fedora, RPM Fusion, Brave, and MWT repository
+declarations used by this project. On x86_64, both also enable the
+`christitustech/copr-fedora` repository; other architectures omit that COPR and
+its x86-only gaming packages. The ISO builder selects the matching standard or
+NVIDIA profile. The NVIDIA profile additionally installs RPM Fusion NVIDIA
+driver packages, blacklists Nouveau, and sets NVIDIA DRM modesetting for first
+boot.

--- a/docs/SETTINGS-CAPABILITIES.md
+++ b/docs/SETTINGS-CAPABILITIES.md
@@ -141,20 +141,20 @@ action.
 
 Package names remain owned by `scripts/dwm-packages.sh`. This document names
 package profiles and runtime capabilities so future Settings code does not
-duplicate distro-specific lists.
+duplicate Fedora package lists.
 
-| Provider capability | Fedora path | Secondary-platform behavior |
+| Provider capability | Fedora path | Missing capability behavior |
 | --- | --- | --- |
-| Quickshell Settings frontend | `rhel:desktop` supplies Quickshell on Fedora | Arch maps Quickshell in `arch:desktop`. The Debian map does not currently supply it, so the Settings UI is unsupported there unless a compatible Quickshell is installed separately; core dwm remains usable. |
-| X11 display state | `rhel:x11` supplies the RandR/X11 tools | `arch:x11` and `debian:x11` supply family equivalents. TearFree and the NVIDIA Full Composition Pipeline remain driver-dependent everywhere. |
-| NetworkManager | `rhel:desktop-optional`; enabled by the Fedora image | Arch and Debian optional profiles provide NetworkManager. Without it, the provider reports unavailable and other sections continue. |
-| BlueZ | `rhel:desktop` plus the Fedora image service/package set | Arch and Debian desktop profiles provide their BlueZ equivalents. Adapter absence is a runtime unsupported state. |
-| PipeWire/WirePlumber and controls | `rhel:desktop`; included by the Fedora image | Arch and Debian desktop profiles provide family equivalents. Helpers fall back between supported session commands. |
-| DPMS and auto-lock | X11 tools plus `rhel:desktop` light-locker and GLib settings | Arch and Debian desktop profiles provide equivalents. Missing schemas or locker disable only lock controls. |
-| Defaults | `rhel:runtime-required` XDG utilities | Arch and Debian required profiles provide equivalents. |
-| Themes and GTK integration | `rhel:theme`, `rhel:theme-gtk`, and optional tool profiles | Family theme profiles provide available equivalents; missing optional theme packages do not disable Settings. |
-| Polkit authorization | Fedora desktop/image installs a polkit agent; health helper can use a trusted system install | Other desktop profiles provide a polkit agent where available. Without an agent or trusted helper, privileged capabilities are restricted while read-only state remains available. |
-| System health | Portable helper probes plus Fedora/systemd providers where present | The helper detects Debian, Arch, and RHEL families and emits partial/restricted records for missing commands, services, hardware, or authorization. |
+| Quickshell Settings frontend | `fedora:desktop` | Missing Quickshell makes the Settings UI unavailable. |
+| X11 display state | `fedora:x11` | Missing RandR tools disable display controls. TearFree and NVIDIA composition remain driver-dependent. |
+| NetworkManager | `fedora:desktop-optional`; enabled by the Fedora image | Missing service reports unavailable while other sections continue. |
+| BlueZ | `fedora:desktop` plus the image service/package set | Adapter absence is a runtime unsupported state. |
+| PipeWire/WirePlumber and controls | `fedora:desktop`; included by the image | Missing session services report unavailable. |
+| DPMS and auto-lock | X11 tools plus `fedora:desktop` | Missing schemas or locker disable only lock controls. |
+| Defaults | `fedora:runtime-required` | Missing XDG utilities disable default-application controls. |
+| Themes and GTK integration | `fedora:theme`, `fedora:theme-gtk`, and optional profiles | Missing optional theme packages do not disable Settings. |
+| Polkit authorization | Fedora desktop/image polkit agent and trusted helper | Missing authorization leaves read-only state available. |
+| System health | Fedora/systemd providers | Missing commands, services, hardware, or authorization emit partial or restricted records. |
 
 ## Phase 1 Constraints Derived From the Inventory
 

--- a/docs/SETTINGS-PLATFORM.md
+++ b/docs/SETTINGS-PLATFORM.md
@@ -151,26 +151,26 @@ Package ownership stays centralized in `scripts/dwm-packages.sh`. Phase 1 adds
 no runtime dependency beyond capabilities already present in the existing
 desktop and image profiles.
 
-| Capability | Fedora source | Current image/map status | Secondary behavior |
+| Capability | Fedora source | Current image/map status | Missing behavior |
 | --- | --- | --- | --- |
-| Settings window | Quickshell 0.3 or newer | `quickshell` is already in both Fedora Kickstarts and `rhel:desktop` | Present in `arch:desktop`; Debian reports the UI unsupported unless Quickshell is installed separately. |
-| Capability helper | POSIX shell and base utilities | Installed as a project command; no new package | Portable across all supported families. |
-| Display/default state | RandR and XDG utilities | Already in Fedora Kickstarts and required profiles | Family X11/runtime profiles provide equivalents. |
-| Network/Bluetooth/audio/power state | NetworkManager, BlueZ, PipeWire/WirePlumber, X11 tools, light-locker | Already in Fedora Kickstarts and desktop profiles | Missing optional providers produce unavailable or partial cards. |
-| Authorization discovery | Polkit agent and trusted installed helper | Fedora image already includes a polkit agent; helper installation remains project-owned | Missing authorization leaves read-only state available. |
-| QML development | Qt declarative development tools | `rhel:qml-development` maps `qt6-qtdeclarative-devel`; intentionally excluded from runtime images | `arch:qml-development` and `debian:qml-development` own their package names. |
+| Settings window | Quickshell 0.3 or newer | Included by both Kickstarts and `fedora:desktop` | Settings is unavailable without Quickshell. |
+| Capability helper | POSIX shell and base utilities | Installed as a project command; no new package | Individual missing tools produce unavailable records. |
+| Display/default state | RandR and XDG utilities | Included by Kickstarts and required profiles | Missing tools disable only their controls. |
+| Network/Bluetooth/audio/power state | NetworkManager, BlueZ, PipeWire/WirePlumber, X11 tools, light-locker | Included by Fedora image/desktop profiles | Missing optional providers produce unavailable or partial cards. |
+| Authorization discovery | Polkit agent and trusted installed helper | Fedora image includes an agent; helper installation remains project-owned | Missing authorization leaves read-only state available. |
+| QML development | Qt declarative development tools | `fedora:qml-development` maps `qt6-qtdeclarative-devel`; excluded from runtime images | Developer tooling is opt-in. |
 
 The `qml-development` profile is opt-in developer tooling and is not part of
 `required`, `recommended`, `optional`, `full`, or either Kickstart. This avoids
 expanding the installed desktop for users who do not develop QML while keeping
-all family-specific package names in one map.
+the Fedora package name in one map.
 
 ## Validation Plan
 
 | Phase 1 exit criterion | Automated evidence | Manual or runtime evidence |
 | --- | --- | --- |
 | Settings opens and navigates without idle polling | `make check-settings check-quickshell-settings-xvfb check-quickshell-qml` | Open from Control Center, search, use keyboard/mouse navigation, close, and record the closed CPU/process sample. |
-| Fedora discovery and clean fallback | `make check-settings` exercises Fedora 44 and Debian 13 fixtures | Run `dwm-settings-provider discover` on the Fedora qualification host and record platform/provider rows. |
+| Fedora discovery and clean fallback | `make check-settings` exercises Fedora 44 plus unavailable service fixtures | Run `dwm-settings-provider discover` on the Fedora qualification host and record platform/provider rows. |
 | Privilege, rollback, errors, unsupported state | `make check-settings check-system-health check-display-setup` plus source assertions for the no-elevation boundary | Cancel or deny any future authorization prompt; verify readable state remains. Phase 1 has no privileged Settings action to authorize. |
 | Existing desktop compatibility | Existing launcher, Control Center, controls, network, health, runtime, install, and preservation checks in `make check` | Verify existing Control Center and hotkeys in the qualification session. |
 | Packaging and ownership | `make check-install check-install-manifest check-kickstart` | Verify installed helper ownership when a privileged Settings helper is introduced. None is introduced in Phase 1. |
@@ -182,15 +182,13 @@ for the managed Quickshell process and no remaining Settings provider process.
 
 Real Fedora evidence must record release, architecture, session type, Settings
 entry path, discovered provider states, CPU/process sample, and limitations.
-Nested X11 does not prove real hardware providers. Debian, Arch, and generic
-RHEL runtime behavior remains unverified until run in those environments even
-when fixture and package-map tests pass.
+Nested X11 does not prove real hardware providers.
 
 ## Phase 1 Qualification Evidence
 
 Evidence recorded on 2026-07-21:
 
-- Fedora Linux 44, x86_64, X11 reported the `rhel` provider family. RandR,
+- Fedora Linux 44, x86_64, X11 reported the `fedora` provider family. RandR,
   NetworkManager, BlueZ, PipeWire Pulse, DPMS, light-locker, XDG defaults,
   themes, system health, and the trusted authorization path were discovered as
   available. Phase 2 display/input mutations and later accessibility/system
@@ -198,9 +196,7 @@ Evidence recorded on 2026-07-21:
 - Nested X11 at 1280x800 opened the 980x620 Settings window, exercised IPC,
   keyboard, mouse, search, Escape close, and provider cleanup. The two-second
   closed-window sample measured 0.00 percent of one CPU for Quickshell.
-- Fedora 44 and Debian 13 fixtures validated available and unavailable provider
-  records. Arch and generic RHEL package names were validated through the
-  centralized package map but were not runtime-tested.
+- Fedora 44 fixtures validated available and unavailable provider records.
 - The live Fedora check was read-only. No settings mutation, authorization
   prompt, hardware change, session restart, or managed-shell replacement was
   performed.
@@ -253,12 +249,8 @@ Evidence recorded on 2026-08-15:
 - Nested X11 at 1280x800 discovered one display and two virtual input devices,
   verified both section states and lifecycle, and measured 0.00 percent of one
   CPU for Quickshell after Settings closed.
-- Debian 13, current Arch, and Fedora 44 containers resolved dependencies,
-  built, validated staged install/uninstall, and passed privilege tests. This
-  qualifies package/build behavior, not real secondary-platform hardware UI.
-- A full Rocky Linux 9 container smoke run is blocked pending a reachable
-  package source in the qualification environment; its package map and shell
-  fixtures are covered, but the complete Rocky install path is not claimed.
+- Fedora 44 container validation resolved dependencies, built, validated
+  staged install/uninstall, and passed privilege tests.
 - Generated display persistence, backup, rollback, and input startup reapply
   are automated. A disposable Fedora 44 UEFI VM with LightDM verified a
   root-owned mode-0644 managed fragment through real Xorg restarts. A

--- a/docs/src/control-center.md
+++ b/docs/src/control-center.md
@@ -94,6 +94,7 @@ repair the detected time-synchronization provider.
 Installing the health helper in a root-owned system path remains recommended:
 
 ```bash
+make
 sudo make install-system
 ```
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -1,7 +1,6 @@
 # Installation
 
-> A supported Debian-, Arch-, or Fedora/RHEL-family distribution with Xorg is
-> required.
+> Fedora Linux with Xorg is required. Other distributions are not supported.
 
 ## Quick Install (Recommended)
 
@@ -27,8 +26,8 @@ install-herdr
 
 ### 1. Dependencies
 
-The supported dependency path is the installer because it resolves package
-names for Debian-, Arch-, and Fedora/RHEL-family systems from the shared map:
+The supported dependency path is the installer because it resolves Fedora
+package names from the shared map:
 
 ```bash
 ./install.sh --dry-run --non-interactive --profile core
@@ -65,8 +64,9 @@ session restart to verify the active runtime.
 ./install.sh
 ```
 
-The script detects the distribution family and handles dependency
-installation, font copying, display-manager integration, and config placement.
+The script verifies Fedora before handling dependency installation, font
+copying, display-manager integration, and config placement. Other
+distributions are rejected before changes are made.
 Existing user configuration and `.xinitrc` files are preserved. Upgrades remove
 the known legacy `dwm-graphical-session.service` and
 `wm-graphical-session.service` early-start configuration so XDG applications
@@ -134,11 +134,9 @@ Installer package profiles are selected with `DWM_INSTALL_PROFILE`:
   group; log out and back in before using its privileged tuning helpers.
 
 The default is `full` to preserve the historical automated installer behavior.
-On non-Fedora RHEL-family systems, `maim` may not be present in the enabled
-repositories. The installer skips that add-on instead of failing the desktop
-install and reports that the screenshot hotkeys are unavailable. Enterprise
-Linux 9 users can enable EPEL and rerun the installer to add `maim` where the
-package is available.
+If `maim` is unavailable in the enabled Fedora repositories, the installer
+skips that add-on instead of failing the desktop install and reports that the
+screenshot hotkeys are unavailable.
 
 For a minimal install:
 

--- a/install.sh
+++ b/install.sh
@@ -34,27 +34,15 @@ EOF
 }
 
 case "$DISTRO_FAMILY" in
-arch)
-	command -v pacman &>/dev/null || {
-		err "Arch-family distribution detected, but pacman was not found."
-		exit 1
-	}
-	;;
-rhel)
+fedora)
 	command -v dnf &>/dev/null || {
-		err "RHEL-family distribution detected, but dnf was not found."
-		exit 1
-	}
-	;;
-debian)
-	command -v apt-get &>/dev/null || {
-		err "Debian-family distribution detected, but apt-get was not found."
+		err "Fedora was detected, but dnf was not found."
 		exit 1
 	}
 	;;
 *)
 	err "Unsupported distribution: $DISTRO_NAME"
-	err "Supported installer families: Debian, Arch, and Fedora/RHEL."
+	err "dwm-titus supports Fedora only."
 	exit 1
 	;;
 esac
@@ -163,11 +151,6 @@ if [[ $EUID -eq 0 && $DRY_RUN != true ]]; then
 	exit 1
 fi
 
-is_arch_arm() {
-	[[ $DISTRO_FAMILY == "arch" &&
-		($ARCH == "aarch64" || $ARCH == "armv7h" || $ARCH == "armv7l") ]]
-}
-
 install_recommended_profile() {
 	[[ $INSTALL_PROFILE == "recommended" || $INSTALL_PROFILE == "full" ]]
 }
@@ -225,16 +208,6 @@ runtime_herdr_available() {
 
 	command -v herdr >/dev/null 2>&1 ||
 		[[ -x ${HOME:-}/.local/bin/herdr ]]
-}
-
-enable_optional_service() {
-	local service=$1
-
-	if sudo systemctl enable "$service"; then
-		ok "Optional service enabled: $service"
-	else
-		warn "Could not enable optional service $service; continuing installation."
-	fi
 }
 
 fedora_gaming_profile() {
@@ -384,12 +357,7 @@ print_install_summary() {
 	else
 		printf '  Optional extras: skipped\n'
 	fi
-	if is_arch_arm; then
-		print_summary_profile "Arch ARM terminal candidates" terminal-arm
-		print_summary_profile "Arch ARM video fallback" arm-video
-	else
-		print_summary_profile "Terminal candidates" terminal
-	fi
+	print_summary_profile "Terminal candidates" terminal
 	if install_herdr_profile; then
 		printf '  Herdr workspace: verified user install from https://herdr.dev/install.sh\n'
 	elif [[ $HERDR_INSTALL_MODE == auto ]] &&
@@ -490,13 +458,7 @@ install_nordic_gtk_theme() {
 }
 
 install_supported_terminal() {
-	local profile="terminal"
-
-	if is_arch_arm; then
-		profile="terminal-arm"
-	fi
-
-	if ! dwm_install_first_available_profile "$profile"; then
+	if ! dwm_install_first_available_profile terminal; then
 		err "No supported terminal is available in the enabled repositories."
 		return 1
 	fi
@@ -606,17 +568,10 @@ install_lightdm_config() {
 	local lightdm_session_wrapper="/etc/lightdm/Xsession"
 	local lightdm_logind_check=false
 
-	if [[ $DISTRO_FAMILY == "rhel" ]]; then
-		lightdm_seat_section="Seat:*"
-		lightdm_greeter_session="slick-greeter"
-		lightdm_session_wrapper=""
-		lightdm_logind_check=true
-	fi
-
-	if [[ $DISTRO_FAMILY == "debian" ]]; then
-		lightdm_greeter_session="slick-greeter"
-		lightdm_session_wrapper=""
-	fi
+	lightdm_seat_section="Seat:*"
+	lightdm_greeter_session="slick-greeter"
+	lightdm_session_wrapper=""
+	lightdm_logind_check=true
 
 	sudo make -C "$REPO_DIR/lightdm" \
 		LIGHTDM_SEAT_SECTION="$lightdm_seat_section" \
@@ -631,27 +586,6 @@ install_lightdm_config() {
 			/usr/share/pixmaps/dwm-titus.jpg \
 			/usr/share/pixmaps/dwm-titus-logo.png
 	fi
-}
-
-disable_selinux_for_fedora() {
-	local selinux_config="/etc/selinux/config"
-
-	if [[ $DISTRO_ID != "fedora" ]]; then
-		return
-	fi
-
-	info "Disabling SELinux for Fedora..."
-	if command -v getenforce &>/dev/null && [[ $(getenforce 2>/dev/null) == "Enforcing" ]]; then
-		sudo setenforce 0 || warn "Could not switch SELinux to permissive for this boot."
-	fi
-	if [[ -f $selinux_config ]]; then
-		sudo sed -i -E 's/^[[:space:]]*SELINUX=.*/SELINUX=disabled/' "$selinux_config"
-	else
-		sudo install -d -m 0755 /etc/selinux
-		printf '%s\n' 'SELINUX=disabled' 'SELINUXTYPE=targeted' |
-			sudo tee "$selinux_config" >/dev/null
-	fi
-	ok "SELinux disabled for future Fedora boots."
 }
 
 echo ""
@@ -672,46 +606,24 @@ else
 	"$REPO_DIR/scripts/configure-build.sh" --non-interactive
 fi
 
-if [[ $DISTRO_FAMILY == "debian" ]]; then
-	info "Refreshing apt package metadata..."
-	sudo apt-get update
-fi
-
-disable_selinux_for_fedora
-
 # ── Required build and runtime dependencies ──────────────
 info "Installing required build and runtime dependencies..."
 dwm_install_package_profile build
-if [[ $DISTRO_FAMILY == "arch" ]]; then
-	if pacman -Qq 2>/dev/null | command grep -q '^xlibre'; then
-		info "Xlibre detected - skipping xorg-server."
-	elif ! pacman -Qi xorg-server &>/dev/null; then
-		dwm_install_package_profile x11-server
-	fi
-else
-	dwm_install_package_profile x11-server
-fi
 dwm_install_package_profile x11
 dwm_install_package_profile runtime-required
-if is_arch_arm; then
-	if dwm_install_first_available_profile arm-video; then
-		ok "ARM framebuffer video driver installed."
-	else
-		warn "ARM framebuffer video driver unavailable; your board's GPU driver may already provide Xorg support."
-	fi
-fi
 ok "Required build and runtime dependencies installed."
 
 # ── Recommended desktop dependencies ─────────────────────
 if install_recommended_profile; then
 	info "Installing recommended desktop dependencies..."
 	dwm_install_package_profile desktop
+	if ! env -u DWM_TEST_MODE -u DWM_TEST_QUICKSHELL_VERSION \
+		"$REPO_DIR/scripts/dwm-quickshell-version-check"; then
+		err "The installed Quickshell build is incompatible with dwm-titus."
+		exit 1
+	fi
 	if ! dwm_install_available_package_profile screenshot-optional; then
 		warn "maim is unavailable in the enabled repositories; screenshot hotkeys will remain disabled."
-		if [[ $DISTRO_FAMILY == rhel && $DISTRO_ID != fedora &&
-			(${VERSION_ID:-} == 9 || ${VERSION_ID:-} == 9.*) ]]; then
-			warn "On Enterprise Linux 9, enable EPEL and rerun the installer to add maim."
-		fi
 	fi
 	dwm_install_package_profile theme
 	if ! dwm_install_available_package_profile theme-gtk; then
@@ -733,10 +645,6 @@ if install_optional_profile; then
 	info "Installing optional desktop extras..."
 	if ! dwm_install_available_package_profile optional; then
 		warn "Some optional desktop extras were unavailable in enabled repositories."
-	fi
-	if [[ $DISTRO_FAMILY == "arch" ]]; then
-		enable_optional_service NetworkManager.service
-		enable_optional_service bluetooth.service
 	fi
 	if fedora_gaming_profile; then
 		if [[ $FEDORA_GAMING_REPOS_APPROVED != true ]]; then
@@ -850,19 +758,11 @@ if [ -n "$currentdm" ]; then
 elif ! install_optional_profile; then
 	warn "No display manager found; skipping display-manager installation for $INSTALL_PROFILE profile."
 else
-	if is_arch_arm; then
-		info "No display manager found - installing SDDM for Arch ARM..."
-		dwm_install_package_profile arm-display-manager
-		sudo systemctl enable sddm.service
-		currentdm="sddm"
-		ok "SDDM installed and enabled."
-	else
-		info "No display manager found - installing LightDM..."
-		dwm_install_package_profile lightdm
-		sudo systemctl enable lightdm.service
-		currentdm="lightdm"
-		ok "LightDM installed and enabled."
-	fi
+	info "No display manager found - installing LightDM..."
+	dwm_install_package_profile lightdm
+	sudo systemctl enable lightdm.service
+	currentdm="lightdm"
+	ok "LightDM installed and enabled."
 fi
 
 # ── LightDM greeter config ───────────────────────────────
@@ -870,11 +770,6 @@ if [[ $currentdm == "lightdm" ]]; then
 	info "Deploying LightDM Slick Greeter config..."
 	install_lightdm_config
 	ok "LightDM config deployed."
-fi
-
-if is_arch_arm; then
-	warn "ARM NOTE: If picom causes display issues, set 'backend = \"xrender\"' in ~/.config/picom.conf"
-	warn "ARM NOTE: Some SBCs may need a board-specific KMS or GPU driver configuration for accelerated Xorg."
 fi
 
 # ── Build & Install ──────────────────────────────────────

--- a/lightdm/Makefile
+++ b/lightdm/Makefile
@@ -3,11 +3,11 @@
 LIGHTDM_DIR = $(DESTDIR)/etc/lightdm
 LIGHTDM_CONF = $(LIGHTDM_DIR)/lightdm.conf
 PIXMAPS_DIR = $(DESTDIR)/usr/share/pixmaps
-LIGHTDM_SEAT_SECTION ?= SeatDefaults
-LIGHTDM_GREETER_SESSION ?= lightdm-slick-greeter
+LIGHTDM_SEAT_SECTION ?= Seat:*
+LIGHTDM_GREETER_SESSION ?= slick-greeter
 LIGHTDM_USER_SESSION ?= dwm
-LIGHTDM_SESSION_WRAPPER ?= /etc/lightdm/Xsession
-LIGHTDM_LOGIND_CHECK ?= false
+LIGHTDM_SESSION_WRAPPER ?=
+LIGHTDM_LOGIND_CHECK ?= true
 
 print-config:
 	@if [ "$(LIGHTDM_LOGIND_CHECK)" = true ]; then \

--- a/lightdm/README.md
+++ b/lightdm/README.md
@@ -1,13 +1,10 @@
 # LightDM Slick Greeter - dwm-titus
 
-A modern LightDM login screen using the distribution's Slick Greeter package
-with a Nord colour palette, blurred background, and the MesloLGS NF font.
+A modern Fedora LightDM login screen using Slick Greeter with a Nord colour
+palette, blurred background, and the MesloLGS NF font.
 
-The main installer selects the distribution-specific package names. Arch uses
-`lightdm-slick-greeter`; Fedora and other RHEL-family systems use
-`slick-greeter`. The dwm-titus LightDM install target renders
-`lightdm.conf` with the matching greeter session name for the detected
-distribution family.
+The Fedora installer uses `slick-greeter`. The dwm-titus LightDM install target
+renders the matching Fedora `lightdm.conf`.
 
 ## Files
 
@@ -25,9 +22,8 @@ The main `install.sh` handles this automatically. To apply manually:
 sudo make install
 ```
 
-The direct `make install` default is Arch-compatible. For Fedora, Rocky,
-AlmaLinux, or RHEL, use `install.sh` so the installer passes the RHEL-family
-LightDM settings.
+The direct `make install` defaults match Fedora. Prefer the top-level
+`install.sh` for a complete installation.
 
 ## Customisation
 

--- a/scripts/autostart.sh
+++ b/scripts/autostart.sh
@@ -142,8 +142,24 @@ fi
 # endpoint before activating the rest of the graphical session.
 QUICKSHELL_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/quickshell/shell.qml"
 if [ -f "$QUICKSHELL_CONFIG" ]; then
-	start_detached_once quickshell quickshell --no-duplicate
-	if command -v quickshell >/dev/null 2>&1; then
+	quickshell_check=
+	quickshell_compatible=0
+	case $0 in
+	*/*)
+		[ ! -x "${0%/*}/dwm-quickshell-version-check" ] ||
+			quickshell_check=${0%/*}/dwm-quickshell-version-check
+		;;
+	esac
+	if [ -z "$quickshell_check" ] && command -v dwm-quickshell-version-check >/dev/null 2>&1; then
+		quickshell_check=dwm-quickshell-version-check
+	fi
+	if [ -n "$quickshell_check" ] && "$quickshell_check"; then
+		quickshell_compatible=1
+		start_detached_once quickshell quickshell --no-duplicate
+	else
+		printf '%s\n' 'dwm-titus: compatible Quickshell 0.3.0 or Fedora 44 snapshot is required' >&2
+	fi
+	if [ "$quickshell_compatible" -eq 1 ]; then
 		i=0
 		while [ "$i" -lt 50 ]; do
 			if quickshell ipc --path "$QUICKSHELL_CONFIG" call tray count \

--- a/scripts/dwm-packages.sh
+++ b/scripts/dwm-packages.sh
@@ -6,215 +6,92 @@ dwm_packages() {
 	local profile=$2
 
 	case "$family:$profile" in
-	arch:build)
-		printf '%s\n' \
-			base-devel libx11 libxft libxinerama libxrender imlib2 \
-			libxcb xcb-util freetype2 fontconfig pkgconf
-		;;
-	arch:x11)
-		printf '%s\n' xorg-xinit xorg-xrandr xorg-xsetroot xorg-xset xorg-xinput xorg-setxkbmap
-		;;
-	arch:x11-server)
-		printf '%s\n' xorg-server
-		;;
-	arch:runtime-required)
-		printf '%s\n' dbus curl git procps-ng psmisc unzip util-linux wmctrl xclip xdotool xorg-xprop xdg-utils
-		;;
-	arch:desktop)
-		printf '%s\n' \
-			quickshell picom feh dex mate-polkit alsa-utils \
-			brightnessctl pipewire pipewire-pulse wireplumber pavucontrol \
-			libnotify light-locker bluez bluez-utils blueman playerctl
-		;;
-	arch:desktop-optional)
-		printf '%s\n' \
-			thunar gvfs gvfs-smb tumbler thunar-archive-plugin nwg-look xdg-user-dirs \
-			xdg-desktop-portal-gtk gnome-keyring networkmanager network-manager-applet \
-			rsync matugen accountsservice upower power-profiles-daemon
-		;;
-	arch:theme)
-		printf '%s\n' dconf
-		;;
-	arch:theme-gtk)
-		printf '%s\n' \
-			adapta-gtk-theme arc-gtk-theme materia-gtk-theme numix-themes \
-			orchis-theme yaru-gtk-theme
-		;;
-	arch:theme-optional)
-		printf '%s\n' qt6ct qt5ct
-		;;
-	arch:fonts)
-		printf '%s\n' noto-fonts-emoji ttf-meslo-nerd
-		;;
-	arch:qml-development)
-		printf '%s\n' qt6-declarative
-		;;
-	arch:lightdm)
-		printf '%s\n' lightdm lightdm-slick-greeter
-		;;
-	arch:terminal)
-		printf '%s\n' alacritty kitty
-		;;
-	arch:terminal-arm)
-		printf '%s\n' alacritty kitty
-		;;
-	arch:arm-video)
-		printf '%s\n' xf86-video-fbdev
-		;;
-	arch:arm-display-manager)
-		printf '%s\n' sddm
-		;;
-	rhel:build)
+	fedora:build)
 		printf '%s\n' \
 			gcc make pkgconf-pkg-config libX11-devel libXft-devel \
 			libXinerama-devel libXrender-devel imlib2-devel libxcb-devel \
 			xcb-util-devel freetype-devel fontconfig-devel
 		;;
-	rhel:x11)
-		printf '%s\n' xorg-x11-server-Xorg xorg-x11-xinit
-		if [[ ${DISTRO_ID:-} == fedora ]]; then
-			printf '%s\n' xrandr xset xsetroot xinput setxkbmap
-		else
-			# Rocky/RHEL bundle xinput in xorg-x11-server-utils.
-			printf '%s\n' xorg-x11-server-utils setxkbmap
-		fi
+	fedora:x11)
+		printf '%s\n' xorg-x11-server-Xorg xorg-x11-xinit xrandr xset xsetroot xinput setxkbmap
 		;;
-	rhel:x11-server)
-		:
-		;;
-	rhel:runtime-required)
+	fedora:runtime-required)
 		printf '%s\n' dbus-x11 curl git procps-ng psmisc unzip util-linux xclip xdotool xprop xdg-utils
 		;;
-	rhel:desktop)
+	fedora:desktop)
+		# Fedora 44 publishes the compatible Quickshell snapshot in its official
+		# fedora/updates repositories. It is required and belongs in the strict
+		# desktop transaction; the Fedora container smoke proves resolution.
 		printf '%s\n' \
 			quickshell picom feh dex-autostart mate-polkit \
 			alsa-utils brightnessctl pulseaudio-utils pipewire pavucontrol \
 			pipewire-pulseaudio wireplumber libnotify light-locker xorg-x11-drv-libinput \
-			bluez blueman
-		if [[ ${DISTRO_ID:-} == fedora ]]; then
-			printf '%s\n' playerctl
-		fi
+			bluez blueman playerctl
 		;;
-	rhel:desktop-optional)
+	fedora:desktop-optional)
 		printf '%s\n' \
 			Thunar gvfs gvfs-smb tumbler thunar-archive-plugin file-roller \
 			xdg-user-dirs xdg-desktop-portal-gtk gnome-keyring gnome-keyring-pam NetworkManager \
 			rsync
-		if [[ ${DISTRO_ID:-} != fedora ]]; then
-			printf '%s\n' playerctl
-		fi
 		;;
-	rhel:gaming)
-		if [[ ${DISTRO_ID:-} == fedora && ${ARCH:-$(uname -m)} == x86_64 ]]; then
+	fedora:gaming)
+		if [[ ${ARCH:-$(uname -m)} == x86_64 ]]; then
 			printf '%s\n' \
 				steam gamescope gamemode.x86_64 gamemode.i686 \
 				mangohud.x86_64 mangohud.i686
 		fi
 		;;
-	rhel:theme)
+	fedora:theme)
 		printf '%s\n' dconf
 		;;
-	rhel:theme-gtk)
-		if [[ ${DISTRO_ID:-} == fedora ]]; then
-			printf '%s\n' \
-				arc-theme adw-gtk3-theme numix-gtk-theme \
-				yaru-gtk3-theme yaru-gtk4-theme deepin-gtk-theme \
-				bluebird-gtk3-theme
-		fi
+	fedora:theme-gtk)
+		printf '%s\n' \
+			arc-theme adw-gtk3-theme numix-gtk-theme \
+			yaru-gtk3-theme yaru-gtk4-theme deepin-gtk-theme \
+			bluebird-gtk3-theme
 		;;
-	rhel:theme-optional)
+	fedora:theme-optional)
 		printf '%s\n' qt6ct qt5ct
 		;;
-	rhel:fonts)
+	fedora:fonts)
 		printf '%s\n' google-noto-color-emoji-fonts google-noto-sans-mono-fonts
 		;;
-	rhel:qml-development)
+	fedora:qml-development)
 		printf '%s\n' qt6-qtdeclarative-devel
 		;;
-	rhel:lightdm)
+	fedora:lightdm)
 		printf '%s\n' lightdm slick-greeter
 		;;
-	rhel:terminal)
+	fedora:terminal)
 		printf '%s\n' alacritty kitty
 		;;
-	debian:build)
-		printf '%s\n' \
-			build-essential pkg-config libx11-dev libxft-dev \
-			libxinerama-dev libxrender-dev libimlib2-dev libx11-xcb-dev \
-			libxcb1-dev libxcb-res0-dev libfontconfig-dev libfreetype-dev
-		;;
-	debian:x11)
-		printf '%s\n' xserver-xorg-core xinit x11-xserver-utils xinput x11-xkb-utils
-		;;
-	debian:x11-server)
-		:
-		;;
-	debian:runtime-required)
-		printf '%s\n' dbus-x11 curl git procps psmisc unzip util-linux xclip xdotool x11-utils xdg-utils
-		;;
-	debian:desktop)
-		printf '%s\n' \
-			picom feh dex mate-polkit alsa-utils \
-			brightnessctl pulseaudio-utils pipewire pipewire-pulse \
-			wireplumber pavucontrol libnotify-bin light-locker bluez blueman playerctl
-		;;
-	debian:desktop-optional)
-		printf '%s\n' \
-			thunar gvfs gvfs-backends tumbler thunar-archive-plugin file-roller \
-			xdg-user-dirs xdg-desktop-portal-gtk gnome-keyring libpam-gnome-keyring \
-			network-manager rsync
-		;;
-	debian:theme)
-		printf '%s\n' dconf-cli
-		;;
-	debian:theme-gtk)
-		printf '%s\n' arc-theme materia-gtk-theme numix-gtk-theme yaru-theme-gtk
-		;;
-	debian:theme-optional)
-		printf '%s\n' qt6ct qt5ct
-		;;
-	debian:fonts)
-		printf '%s\n' fonts-noto-color-emoji fonts-noto-mono
-		;;
-	debian:qml-development)
-		printf '%s\n' qt6-declarative-dev-tools
-		;;
-	debian:lightdm)
-		printf '%s\n' lightdm slick-greeter
-		;;
-	debian:terminal)
-		printf '%s\n' alacritty kitty
-		;;
-	*:terminal-primary)
+	fedora:terminal-primary)
 		printf '%s\n' alacritty
 		;;
-	*:screenshot-optional)
+	fedora:screenshot-optional)
 		printf '%s\n' maim
 		;;
-	*:required)
+	fedora:required)
 		dwm_packages "$family" build
 		dwm_packages "$family" x11
-		dwm_packages "$family" x11-server
 		dwm_packages "$family" runtime-required
 		;;
-	*:recommended)
+	fedora:recommended)
 		dwm_packages "$family" desktop
 		dwm_packages "$family" screenshot-optional
 		dwm_packages "$family" theme
 		dwm_packages "$family" theme-gtk
 		dwm_packages "$family" fonts
 		;;
-	*:optional)
+	fedora:optional)
 		dwm_packages "$family" theme-optional
 		dwm_packages "$family" desktop-optional
 		;;
-	*:full)
+	fedora:full)
 		dwm_packages "$family" required
 		dwm_packages "$family" recommended
 		dwm_packages "$family" optional
-		if [[ $family == rhel && ${DISTRO_ID:-} == fedora ]]; then
-			dwm_packages "$family" gaming
-		fi
+		dwm_packages "$family" gaming
 		;;
 	*)
 		return 1

--- a/scripts/dwm-quickshell-controlcenter
+++ b/scripts/dwm-quickshell-controlcenter
@@ -519,6 +519,14 @@ restart_quickshell() {
 		printf 'quickshell config is unavailable: %s\n' "$config" >&2
 		return 1
 	fi
+	version_check=$repo_dir/scripts/dwm-quickshell-version-check
+	if [ ! -x "$version_check" ]; then
+		version_check=$(command -v dwm-quickshell-version-check 2>/dev/null || true)
+	fi
+	if [ -z "$version_check" ] || ! "$version_check"; then
+		printf 'compatible Quickshell 0.3.0 or Fedora 44 snapshot is required\n' >&2
+		return 1
+	fi
 
 	pkill -x quickshell 2>/dev/null || true
 	if command -v quickshell >/dev/null 2>&1; then

--- a/scripts/dwm-quickshell-version-check
+++ b/scripts/dwm-quickshell-version-check
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -eu
+
+detail=
+if [ "${DWM_TEST_MODE:-0}" = 1 ]; then
+	detail=${DWM_TEST_QUICKSHELL_VERSION:-}
+fi
+if [ -z "$detail" ]; then
+	command -v quickshell >/dev/null 2>&1 || {
+		printf 'quickshell is not installed\n' >&2
+		exit 1
+	}
+	detail=$(quickshell --version 2>/dev/null | sed -n '1p') || detail=
+	if [ -z "$detail" ]; then
+		printf 'unable to determine the Quickshell version\n' >&2
+		exit 1
+	fi
+fi
+
+case $detail in
+*"dacfa9de829ac7cb173825f593236bf2c21f637e"*) exit 0 ;;
+esac
+
+version=$(printf '%s\n' "$detail" | grep -oE '[0-9]+([.][0-9]+){1,2}' | sed -n '1p')
+if [ "$version" = 0.2.1 ]; then
+	case $detail in
+	0.2.1^git20260209.dacfa9d*) exit 0 ;;
+	esac
+fi
+
+if [ -n "$version" ] && awk -F. '
+	{
+		major = $1 + 0
+		minor = $2 + 0
+		patch = $3 + 0
+		exit !(major > 0 || minor > 3 || (minor == 3 && patch >= 0))
+	}
+' <<EOF; then
+$version
+EOF
+	exit 0
+fi
+
+printf 'unsupported Quickshell version: %s\n' "${detail:-unknown}" >&2
+exit 1

--- a/scripts/dwm-quickshell-version-check
+++ b/scripts/dwm-quickshell-version-check
@@ -24,7 +24,7 @@ esac
 version=$(printf '%s\n' "$detail" | grep -oE '[0-9]+([.][0-9]+){1,2}' | sed -n '1p')
 if [ "$version" = 0.2.1 ]; then
 	case $detail in
-	0.2.1^git20260209.dacfa9d*) exit 0 ;;
+	0.2.1^git20260209.dacfa9d-*.fc44) exit 0 ;;
 	esac
 fi
 

--- a/scripts/dwm-settings-provider
+++ b/scripts/dwm-settings-provider
@@ -33,12 +33,9 @@ os_value() {
 
 platform_family() {
 	id=$1
-	id_like=$2
 
-	case " $id $id_like " in
-	*" arch "*) printf '%s\n' arch ;;
-	*" debian "* | *" ubuntu "*) printf '%s\n' debian ;;
-	*" fedora "* | *" rhel "* | *" centos "*) printf '%s\n' rhel ;;
+	case "$id" in
+	fedora) printf '%s\n' fedora ;;
 	*) printf '%s\n' unknown ;;
 	esac
 }
@@ -163,16 +160,14 @@ trusted_display_helper() {
 discover() {
 	os_release=${DWM_SETTINGS_OS_RELEASE:-/etc/os-release}
 	platform_id=unknown
-	platform_like=
 	platform_pretty='Unknown Linux'
 	if [ -r "$os_release" ]; then
 		platform_id=$(os_value ID "$os_release")
-		platform_like=$(os_value ID_LIKE "$os_release")
 		platform_pretty=$(os_value PRETTY_NAME "$os_release")
 		[ -n "$platform_id" ] || platform_id=unknown
 		[ -n "$platform_pretty" ] || platform_pretty=$platform_id
 	fi
-	platform_family_name=$(platform_family "$platform_id" "$platform_like")
+	platform_family_name=$(platform_family "$platform_id")
 
 	printf 'settings-protocol\t1\n'
 	printf 'platform\t%s\t%s\t%s\n' \

--- a/scripts/dwm-system-health
+++ b/scripts/dwm-system-health
@@ -149,6 +149,18 @@ version_at_least() {
 	return 0
 }
 
+quickshell_compatible() {
+	local version=$1 detail=$2
+
+	[[ $detail == *"dacfa9de829ac7cb173825f593236bf2c21f637e"* ]] && return 0
+	version_at_least "$version" 0.3.0 && return 0
+	[[ $version == 0.2.1 ]] || return 1
+	case $detail in
+	*"0.2.1^git20260209.dacfa9d"*) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
 find_sibling_command() {
 	local name=$1
 
@@ -443,15 +455,15 @@ scan_desktop() {
 	if command -v quickshell >/dev/null 2>&1; then
 		detail=$(quickshell --version 2>/dev/null | first_lines 1 || true)
 		version=$(grep -oE '[0-9]+([.][0-9]+){1,2}' <<<"$detail" | first_lines 1 || true)
-		if [[ -n $version ]] && version_at_least "$version" 0.3.0; then
+		if quickshell_compatible "$version" "$detail"; then
 			emit_check desktop ok quickshell-version "Quickshell" "Available" "$detail" restart-quickshell "Restart Quickshell" user
 		elif [[ -n $version ]]; then
-			emit_check desktop error quickshell-version "Quickshell" "Outdated" "$detail; version 0.3.0 or newer is required" install-dependencies "Open dependency installer" user
+			emit_check desktop error quickshell-version "Quickshell" "Outdated" "$detail; version 0.3.0 or the supported Fedora 44 snapshot is required" install-dependencies "Open dependency installer" user
 		else
-			emit_check desktop error quickshell-version "Quickshell" "Version unavailable" "Could not verify Quickshell 0.3.0 or newer" install-dependencies "Open dependency installer" user
+			emit_check desktop error quickshell-version "Quickshell" "Version unavailable" "Could not verify Quickshell 0.3.0 or the supported Fedora 44 snapshot" install-dependencies "Open dependency installer" user
 		fi
 	else
-		emit_check desktop error quickshell-version "Quickshell" "Missing" "The managed shell requires Quickshell 0.3.0 or newer" install-dependencies "Open dependency installer" user
+		emit_check desktop error quickshell-version "Quickshell" "Missing" "The managed shell requires Quickshell 0.3.0 or the supported Fedora 44 snapshot" install-dependencies "Open dependency installer" user
 	fi
 
 	if command -v picom >/dev/null 2>&1; then
@@ -519,41 +531,17 @@ scan_network() {
 
 scan_package_database() {
 	local os_file=${DWM_HEALTH_OS_RELEASE:-/etc/os-release}
-	local id=unknown id_like='' output='' family=unknown status=ok
+	local id=unknown output='' family=unknown status=ok
 
 	if [[ -r $os_file ]]; then
 		# shellcheck disable=SC1090
 		source "$os_file"
 		id=${ID:-unknown}
-		id_like=${ID_LIKE:-}
 	fi
-	case " $id $id_like " in
-	*" arch "*) family=arch ;;
-	*" fedora "* | *" rhel "* | *" centos "*) family=rhel ;;
-	*" debian "* | *" ubuntu "*) family=debian ;;
-	esac
+	[[ $id == fedora ]] && family=fedora
 
 	case $family in
-	debian)
-		if command -v dpkg >/dev/null 2>&1; then
-			output=$(run_bounded dpkg --audit 2>&1 || true)
-			[[ -z $output ]] || status=warn
-		else
-			output="dpkg is unavailable"
-			status=restricted
-		fi
-		;;
-	arch)
-		if command -v pacman >/dev/null 2>&1; then
-			if ! output=$(run_bounded pacman -Dk 2>&1); then
-				status=warn
-			fi
-		else
-			output="pacman is unavailable"
-			status=restricted
-		fi
-		;;
-	rhel)
+	fedora)
 		if command -v dnf >/dev/null 2>&1; then
 			if ! output=$(run_bounded dnf -q --cacheonly check 2>&1); then
 				status=warn
@@ -564,7 +552,7 @@ scan_package_database() {
 		fi
 		;;
 	*)
-		emit_check dependencies info package-database "Package database" "Unsupported distribution family" "$id"
+		emit_check dependencies info package-database "Package database" "Fedora is required for package validation" "$id"
 		return
 		;;
 	esac

--- a/scripts/dwm-system-health
+++ b/scripts/dwm-system-health
@@ -812,7 +812,7 @@ scan_privileged() {
 		"$pkexec_command" "$helper" scan-system
 		return
 	fi
-	emit_meta overview restricted scan-system "Privileged scan" "No trusted installed helper" "Run sudo make install-system, then refresh to request polkit authorization"
+	emit_meta overview restricted scan-system "Privileged scan" "No trusted installed helper" "Run make && sudo make install-system, then refresh to request polkit authorization"
 	return 1
 }
 

--- a/scripts/dwm-system-health
+++ b/scripts/dwm-system-health
@@ -156,7 +156,7 @@ quickshell_compatible() {
 	version_at_least "$version" 0.3.0 && return 0
 	[[ $version == 0.2.1 ]] || return 1
 	case $detail in
-	*"0.2.1^git20260209.dacfa9d"*) return 0 ;;
+	*"0.2.1^git20260209.dacfa9d-"*.fc44) return 0 ;;
 	*) return 1 ;;
 	esac
 }

--- a/scripts/dwm-utils.sh
+++ b/scripts/dwm-utils.sh
@@ -7,45 +7,33 @@
 
 # ── Distribution and package manager ────────────────────
 DISTRO_ID="unknown"
-DISTRO_ID_LIKE=""
 DISTRO_NAME="Unknown Linux"
 DISTRO_FAMILY="unknown"
+DWM_PACKAGE_COMMAND=()
+OS_RELEASE_FILE="/etc/os-release"
+if [[ ${DWM_TEST_MODE:-0} == 1 && -n ${DWM_OS_RELEASE:-} ]]; then
+	OS_RELEASE_FILE=$DWM_OS_RELEASE
+fi
 
-if [[ -r /etc/os-release ]]; then
-	# shellcheck disable=SC1091
-	source /etc/os-release
+if [[ -r $OS_RELEASE_FILE ]]; then
+	# shellcheck disable=SC1090
+	source "$OS_RELEASE_FILE"
 	DISTRO_ID="${ID:-unknown}"
-	DISTRO_ID_LIKE="${ID_LIKE:-}"
 	DISTRO_NAME="${PRETTY_NAME:-${NAME:-Unknown Linux}}"
 fi
 
-case " ${DISTRO_ID} ${DISTRO_ID_LIKE} " in
-*" arch "*)
-	DISTRO_FAMILY="arch"
-	;;
-*" fedora "* | *" rhel "* | *" centos "*)
-	DISTRO_FAMILY="rhel"
-	;;
-*" debian "* | *" ubuntu "*)
-	DISTRO_FAMILY="debian"
-	;;
-esac
+if [[ $DISTRO_ID == "fedora" ]]; then
+	DISTRO_FAMILY="fedora"
+fi
 
 case "$DISTRO_FAMILY" in
-arch)
-	if command -v paru &>/dev/null && paru --version &>/dev/null; then
-		PKG_CMD="paru -S --needed --noconfirm"
-	elif command -v yay &>/dev/null && yay --version &>/dev/null; then
-		PKG_CMD="yay -S --needed --noconfirm"
+fedora)
+	if ((EUID == 0)); then
+		DWM_PACKAGE_COMMAND=(dnf install -y)
 	else
-		PKG_CMD="sudo pacman -S --needed --noconfirm"
+		DWM_PACKAGE_COMMAND=(sudo dnf install -y)
 	fi
-	;;
-rhel)
-	PKG_CMD="sudo dnf install -y"
-	;;
-debian)
-	PKG_CMD="sudo apt-get install -y"
+	PKG_CMD="${DWM_PACKAGE_COMMAND[*]}"
 	;;
 *)
 	PKG_CMD="unavailable"
@@ -55,23 +43,11 @@ export PKG_CMD
 
 install_packages() {
 	case "$DISTRO_FAMILY" in
-	arch)
-		if command -v paru &>/dev/null && paru --version &>/dev/null; then
-			paru -S --needed --noconfirm "$@"
-		elif command -v yay &>/dev/null && yay --version &>/dev/null; then
-			yay -S --needed --noconfirm "$@"
-		else
-			sudo pacman -S --needed --noconfirm "$@"
-		fi
-		;;
-	rhel)
-		sudo dnf install -y "$@"
-		;;
-	debian)
-		sudo apt-get install -y "$@"
+	fedora)
+		"${DWM_PACKAGE_COMMAND[@]}" "$@"
 		;;
 	*)
-		printf 'Unsupported distribution: %s\n' "$DISTRO_NAME" >&2
+		printf 'Unsupported distribution: %s (Fedora is required)\n' "$DISTRO_NAME" >&2
 		return 1
 		;;
 	esac
@@ -81,10 +57,7 @@ package_available() {
 	local package_arch
 
 	case "$DISTRO_FAMILY" in
-	arch)
-		pacman -Si "$1" &>/dev/null
-		;;
-	rhel)
+	fedora)
 		package_arch=${1##*.}
 		case "$package_arch" in
 		i686 | x86_64 | aarch64)
@@ -96,9 +69,6 @@ package_available() {
 				command grep -Fxq "$1"
 			;;
 		esac
-		;;
-	debian)
-		apt-cache show "$1" &>/dev/null
 		;;
 	*)
 		return 1

--- a/scripts/pkg-scan.py
+++ b/scripts/pkg-scan.py
@@ -22,13 +22,9 @@ def list_python_packages():
 
 def list_system_packages():
     managers = [
-        ("pacman",  ["pacman", "-Q"]),
-        ("dpkg",    ["dpkg-query", "-W", "-f=${Package}\t${Version}\n"]),
-        ("rpm",     ["rpm", "-qa", "--qf", "%{NAME}\t%{VERSION}\n"]),
-        ("apk",     ["apk", "info", "-v"]),
-        ("zypper",  ["zypper", "se", "--installed-only", "-s"]),
+        ("rpm", ["rpm", "-qa", "--qf", "%{NAME}\t%{VERSION}\n"]),
         ("flatpak", ["flatpak", "list", "--columns=application,version"]),
-        ("snap",    ["snap", "list"]),
+        ("snap", ["snap", "list"]),
     ]
 
     found = False
@@ -40,7 +36,7 @@ def list_system_packages():
             found = True
 
     if not found:
-        print("No supported package manager found.")
+        print("No Fedora package database found.")
 
 
 if __name__ == "__main__":

--- a/scripts/power-management.sh
+++ b/scripts/power-management.sh
@@ -11,7 +11,7 @@
 #   ./power-management.sh --help      # show this help
 #
 # Hardware: Laptop-oriented Linux systems with ACPI power interfaces
-# OS:       Debian-, Arch-, and Fedora/RHEL-family systems
+# OS:       Fedora Linux
 # =============================================================================
 
 set -euo pipefail
@@ -58,14 +58,10 @@ read_sys() { cat "$1" 2>/dev/null || echo "N/A"; }
 package_install_hint() {
 	local package=$1
 
-	if command -v pacman &>/dev/null; then
-		printf 'sudo pacman -S %s' "$package"
-	elif command -v dnf &>/dev/null; then
+	if command -v dnf &>/dev/null; then
 		printf 'sudo dnf install %s' "$package"
-	elif command -v apt-get &>/dev/null; then
-		printf 'sudo apt-get install %s' "$package"
 	else
-		printf 'install package: %s' "$package"
+		printf 'install Fedora package: %s' "$package"
 	fi
 }
 

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+umask 077
+
+test_root=${DWM_TEST_TMP_ROOT:-${HOME:?HOME is required}/tmp}
+if [[ -z $test_root ]]; then
+	printf 'Refusing unsafe DWM_TEST_TMP_ROOT: %s\n' "$test_root" >&2
+	exit 2
+fi
+if [[ -L $test_root ]]; then
+	printf 'Refusing symbolic-link test root: %s\n' "$test_root" >&2
+	exit 2
+fi
+test_root=$(realpath -m -- "$test_root")
+if [[ $test_root == / || $test_root == /tmp ]]; then
+	printf 'Refusing unsafe DWM_TEST_TMP_ROOT: %s\n' "$test_root" >&2
+	exit 2
+fi
+if [[ -e $test_root ]]; then
+	[[ -d $test_root ]] || {
+		printf 'Test root is not a directory: %s\n' "$test_root" >&2
+		exit 2
+	}
+else
+	if ((EUID == 0)); then
+		install -d -m 0711 -- "$test_root"
+	else
+		install -d -m 0700 -- "$test_root"
+	fi
+fi
+
+work=$(mktemp -d "$test_root/dwm-titus-tests.XXXXXX")
+# shellcheck disable=SC2329
+cleanup() {
+	local status=$?
+	trap - EXIT HUP INT TERM
+	if ! find "$work" -depth -delete 2>/dev/null; then
+		if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+			if ! sudo -n find "$work" -depth -delete; then
+				printf 'Could not clear test workspace: %s\n' "$work" >&2
+				((status != 0)) || status=1
+			fi
+		else
+			printf 'Could not clear test workspace without sudo: %s\n' "$work" >&2
+			((status != 0)) || status=1
+		fi
+	fi
+	exit "$status"
+}
+trap cleanup EXIT
+if ((EUID == 0)); then
+	# Root-run container tests drop privileges for ownership checks. Allow those
+	# users to traverse the randomized path without allowing directory listing.
+	chmod 0711 "$work"
+fi
+runner_token=$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')
+printf '%s\n' "$runner_token" >"$work/.runner"
+chmod 0400 "$work/.runner"
+child_pid=
+child_group=false
+# shellcheck disable=SC2329
+child_alive() {
+	if [[ $child_group == true ]]; then
+		kill -0 -- "-$child_pid" 2>/dev/null
+	else
+		kill -0 "$child_pid" 2>/dev/null
+	fi
+}
+# shellcheck disable=SC2329
+stop_child() {
+	local signal=$1 attempt
+
+	if [[ -n $child_pid ]]; then
+		if [[ $child_group == true ]]; then
+			kill -s "$signal" -- "-$child_pid" 2>/dev/null || true
+		else
+			kill -s "$signal" -- "$child_pid" 2>/dev/null || true
+		fi
+		for ((attempt = 0; attempt < 20; attempt++)); do
+			child_alive || break
+			sleep 0.05
+		done
+		if child_alive; then
+			if [[ $child_group == true ]]; then
+				kill -KILL -- "-$child_pid" 2>/dev/null || true
+			else
+				kill -KILL -- "$child_pid" 2>/dev/null || true
+			fi
+		fi
+		wait "$child_pid" 2>/dev/null || true
+	fi
+}
+# shellcheck disable=SC2329
+interrupt() {
+	local signal=$1 status=$2
+
+	trap - HUP INT TERM
+	stop_child "$signal"
+	child_pid=
+	exit "$status"
+}
+trap 'interrupt HUP 129' HUP
+trap 'interrupt INT 130' INT
+trap 'interrupt TERM 143' TERM
+
+export TMPDIR=$work
+export DWM_TEST_WORKSPACE=$work
+export DWM_TEST_RUNNER_TOKEN=$runner_token
+printf '==> Test workspace: %s\n' "$work"
+
+if (($# == 0)); then
+	set -- make check
+fi
+
+if command -v setsid >/dev/null 2>&1; then
+	child_group=true
+	setsid "$@" &
+	child_pid=$!
+else
+	"$@" &
+	child_pid=$!
+fi
+if wait "$child_pid"; then
+	status=0
+else
+	status=$?
+fi
+# A test may leave a monitor or helper behind after its main process exits.
+# The runner owns the complete session and must not orphan those descendants.
+if [[ $child_group == true ]] && child_alive; then
+	stop_child TERM
+fi
+child_pid=
+exit "$status"

--- a/scripts/xscreensaver-setup.sh
+++ b/scripts/xscreensaver-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # ─────────────────────────────────────────────────────────
 # xscreensaver-setup.sh — Install and configure xscreensaver
-# Detects the package manager, installs xscreensaver, writes
+# Uses Fedora's package manager, installs xscreensaver, writes
 # a sensible default config, and sets it up to start on login.
 # ─────────────────────────────────────────────────────────
 set -euo pipefail
@@ -22,28 +22,25 @@ fail() {
 }
 header() { echo -e "\n${BOLD}=== $1 ===${NC}"; }
 
+DISTRO_ID=unknown
+OS_RELEASE_FILE=/etc/os-release
+if [[ ${DWM_TEST_MODE:-0} == 1 && -n ${DWM_OS_RELEASE:-} ]]; then
+	OS_RELEASE_FILE=$DWM_OS_RELEASE
+fi
+if [[ -r $OS_RELEASE_FILE ]]; then
+	# shellcheck disable=SC1090
+	source "$OS_RELEASE_FILE"
+	DISTRO_ID=${ID:-unknown}
+fi
+[[ $DISTRO_ID == fedora ]] || fail "dwm-titus supports Fedora only."
+
 # ── Detect package manager and install ───────────────────
 header "Installing xscreensaver"
 
 install_pkg() {
-	if command -v pacman &>/dev/null; then
-		info "Detected pacman (Arch-based)"
-		sudo pacman -S --needed --noconfirm xscreensaver
-	elif command -v apt &>/dev/null; then
-		info "Detected apt (Debian/Ubuntu-based)"
-		sudo apt update && sudo apt install -y xscreensaver
-	elif command -v dnf &>/dev/null; then
-		info "Detected dnf (Fedora-based)"
-		sudo dnf install -y xscreensaver
-	elif command -v zypper &>/dev/null; then
-		info "Detected zypper (openSUSE-based)"
-		sudo zypper install -y xscreensaver
-	elif command -v xbps-install &>/dev/null; then
-		info "Detected xbps (Void Linux)"
-		sudo xbps-install -Sy xscreensaver
-	else
-		fail "No supported package manager found. Install xscreensaver manually."
-	fi
+	command -v dnf >/dev/null 2>&1 || fail "dnf is required; dwm-titus supports Fedora only."
+	info "Installing with dnf"
+	sudo dnf install -y xscreensaver
 }
 
 if command -v xscreensaver &>/dev/null; then

--- a/tests/test-autostart.sh
+++ b/tests/test-autostart.sh
@@ -66,6 +66,14 @@ while [ "$#" -gt 0 ]; do
 	shift
 done
 [ -n "$name" ] || exit 1
+if [ "$name" = quickshell ] && [ "${TEST_QUICKSHELL_PGREP_RACE:-0}" = 1 ]; then
+	count_file="${TEST_STATE:?}/quickshell-pgrep-${TEST_AUTOSTART_ITERATION:?}.count"
+	count=0
+	[ ! -f "$count_file" ] || count=$(cat "$count_file")
+	count=$((count + 1))
+	printf '%s\n' "$count" >"$count_file"
+	[ "$count" -ne 2 ] || exit 1
+fi
 test -f "${TEST_STATE:?}/$name.running"
 EOF
 
@@ -115,6 +123,10 @@ done
 
 cat >"$work/bin/quickshell" <<'EOF'
 #!/bin/sh
+if [ "${1:-}" = --version ]; then
+	printf '%s\n' 'quickshell 0.3.0'
+	exit 0
+fi
 if [ "${1:-}" = ipc ]; then
 	test -f "${TEST_STATE:?}/quickshell.running"
 	: >"${TEST_STATE:?}/quickshell-tray.ready"
@@ -143,7 +155,7 @@ run_duplicate_case() {
 	# Prevent this isolated test from starting a host polkit agent.
 	: >"$state/polkit-mate-authentication-agent-1.running"
 
-	for _ in 1 2; do
+	for iteration in 1 2; do
 		if [ "$mode" = startx ]; then
 			XDG_RUNTIME_DIR="$runtime" dbus-run-session -- env \
 				DISPLAY=:99 \
@@ -155,6 +167,8 @@ run_duplicate_case() {
 				XDG_CONFIG_HOME="$home/.config" \
 				XDG_SESSION_TYPE=wayland \
 				DWM_AUTOSTART_NO_INPUT_WATCH=1 \
+				TEST_AUTOSTART_ITERATION="$iteration" \
+				TEST_QUICKSHELL_PGREP_RACE="$([ "$iteration" = 1 ] && printf 1 || printf 0)" \
 				DWM_AUTOSTART_NO_SETSID=1 \
 				sh "$repo_dir/scripts/autostart.sh"
 		else
@@ -168,6 +182,8 @@ run_duplicate_case() {
 				XDG_RUNTIME_DIR="$runtime" \
 				XDG_SESSION_TYPE=wayland \
 				DWM_AUTOSTART_NO_INPUT_WATCH=1 \
+				TEST_AUTOSTART_ITERATION="$iteration" \
+				TEST_QUICKSHELL_PGREP_RACE="$([ "$mode" = display-manager ] && [ "$iteration" = 1 ] && printf 1 || printf 0)" \
 				DWM_AUTOSTART_NO_SETSID=1 \
 				sh "$repo_dir/scripts/autostart.sh"
 		fi

--- a/tests/test-container-smoke.sh
+++ b/tests/test-container-smoke.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENGINE="${CONTAINER_ENGINE:-}"
+IMAGE="${DWM_CONTAINER_FEDORA_IMAGE:-fedora:44}"
 
 if [[ -z $ENGINE ]]; then
 	if command -v podman >/dev/null 2>&1; then
@@ -23,72 +24,35 @@ podman | docker) ;;
 	;;
 esac
 
-DEBIAN_IMAGE="${DWM_CONTAINER_DEBIAN_IMAGE:-debian:stable-slim}"
-ARCH_IMAGE="${DWM_CONTAINER_ARCH_IMAGE:-archlinux:latest}"
-RHEL_IMAGE="${DWM_CONTAINER_RHEL_IMAGE:-fedora:latest}"
-FAMILIES="${DWM_CONTAINER_FAMILIES:-debian arch rhel}"
+run_args=(run --rm --security-opt label=disable)
+source_mount="${REPO_DIR}:/src:ro"
 
-run_container() {
-	local family=$1
-	local image=$2
-	local volume="${REPO_DIR}:/src:ro"
-	local run_args=(run --rm)
-
-	if [[ $ENGINE == "podman" ]]; then
-		run_args+=(--security-opt label=disable)
-	fi
-
-	printf '==> Container smoke: %s (%s)\n' "$family" "$image"
-	# Expansion in these single-quoted scripts must happen inside the container.
-	# shellcheck disable=SC2016
-	"$ENGINE" "${run_args[@]}" \
-		-e "DWM_SMOKE_FAMILY=$family" \
-		-v "$volume" \
-		"$image" \
-		/bin/sh -eu -c '
-case "$DWM_SMOKE_FAMILY" in
-debian)
-	apt-get update
-	apt-get install -y --no-install-recommends bash ca-certificates
-	;;
-arch)
-	pacman -Syu --noconfirm
-	pacman -S --needed --noconfirm bash ca-certificates
-	;;
-rhel)
-	dnf install -y bash ca-certificates
-	;;
-*)
-	printf "Unsupported smoke family: %s\n" "$DWM_SMOKE_FAMILY" >&2
-	exit 1
-	;;
-esac
-
-rm -rf /work
-mkdir -p /work
-cp -a /src/. /work/
-cd /work
+printf '==> Fedora container smoke: %s\n' "$IMAGE"
+# Expansion in this single-quoted script must happen inside the container.
+# shellcheck disable=SC2016
+"$ENGINE" "${run_args[@]}" \
+	-v "$source_mount" \
+	"$IMAGE" \
+	/bin/sh -eu -c '
+dnf install -y bash ca-certificates
+install -d -m 0700 /var/tmp/dwm-titus-smoke
+install -d -m 0700 /var/tmp/dwm-titus-smoke/repo
+tar -C /src \
+	--exclude=.git \
+	--exclude=release \
+	--exclude='*.iso' \
+	-cf - . | tar -C /var/tmp/dwm-titus-smoke/repo -xf -
+cd /var/tmp/dwm-titus-smoke/repo
 
 bash -euo pipefail -c '"'"'
 source scripts/dwm-utils.sh
 source scripts/dwm-packages.sh
-mapfile -t packages < <(dwm_packages "$DISTRO_FAMILY" required | awk "NF" | sort -u)
-
-case "$DISTRO_FAMILY" in
-debian)
-	apt-get install -y --no-install-recommends "${packages[@]}"
-	;;
-arch)
-	pacman -S --needed --noconfirm "${packages[@]}"
-	;;
-rhel)
-	dnf install -y "${packages[@]}"
-	;;
-*)
-	printf "Unsupported detected family: %s\n" "$DISTRO_FAMILY" >&2
-	exit 1
-	;;
-esac
+[[ $DISTRO_ID == fedora ]]
+[[ $DISTRO_FAMILY == fedora ]]
+mapfile -t packages < <(dwm_packages fedora required | awk "NF" | sort -u)
+mapfile -t desktop_packages < <(dwm_packages fedora desktop | awk "NF" | sort -u)
+dnf install -y "${packages[@]}" "${desktop_packages[@]}"
+scripts/dwm-quickshell-version-check
 
 ./install.sh --dry-run --non-interactive --profile core
 make clean
@@ -98,18 +62,5 @@ make check-install-manifest
 DWM_SECURITY_CONTAINER=1 tests/test-settings-display-security.sh
 '"'"'
 '
-}
 
-for family in $FAMILIES; do
-	case "$family" in
-	debian) run_container debian "$DEBIAN_IMAGE" ;;
-	arch) run_container arch "$ARCH_IMAGE" ;;
-	rhel) run_container rhel "$RHEL_IMAGE" ;;
-	*)
-		printf 'Unsupported DWM_CONTAINER_FAMILIES entry: %s\n' "$family" >&2
-		exit 1
-		;;
-	esac
-done
-
-printf '==> Container smoke validation completed.\n'
+printf '==> Fedora container smoke validation completed.\n'

--- a/tests/test-fedora-platform.sh
+++ b/tests/test-fedora-platform.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+work=$(mktemp -d)
+trap 'find "$work" -depth -delete' EXIT
+
+snapshot_tree() {
+	local root=$1 output=$2
+	{
+		find "$root" -printf 'entry\t%P\t%y\t%m\t%s\t%l\n'
+		find "$root" -type f -exec sha256sum {} + |
+			sed "s#  $root/#  #"
+	} | sort >"$output"
+}
+
+cat >"$work/fedora" <<'EOF'
+ID=fedora
+PRETTY_NAME="Fedora Linux 44"
+EOF
+cat >"$work/unsupported" <<'EOF'
+ID=example
+ID_LIKE="rhel"
+PRETTY_NAME="Unsupported Linux"
+EOF
+
+fedora_family=$(DWM_TEST_MODE=1 DWM_OS_RELEASE="$work/fedora" bash -c \
+	'. "$1"; printf "%s" "$DISTRO_FAMILY"' sh "$repo/scripts/dwm-utils.sh")
+[[ $fedora_family == fedora ]]
+
+unsupported_family=$(DWM_TEST_MODE=1 DWM_OS_RELEASE="$work/unsupported" bash -c \
+	'. "$1"; printf "%s" "$DISTRO_FAMILY"' sh "$repo/scripts/dwm-utils.sh")
+[[ $unsupported_family == unknown ]]
+
+mkdir -p "$work/bin" "$work/unsupported-home"
+for command_name in chmod chown cp curl dnf git install ln make mkdir mv rm sudo systemctl tee touch unzip usermod; do
+	cat >"$work/bin/$command_name" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\t%s\n' "${0##*/}" "$*" >>"${DWM_MUTATION_LOG:?}"
+exit 99
+EOF
+done
+/usr/bin/chmod +x "$work/bin/"*
+snapshot_tree "$work/unsupported-home" "$work/home.before"
+set +e
+DWM_TEST_MODE=1 DWM_OS_RELEASE="$work/unsupported" \
+	DWM_MUTATION_LOG="$work/mutations.log" HOME="$work/unsupported-home" \
+	PATH="$work/bin:$PATH" "$repo/install.sh" \
+	--non-interactive --profile core >"$work/install-rejection.out" 2>&1
+install_status=$?
+set -e
+if [[ $install_status -ne 1 ]]; then
+	printf 'Unsupported installer exited with %s instead of 1.\n' "$install_status" >&2
+	exit 1
+fi
+grep -Fq 'Unsupported distribution: Unsupported Linux' "$work/install-rejection.out"
+grep -Fq 'dwm-titus supports Fedora only.' "$work/install-rejection.out"
+if [[ -e $work/mutations.log ]]; then
+	printf 'Unsupported installer attempted a package or system mutation.\n' >&2
+	exit 1
+fi
+snapshot_tree "$work/unsupported-home" "$work/home.after"
+cmp "$work/home.before" "$work/home.after"
+
+# Expansion is intentionally deferred to the child shell.
+# shellcheck disable=SC2016
+host_family=$(env -u DWM_TEST_MODE DWM_OS_RELEASE="$work/unsupported" bash -c \
+	'. "$1"; printf "%s" "$DISTRO_FAMILY"' sh "$repo/scripts/dwm-utils.sh")
+[[ $host_family == fedora ]]
+
+root_package_command=$(DWM_TEST_MODE=1 DWM_OS_RELEASE="$work/fedora" bash -c \
+	'. "$1"; printf "%s" "$PKG_CMD"' sh "$repo/scripts/dwm-utils.sh")
+if [[ $EUID -eq 0 ]]; then
+	[[ $root_package_command == 'dnf install -y' ]]
+else
+	[[ $root_package_command == 'sudo dnf install -y' ]]
+fi
+
+set +e
+snapshot_tree "$work/unsupported-home" "$work/screensaver-home.before"
+DWM_TEST_MODE=1 DWM_OS_RELEASE="$work/unsupported" \
+	DWM_MUTATION_LOG="$work/mutations.log" HOME="$work/unsupported-home" \
+	PATH="$work/bin:$PATH" "$repo/scripts/xscreensaver-setup.sh" \
+	>"$work/xscreensaver-rejection.out" 2>&1
+screensaver_status=$?
+set -e
+if [[ $screensaver_status -ne 1 ]]; then
+	printf 'Unsupported screensaver setup exited with %s instead of 1.\n' \
+		"$screensaver_status" >&2
+	exit 1
+fi
+grep -Fq 'dwm-titus supports Fedora only.' "$work/xscreensaver-rejection.out"
+snapshot_tree "$work/unsupported-home" "$work/screensaver-home.after"
+if [[ -e $work/mutations.log ]] ||
+	! cmp "$work/screensaver-home.before" "$work/screensaver-home.after"; then
+	printf 'Unsupported screensaver setup attempted a mutation.\n' >&2
+	exit 1
+fi
+
+if grep -ERq 'setenforce|/etc/selinux/config|(^|[[:space:]])(sudo[[:space:]]+)?chcon([[:space:]]|$)|semanage[[:space:]]+fcontext' \
+	"$repo/install.sh" "$repo/scripts"; then
+	printf 'Existing-system tools must not change host SELinux policy or assign file contexts.\n' >&2
+	exit 1
+fi
+# restorecon is intentionally allowed for files these tools install: it applies
+# the host policy's existing label and does not alter that policy.
+
+printf 'Fedora-only platform contract: PASS\n'

--- a/tests/test-install-preservation.sh
+++ b/tests/test-install-preservation.sh
@@ -11,7 +11,26 @@ XDG_CONFIG_HOME="$TEST_HOME/.config"
 XDG_DATA_HOME="$TEST_HOME/.local/share"
 XDG_CONFIG_DIRS="$WORK_DIR/etc-xdg"
 OWNER="$(id -un)"
-OWNER_GROUP="$(id -gn)"
+if [[ $(id -u) -eq 0 ]]; then
+	command -v runuser >/dev/null 2>&1 || {
+		printf 'runuser is required for root-run install preservation tests.\n' >&2
+		exit 1
+	}
+	getent passwd nobody >/dev/null 2>&1 || {
+		printf 'The nobody fixture user is required for root-run tests.\n' >&2
+		exit 1
+	}
+	OWNER=nobody
+fi
+OWNER_GROUP="$(id -gn "$OWNER")"
+
+run_as_owner() {
+	if [[ $(id -u) -eq 0 ]]; then
+		runuser -u "$OWNER" -- "$@"
+	else
+		"$@"
+	fi
+}
 
 if grep -Eq 'sudo systemctl enable (NetworkManager|bluetooth)\.service' "$REPO_DIR/install.sh"; then
 	printf 'Optional Arch services are enabled without the non-fatal guard.\n' >&2
@@ -43,6 +62,35 @@ if grep -Eq 'sudo make install($|[[:space:]&;])' "$REPO_DIR/scripts/check-deps.s
 fi
 if grep -Eq 'sudo chown (-R|--recursive)' "$REPO_DIR/install.sh"; then
 	printf 'Installer uses a broad recursive ownership repair.\n' >&2
+	exit 1
+fi
+MAKE_DATABASE=$(make -qp -C "$REPO_DIR" 2>/dev/null || true)
+if awk '$1 == "install-system:" || $1 == "install:" { for (i = 2; i <= NF; i++) if ($i == "all") found = 1 } END { exit !found }' \
+	<<<"$MAKE_DATABASE"; then
+	printf 'The privileged system install still rebuilds user-owned sources.\n' >&2
+	exit 1
+fi
+grep -Fq "runuser -u \"\${OWNER}\" -- env HOME=\"\${USER_HOME}\" \$(MAKE) all" \
+	"$REPO_DIR/Makefile"
+grep -Fq 'dwm is not built. Run make before install-system.' "$REPO_DIR/Makefile"
+grep -Fq 'dwm build input is missing:' "$REPO_DIR/Makefile"
+grep -Fq 'dwm is stale. Run make before install-system.' "$REPO_DIR/Makefile"
+INSTALL_USER_RECIPE=$(sed -n '/^install-user:/,/^uninstall:/p' "$REPO_DIR/Makefile")
+if ! grep -Fq "@test \"\$\$(id -u)\" -ne 0" <<<"$INSTALL_USER_RECIPE"; then
+	printf 'Unprivileged user install does not reject direct root invocation.\n' >&2
+	exit 1
+fi
+if grep -Eq '(^|[[:space:]])chown([[:space:]]|$)' <<<"$INSTALL_USER_RECIPE"; then
+	printf 'Unprivileged user install still attempts to change ownership.\n' >&2
+	exit 1
+fi
+if grep -Fq 'DWM_INSTALL_OWNER=' <<<"$INSTALL_USER_RECIPE"; then
+	printf 'Unprivileged user install requests owner-setting helper behavior.\n' >&2
+	exit 1
+fi
+if grep -E 'cp[[:space:]].*-a' <<<"$INSTALL_USER_RECIPE" |
+	grep -Fv -- '--no-preserve=ownership' >/dev/null; then
+	printf 'Unprivileged user install preserves source ownership during a copy.\n' >&2
 	exit 1
 fi
 
@@ -78,6 +126,51 @@ if [[ $EXPLICIT_OWNER_HOME != "$WORK_DIR/explicit-home" ]]; then
 fi
 
 cp -a "$REPO_DIR/." "$TEST_REPO/"
+test -f "$TEST_REPO/config.h" || cp "$TEST_REPO/config.def.h" "$TEST_REPO/config.h"
+rm -f "$TEST_REPO/dwm"
+if make -C "$TEST_REPO" install-system \
+	DESTDIR="$WORK_DIR/stale-stage" >"$WORK_DIR/unbuilt-install.log" 2>&1; then
+	printf 'System install accepted a missing dwm binary.\n' >&2
+	exit 1
+fi
+grep -Fq 'dwm is not built. Run make before install-system.' \
+	"$WORK_DIR/unbuilt-install.log"
+test ! -e "$WORK_DIR/stale-stage"
+for object in drw.o dwm.o util.o tomlparser.o; do
+	install -Dm644 /dev/null "$TEST_REPO/$object"
+done
+install -Dm755 /bin/true "$TEST_REPO/dwm"
+mv "$TEST_REPO/config.h" "$TEST_REPO/config.h.saved"
+if make -C "$TEST_REPO" install-system \
+	DESTDIR="$WORK_DIR/stale-stage" >"$WORK_DIR/missing-input-install.log" 2>&1; then
+	printf 'System install accepted a missing build input.\n' >&2
+	exit 1
+fi
+grep -Fq 'dwm build input is missing: config.h. Run make before install-system.' \
+	"$WORK_DIR/missing-input-install.log"
+test ! -e "$WORK_DIR/stale-stage"
+mv "$TEST_REPO/config.h.saved" "$TEST_REPO/config.h"
+sleep 1
+touch "$TEST_REPO/drw.o"
+if make -C "$TEST_REPO" install-system \
+	DESTDIR="$WORK_DIR/stale-stage" >"$WORK_DIR/stale-object-install.log" 2>&1; then
+	printf 'System install accepted an object newer than dwm.\n' >&2
+	exit 1
+fi
+grep -Fq 'dwm is stale. Run make before install-system.' \
+	"$WORK_DIR/stale-object-install.log"
+test ! -e "$WORK_DIR/stale-stage"
+touch "$TEST_REPO/dwm"
+sleep 1
+touch "$TEST_REPO/dwm.c"
+if make -C "$TEST_REPO" install-system \
+	DESTDIR="$WORK_DIR/stale-stage" >"$WORK_DIR/stale-install.log" 2>&1; then
+	printf 'System install accepted a stale dwm binary.\n' >&2
+	exit 1
+fi
+grep -Fq 'dwm is stale. Run make before install-system.' \
+	"$WORK_DIR/stale-install.log"
+test ! -e "$WORK_DIR/stale-stage"
 mkdir -p \
 	"$XDG_CONFIG_HOME/dwm-titus" \
 	"$XDG_CONFIG_HOME/picom" \
@@ -170,8 +263,12 @@ snapshot_file "$XDG_CONFIG_HOME/Thunar/uca.xml" "$WORK_DIR/thunar-uca.before"
 snapshot_file "$XDG_CONFIG_HOME/autostart/picom.desktop" "$WORK_DIR/picom-autostart.before"
 snapshot_file "$XDG_CONFIG_HOME/systemd/user/custom.service" "$WORK_DIR/custom-service.before"
 
+if [[ $(id -u) -eq 0 ]]; then
+	chown -R "$OWNER:$OWNER_GROUP" "$WORK_DIR"
+fi
+
 for _ in 1 2; do
-	make -C "$TEST_REPO" install-user \
+	run_as_owner env HOME="$TEST_HOME" make -C "$TEST_REPO" install-user \
 		USER_HOME="$TEST_HOME" \
 		OWNER="$OWNER" \
 		XDG_CONFIG_HOME="$XDG_CONFIG_HOME" \
@@ -239,7 +336,10 @@ FRESH_CONFIG_HOME="$FRESH_HOME/.config"
 FRESH_DATA_HOME="$FRESH_HOME/.local/share"
 FRESH_CONFIG_DIRS="$WORK_DIR/fresh-etc-xdg"
 mkdir -p "$FRESH_CONFIG_DIRS/autostart"
-make -C "$TEST_REPO" install-user \
+if [[ $(id -u) -eq 0 ]]; then
+	chown -R "$OWNER:$OWNER_GROUP" "$FRESH_CONFIG_DIRS"
+fi
+run_as_owner env HOME="$FRESH_HOME" make -C "$TEST_REPO" install-user \
 	USER_HOME="$FRESH_HOME" \
 	OWNER="$OWNER" \
 	XDG_CONFIG_HOME="$FRESH_CONFIG_HOME" \

--- a/tests/test-install-preservation.sh
+++ b/tests/test-install-preservation.sh
@@ -10,6 +10,8 @@ TEST_HOME="$WORK_DIR/home"
 XDG_CONFIG_HOME="$TEST_HOME/.config"
 XDG_DATA_HOME="$TEST_HOME/.local/share"
 XDG_CONFIG_DIRS="$WORK_DIR/etc-xdg"
+OWNER_TMPDIR="$WORK_DIR/owner-tmp"
+mkdir -p "$OWNER_TMPDIR"
 OWNER="$(id -un)"
 if [[ $(id -u) -eq 0 ]]; then
 	command -v runuser >/dev/null 2>&1 || {
@@ -26,19 +28,12 @@ OWNER_GROUP="$(id -gn "$OWNER")"
 
 run_as_owner() {
 	if [[ $(id -u) -eq 0 ]]; then
-		runuser -u "$OWNER" -- "$@"
+		runuser -u "$OWNER" -- env TMPDIR="$OWNER_TMPDIR" "$@"
 	else
-		"$@"
+		env TMPDIR="$OWNER_TMPDIR" "$@"
 	fi
 }
 
-if grep -Eq 'sudo systemctl enable (NetworkManager|bluetooth)\.service' "$REPO_DIR/install.sh"; then
-	printf 'Optional Arch services are enabled without the non-fatal guard.\n' >&2
-	exit 1
-fi
-for service in NetworkManager.service bluetooth.service; do
-	grep -Fq "enable_optional_service $service" "$REPO_DIR/install.sh"
-done
 grep -Fq 'Start LightDM now (optional): sudo systemctl start lightdm.service' \
 	"$REPO_DIR/install.sh"
 grep -Fq "sudo make install-system \\" "$REPO_DIR/install.sh"

--- a/tests/test-kickstart-variants.sh
+++ b/tests/test-kickstart-variants.sh
@@ -58,49 +58,27 @@ required_packages=(
 )
 
 mapfile -t mapped_fedora_packages < <(
-	DISTRO_ID=fedora ARCH=x86_64 dwm_packages rhel full | awk 'NF' | sort -u
+	ARCH=x86_64 dwm_packages fedora full | awk 'NF' | sort -u
 )
 
-for family in arch debian rhel; do
-	DISTRO_ID=$([[ $family == rhel ]] && printf fedora || printf '%s' "$family") \
-		dwm_packages "$family" runtime-required | grep -Fx xclip >/dev/null
-	DISTRO_ID=$([[ $family == rhel ]] && printf fedora || printf '%s' "$family") \
-		dwm_packages "$family" runtime-required | grep -Fx xdotool >/dev/null
-	DISTRO_ID=$([[ $family == rhel ]] && printf fedora || printf '%s' "$family") \
-		dwm_packages "$family" recommended | grep -Fx maim >/dev/null
-done
+dwm_packages fedora runtime-required | grep -Fx xclip >/dev/null
+dwm_packages fedora runtime-required | grep -Fx xdotool >/dev/null
+dwm_packages fedora recommended | grep -Fx maim >/dev/null
 
-if DISTRO_ID=rocky dwm_packages rhel runtime-required | grep -Fx maim >/dev/null; then
-	printf 'Optional screenshot package leaked into required RHEL packages.\n' >&2
+if dwm_packages fedora runtime-required | grep -Fx maim >/dev/null; then
+	printf 'Optional screenshot package leaked into required Fedora packages.\n' >&2
 	exit 1
 fi
-DISTRO_ID=rocky dwm_packages rhel screenshot-optional | grep -Fx maim >/dev/null
-DISTRO_ID=rocky dwm_packages rhel x11 | grep -Fx setxkbmap >/dev/null
-
-DISTRO_ID=fedora dwm_packages rhel recommended | grep -Fx playerctl >/dev/null
-if DISTRO_ID=rocky dwm_packages rhel recommended | grep -Fx playerctl >/dev/null; then
-	printf 'EPEL-only playerctl leaked into required RHEL desktop packages.\n' >&2
-	exit 1
-fi
-DISTRO_ID=rocky dwm_packages rhel optional | grep -Fx playerctl >/dev/null
-if DISTRO_ID=fedora ARCH=x86_64 dwm_packages rhel full | grep -Fx nwg-look >/dev/null; then
+dwm_packages fedora screenshot-optional | grep -Fx maim >/dev/null
+dwm_packages fedora x11 | grep -Fx setxkbmap >/dev/null
+dwm_packages fedora recommended | grep -Fx playerctl >/dev/null
+dwm_packages fedora desktop | grep -Fx quickshell >/dev/null
+if ARCH=x86_64 dwm_packages fedora full | grep -Fx nwg-look >/dev/null; then
 	printf 'Unavailable Fedora package leaked into the image package set: nwg-look\n' >&2
 	exit 1
 fi
-
-for mapping in arch:gvfs-smb rhel:gvfs-smb debian:gvfs-backends; do
-	family=${mapping%%:*}
-	package=${mapping#*:}
-	DISTRO_ID=$([[ $family == rhel ]] && printf fedora || printf '%s' "$family") \
-		dwm_packages "$family" full | grep -Fx "$package" >/dev/null
-done
-
-for mapping in arch:gnome-keyring rhel:gnome-keyring-pam debian:libpam-gnome-keyring; do
-	family=${mapping%%:*}
-	package=${mapping#*:}
-	DISTRO_ID=$([[ $family == rhel ]] && printf fedora || printf '%s' "$family") \
-		dwm_packages "$family" full | grep -Fx "$package" >/dev/null
-done
+dwm_packages fedora full | grep -Fx gvfs-smb >/dev/null
+dwm_packages fedora full | grep -Fx gnome-keyring-pam >/dev/null
 
 for ks in "$standard_ks" "$nvidia_ks"; do
 	if grep -Fxq nwg-look "$ks"; then
@@ -158,18 +136,14 @@ for ks in "$standard_ks" "$nvidia_ks"; do
 done
 
 for package in steam gamescope gamemode.x86_64 gamemode.i686 mangohud.x86_64 mangohud.i686; do
-	DISTRO_ID=fedora ARCH=x86_64 dwm_packages rhel full | grep -Fx "$package" >/dev/null
-	DISTRO_ID=fedora ARCH=x86_64 dwm_packages rhel gaming | grep -Fx "$package" >/dev/null
-	if DISTRO_ID=fedora ARCH=x86_64 dwm_packages rhel optional | grep -Fx "$package" >/dev/null; then
-		printf 'Fedora gaming package leaked into the generic optional profile: %s\n' "$package" >&2
+	ARCH=x86_64 dwm_packages fedora full | grep -Fx "$package" >/dev/null
+	ARCH=x86_64 dwm_packages fedora gaming | grep -Fx "$package" >/dev/null
+	if ARCH=x86_64 dwm_packages fedora optional | grep -Fx "$package" >/dev/null; then
+		printf 'Fedora gaming package leaked into the optional profile: %s\n' "$package" >&2
 		exit 1
 	fi
-	if DISTRO_ID=fedora ARCH=aarch64 dwm_packages rhel full | grep -Fx "$package" >/dev/null; then
+	if ARCH=aarch64 dwm_packages fedora full | grep -Fx "$package" >/dev/null; then
 		printf 'x86-only Fedora gaming package leaked into aarch64 mapping: %s\n' "$package" >&2
-		exit 1
-	fi
-	if DISTRO_ID=rocky dwm_packages rhel full | grep -Fx "$package" >/dev/null; then
-		printf 'Fedora gaming package leaked into generic RHEL mapping: %s\n' "$package" >&2
 		exit 1
 	fi
 done

--- a/tests/test-lightdm-config.sh
+++ b/tests/test-lightdm-config.sh
@@ -8,26 +8,16 @@ repo=$(
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
-arch_stage="$work/arch"
-rhel_stage="$work/rhel"
-
-make -C "$repo/lightdm" --no-print-directory DESTDIR="$arch_stage" install >/dev/null
-cat >"$work/arch.expected" <<'CONF'
-[SeatDefaults]
-greeter-session=lightdm-slick-greeter
-user-session=dwm
-session-wrapper=/etc/lightdm/Xsession
-CONF
-cmp -s "$work/arch.expected" "$arch_stage/etc/lightdm/lightdm.conf"
+fedora_stage="$work/fedora"
 
 make -C "$repo/lightdm" --no-print-directory \
-	DESTDIR="$rhel_stage" \
+	DESTDIR="$fedora_stage" \
 	LIGHTDM_SEAT_SECTION='Seat:*' \
 	LIGHTDM_GREETER_SESSION=slick-greeter \
 	LIGHTDM_SESSION_WRAPPER= \
 	LIGHTDM_LOGIND_CHECK=true \
 	install >/dev/null
-cat >"$work/rhel.expected" <<'CONF'
+cat >"$work/fedora.expected" <<'CONF'
 [LightDM]
 logind-check-graphical=true
 
@@ -35,9 +25,9 @@ logind-check-graphical=true
 greeter-session=slick-greeter
 user-session=dwm
 CONF
-cmp -s "$work/rhel.expected" "$rhel_stage/etc/lightdm/lightdm.conf"
+cmp -s "$work/fedora.expected" "$fedora_stage/etc/lightdm/lightdm.conf"
 
-grep -Fqx 'xft-dpi=96' "$rhel_stage/etc/lightdm/slick-greeter.conf"
-grep -Fqx 'activate-numlock=false' "$rhel_stage/etc/lightdm/slick-greeter.conf"
+grep -Fqx 'xft-dpi=96' "$fedora_stage/etc/lightdm/slick-greeter.conf"
+grep -Fqx 'activate-numlock=false' "$fedora_stage/etc/lightdm/slick-greeter.conf"
 
 printf 'LightDM config rendering: PASS\n'

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -199,6 +199,7 @@ run_helper() {
 		XDG_CONFIG_HOME="$work/config" \
 		XDG_DATA_HOME="$work/data" \
 		DWM_TEST_POWER_STATE="$work/power-state" \
+		DWM_TEST_MODE=1 \
 		DWM_TEST_QUICKSHELL_VERSION="${DWM_TEST_QUICKSHELL_VERSION:-0.3.0}" \
 		DWM_HEALTH_COMMAND_TIMEOUT=2 \
 		PATH="$work/bin:/usr/bin:/bin" \
@@ -211,6 +212,23 @@ printf '%s\n' "$health" | grep -Fqx 'ok	xset	xset is available'
 printf '%s\n' "$health" | grep -Fqx 'ok	light-locker	light-locker is available'
 printf '%s\n' "$health" | grep -Fqx 'ok	Themes configuration	Readable'
 printf '%s\n' "$health" | grep -Fqx 'ok	Quickshell configuration	Readable'
+
+fedora_health=$(DWM_TEST_QUICKSHELL_VERSION='0.2.1, revision dacfa9de829ac7cb173825f593236bf2c21f637e' run_helper health)
+printf '%s\n' "$fedora_health" | grep -Fqx "$(printf 'ok\tQuickshell\tAvailable')"
+DWM_TEST_MODE=1 DWM_TEST_QUICKSHELL_VERSION='0.2.1^git20260209.dacfa9d-3.fc44' \
+	"$repo/scripts/dwm-quickshell-version-check"
+DWM_TEST_MODE=1 DWM_TEST_QUICKSHELL_VERSION='0.2.1, revision dacfa9de829ac7cb173825f593236bf2c21f637e' \
+	"$repo/scripts/dwm-quickshell-version-check"
+DWM_TEST_MODE=1 DWM_TEST_QUICKSHELL_VERSION='quickshell pre-release, revision: dacfa9de829ac7cb173825f593236bf2c21f637e' \
+	"$repo/scripts/dwm-quickshell-version-check"
+DWM_TEST_MODE=1 DWM_TEST_QUICKSHELL_VERSION=0.3.0 \
+	"$repo/scripts/dwm-quickshell-version-check"
+if DWM_TEST_MODE=1 DWM_TEST_QUICKSHELL_VERSION=0.2.1 \
+	"$repo/scripts/dwm-quickshell-version-check" 2>"$work/quickshell-version.err"; then
+	printf 'Version check accepted unsupported upstream Quickshell 0.2.1.\n' >&2
+	exit 1
+fi
+grep -Fq 'unsupported Quickshell version: 0.2.1' "$work/quickshell-version.err"
 
 outdated_health=$(DWM_TEST_QUICKSHELL_VERSION=0.2.1 run_helper health)
 printf '%s\n' "$outdated_health" | grep -Fqx 'error	Quickshell	Outdated'
@@ -319,6 +337,13 @@ test ! -e "$work/power-state/light-locker.running"
 : >"$work/actions.log"
 run_helper action restart-quickshell >"$work/quickshell.out"
 grep -Fqx 'action	restart-quickshell' "$work/quickshell.out"
+if DWM_TEST_QUICKSHELL_VERSION=0.2.1 run_helper action restart-quickshell \
+	>"$work/quickshell-outdated.out" 2>"$work/quickshell-outdated.err"; then
+	printf 'Restart accepted an unsupported Quickshell version.\n' >&2
+	exit 1
+fi
+grep -Fq 'compatible Quickshell 0.3.0 or Fedora 44 snapshot is required' \
+	"$work/quickshell-outdated.err"
 grep -Fq 'pkill -x quickshell' "$work/actions.log"
 grep -Fq 'quickshell --no-duplicate' "$work/actions.log"
 

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -223,6 +223,17 @@ DWM_TEST_MODE=1 DWM_TEST_QUICKSHELL_VERSION='quickshell pre-release, revision: d
 	"$repo/scripts/dwm-quickshell-version-check"
 DWM_TEST_MODE=1 DWM_TEST_QUICKSHELL_VERSION=0.3.0 \
 	"$repo/scripts/dwm-quickshell-version-check"
+for unsupported_snapshot in \
+	0.2.1^git20260209.dacfa9d-3.fc43 \
+	0.2.1^git20260209.dacfa9d-3.fc45 \
+	0.2.1^git20260209.dacfa9d; do
+	if DWM_TEST_MODE=1 DWM_TEST_QUICKSHELL_VERSION=$unsupported_snapshot \
+		"$repo/scripts/dwm-quickshell-version-check" 2>/dev/null; then
+		printf 'Version check accepted snapshot outside the Fedora 44 contract: %s.\n' \
+			"$unsupported_snapshot" >&2
+		exit 1
+	fi
+done
 if DWM_TEST_MODE=1 DWM_TEST_QUICKSHELL_VERSION=0.2.1 \
 	"$repo/scripts/dwm-quickshell-version-check" 2>"$work/quickshell-version.err"; then
 	printf 'Version check accepted unsupported upstream Quickshell 0.2.1.\n' >&2
@@ -232,6 +243,8 @@ grep -Fq 'unsupported Quickshell version: 0.2.1' "$work/quickshell-version.err"
 
 outdated_health=$(DWM_TEST_QUICKSHELL_VERSION=0.2.1 run_helper health)
 printf '%s\n' "$outdated_health" | grep -Fqx 'error	Quickshell	Outdated'
+fc43_health=$(DWM_TEST_QUICKSHELL_VERSION=0.2.1^git20260209.dacfa9d-3.fc43 run_helper health)
+printf '%s\n' "$fc43_health" | grep -Fqx 'error	Quickshell	Outdated'
 
 info=$(run_helper info)
 printf '%s\n' "$info" | grep -Fqx 'Theme	nord'

--- a/tests/test-run-tests.sh
+++ b/tests/test-run-tests.sh
@@ -6,6 +6,18 @@ work=$(mktemp -d)
 trap 'find "$work" -depth -delete' EXIT
 
 test_root=$work/root
+process_is_live() {
+	local pid=$1 process_stat process_state
+
+	kill -0 "$pid" 2>/dev/null || return 1
+	if [[ -r /proc/$pid/stat ]]; then
+		process_stat=$(<"/proc/$pid/stat")
+		process_state=${process_stat#*) }
+		process_state=${process_state%% *}
+		[[ $process_state != Z ]]
+	fi
+}
+
 assert_workspace_removed() {
 	local output=$1 root=$2 label=$3 workspace
 	workspace=$(sed -n 's/^==> Test workspace: //p' "$output" | sed -n '1p')
@@ -57,7 +69,7 @@ DWM_TEST_TMP_ROOT=$work/descendant-root "$repo/scripts/run-tests" \
 	bash -c '(trap "" TERM; exec sleep 300) & printf "descendant=%s\n" "$!"' \
 	>"$descendant_out"
 descendant_pid=$(sed -n 's/^descendant=//p' "$descendant_out")
-if [[ -z $descendant_pid ]] || kill -0 "$descendant_pid" 2>/dev/null; then
+if [[ -z $descendant_pid ]] || process_is_live "$descendant_pid"; then
 	printf 'Successful test run left a descendant process alive: %s.\n' \
 		"${descendant_pid:-unknown}" >&2
 	[[ -z $descendant_pid ]] || kill -KILL "$descendant_pid" 2>/dev/null || true
@@ -113,12 +125,12 @@ if [[ $runner_status -ne 143 ]]; then
 	printf 'Interrupted test run exited with %s instead of 143.\n' "$runner_status" >&2
 	exit 1
 fi
-if kill -0 "$child_pid" 2>/dev/null; then
+if process_is_live "$child_pid"; then
 	printf 'Interrupted test run left its child process alive: %s.\n' "$child_pid" >&2
 	kill -KILL "$child_pid" 2>/dev/null || true
 	exit 1
 fi
-if kill -0 "$grandchild_pid" 2>/dev/null; then
+if process_is_live "$grandchild_pid"; then
 	printf 'Interrupted test run left its grandchild process alive: %s.\n' "$grandchild_pid" >&2
 	kill -KILL "$grandchild_pid" 2>/dev/null || true
 	exit 1

--- a/tests/test-run-tests.sh
+++ b/tests/test-run-tests.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+work=$(mktemp -d)
+trap 'find "$work" -depth -delete' EXIT
+
+test_root=$work/root
+assert_workspace_removed() {
+	local output=$1 root=$2 label=$3 workspace
+	workspace=$(sed -n 's/^==> Test workspace: //p' "$output" | sed -n '1p')
+	if [[ -z $workspace || $workspace != "$root"/dwm-titus-tests.* ]]; then
+		printf '%s run did not report a workspace below its test root.\n' "$label" >&2
+		exit 1
+	fi
+	if [[ -e $workspace ]]; then
+		printf '%s run left its reported workspace behind: %s\n' "$label" "$workspace" >&2
+		exit 1
+	fi
+	if [[ ! -d $root ]]; then
+		printf '%s run removed its test root: %s\n' "$label" "$root" >&2
+		exit 1
+	fi
+}
+
+mkdir "$work/init-bin"
+cat >"$work/init-bin/od" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+chmod +x "$work/init-bin/od"
+if DWM_TEST_TMP_ROOT=$work/init-root PATH="$work/init-bin:$PATH" \
+	"$repo/scripts/run-tests" true >"$work/init.out" 2>"$work/init.err"; then
+	printf 'Test runner unexpectedly survived token-generation failure.\n' >&2
+	exit 1
+fi
+if find "$work/init-root" -mindepth 1 -print -quit | grep -q .; then
+	printf 'Initialization failure left a test workspace behind.\n' >&2
+	exit 1
+fi
+
+success_out=$work/success.out
+# Expansion is intentionally deferred to the child shell.
+# shellcheck disable=SC2016
+DWM_TEST_TMP_ROOT=$test_root "$repo/scripts/run-tests" \
+	bash -e -c 'test "$TMPDIR" != /tmp; touch "$TMPDIR/marker"' >"$success_out"
+assert_workspace_removed "$success_out" "$test_root" Successful
+if find "$test_root" -mindepth 1 -print -quit | grep -q .; then
+	printf 'Successful test run left temporary files behind.\n' >&2
+	exit 1
+fi
+
+descendant_out=$work/descendant.out
+# Expansion is intentionally deferred to the child shell.
+# shellcheck disable=SC2016
+DWM_TEST_TMP_ROOT=$work/descendant-root "$repo/scripts/run-tests" \
+	bash -c '(trap "" TERM; exec sleep 300) & printf "descendant=%s\n" "$!"' \
+	>"$descendant_out"
+descendant_pid=$(sed -n 's/^descendant=//p' "$descendant_out")
+if [[ -z $descendant_pid ]] || kill -0 "$descendant_pid" 2>/dev/null; then
+	printf 'Successful test run left a descendant process alive: %s.\n' \
+		"${descendant_pid:-unknown}" >&2
+	[[ -z $descendant_pid ]] || kill -KILL "$descendant_pid" 2>/dev/null || true
+	exit 1
+fi
+assert_workspace_removed "$descendant_out" "$work/descendant-root" Descendant
+
+failure_out=$work/failure.out
+# Expansion is intentionally deferred to the child shell.
+# shellcheck disable=SC2016
+if DWM_TEST_TMP_ROOT=$test_root "$repo/scripts/run-tests" \
+	bash -c 'touch "$TMPDIR/failure-marker"; exit 9' >"$failure_out"; then
+	printf 'Failing test command unexpectedly succeeded.\n' >&2
+	exit 1
+fi
+assert_workspace_removed "$failure_out" "$test_root" Failed
+if find "$test_root" -mindepth 1 -print -quit | grep -q .; then
+	printf 'Failed test run left temporary files behind.\n' >&2
+	exit 1
+fi
+
+interrupt_root=$work/interrupt-root
+interrupt_out=$work/interrupt.out
+# Expansion is intentionally deferred to the child shell.
+# shellcheck disable=SC2016
+env DWM_TEST_TMP_ROOT="$interrupt_root" "$repo/scripts/run-tests" \
+	bash -c 'printf "%s\n" "$$" >"$TMPDIR/child.pid"; trap "exit 0" TERM; (trap "" TERM; exec sleep 300) & printf "%s\n" "$!" >"$TMPDIR/grandchild.pid"; mkdir -p "$TMPDIR/qualification"; touch "$TMPDIR/ready" "$TMPDIR/qualification/disk"; wait' \
+	>"$interrupt_out" 2>&1 &
+runner_pid=$!
+ready=
+child_pid=
+for _ in {1..100}; do
+	ready=$(find "$interrupt_root" -type f -name ready -print -quit 2>/dev/null || true)
+	[[ -z $ready ]] || break
+	sleep 0.05
+done
+if [[ -z $ready ]]; then
+	kill -TERM -- "$runner_pid" 2>/dev/null || true
+	wait "$runner_pid" 2>/dev/null || true
+	printf 'Interrupted test run did not become ready.\n' >&2
+	exit 1
+fi
+child_pid=$(cat "${ready%/ready}/child.pid")
+grandchild_pid=$(cat "${ready%/ready}/grandchild.pid")
+kill -TERM -- "$runner_pid"
+if wait "$runner_pid"; then
+	printf 'Interrupted test run unexpectedly succeeded.\n' >&2
+	exit 1
+else
+	runner_status=$?
+fi
+if [[ $runner_status -ne 143 ]]; then
+	printf 'Interrupted test run exited with %s instead of 143.\n' "$runner_status" >&2
+	exit 1
+fi
+if kill -0 "$child_pid" 2>/dev/null; then
+	printf 'Interrupted test run left its child process alive: %s.\n' "$child_pid" >&2
+	kill -KILL "$child_pid" 2>/dev/null || true
+	exit 1
+fi
+if kill -0 "$grandchild_pid" 2>/dev/null; then
+	printf 'Interrupted test run left its grandchild process alive: %s.\n' "$grandchild_pid" >&2
+	kill -KILL "$grandchild_pid" 2>/dev/null || true
+	exit 1
+fi
+assert_workspace_removed "$interrupt_out" "$interrupt_root" Interrupted
+if find "$interrupt_root" -mindepth 1 -print -quit | grep -q .; then
+	printf 'Interrupted test run left temporary files behind.\n' >&2
+	exit 1
+fi
+
+for unsafe_root in / // /tmp /tmp/..; do
+	if DWM_TEST_TMP_ROOT=$unsafe_root "$repo/scripts/run-tests" true 2>"$work/unsafe.err"; then
+		printf 'Test runner accepted an unsafe root alias: %s\n' "$unsafe_root" >&2
+		exit 1
+	fi
+	grep -Fq 'Refusing unsafe DWM_TEST_TMP_ROOT' "$work/unsafe.err"
+done
+
+existing_root=$work/existing-root
+mkdir -m 0750 "$existing_root"
+DWM_TEST_TMP_ROOT=$existing_root "$repo/scripts/run-tests" true >"$work/existing.out"
+assert_workspace_removed "$work/existing.out" "$existing_root" Existing-root
+if [[ $(stat -c %a "$existing_root") != 750 ]]; then
+	printf 'Test runner changed the existing test-root mode.\n' >&2
+	exit 1
+fi
+
+stale_marker_out=$work/stale-marker.out
+mkdir "$work/stale-workspace" "$work/stale-tmp"
+DWM_TEST_WORKSPACE=$work/stale-workspace TMPDIR=$work/stale-tmp \
+	DWM_TEST_TMP_ROOT=$work/stale-marker-root \
+	make -s -C "$repo" check-fedora-platform >"$stale_marker_out"
+grep -Fq '==> Test workspace: ' "$stale_marker_out"
+grep -Fq 'Fedora-only platform contract: PASS' "$stale_marker_out"
+
+forged_marker_out=$work/forged-marker.out
+mkdir "$work/forged-workspace"
+printf '%s\n' forged >"$work/forged-workspace/.runner"
+DWM_TEST_WORKSPACE=$work/forged-workspace TMPDIR=$work/forged-workspace \
+	DWM_TEST_RUNNER_TOKEN=wrong DWM_TEST_TMP_ROOT=$work/forged-marker-root \
+	make -s -C "$repo" check-fedora-platform >"$forged_marker_out"
+grep -Fq '==> Test workspace: ' "$forged_marker_out"
+grep -Fq 'Fedora-only platform contract: PASS' "$forged_marker_out"
+
+link_root=$work/link-root
+ln -s "$test_root" "$link_root"
+if DWM_TEST_TMP_ROOT=$link_root "$repo/scripts/run-tests" true 2>"$work/symlink.err"; then
+	printf 'Test runner accepted a symbolic-link root.\n' >&2
+	exit 1
+fi
+grep -Fq 'Refusing symbolic-link test root' "$work/symlink.err"
+
+printf 'Managed test workspace: PASS\n'

--- a/tests/test-settings.sh
+++ b/tests/test-settings.sh
@@ -43,9 +43,9 @@ done
 make_failing_stub "$fedora_bin/pkexec"
 make_failing_stub "$fedora_bin/sudo"
 
-mkdir -p "$work/fedora-config/dwm-titus" "$work/debian-config/dwm-titus"
+mkdir -p "$work/fedora-config/dwm-titus" "$work/unsupported-config/dwm-titus"
 cp "$repo/config/themes.toml" "$work/fedora-config/dwm-titus/themes.toml"
-cp "$repo/config/themes.toml" "$work/debian-config/dwm-titus/themes.toml"
+cp "$repo/config/themes.toml" "$work/unsupported-config/dwm-titus/themes.toml"
 
 printf 'ID=fedora\nID_LIKE="rhel"\nPRETTY_NAME="Fedora\tLinux 44"\n' \
 	>"$work/fedora-os-release"
@@ -53,7 +53,7 @@ printf 'ID=fedora\nID_LIKE="rhel"\nPRETTY_NAME="Fedora\tLinux 44"\n' \
 fedora_output=$(PATH="$fedora_bin" XDG_CONFIG_HOME="$work/fedora-config" \
 	DWM_SETTINGS_OS_RELEASE="$work/fedora-os-release" "$provider" discover)
 printf '%s\n' "$fedora_output" | grep -Fqx 'settings-protocol	1'
-printf '%s\n' "$fedora_output" | grep -Fqx 'platform	fedora	rhel	Fedora Linux 44'
+printf '%s\n' "$fedora_output" | grep -Fqx 'platform	fedora	fedora	Fedora Linux 44'
 printf '%s\n' "$fedora_output" | grep -Fqx \
 	'capability	displays	randr	Display discovery	available	read-only	xrandr	RandR display state is available'
 printf '%s\n' "$fedora_output" | grep -Fqx \
@@ -74,19 +74,20 @@ printf '%s\n' "$fedora_output" | grep -Fqx \
 printf '%s\n' "$fedora_output" | grep -Eq \
 	'^capability	system	authorization	Administrative authorization	(available|restricted)	privileged	polkit	'
 
-cat >"$work/debian-os-release" <<'EOF'
-ID=debian
-PRETTY_NAME="Debian GNU/Linux 13"
+cat >"$work/unsupported-os-release" <<'EOF'
+ID=example
+ID_LIKE="fedora rhel"
+PRETTY_NAME="Unsupported Linux"
 EOF
 
-debian_output=$(PATH="$base_bin" XDG_CONFIG_HOME="$work/debian-config" \
-	DWM_SETTINGS_OS_RELEASE="$work/debian-os-release" "$provider" discover)
-printf '%s\n' "$debian_output" | grep -Fqx 'platform	debian	debian	Debian GNU/Linux 13'
-printf '%s\n' "$debian_output" | grep -Fqx \
+unsupported_output=$(PATH="$base_bin" XDG_CONFIG_HOME="$work/unsupported-config" \
+	DWM_SETTINGS_OS_RELEASE="$work/unsupported-os-release" "$provider" discover)
+printf '%s\n' "$unsupported_output" | grep -Fqx 'platform	example	unknown	Unsupported Linux'
+printf '%s\n' "$unsupported_output" | grep -Fqx \
 	'capability	network	networkmanager	NetworkManager	unavailable	delegated	nmcli	Install NetworkManager to enable this section'
-printf '%s\n' "$debian_output" | grep -Fqx \
+printf '%s\n' "$unsupported_output" | grep -Fqx \
 	'capability	bluetooth	bluez	Bluetooth	unavailable	delegated	bluetoothctl	Install BlueZ tools to enable this section'
-printf '%s\n' "$debian_output" | grep -Fqx \
+printf '%s\n' "$unsupported_output" | grep -Fqx \
 	'capability	system	authorization	Administrative authorization	restricted	privileged	polkit	Read-only state remains available; install the trusted system helper for authorized actions'
 
 runtime_down_bin=$work/runtime-down-bin
@@ -187,19 +188,16 @@ grep -Fq 'root.settingsModel.openOnScreen(targetScreen)' "$repo/config/quickshel
 grep -Fq '{ title="dwm settings",             isfloating=1, alwaysontop=1 }' \
 	"$repo/config/window-rules.toml"
 
-arch_qml=$(bash -c '. "$1"; dwm_packages arch qml-development' sh \
+fedora_qml=$(bash -c '. "$1"; dwm_packages fedora qml-development' sh \
 	"$repo/scripts/dwm-packages.sh")
-rhel_qml=$(bash -c '. "$1"; dwm_packages rhel qml-development' sh \
-	"$repo/scripts/dwm-packages.sh")
-debian_qml=$(bash -c '. "$1"; dwm_packages debian qml-development' sh \
-	"$repo/scripts/dwm-packages.sh")
-[ "$arch_qml" = qt6-declarative ]
-[ "$rhel_qml" = qt6-qtdeclarative-devel ]
-[ "$debian_qml" = qt6-declarative-dev-tools ]
-for family in arch rhel debian; do
-	bash -c '. "$1"; dwm_packages "$2" runtime-required' sh \
-		"$repo/scripts/dwm-packages.sh" "$family" | grep -Fx util-linux >/dev/null
-done
+[ "$fedora_qml" = qt6-qtdeclarative-devel ]
+bash -c '. "$1"; dwm_packages fedora runtime-required' sh \
+	"$repo/scripts/dwm-packages.sh" | grep -Fx util-linux >/dev/null
+if bash -c '. "$1"; dwm_packages unsupported runtime-required' sh \
+	"$repo/scripts/dwm-packages.sh"; then
+	printf 'Unsupported package family unexpectedly resolved.\n' >&2
+	exit 1
+fi
 
 if grep -Eq '^[[:space:]]*(sudo|pkexec)([[:space:]]|$)' "$provider"; then
 	printf 'Settings discovery must not execute an elevation tool.\n' >&2

--- a/tests/test-system-health.sh
+++ b/tests/test-system-health.sh
@@ -7,20 +7,26 @@ work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
 mkdir -p "$work/bin" "$work/home/.config/dwm-titus" "$work/home/.config/quickshell"
-printf 'ID=debian\nID_LIKE=debian\nPRETTY_NAME="Test Linux"\n' >"$work/os-release"
+printf 'ID=fedora\nPRETTY_NAME="Fedora Test"\n' >"$work/os-release"
 : >"$work/home/.config/dwm-titus/hotkeys.toml"
 : >"$work/home/.config/dwm-titus/themes.toml"
 : >"$work/home/.config/dwm-titus/window-rules.toml"
 : >"$work/home/.config/quickshell/shell.qml"
 
-cat >"$work/bin/dpkg" <<'SCRIPT'
+cat >"$work/bin/dnf" <<'SCRIPT'
 #!/bin/sh
-printf 'package is unpacked but not configured\n'
+printf 'package consistency problem\n'
+exit 1
 SCRIPT
 
 cat >"$work/bin/xclip" <<'SCRIPT'
 #!/bin/sh
 cat >"${DWM_HEALTH_XCLIP_OUTPUT:?}"
+SCRIPT
+
+cat >"$work/bin/quickshell" <<'SCRIPT'
+#!/bin/sh
+printf '%s\n' 'quickshell pre-release, revision: dacfa9de829ac7cb173825f593236bf2c21f637e'
 SCRIPT
 
 cat >"$work/bin/systemctl" <<'SCRIPT'
@@ -31,7 +37,7 @@ case " $* " in
 *) exit 1 ;;
 esac
 SCRIPT
-chmod +x "$work/bin/dpkg" "$work/bin/systemctl" "$work/bin/xclip"
+chmod +x "$work/bin/dnf" "$work/bin/quickshell" "$work/bin/systemctl" "$work/bin/xclip"
 
 DWM_HEALTH_XCLIP_OUTPUT="$work/clipboard.txt" \
 	PATH="$work/bin:/usr/bin:/bin" \
@@ -76,6 +82,7 @@ grep -Fq $'check\tresources\t' "$work/user.tsv"
 grep -Fq $'check\tstorage\t' "$work/user.tsv"
 grep -Fq $'check\tnetwork\t' "$work/user.tsv"
 grep -Fq $'check\tdependencies\twarn\tpackage-database' "$work/user.tsv"
+grep -Fq $'check\tdesktop\tok\tquickshell-version\tQuickshell\tAvailable' "$work/user.tsv"
 grep -Fq $'check\tservices\twarn\tuser-failed-user-broken-service\tuser-broken.service (user)' "$work/user.tsv"
 grep -Fq $'manage-user-service|user-broken.service\tService actions\tuser' "$work/user.tsv"
 grep -Fq $'meta\toverview\tok\tscan-user-complete' "$work/user.tsv"


### PR DESCRIPTION
## Summary

- fix the v0.6.0 Fedora ISO ownership regression from #150 by separating privileged system installation from the unprivileged user stage
- make the existing-system installer, package map, settings/platform reporting, CI, and documentation Fedora-only
- run all repository tests in isolated workspaces under `${DWM_TEST_TMP_ROOT:-$HOME/tmp}` with bounded descendant cleanup on success, failure, and interruption
- enforce the Fedora 44 Quickshell snapshot compatibility contract and preserve Fedora RPM, Flatpak, and Snap package inventory
- prepare the corrected v0.6.1 replacement release and document v0.6.0 as withdrawn

## Validation

- `DWM_TEST_TMP_ROOT=/home/titus/tmp scripts/run-tests`
- `sudo -n env CONTAINER_ENGINE=podman DWM_TEST_TMP_ROOT=/home/titus/tmp scripts/run-tests make check-container-smoke`
- `DWM_TEST_TMP_ROOT=/home/titus/tmp scripts/run-tests actionlint`
- `DWM_TEST_TMP_ROOT=/home/titus/tmp scripts/run-tests mdbook build docs`
- `DWM_TEST_TMP_ROOT=/home/titus/tmp scripts/run-tests mdbook test docs`
- CodeRabbit review: clean
- Codex review: clean

Addresses #150.
