### PR TITLE
Harden Fedora mutation and install guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ versions from `config.mk`.
 
 ### Fixed
 
+- Reject non-Fedora power-management mutation modes before any status scan or
+  system change, and keep fixture overrides out of the privileged path.
+- Reject direct root `make install` calls without a target user before building
+  or writing any system files.
 - Keep Fedora image XDG parents owned by the installer-created user, run the
   user-scoped install stage without root privileges or ownership-changing
   syscalls, avoid rebuilding user-owned sources during the privileged system

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,11 @@ native:
 	$(MAKE) OPTIMISATIONS="${NATIVE_OPTIMISATIONS}" all
 
 install:
+	if [ -z "${DESTDIR}" ] && [ "$$(id -u)" -eq 0 ] && \
+		{ [ -z "${OWNER}" ] || [ "${OWNER}" = root ]; }; then \
+		echo "Refusing to install user files as root. Run install-user as the target user." >&2; \
+		exit 1; \
+	fi
 	if [ "$$(id -u)" -eq 0 ] && [ -n "${OWNER}" ] && [ "${OWNER}" != root ]; then \
 		test -n "${USER_HOME}" || { echo "USER_HOME could not be determined." >&2; exit 1; }; \
 		command -v runuser >/dev/null 2>&1 || { \

--- a/scripts/power-management.sh
+++ b/scripts/power-management.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 APPLY=false
 APPLY_TLP=false
+OS_RELEASE_FILE=/etc/os-release
 
 for arg in "$@"; do
 	case "$arg" in
@@ -30,9 +31,19 @@ for arg in "$@"; do
 	esac
 done
 
-if ($APPLY || $APPLY_TLP) && [[ $EUID -ne 0 ]]; then
-	echo "ERROR: --apply and --apply-tlp require root. Run with sudo." >&2
-	exit 1
+if $APPLY || $APPLY_TLP; then
+	DISTRO_ID=
+	if [[ -r $OS_RELEASE_FILE ]]; then
+		DISTRO_ID=$(awk -F= '$1 == "ID" { value = substr($0, index($0, "=") + 1); gsub(/^"|"$/, "", value); print value; exit }' "$OS_RELEASE_FILE")
+	fi
+	if [[ $DISTRO_ID != fedora ]]; then
+		echo "ERROR: --apply and --apply-tlp support Fedora only." >&2
+		exit 1
+	fi
+	if [[ $EUID -ne 0 ]]; then
+		echo "ERROR: --apply and --apply-tlp require root. Run with sudo." >&2
+		exit 1
+	fi
 fi
 
 # Color helpers

--- a/tests/test-fedora-platform.sh
+++ b/tests/test-fedora-platform.sh
@@ -62,6 +62,32 @@ fi
 snapshot_tree "$work/unsupported-home" "$work/home.after"
 cmp "$work/home.before" "$work/home.after"
 
+awk -v os_release="$work/unsupported" '
+	$0 == "OS_RELEASE_FILE=/etc/os-release" {
+		print "OS_RELEASE_FILE=" os_release
+		next
+	}
+	{ print }
+' "$repo/scripts/power-management.sh" >"$work/power-management-unsupported"
+grep -Fqx "OS_RELEASE_FILE=$work/unsupported" \
+	"$work/power-management-unsupported"
+chmod +x "$work/power-management-unsupported"
+set +e
+"$work/power-management-unsupported" --apply >"$work/power-rejection.out" 2>&1
+power_status=$?
+set -e
+if [[ $power_status -ne 1 ]]; then
+	printf 'Unsupported power mutation exited with %s instead of 1.\n' \
+		"$power_status" >&2
+	exit 1
+fi
+grep -Fq -- '--apply and --apply-tlp support Fedora only.' \
+	"$work/power-rejection.out"
+if grep -Fq 'System Identity' "$work/power-rejection.out"; then
+	printf 'Unsupported power mutation continued into the status report.\n' >&2
+	exit 1
+fi
+
 # Expansion is intentionally deferred to the child shell.
 # shellcheck disable=SC2016
 host_family=$(env -u DWM_TEST_MODE DWM_OS_RELEASE="$work/unsupported" bash -c \

--- a/tests/test-install-preservation.sh
+++ b/tests/test-install-preservation.sh
@@ -122,6 +122,24 @@ fi
 
 cp -a "$REPO_DIR/." "$TEST_REPO/"
 test -f "$TEST_REPO/config.h" || cp "$TEST_REPO/config.def.h" "$TEST_REPO/config.h"
+if [[ $(id -u) -eq 0 ]]; then
+	if make -C "$TEST_REPO" install \
+		OWNER=root USER_HOME="$WORK_DIR/root-home" \
+		PREFIX="$WORK_DIR/root-prefix" \
+		XSESSIONSDIR="$WORK_DIR/root-xsessions" \
+		SYSTEMDUSERDIR="$WORK_DIR/root-systemd-user" \
+		>"$WORK_DIR/root-install-rejection.log" 2>&1; then
+		printf 'Direct root install unexpectedly succeeded.\n' >&2
+		exit 1
+	fi
+	grep -Fq 'Refusing to install user files as root.' \
+		"$WORK_DIR/root-install-rejection.log"
+	if [[ -e $WORK_DIR/root-prefix || -e $WORK_DIR/root-xsessions ||
+		-e $WORK_DIR/root-systemd-user || -e $WORK_DIR/root-home ]]; then
+		printf 'Rejected root install wrote files before its preflight.\n' >&2
+		exit 1
+	fi
+fi
 rm -f "$TEST_REPO/dwm"
 if make -C "$TEST_REPO" install-system \
 	DESTDIR="$WORK_DIR/stale-stage" >"$WORK_DIR/unbuilt-install.log" 2>&1; then


### PR DESCRIPTION
## Summary

- reject non-Fedora power-management mutation modes before status scanning or system changes
- reject direct root `make install` without a non-root target before build or system installation
- add Fedora-platform and root-install regression coverage
- record the follow-up fixes in the v0.6.1 changelog

This addresses the two late review findings posted on #154 after it merged.

## Validation

- `DWM_TEST_TMP_ROOT=/home/titus/tmp scripts/run-tests make check`
- `sudo -n env DWM_TEST_TMP_ROOT=/home/titus/tmp scripts/run-tests make check-container-smoke`
- focused Fedora-platform and install-preservation tests
- ShellCheck, shfmt, Bash syntax, and `git diff --check`
- Codex review: clean
- CodeRabbit CLI review: clean
