### PR TITLE
Quickshell: restyle the X11 panel and menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ versions from `config.mk`.
 
 ### Changed
 
+- Restyle the X11 Quickshell panel and its Audio, Bluetooth, Network, Control
+  Center, and Power popups with shared Omarchy-inspired hero, separator,
+  slider, toggle, and semantic interaction components while preserving DWM
+  state, Fedora helpers, IPC, monitor routing, and click-away behavior.
+
 - Consolidate Fedora package, build, install, and privileged-helper validation
   into the existing Fedora CI job, removing the nested container smoke job and
   redundant install and monitor checks. Keep the optional Clang portability

--- a/Makefile
+++ b/Makefile
@@ -384,6 +384,9 @@ check-quickshell-controlcenter:
 check-quickshell-design-system:
 	tests/test-quickshell-design-system.sh
 
+check-quickshell-panel-menus:
+	tests/test-quickshell-panel-menus.sh
+
 check-quickshell-notifications:
 	tests/test-quickshell-notifications.sh
 
@@ -531,6 +534,7 @@ check:
 	$(MAKE) check-quickshell-controls
 	$(MAKE) check-quickshell-controlcenter
 	$(MAKE) check-quickshell-design-system
+	$(MAKE) check-quickshell-panel-menus
 	$(MAKE) check-quickshell-qml
 	$(MAKE) check-quickshell-notifications
 	$(MAKE) check-quickshell-tray
@@ -557,5 +561,5 @@ check:
 	check-display-profile check-display-setup check-fedora-iso-builder check-fedora-packages check-fedora-platform check-format check-install \
 	check-gearlever-install check-herdr-install check-install-manifest check-install-preservation check-kickstart check-lock \
 	check-session-guards check-session-migration check-screenshot check-release-helper check-shell check-diagnostics check-status check-system-health check-settings \
-	check-quickshell-launcher check-quickshell-controls check-quickshell-controlcenter check-quickshell-design-system check-quickshell-notifications check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-qml check-lightdm-config check-terminal check-xvfb-runtime install install-system install-user \
+	check-quickshell-launcher check-quickshell-controls check-quickshell-controlcenter check-quickshell-design-system check-quickshell-panel-menus check-quickshell-notifications check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-qml check-lightdm-config check-terminal check-xvfb-runtime install install-system install-user \
 	install-cursors native release release-check uninstall

--- a/config/quickshell/controlcenter/ControlCenterActionButton.qml
+++ b/config/quickshell/controlcenter/ControlCenterActionButton.qml
@@ -12,10 +12,23 @@ Rectangle {
     signal activated
 
     implicitHeight: 58
-    color: Theme.surface
-    border.color: Theme.border
-    border.width: 1
+    activeFocusOnTab: root.enabled
+    color: !root.enabled ? Theme.controlDisabledFill
+        : root.activeFocus ? Theme.controlFocusFill
+        : root.hovered ? Theme.controlHoverFill : Theme.controlNormalFill
+    border.color: root.activeFocus ? Theme.controlFocusBorder
+        : !root.enabled ? Theme.controlDisabledBorder
+        : root.hovered ? Theme.controlHoverBorder : Theme.controlNormalBorder
+    border.width: root.activeFocus ? Theme.controlFocusBorderWidth : Theme.controlBorderWidth
     radius: Theme.radius
+
+    Keys.onPressed: function(event) {
+        if (!root.enabled || event.isAutoRepeat) return;
+        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Space) {
+            root.activated();
+            event.accepted = true;
+        }
+    }
 
     ColumnLayout {
         anchors.fill: parent
@@ -25,7 +38,8 @@ Rectangle {
         Text {
             Layout.fillWidth: true
             text: root.label
-            color: Theme.textStrong
+            color: !root.enabled ? Theme.controlDisabledText
+                : root.hovered ? Theme.controlHoverText : Theme.textStrong
             font.family: Theme.fontFamily
             font.pixelSize: Theme.panelFontSize
             font.bold: true

--- a/config/quickshell/controlcenter/ControlCenterOptionButton.qml
+++ b/config/quickshell/controlcenter/ControlCenterOptionButton.qml
@@ -15,10 +15,26 @@ Rectangle {
 
     implicitWidth: Math.max(76, optionLabel.implicitWidth + 22)
     implicitHeight: root.detail.length > 0 ? 48 : Theme.buttonHeight
-    color: root.active ? Theme.accent : root.hovered && enabled ? Theme.surfaceHover : Theme.surface
-    border.color: root.danger ? Theme.danger : root.active ? Theme.accent : Theme.border
-    border.width: 1
+    activeFocusOnTab: root.enabled
+    color: !root.enabled ? Theme.controlDisabledFill
+        : root.active ? Theme.controlSelectedFill
+        : root.activeFocus ? Theme.controlFocusFill
+        : root.hovered ? Theme.controlHoverFill : Theme.controlNormalFill
+    border.color: root.activeFocus ? Theme.controlFocusBorder
+        : !root.enabled ? Theme.controlDisabledBorder
+        : root.danger ? Theme.danger
+        : root.active ? Theme.controlSelectedBorder
+        : root.hovered ? Theme.controlHoverBorder : Theme.controlNormalBorder
+    border.width: root.activeFocus ? Theme.controlFocusBorderWidth : Theme.controlBorderWidth
     radius: Theme.radius
+
+    Keys.onPressed: function(event) {
+        if (!root.enabled || event.isAutoRepeat) return;
+        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Space) {
+            root.activated();
+            event.accepted = true;
+        }
+    }
 
     ColumnLayout {
         anchors.fill: parent
@@ -31,7 +47,9 @@ Rectangle {
             Layout.fillWidth: true
             Layout.fillHeight: root.detail.length === 0
             text: root.label
-            color: root.active ? Theme.accentText : Theme.textStrong
+            color: !root.enabled ? Theme.controlDisabledText
+                : root.active ? Theme.controlSelectedText
+                : root.hovered ? Theme.controlHoverText : Theme.textStrong
             font.family: Theme.fontFamily
             font.pixelSize: Theme.smallFontSize
             font.bold: true
@@ -44,7 +62,7 @@ Rectangle {
             Layout.fillWidth: true
             visible: root.detail.length > 0
             text: root.detail
-            color: root.active ? Theme.accentText : Theme.textMuted
+            color: root.active ? Theme.controlSelectedText : Theme.textMuted
             font.family: Theme.fontFamily
             font.pixelSize: Theme.tinyFontSize
             horizontalAlignment: Text.AlignHCenter

--- a/config/quickshell/controlcenter/ControlCenterRow.qml
+++ b/config/quickshell/controlcenter/ControlCenterRow.qml
@@ -8,12 +8,13 @@ Rectangle {
     property string title: ""
     property string detail: ""
     property string status: ""
-    readonly property color statusColor: root.status === "error" ? Theme.danger : root.status === "warn" ? "#ebcb8b" : Theme.accent
+    readonly property color statusColor: root.status === "error" ? Theme.danger
+        : root.status === "warn" ? Theme.warning : Theme.accent
 
     implicitHeight: Math.max(42, row.implicitHeight + 16)
-    color: Theme.surface
-    border.color: root.status === "error" ? Theme.danger : Theme.border
-    border.width: 1
+    color: Theme.controlNormalFill
+    border.color: root.status === "error" ? Theme.danger : Theme.controlNormalBorder
+    border.width: Theme.controlBorderWidth
     radius: Theme.radius
 
     RowLayout {

--- a/config/quickshell/controlcenter/ControlCenterWindow.qml
+++ b/config/quickshell/controlcenter/ControlCenterWindow.qml
@@ -130,14 +130,19 @@ ClickAwayPopup {
 
         implicitHeight: 28
         radius: Theme.smallRadius
-        color: active ? Theme.surfaceActive : presetMouse.containsMouse ? Theme.surfaceHover : Theme.surface
-        border.color: active ? Theme.accentSecondary : presetMouse.containsMouse ? Theme.borderStrong : Theme.border
-        border.width: Theme.pillBorderWidth
+        color: !enabled ? Theme.controlDisabledFill
+            : active ? Theme.controlSelectedFill
+            : presetMouse.containsMouse ? Theme.controlHoverFill : Theme.controlNormalFill
+        border.color: !enabled ? Theme.controlDisabledBorder
+            : active ? Theme.controlSelectedBorder
+            : presetMouse.containsMouse ? Theme.controlHoverBorder : Theme.controlNormalBorder
+        border.width: Theme.controlBorderWidth
 
         UiText {
             anchors.centerIn: parent
             text: presetButton.label
-            color: presetButton.active ? Theme.accentSecondary : Theme.text
+            color: !presetButton.enabled ? Theme.controlDisabledText
+                : presetButton.active ? Theme.controlSelectedText : Theme.controlNormalText
         }
 
         MouseArea {
@@ -198,11 +203,7 @@ ClickAwayPopup {
                     elide: Text.ElideRight
                 }
 
-                Rectangle {
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 1
-                    color: Theme.border
-                }
+                PanelSeparator {}
 
                 ColumnLayout {
                     Layout.fillWidth: true
@@ -223,12 +224,9 @@ ClickAwayPopup {
                         onActivated: root.openSessionPower()
                     }
 
-                    Rectangle {
-                        Layout.fillWidth: true
-                        Layout.preferredHeight: 1
+                    PanelSeparator {
                         Layout.topMargin: 3
                         Layout.bottomMargin: 3
-                        color: Theme.border
                     }
 
                     SectionLabel { label: "Desktop" }
@@ -258,12 +256,9 @@ ClickAwayPopup {
                         onActivated: root.controlCenterModel.openPower()
                     }
 
-                    Rectangle {
-                        Layout.fillWidth: true
-                        Layout.preferredHeight: 1
+                    PanelSeparator {
                         Layout.topMargin: 3
                         Layout.bottomMargin: 3
-                        color: Theme.border
                     }
 
                     SectionLabel { label: "Utilities" }
@@ -392,12 +387,9 @@ ClickAwayPopup {
                         }
                     }
 
-                    Rectangle {
-                        Layout.fillWidth: true
-                        Layout.preferredHeight: 1
+                    PanelSeparator {
                         Layout.topMargin: 3
                         Layout.bottomMargin: 3
-                        color: Theme.border
                     }
 
                     UiText {

--- a/config/quickshell/controlcenter/ControlCenterWindow.qml
+++ b/config/quickshell/controlcenter/ControlCenterWindow.qml
@@ -130,18 +130,30 @@ ClickAwayPopup {
 
         implicitHeight: 28
         radius: Theme.smallRadius
-        color: !enabled ? Theme.controlDisabledFill
-            : active ? Theme.controlSelectedFill
+        activeFocusOnTab: presetButton.enabled
+        color: !presetButton.enabled ? Theme.controlDisabledFill
+            : presetButton.activeFocus ? Theme.controlFocusFill
+            : presetButton.active ? Theme.controlSelectedFill
             : presetMouse.containsMouse ? Theme.controlHoverFill : Theme.controlNormalFill
-        border.color: !enabled ? Theme.controlDisabledBorder
-            : active ? Theme.controlSelectedBorder
+        border.color: !presetButton.enabled ? Theme.controlDisabledBorder
+            : presetButton.activeFocus ? Theme.controlFocusBorder
+            : presetButton.active ? Theme.controlSelectedBorder
             : presetMouse.containsMouse ? Theme.controlHoverBorder : Theme.controlNormalBorder
-        border.width: Theme.controlBorderWidth
+        border.width: presetButton.activeFocus ? Theme.controlFocusBorderWidth : Theme.controlBorderWidth
+
+        Keys.onPressed: function(event) {
+            if (!presetButton.enabled || event.isAutoRepeat) return;
+            if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Space) {
+                presetButton.activated();
+                event.accepted = true;
+            }
+        }
 
         UiText {
             anchors.centerIn: parent
             text: presetButton.label
             color: !presetButton.enabled ? Theme.controlDisabledText
+                : presetButton.activeFocus ? Theme.controlFocusText
                 : presetButton.active ? Theme.controlSelectedText : Theme.controlNormalText
         }
 
@@ -152,7 +164,10 @@ ClickAwayPopup {
             enabled: presetButton.enabled
             hoverEnabled: true
             cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-            onClicked: presetButton.activated()
+            onClicked: {
+                presetButton.forceActiveFocus();
+                presetButton.activated();
+            }
         }
     }
 

--- a/config/quickshell/controls/BluetoothModel.qml
+++ b/config/quickshell/controls/BluetoothModel.qml
@@ -10,6 +10,8 @@ Scope {
     property string statusText: "BT unavailable"
     property var devices: []
     property string message: ""
+    readonly property bool available: statusText !== "BT unavailable"
+    readonly property bool powered: available && statusText !== "BT off"
 
     function open() {
         root.visible = true;

--- a/config/quickshell/controls/BluetoothWindow.qml
+++ b/config/quickshell/controls/BluetoothWindow.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Layouts
-import Quickshell
 import qs.core
 
 pragma ComponentBehavior: Bound
@@ -41,17 +40,38 @@ ClickAwayPopup {
             anchors.fill: parent
             spacing: Theme.popupSpacing
 
-            RowLayout {
+            PanelHero {
                 Layout.fillWidth: true
-                UiText { Layout.fillWidth: true; text: root.bluetoothModel.statusText; color: Theme.textStrong; font.pixelSize: Theme.titleFontSize; font.bold: true }
-                ShellButton { label: "Scan"; onActivated: root.bluetoothModel.refresh(true) }
+                iconText: "󰂯"
+                iconColor: root.bluetoothModel.powered ? Theme.popupText : Theme.menuMutedText
+                title: "Bluetooth"
+                subtitle: root.bluetoothModel.statusText
+
+                ShellButton {
+                    label: "Scan"
+                    enabled: root.bluetoothModel.powered && !root.bluetoothModel.busy
+                    onActivated: root.bluetoothModel.refresh(true)
+                }
+
+                PanelToggleSwitch {
+                    checked: root.bluetoothModel.powered
+                    busy: root.bluetoothModel.busy
+                    enabled: root.bluetoothModel.available
+                    onToggled: root.bluetoothModel.action("bluetooth-power", [checked ? "off" : "on"])
+                }
             }
 
-            RowLayout {
+            UiText {
                 Layout.fillWidth: true
-                ShellButton { Layout.fillWidth: true; label: "Bluetooth On"; onActivated: root.bluetoothModel.action("bluetooth-power", ["on"]) }
-                ShellButton { Layout.fillWidth: true; label: "Bluetooth Off"; onActivated: root.bluetoothModel.action("bluetooth-power", ["off"]) }
+                visible: root.bluetoothModel.message.length > 0
+                text: root.bluetoothModel.message
+                color: Theme.menuMutedText
+                elide: Text.ElideRight
             }
+
+            PanelSeparator {}
+
+            SectionLabel { label: "Devices" }
 
             ListView {
                 Layout.fillWidth: true
@@ -67,24 +87,55 @@ ClickAwayPopup {
                     width: ListView.view.width
                     height: 58
                     radius: Theme.smallRadius
-                    color: Theme.surface
-                    border.color: Theme.border
-                    border.width: Theme.pillBorderWidth
+                    color: deviceMouse.containsMouse ? Theme.controlHoverFill : Theme.controlNormalFill
+                    border.color: deviceMouse.containsMouse ? Theme.controlHoverBorder : Theme.controlNormalBorder
+                    border.width: Theme.controlBorderWidth
 
                     RowLayout {
                         anchors.fill: parent
                         anchors.margins: 10
-                        UiText {
+                        ColumnLayout {
                             Layout.fillWidth: true
-                            text: deviceRow.modelData.name.length > 0 ? deviceRow.modelData.name : deviceRow.modelData.address
-                            elide: Text.ElideRight
+
+                            UiText {
+                                Layout.fillWidth: true
+                                text: deviceRow.modelData.name.length > 0 ? deviceRow.modelData.name : deviceRow.modelData.address
+                                color: Theme.textStrong
+                                font.bold: true
+                                elide: Text.ElideRight
+                            }
+
+                            UiText {
+                                Layout.fillWidth: true
+                                text: deviceRow.modelData.connected ? "Connected"
+                                    : deviceRow.modelData.paired ? "Paired" : deviceRow.modelData.address
+                                color: Theme.menuMutedText
+                                font.pixelSize: Theme.fontCaptionSize
+                                elide: Text.ElideRight
+                            }
                         }
                         ShellButton {
                             label: deviceRow.modelData.connected ? "Disconnect" : (deviceRow.modelData.paired ? "Connect" : "Pair")
+                            enabled: !root.bluetoothModel.busy
                             onActivated: root.bluetoothModel.action(deviceRow.modelData.connected ? "bluetooth-disconnect" : (deviceRow.modelData.paired ? "bluetooth-connect" : "bluetooth-pair"), [deviceRow.modelData.address])
                         }
                     }
+
+                    MouseArea {
+                        id: deviceMouse
+                        anchors.fill: parent
+                        acceptedButtons: Qt.NoButton
+                        hoverEnabled: true
+                    }
                 }
+            }
+
+            UiText {
+                Layout.fillWidth: true
+                visible: root.bluetoothModel.devices.length === 0
+                text: root.bluetoothModel.powered ? "No Bluetooth devices found" : "Turn Bluetooth on to scan"
+                color: Theme.menuMutedText
+                wrapMode: Text.WordWrap
             }
         }
     }

--- a/config/quickshell/controls/ControlsActionButton.qml
+++ b/config/quickshell/controls/ControlsActionButton.qml
@@ -8,15 +8,29 @@ Rectangle {
 
     signal activated
 
+    activeFocusOnTab: root.enabled
     radius: Theme.radius
-    color: Theme.surface
-    border.color: Theme.border
-    border.width: 1
+    color: !root.enabled ? Theme.controlDisabledFill
+        : root.activeFocus ? Theme.controlFocusFill
+        : controlMouse.containsMouse ? Theme.controlHoverFill : Theme.controlNormalFill
+    border.color: root.activeFocus ? Theme.controlFocusBorder
+        : !root.enabled ? Theme.controlDisabledBorder
+        : controlMouse.containsMouse ? Theme.controlHoverBorder : Theme.controlNormalBorder
+    border.width: root.activeFocus ? Theme.controlFocusBorderWidth : Theme.controlBorderWidth
+
+    Keys.onPressed: function(event) {
+        if (!root.enabled || event.isAutoRepeat) return;
+        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Space) {
+            root.activated();
+            event.accepted = true;
+        }
+    }
 
     Text {
         anchors.centerIn: parent
         text: root.label
-        color: Theme.text
+        color: !root.enabled ? Theme.controlDisabledText
+            : controlMouse.containsMouse ? Theme.controlHoverText : Theme.controlNormalText
         font.family: Theme.fontFamily
         font.pixelSize: Theme.panelFontSize
         font.bold: true

--- a/config/quickshell/controls/ControlsWindow.qml
+++ b/config/quickshell/controls/ControlsWindow.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Layouts
-import Quickshell
 import qs.core
 
 pragma ComponentBehavior: Bound
@@ -40,10 +39,6 @@ ClickAwayPopup {
         }
     }
 
-    function setVolumePendingFromX(x) {
-        volumeSlider.pendingPercent = volumeSlider.percentFromX(x);
-    }
-
     ShellSurface {
         id: content
 
@@ -61,24 +56,13 @@ ClickAwayPopup {
             anchors.fill: parent
             spacing: root.contentSpacing
 
-            RowLayout {
+            PanelHero {
                 Layout.fillWidth: true
-                spacing: root.rowSpacing
-
-                Text {
-                    Layout.fillWidth: true
-                    text: root.controlsModel.volumeDisplayText
-                    color: Theme.text
-                    font.family: Theme.fontFamily
-                    font.pixelSize: Theme.titleFontSize
-                    font.bold: true
-                    elide: Text.ElideRight
-                    verticalAlignment: Text.AlignVCenter
-                }
+                iconText: root.controlsModel.volumeMuted ? "󰝟" : "󰕾"
+                title: "Audio"
+                subtitle: root.controlsModel.volumeDisplayText
 
                 ShellButton {
-                    Layout.preferredWidth: implicitWidth
-                    Layout.preferredHeight: Theme.buttonHeight
                     label: "Refresh"
                     onActivated: root.controlsModel.refresh()
                 }
@@ -94,6 +78,8 @@ ClickAwayPopup {
                 elide: Text.ElideRight
             }
 
+            PanelSeparator {}
+
             SectionLabel {
                 label: "Volume"
             }
@@ -102,73 +88,20 @@ ClickAwayPopup {
                 Layout.fillWidth: true
                 spacing: root.rowSpacing
 
-                Item {
+                PanelSlider {
                     id: volumeSlider
-
-                    property int pendingPercent: root.controlsModel.volumePercent
-                    property int displayPercent: volumeMouse.pressed ? pendingPercent : root.controlsModel.volumePercent
 
                     Layout.fillWidth: true
                     Layout.preferredHeight: root.volumeControlHeight
-
-                    function percentFromX(x) {
-                        return Math.max(0, Math.min(100, Math.round((x / Math.max(1, width)) * 100)));
-                    }
-
-                    Rectangle {
-                        id: sliderTrack
-
-                        anchors.left: parent.left
-                        anchors.right: parent.right
-                        anchors.verticalCenter: parent.verticalCenter
-                        height: 8
-                        color: Theme.surface
-                        radius: Theme.radius
-
-                        Rectangle {
-                            width: Math.round((volumeSlider.displayPercent / 100) * parent.width)
-                            height: parent.height
-                            color: root.controlsModel.volumeMuted ? Theme.textMuted : Theme.accent
-                            radius: parent.radius
-                        }
-                    }
-
-                    Rectangle {
-                        width: 20
-                        height: 20
-                        x: Math.max(0, Math.min(parent.width - width, Math.round((volumeSlider.displayPercent / 100) * parent.width) - width / 2))
-                        y: parent.height / 2 - height / 2
-                        color: volumeMouse.enabled ? Theme.text : Theme.textMuted
-                        border.color: Theme.border
-                        border.width: 1
-                        radius: height / 2
-                    }
-
-                    MouseArea {
-                        id: volumeMouse
-
-                        anchors.fill: parent
-                        enabled: !root.controlsModel.busy
-                        hoverEnabled: true
-                        cursorShape: Qt.PointingHandCursor
-                        onPressed: function(mouse) {
-                            root.setVolumePendingFromX(mouse.x);
-                        }
-                        onPositionChanged: function(mouse) {
-                            if (pressed) {
-                                root.setVolumePendingFromX(mouse.x);
-                            }
-                        }
-                        onReleased: function(mouse) {
-                            root.setVolumePendingFromX(mouse.x);
-                            root.controlsModel.volumeSet(volumeSlider.pendingPercent);
-                        }
-                    }
+                    value: root.controlsModel.volumePercent
+                    muted: root.controlsModel.volumeMuted
+                    enabled: !root.controlsModel.busy
+                    onValueCommitted: value => root.controlsModel.volumeSet(Math.round(value))
                 }
 
                 Text {
                     Layout.preferredWidth: root.volumePercentWidth
-                    text: root.controlsModel.volumePercent + "%"
+                    text: Math.round(volumeSlider.dragging ? volumeSlider.liveValue : root.controlsModel.volumePercent) + "%"
                     color: Theme.text
                     font.family: Theme.fontFamily
                     font.pixelSize: Theme.panelFontSize
@@ -217,9 +150,11 @@ ClickAwayPopup {
                         Layout.fillWidth: true
                         Layout.preferredHeight: root.outputDeviceRowHeight
                         radius: Theme.radius
-                        color: outputMouse.containsMouse && !outputDeviceRow.modelData.isDefault && !root.controlsModel.busy ? Theme.surfaceHover : Theme.surface
-                        border.color: outputDeviceRow.modelData.isDefault ? Theme.accent : Theme.border
-                        border.width: 1
+                        color: outputDeviceRow.modelData.isDefault ? Theme.controlSelectedFill
+                            : outputMouse.containsMouse && !root.controlsModel.busy ? Theme.controlHoverFill : Theme.controlNormalFill
+                        border.color: outputDeviceRow.modelData.isDefault ? Theme.controlSelectedBorder
+                            : outputMouse.containsMouse ? Theme.controlHoverBorder : Theme.controlNormalBorder
+                        border.width: Theme.controlBorderWidth
 
                         RowLayout {
                             anchors.fill: parent
@@ -241,7 +176,7 @@ ClickAwayPopup {
                             Text {
                                 Layout.preferredWidth: 58
                                 text: outputDeviceRow.modelData.isDefault ? "Default" : "Set"
-                                color: outputDeviceRow.modelData.isDefault ? Theme.accent : Theme.textMuted
+                                color: outputDeviceRow.modelData.isDefault ? Theme.controlSelectedText : Theme.textMuted
                                 font.family: Theme.fontFamily
                                 font.pixelSize: Theme.smallFontSize
                                 font.bold: true
@@ -281,6 +216,8 @@ ClickAwayPopup {
                 }
             }
 
+            PanelSeparator {}
+
             SectionLabel {
                 label: "Media"
             }
@@ -288,10 +225,10 @@ ClickAwayPopup {
             Rectangle {
                 Layout.fillWidth: true
                 Layout.preferredHeight: 54
-                color: Theme.surface
+                color: Theme.controlNormalFill
                 radius: Theme.radius
-                border.color: Theme.border
-                border.width: 1
+                border.color: Theme.controlNormalBorder
+                border.width: Theme.controlBorderWidth
 
                 Column {
                     anchors.left: parent.left

--- a/config/quickshell/core/PanelHero.qml
+++ b/config/quickshell/core/PanelHero.qml
@@ -1,0 +1,55 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.core
+
+RowLayout {
+    id: root
+
+    default property alias actions: heroActions.data
+    required property string title
+    property string subtitle: ""
+    property string iconText: ""
+    property color iconColor: Theme.popupText
+
+    spacing: Theme.sectionSpacing
+
+    IconText {
+        visible: root.iconText.length > 0
+        text: root.iconText
+        color: root.iconColor
+        font.pixelSize: Theme.panelHeroIconSize
+        Layout.alignment: Qt.AlignVCenter
+    }
+
+    ColumnLayout {
+        Layout.fillWidth: true
+        spacing: Theme.spacingXxs
+
+        UiText {
+            Layout.fillWidth: true
+            text: root.title
+            color: Theme.popupText
+            font.pixelSize: Theme.fontTitleSize
+            font.bold: true
+            elide: Text.ElideRight
+        }
+
+        UiText {
+            Layout.fillWidth: true
+            visible: root.subtitle.length > 0
+            text: root.subtitle.toUpperCase()
+            color: Theme.menuMutedText
+            font.pixelSize: Theme.fontCaptionSize
+            font.bold: true
+            font.letterSpacing: Theme.panelMetaLetterSpacing
+            elide: Text.ElideRight
+        }
+    }
+
+    RowLayout {
+        id: heroActions
+
+        spacing: Theme.spacingMd
+        Layout.alignment: Qt.AlignVCenter
+    }
+}

--- a/config/quickshell/core/PanelPill.qml
+++ b/config/quickshell/core/PanelPill.qml
@@ -6,11 +6,16 @@ Rectangle {
 
     property bool active: false
     property bool hovered: false
+    property bool outlined: false
 
     implicitHeight: Theme.pillHeight
     opacity: 1.0
-    color: active ? Theme.surfaceActive : hovered ? Theme.surfaceHover : Theme.surface
-    border.color: active ? Theme.accent : hovered ? Theme.borderStrong : Theme.barBackground
+    color: active ? Theme.controlSelectedFill
+        : hovered ? Theme.controlHoverFill
+        : outlined ? Theme.controlNormalFill : Theme.transparent
+    border.color: active ? Theme.controlSelectedBorder
+        : hovered ? Theme.controlHoverBorder
+        : outlined ? Theme.controlNormalBorder : Theme.transparent
     border.width: Theme.pillBorderWidth
     radius: Theme.pillRadius
 

--- a/config/quickshell/core/PanelSeparator.qml
+++ b/config/quickshell/core/PanelSeparator.qml
@@ -1,0 +1,10 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.core
+
+Rectangle {
+    Layout.fillWidth: true
+    implicitHeight: Theme.controlBorderWidth
+    color: Theme.popupBorder
+    opacity: 0.55
+}

--- a/config/quickshell/core/PanelSlider.qml
+++ b/config/quickshell/core/PanelSlider.qml
@@ -32,6 +32,7 @@ Item {
     }
 
     onValueChanged: if (!dragging) liveValue = value
+    onEnabledChanged: if (enabled && !dragging) liveValue = value
 
     implicitHeight: Theme.panelSliderHeight
     activeFocusOnTab: root.enabled
@@ -112,6 +113,10 @@ Item {
             root.valueCommitted(root.liveValue);
         }
         onWheel: function(wheel) {
+            if (wheel.angleDelta.y === 0) {
+                wheel.accepted = false;
+                return;
+            }
             const direction = wheel.angleDelta.y > 0 ? 1 : -1;
             root.moveTo(root.liveValue + direction * root.step);
             root.valueCommitted(root.liveValue);

--- a/config/quickshell/core/PanelSlider.qml
+++ b/config/quickshell/core/PanelSlider.qml
@@ -1,0 +1,121 @@
+import QtQuick
+import qs.core
+
+Item {
+    id: root
+
+    property real value: 0
+    property real minimum: 0
+    property real maximum: 100
+    property real step: 5
+    property bool muted: false
+    property real liveValue: value
+    property bool dragging: sliderMouse.pressed
+
+    signal valueMoved(real value)
+    signal valueCommitted(real value)
+
+    readonly property real valueRange: Math.max(0.0001, maximum - minimum)
+    readonly property real progress: Math.max(0, Math.min(1, (liveValue - minimum) / valueRange))
+
+    function bounded(value) {
+        return Math.max(root.minimum, Math.min(root.maximum, value));
+    }
+
+    function valueFromX(x) {
+        return root.bounded(root.minimum + (Math.max(0, Math.min(width, x)) / Math.max(1, width)) * root.valueRange);
+    }
+
+    function moveTo(value) {
+        root.liveValue = root.bounded(value);
+        root.valueMoved(root.liveValue);
+    }
+
+    onValueChanged: if (!dragging) liveValue = value
+
+    implicitHeight: Theme.panelSliderHeight
+    activeFocusOnTab: root.enabled
+
+    Keys.onPressed: function(event) {
+        if (!root.enabled || (event.key !== Qt.Key_Left && event.key !== Qt.Key_Right)) return;
+        const direction = event.key === Qt.Key_Right ? 1 : -1;
+        root.moveTo(root.liveValue + direction * root.step);
+        root.valueCommitted(root.liveValue);
+        event.accepted = true;
+    }
+
+    Rectangle {
+        id: sliderTrack
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        height: Theme.panelSliderTrackHeight
+        radius: height / 2
+        color: Theme.controlNormalFill
+        border.color: root.activeFocus ? Theme.controlFocusBorder : Theme.controlNormalBorder
+        border.width: root.activeFocus ? Theme.controlFocusBorderWidth : Theme.controlBorderWidth
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            width: Math.round(parent.width * root.progress)
+            height: parent.height
+            radius: parent.radius
+            color: root.muted ? Theme.controlDisabledText : Theme.accent
+
+            Behavior on width {
+                enabled: !root.dragging
+                NumberAnimation { duration: Theme.animationFast; easing.type: Easing.OutCubic }
+            }
+        }
+    }
+
+    Rectangle {
+        anchors.verticalCenter: sliderTrack.verticalCenter
+        x: Math.max(0, Math.min(root.width - width, Math.round(sliderTrack.width * root.progress) - width / 2))
+        width: Theme.panelSliderKnobSize
+        height: width
+        radius: width / 2
+        color: root.enabled ? Theme.popupText : Theme.controlDisabledText
+        border.color: Theme.popupBackground
+        border.width: Theme.controlFocusBorderWidth
+        scale: sliderMouse.containsMouse || root.dragging || root.activeFocus ? 1.12 : 1
+
+        Behavior on x {
+            enabled: !root.dragging
+            NumberAnimation { duration: Theme.animationFast; easing.type: Easing.OutCubic }
+        }
+
+        Behavior on scale {
+            NumberAnimation { duration: Theme.animationFast; easing.type: Easing.OutCubic }
+        }
+    }
+
+    MouseArea {
+        id: sliderMouse
+
+        anchors.fill: parent
+        enabled: root.enabled
+        hoverEnabled: true
+        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+
+        onPressed: function(mouse) {
+            root.forceActiveFocus();
+            root.moveTo(root.valueFromX(mouse.x));
+        }
+        onPositionChanged: function(mouse) {
+            if (pressed) root.moveTo(root.valueFromX(mouse.x));
+        }
+        onReleased: function(mouse) {
+            root.moveTo(root.valueFromX(mouse.x));
+            root.valueCommitted(root.liveValue);
+        }
+        onWheel: function(wheel) {
+            const direction = wheel.angleDelta.y > 0 ? 1 : -1;
+            root.moveTo(root.liveValue + direction * root.step);
+            root.valueCommitted(root.liveValue);
+            wheel.accepted = true;
+        }
+    }
+}

--- a/config/quickshell/core/PanelToggleSwitch.qml
+++ b/config/quickshell/core/PanelToggleSwitch.qml
@@ -1,0 +1,64 @@
+import QtQuick
+import qs.core
+
+Item {
+    id: root
+
+    property bool checked: false
+    property bool busy: false
+    signal toggled
+
+    readonly property bool hot: toggleMouse.containsMouse || activeFocus
+
+    implicitWidth: Theme.panelToggleWidth
+    implicitHeight: Theme.panelToggleHeight
+    activeFocusOnTab: root.enabled && !root.busy
+
+    Keys.onPressed: function(event) {
+        if (!root.enabled || root.busy || event.isAutoRepeat) return;
+        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Space) {
+            root.toggled();
+            event.accepted = true;
+        }
+    }
+
+    Rectangle {
+        id: track
+
+        anchors.fill: parent
+        radius: height / 2
+        color: root.checked ? Theme.controlSelectedFill : Theme.controlNormalFill
+        border.color: root.activeFocus ? Theme.controlFocusBorder
+            : root.hot ? Theme.controlHoverBorder
+            : root.checked ? Theme.controlSelectedBorder : Theme.controlNormalBorder
+        border.width: root.activeFocus ? Theme.controlFocusBorderWidth : Theme.controlBorderWidth
+
+        Behavior on color { ColorAnimation { duration: Theme.animationFast } }
+
+        Rectangle {
+            width: Theme.panelToggleKnobSize
+            height: width
+            radius: width / 2
+            anchors.verticalCenter: parent.verticalCenter
+            x: root.checked ? parent.width - width - Theme.panelToggleInset : Theme.panelToggleInset
+            color: root.checked ? Theme.controlSelectedText : Theme.controlDisabledText
+
+            Behavior on x {
+                NumberAnimation { duration: Theme.animationFast; easing.type: Easing.OutCubic }
+            }
+        }
+    }
+
+    MouseArea {
+        id: toggleMouse
+
+        anchors.fill: parent
+        enabled: root.enabled && !root.busy
+        hoverEnabled: true
+        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+        onClicked: {
+            root.forceActiveFocus();
+            root.toggled();
+        }
+    }
+}

--- a/config/quickshell/core/SectionLabel.qml
+++ b/config/quickshell/core/SectionLabel.qml
@@ -6,10 +6,11 @@ Text {
     required property string label
 
     Layout.fillWidth: true
-    text: label
+    text: label.toUpperCase()
     color: Theme.menuMutedText
     font.family: Theme.fontFamily
     font.pixelSize: Theme.fontBodySmallSize
     font.bold: true
+    font.letterSpacing: Theme.panelMetaLetterSpacing
     elide: Text.ElideRight
 }

--- a/config/quickshell/core/Theme.qml
+++ b/config/quickshell/core/Theme.qml
@@ -146,6 +146,15 @@ Singleton {
     readonly property int menuHeaderHeight: 26
     readonly property int popupPadding: spacingHuge
     readonly property int popupRadius: controlRadius
+    readonly property int panelHeroIconSize: 32
+    readonly property real panelMetaLetterSpacing: 1.2
+    readonly property int panelSliderHeight: 32
+    readonly property int panelSliderTrackHeight: 6
+    readonly property int panelSliderKnobSize: 16
+    readonly property int panelToggleWidth: 40
+    readonly property int panelToggleHeight: 22
+    readonly property int panelToggleKnobSize: 14
+    readonly property int panelToggleInset: 3
 
     readonly property int panelHeight: 30
     readonly property int panelMargin: 0

--- a/config/quickshell/network/NetworkProfileRow.qml
+++ b/config/quickshell/network/NetworkProfileRow.qml
@@ -16,6 +16,14 @@ Rectangle {
     border.width: Theme.controlBorderWidth
     radius: Theme.radius
 
+    MouseArea {
+        id: rowMouse
+
+        anchors.fill: parent
+        hoverEnabled: true
+        acceptedButtons: Qt.NoButton
+    }
+
     RowLayout {
         anchors.fill: parent
         anchors.leftMargin: Theme.rowSpacing
@@ -45,40 +53,10 @@ Rectangle {
             }
         }
 
-        Rectangle {
-            Layout.preferredWidth: actionText.implicitWidth + 18
+        ShellButton {
             Layout.preferredHeight: Theme.chipHeight
-            color: actionMouse.containsMouse ? Theme.controlHoverFill : Theme.controlNormalFill
-            border.color: actionMouse.containsMouse ? Theme.controlHoverBorder : Theme.controlNormalBorder
-            border.width: Theme.controlBorderWidth
-            radius: Theme.radius
-
-            Text {
-                id: actionText
-
-                anchors.centerIn: parent
-                text: root.active ? "Disconnect" : "Connect"
-                color: Theme.textStrong
-                font.family: Theme.fontFamily
-                font.pixelSize: Theme.smallFontSize
-            }
-
-            MouseArea {
-                id: actionMouse
-
-                anchors.fill: parent
-                hoverEnabled: true
-                cursorShape: Qt.PointingHandCursor
-                onClicked: root.active ? root.disconnectRequested(root.profile.device) : root.connectRequested(root.profile)
-            }
+            label: root.active ? "Disconnect" : "Connect"
+            onActivated: root.active ? root.disconnectRequested(root.profile.device) : root.connectRequested(root.profile)
         }
-    }
-
-    MouseArea {
-        id: rowMouse
-
-        anchors.fill: parent
-        hoverEnabled: true
-        acceptedButtons: Qt.NoButton
     }
 }

--- a/config/quickshell/network/NetworkProfileRow.qml
+++ b/config/quickshell/network/NetworkProfileRow.qml
@@ -11,7 +11,9 @@ Rectangle {
     signal disconnectRequested(string device)
 
     height: Theme.confirmButtonHeight
-    color: Theme.surface
+    color: rowMouse.containsMouse ? Theme.controlHoverFill : Theme.controlNormalFill
+    border.color: rowMouse.containsMouse ? Theme.controlHoverBorder : Theme.controlNormalBorder
+    border.width: Theme.controlBorderWidth
     radius: Theme.radius
 
     RowLayout {
@@ -46,7 +48,9 @@ Rectangle {
         Rectangle {
             Layout.preferredWidth: actionText.implicitWidth + 18
             Layout.preferredHeight: Theme.chipHeight
-            color: Theme.border
+            color: actionMouse.containsMouse ? Theme.controlHoverFill : Theme.controlNormalFill
+            border.color: actionMouse.containsMouse ? Theme.controlHoverBorder : Theme.controlNormalBorder
+            border.width: Theme.controlBorderWidth
             radius: Theme.radius
 
             Text {

--- a/config/quickshell/network/NetworkWifiRow.qml
+++ b/config/quickshell/network/NetworkWifiRow.qml
@@ -12,9 +12,11 @@ Rectangle {
     signal connectRequested(var network)
 
     height: 54
-    color: root.selected ? Theme.surfaceActive : Theme.surface
-    border.color: root.selected ? Theme.accent : Theme.border
-    border.width: root.selected ? 1 : 0
+    color: root.selected ? Theme.controlSelectedFill
+        : rowMouse.containsMouse ? Theme.controlHoverFill : Theme.controlNormalFill
+    border.color: root.selected ? Theme.controlSelectedBorder
+        : rowMouse.containsMouse ? Theme.controlHoverBorder : Theme.controlNormalBorder
+    border.width: Theme.controlBorderWidth
     radius: Theme.radius
 
     MouseArea {
@@ -58,7 +60,7 @@ Rectangle {
         Text {
             Layout.preferredWidth: 54
             text: root.network.active ? "Active" : ""
-            color: Theme.accent
+            color: Theme.controlSelectedText
             font.family: Theme.fontFamily
             font.pixelSize: Theme.smallFontSize
             horizontalAlignment: Text.AlignRight
@@ -68,7 +70,11 @@ Rectangle {
         Rectangle {
             Layout.preferredWidth: actionText.implicitWidth + 18
             Layout.preferredHeight: Theme.chipHeight
-            color: root.busy ? Theme.surface : Theme.border
+            color: root.busy ? Theme.controlDisabledFill
+                : actionMouse.containsMouse ? Theme.controlHoverFill : Theme.controlNormalFill
+            border.color: root.busy ? Theme.controlDisabledBorder
+                : actionMouse.containsMouse ? Theme.controlHoverBorder : Theme.controlNormalBorder
+            border.width: Theme.controlBorderWidth
             radius: Theme.radius
 
             Text {
@@ -76,7 +82,7 @@ Rectangle {
 
                 anchors.centerIn: parent
                 text: root.busy ? "Connecting..." : "Connect"
-                color: Theme.textStrong
+                color: root.busy ? Theme.controlDisabledText : Theme.textStrong
                 font.family: Theme.fontFamily
                 font.pixelSize: Theme.smallFontSize
             }

--- a/config/quickshell/network/NetworkWifiRow.qml
+++ b/config/quickshell/network/NetworkWifiRow.qml
@@ -67,35 +67,11 @@ Rectangle {
             elide: Text.ElideRight
         }
 
-        Rectangle {
-            Layout.preferredWidth: actionText.implicitWidth + 18
+        ShellButton {
             Layout.preferredHeight: Theme.chipHeight
-            color: root.busy ? Theme.controlDisabledFill
-                : actionMouse.containsMouse ? Theme.controlHoverFill : Theme.controlNormalFill
-            border.color: root.busy ? Theme.controlDisabledBorder
-                : actionMouse.containsMouse ? Theme.controlHoverBorder : Theme.controlNormalBorder
-            border.width: Theme.controlBorderWidth
-            radius: Theme.radius
-
-            Text {
-                id: actionText
-
-                anchors.centerIn: parent
-                text: root.busy ? "Connecting..." : "Connect"
-                color: root.busy ? Theme.controlDisabledText : Theme.textStrong
-                font.family: Theme.fontFamily
-                font.pixelSize: Theme.smallFontSize
-            }
-
-            MouseArea {
-                id: actionMouse
-
-                anchors.fill: parent
-                enabled: !root.busy
-                hoverEnabled: true
-                cursorShape: Qt.PointingHandCursor
-                onClicked: root.connectRequested(root.network)
-            }
+            label: root.busy ? "Connecting..." : "Connect"
+            enabled: !root.busy
+            onActivated: root.connectRequested(root.network)
         }
     }
 }

--- a/config/quickshell/network/NetworkWindow.qml
+++ b/config/quickshell/network/NetworkWindow.qml
@@ -55,24 +55,16 @@ ClickAwayPopup {
             enabled: !root.networkModel.wifiPasswordPromptVisible
             spacing: Theme.popupSpacing
 
-            RowLayout {
+            PanelHero {
                 Layout.fillWidth: true
-                spacing: Theme.rowSpacing
-
-                Text {
-                    Layout.fillWidth: true
-                    text: root.networkModel.statusText
-                    color: Theme.text
-                    font.family: Theme.fontFamily
-                    font.pixelSize: Theme.titleFontSize
-                    font.bold: true
-                    elide: Text.ElideRight
-                    verticalAlignment: Text.AlignVCenter
-                }
+                iconText: root.networkModel.statusText.indexOf("offline") >= 0
+                    || root.networkModel.statusText.indexOf("unavailable") >= 0 ? "󰤭" : "󰤨"
+                iconColor: root.networkModel.statusText.indexOf("unavailable") >= 0
+                    ? Theme.menuMutedText : Theme.popupText
+                title: "Network"
+                subtitle: root.networkModel.statusText
 
                 ShellButton {
-                    Layout.preferredWidth: implicitWidth
-                    Layout.preferredHeight: Theme.buttonHeight
                     label: "Scan"
                     enabled: !root.networkModel.busy
                     onActivated: root.networkModel.refresh(true)
@@ -88,6 +80,8 @@ ClickAwayPopup {
                 font.pixelSize: Theme.smallFontSize
                 elide: Text.ElideRight
             }
+
+            PanelSeparator {}
 
             SectionLabel {
                 label: "Active"
@@ -225,9 +219,9 @@ ClickAwayPopup {
             Rectangle {
                 anchors.fill: parent
                 focus: true
-                color: Theme.surface
-                border.color: Theme.accent
-                border.width: 1
+                color: Theme.popupBackground
+                border.color: Theme.popupBorder
+                border.width: Theme.controlBorderWidth
                 radius: Theme.radius
 
                 Keys.onPressed: function(event) {
@@ -271,9 +265,10 @@ ClickAwayPopup {
                         Rectangle {
                             Layout.fillWidth: true
                             Layout.fillHeight: true
-                            color: Theme.bg
-                            border.color: wifiPasswordInput.activeFocus ? Theme.accent : Theme.border
-                            border.width: 1
+                            color: Theme.controlNormalFill
+                            border.color: wifiPasswordInput.activeFocus ? Theme.controlFocusBorder : Theme.controlNormalBorder
+                            border.width: wifiPasswordInput.activeFocus
+                                ? Theme.controlFocusBorderWidth : Theme.controlBorderWidth
                             radius: Theme.radius
 
                             TextInput {

--- a/config/quickshell/panel/DwmPanel.qml
+++ b/config/quickshell/panel/DwmPanel.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
 import Quickshell
-import Quickshell.Widgets
 import qs.core
 
 pragma ComponentBehavior: Bound
@@ -121,6 +120,7 @@ PanelWindow {
                     PanelPill {
                         Layout.preferredWidth: Math.min(activeTitle.implicitWidth + Theme.pillHorizontalPadding * 2, 260)
                         Layout.preferredHeight: Theme.pillHeight
+                        outlined: true
 
                         UiText {
                             id: activeTitle
@@ -140,6 +140,7 @@ PanelWindow {
             PanelPill {
                 Layout.preferredWidth: clockLabel.implicitWidth + Theme.pillHorizontalPadding * 2
                 Layout.preferredHeight: Theme.pillHeight
+                outlined: true
 
                 UiText {
                     id: clockLabel
@@ -169,6 +170,7 @@ PanelWindow {
                             required property string modelData
                             Layout.preferredWidth: statusLabel.implicitWidth + Theme.pillHorizontalPadding * 2
                             Layout.preferredHeight: Theme.pillHeight
+                            outlined: true
 
                             UiText {
                                 id: statusLabel
@@ -191,6 +193,7 @@ PanelWindow {
                         visible: root.state.batteryAvailable
                         Layout.preferredWidth: batteryRow.implicitWidth + Theme.compactWidgetHorizontalPadding * 2
                         Layout.preferredHeight: Theme.compactWidgetSize
+                        hovered: batteryMouse.containsMouse
 
                         RowLayout {
                             id: batteryRow

--- a/config/quickshell/panel/RunningAppItem.qml
+++ b/config/quickshell/panel/RunningAppItem.qml
@@ -13,9 +13,11 @@ Rectangle {
     Layout.preferredWidth: Theme.pillHeight
     Layout.preferredHeight: Theme.pillHeight
     radius: Theme.pillRadius
-    color: appMouse.containsMouse ? Theme.surfaceHover : Theme.surface
-    border.color: active ? Theme.accent : appMouse.containsMouse ? Theme.borderStrong : Theme.border
-    border.width: Theme.pillBorderWidth
+    color: active ? Theme.controlSelectedFill
+        : appMouse.containsMouse ? Theme.controlHoverFill : Theme.transparent
+    border.color: active ? Theme.controlSelectedBorder
+        : appMouse.containsMouse ? Theme.controlHoverBorder : Theme.transparent
+    border.width: active || appMouse.containsMouse ? Theme.pillBorderWidth : 0
 
     IconImage {
         anchors.centerIn: parent

--- a/config/quickshell/panel/TrayItem.qml
+++ b/config/quickshell/panel/TrayItem.qml
@@ -36,7 +36,9 @@ Rectangle {
     Layout.preferredWidth: Theme.trayItemSize
     Layout.preferredHeight: Theme.trayItemSize
     radius: Theme.smallRadius
-    color: trayMouse.containsMouse ? Theme.surfaceHover : "transparent"
+    color: trayMouse.containsMouse ? Theme.controlHoverFill : Theme.transparent
+    border.color: trayMouse.containsMouse ? Theme.controlHoverBorder : Theme.transparent
+    border.width: trayMouse.containsMouse ? Theme.pillBorderWidth : 0
 
     QsMenuAnchor {
         id: trayMenu

--- a/config/quickshell/panel/WorkspaceButton.qml
+++ b/config/quickshell/panel/WorkspaceButton.qml
@@ -13,14 +13,17 @@ Rectangle {
     Layout.preferredWidth: Theme.workspaceButtonSize
     Layout.preferredHeight: Theme.workspaceButtonSize
     radius: Theme.smallRadius
-    color: Theme.transparent
-    border.color: selected ? Theme.accent : Theme.transparent
-    border.width: selected ? Theme.pillBorderWidth : 0
+    color: selected ? Theme.controlSelectedFill
+        : workspaceMouse.containsMouse ? Theme.controlHoverFill : Theme.transparent
+    border.color: selected ? Theme.controlSelectedBorder
+        : workspaceMouse.containsMouse ? Theme.controlHoverBorder : Theme.transparent
+    border.width: selected || workspaceMouse.containsMouse ? Theme.pillBorderWidth : 0
 
     Text {
         anchors.centerIn: parent
         text: root.label
-        color: root.selected ? Theme.accent : Theme.textMuted
+        color: root.selected ? Theme.controlSelectedText
+            : workspaceMouse.containsMouse ? Theme.controlHoverText : Theme.textMuted
         font.family: Theme.fontFamily
         font.pixelSize: Theme.panelFontSize
         font.bold: root.selected

--- a/config/quickshell/power/PowerMenuWindow.qml
+++ b/config/quickshell/power/PowerMenuWindow.qml
@@ -69,11 +69,7 @@ ClickAwayPopup {
                 onCloseRequested: root.powerMenuModel.close()
             }
 
-            Rectangle {
-                Layout.fillWidth: true
-                Layout.preferredHeight: 1
-                color: Theme.border
-            }
+            PanelSeparator {}
 
             ColumnLayout {
                 Layout.fillWidth: true
@@ -88,6 +84,7 @@ ClickAwayPopup {
 
                         Layout.fillWidth: true
                         label: modelData.label
+                        detail: modelData.detail
                         navigates: modelData.confirm
                         onActivated: root.powerMenuModel.requestAction(modelData)
                     }

--- a/docs/OMARCHY-UI-ADAPTATION.md
+++ b/docs/OMARCHY-UI-ADAPTATION.md
@@ -85,3 +85,28 @@ make check-quickshell-design-system
 
 It is also part of the repository-wide `make check` gate. QML changes still
 require `make check-quickshell-qml` plus the applicable X11 runtime suite.
+
+## Panel and Popup Contract
+
+The DWM panel keeps its 30px exclusive zone, one-panel-per-screen lifecycle,
+workspace ownership, focused-window state, running applications, system tray,
+and popup coordinator. Its Omarchy influence is visual: flat modules on the
+bar, semantic hover and selected states, and outlined information groups. It
+does not adopt Omarchy's configurable plugin registry, layer-shell placement,
+or compositor-owned workspace model.
+
+Audio, Bluetooth, Network, Control Center, and Power retain their existing
+root-scoped models, helpers, IPC targets, monitor routing, and click-away
+surfaces. Shared `PanelHero`, `PanelSeparator`, `PanelSlider`, and
+`PanelToggleSwitch` components supply the common hero hierarchy, small-caps
+section rhythm, slider treatment, and compact toggle without owning system
+state or starting helper processes.
+
+Run the focused panel-menu contract with:
+
+```sh
+make check-quickshell-panel-menus
+```
+
+The QML lint and nested-X11 health test remain required for popup focus,
+outside-click dismissal, Escape behavior, tray ownership, and idle lifecycle.

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -404,7 +404,7 @@ grep -Fq 'onDismissed: controlCenterModel.close()' "$repo/config/quickshell/cont
 grep -Fq 'grabFocus: true' "$repo/config/quickshell/core/ClickAwayPopup.qml"
 grep -Fq 'function applyThemes(themeText)' "$repo/config/quickshell/core/Theme.qml"
 grep -Fq 'root.text = value("normfgcolor", root.text)' "$repo/config/quickshell/core/Theme.qml"
-grep -Fq 'text: root.busy ? "Connecting..." : "Connect"' "$repo/config/quickshell/network/NetworkWifiRow.qml"
+grep -Fq 'label: root.busy ? "Connecting..." : "Connect"' "$repo/config/quickshell/network/NetworkWifiRow.qml"
 grep -Fq 'property bool wifiPasswordPromptVisible: false' "$repo/config/quickshell/network/NetworkModel.qml"
 grep -Fq 'root.wifiPasswordPromptVisible = true;' "$repo/config/quickshell/network/NetworkModel.qml"
 grep -Fq 'root.networkModel.cancelWifiPasswordPrompt()' "$repo/config/quickshell/network/NetworkWindow.qml"

--- a/tests/test-quickshell-health-xvfb.sh
+++ b/tests/test-quickshell-health-xvfb.sh
@@ -42,7 +42,8 @@ sed -i '/title="dwm network password"/a\
 grep -Fqx '  { title="dwm control center",         isfloating=1, alwaysontop=1 },' \
 	"$config_home/dwm-titus/window-rules.toml"
 cp "$repo/scripts/dwm-system-health" "$repo/scripts/dwm-diagnostics" \
-	"$repo/scripts/dwm-quickshell-controlcenter" "$repo/scripts/dwm-quickshell-launcher" \
+	"$repo/scripts/dwm-quickshell-controlcenter" "$repo/scripts/dwm-quickshell-controls" \
+	"$repo/scripts/dwm-quickshell-launcher" "$repo/scripts/dwm-quickshell-network" \
 	"$data_home/dwm-titus/scripts/"
 
 Xvfb "$display" -screen 0 1024x768x24 -nolisten tcp -extension GLX >"$work/xvfb.log" 2>&1 &
@@ -195,6 +196,57 @@ if DISPLAY=$display xdotool search --onlyvisible --pid "$quickshell_pid" 2>/dev/
 	printf 'Control Center popup did not close on Escape\n' >&2
 	exit 1
 fi
+
+exercise_panel_popup() {
+	target=$1
+	label=$2
+	visible_windows=$(DISPLAY=$display xdotool search --onlyvisible --pid "$quickshell_pid" 2>/dev/null || true)
+	DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home XDG_RUNTIME_DIR=$runtime \
+		quickshell ipc --path "$config" call "$target" open >/dev/null
+
+	popup_window=
+	i=0
+	while [ "$i" -lt 200 ]; do
+		for candidate in $(DISPLAY=$display xdotool search --onlyvisible --pid "$quickshell_pid" 2>/dev/null || true); do
+			was_visible=0
+			for existing in $visible_windows; do
+				[ "$candidate" = "$existing" ] && was_visible=1
+			done
+			if [ "$was_visible" = 0 ]; then
+				popup_window=$candidate
+				break
+			fi
+		done
+		[ -n "$popup_window" ] && break
+		i=$((i + 1))
+		sleep 0.05
+	done
+
+	if [ -z "$popup_window" ]; then
+		printf '%s popup did not open\n' "$label" >&2
+		tail -40 "$work/quickshell.log" >&2
+		exit 1
+	fi
+
+	DISPLAY=$display xdotool windowfocus --sync "$popup_window"
+	DISPLAY=$display xdotool key Escape
+	i=0
+	while [ "$i" -lt 100 ]; do
+		if ! DISPLAY=$display xdotool search --onlyvisible --pid "$quickshell_pid" 2>/dev/null | grep -Fqx "$popup_window"; then
+			break
+		fi
+		i=$((i + 1))
+		sleep 0.05
+	done
+	if DISPLAY=$display xdotool search --onlyvisible --pid "$quickshell_pid" 2>/dev/null | grep -Fqx "$popup_window"; then
+		printf '%s popup did not close on Escape\n' "$label" >&2
+		exit 1
+	fi
+}
+
+exercise_panel_popup controls Audio
+exercise_panel_popup network Network
+exercise_panel_popup power Power
 
 # An in-place page keeps one popup surface and Escape still closes the menu.
 visible_windows=$(DISPLAY=$display xdotool search --onlyvisible --pid "$quickshell_pid" 2>/dev/null || true)

--- a/tests/test-quickshell-panel-menus.sh
+++ b/tests/test-quickshell-panel-menus.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+set -eu
+
+repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+core=$repo/config/quickshell/core
+panel=$repo/config/quickshell/panel
+controls=$repo/config/quickshell/controls
+network=$repo/config/quickshell/network
+controlcenter=$repo/config/quickshell/controlcenter
+power=$repo/config/quickshell/power
+
+for component in PanelHero PanelSeparator PanelSlider PanelToggleSwitch; do
+	test -f "$core/$component.qml"
+done
+
+grep -Fq 'readonly property int panelHeight: 30' "$core/Theme.qml"
+grep -Fq 'exclusiveZone: Theme.panelHeight' "$panel/DwmPanel.qml"
+grep -Fq 'aboveWindows: root.state.fullscreenMonitorIndexes.indexOf(' "$panel/DwmPanel.qml"
+grep -Fq 'signal popupRequested(var panelWindow, string popupId)' "$panel/DwmPanel.qml"
+grep -Fq 'model: root.state.workspaceIndexes(root.screen)' "$panel/DwmPanel.qml"
+grep -Fq 'sourceComponent: TrayArea {}' "$panel/DwmPanel.qml"
+grep -Fq 'RunningAppsArea { state: root.state }' "$panel/DwmPanel.qml"
+
+grep -Fq 'outlined: true' "$panel/DwmPanel.qml"
+grep -Fq 'outlined ? Theme.controlNormalFill : Theme.transparent' "$core/PanelPill.qml"
+grep -Fq 'Theme.controlSelectedFill' "$panel/WorkspaceButton.qml"
+grep -Fq 'Theme.controlSelectedFill' "$panel/RunningAppItem.qml"
+grep -Fq 'Theme.controlHoverFill' "$panel/TrayItem.qml"
+
+grep -Fq 'PanelHero {' "$controls/ControlsWindow.qml"
+grep -Fq 'title: "Audio"' "$controls/ControlsWindow.qml"
+grep -Fq 'PanelSlider {' "$controls/ControlsWindow.qml"
+grep -Fq 'root.controlsModel.volumeSet(Math.round(value))' "$controls/ControlsWindow.qml"
+grep -Fq 'PanelHero {' "$controls/BluetoothWindow.qml"
+grep -Fq 'PanelToggleSwitch {' "$controls/BluetoothWindow.qml"
+grep -Fq 'root.bluetoothModel.action("bluetooth-power", [checked ? "off" : "on"])' \
+	"$controls/BluetoothWindow.qml"
+grep -Fq 'readonly property bool powered: available && statusText !== "BT off"' \
+	"$controls/BluetoothModel.qml"
+
+grep -Fq 'PanelHero {' "$network/NetworkWindow.qml"
+grep -Fq 'title: "Network"' "$network/NetworkWindow.qml"
+grep -Fq 'onDismissed: networkModel.close()' "$network/NetworkWindow.qml"
+grep -Fq 'FloatingWindow {' "$network/NetworkWindow.qml"
+grep -Fq 'wifiPasswordInput.forceActiveFocus();' "$network/NetworkWindow.qml"
+grep -Fq 'Theme.controlSelectedFill' "$network/NetworkWifiRow.qml"
+grep -Fq 'Theme.controlHoverFill' "$network/NetworkProfileRow.qml"
+
+grep -Fq 'PanelSeparator {' "$controlcenter/ControlCenterWindow.qml"
+grep -Fq 'PanelSeparator {}' "$power/PowerMenuWindow.qml"
+grep -Fq 'detail: modelData.detail' "$power/PowerMenuWindow.qml"
+grep -Fq 'onDismissed: powerMenuModel.close()' "$power/PowerMenuWindow.qml"
+
+if grep -REn 'Quickshell\.(Wayland|Hyprland)|WlrLayershell|hyprctl|uwsm-app|wl-copy|wl-paste' \
+	"$core"/PanelHero.qml "$core"/PanelSeparator.qml "$core"/PanelSlider.qml \
+	"$core"/PanelToggleSwitch.qml "$panel" "$controls" "$network" "$controlcenter" "$power"; then
+	printf 'Panel-menu views must remain X11-safe.\n' >&2
+	exit 1
+fi
+
+if grep -REn '(^|[[:space:]])Process[[:space:]]*\{' \
+	"$core"/PanelHero.qml "$core"/PanelSeparator.qml "$core"/PanelSlider.qml \
+	"$core"/PanelToggleSwitch.qml; then
+	printf 'Visual panel primitives must not own helper processes.\n' >&2
+	exit 1
+fi
+
+printf 'Quickshell panel menus: PASS\n'

--- a/tests/test-quickshell-panel-menus.sh
+++ b/tests/test-quickshell-panel-menus.sh
@@ -45,8 +45,13 @@ grep -Fq 'FloatingWindow {' "$network/NetworkWindow.qml"
 grep -Fq 'wifiPasswordInput.forceActiveFocus();' "$network/NetworkWindow.qml"
 grep -Fq 'Theme.controlSelectedFill' "$network/NetworkWifiRow.qml"
 grep -Fq 'Theme.controlHoverFill' "$network/NetworkProfileRow.qml"
+grep -Fq 'ShellButton {' "$network/NetworkWifiRow.qml"
+grep -Fq 'ShellButton {' "$network/NetworkProfileRow.qml"
 
 grep -Fq 'PanelSeparator {' "$controlcenter/ControlCenterWindow.qml"
+grep -Fq 'activeFocusOnTab: presetButton.enabled' "$controlcenter/ControlCenterWindow.qml"
+grep -Fq 'event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Space' \
+	"$controlcenter/ControlCenterWindow.qml"
 grep -Fq 'PanelSeparator {}' "$power/PowerMenuWindow.qml"
 grep -Fq 'detail: modelData.detail' "$power/PowerMenuWindow.qml"
 grep -Fq 'onDismissed: powerMenuModel.close()' "$power/PowerMenuWindow.qml"

--- a/tests/test-quickshell-panel-menus.sh
+++ b/tests/test-quickshell-panel-menus.sh
@@ -12,6 +12,8 @@ power=$repo/config/quickshell/power
 for component in PanelHero PanelSeparator PanelSlider PanelToggleSwitch; do
 	test -f "$core/$component.qml"
 done
+grep -Fq 'onEnabledChanged: if (enabled && !dragging) liveValue = value' "$core/PanelSlider.qml"
+grep -Fq 'if (wheel.angleDelta.y === 0)' "$core/PanelSlider.qml"
 
 grep -Fq 'readonly property int panelHeight: 30' "$core/Theme.qml"
 grep -Fq 'exclusiveZone: Theme.panelHeight' "$panel/DwmPanel.qml"


### PR DESCRIPTION
## Summary

- restyle the DWM panel with the shared Omarchy-inspired semantic tokens while preserving its 30px X11 exclusive zone, workspace ownership, tray, focused-window state, and popup routing
- add shared hero, separator, slider, and toggle primitives and apply them to Audio, Bluetooth, Network, Control Center, and Power
- keep the existing DWM state, Fedora helpers, IPC targets, click-away behavior, and X11-only backend intact
- add a focused source contract plus nested-X11 popup open/focus/Escape coverage

## Validation

- `shellcheck tests/test-quickshell-health-xvfb.sh tests/test-quickshell-panel-menus.sh`
- `shfmt -d tests/test-quickshell-health-xvfb.sh tests/test-quickshell-panel-menus.sh`
- `make check-quickshell-network check-quickshell-panel-menus check-quickshell-qml check-quickshell-health-xvfb`
- `scripts/run-tests make clean all`
- `scripts/run-tests`
- `git diff --check`

The nested Fedora X11 run opened Audio, Network, and Power through Quickshell IPC, gave each detected popup direct X input focus, and verified Escape dismissal. Existing Control Center click-away/Escape, tray ownership, idle lifecycle, and managed-install tests also passed.

## Review notes

- Automatic CodeRabbit review was paused per request; no CodeRabbit review is required for this PR.
- Review found and we fixed disabled Wi-Fi action text plus nondeterministic popup focus in the Xvfb test.
- Existing qmllint warnings remain limited to the pre-existing PanelTooltip qmltypes gap and RunningAppsArea property/unqualified-access warnings.
- This is an independent child of PR #157, matching the original parallel phase plan. PR #158 was merged into its feature base rather than `main`, so its command-menu commits are intentionally not duplicated here; this PR should not be used for a live managed sync until that branch-history issue is corrected or PR #158 is separately landed on `main`.
