### PR TITLE
Land the X11 Quickshell command menu on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ versions from `config.mk`.
 
 ### Added
 
+- Add an X11-native Quickshell command menu with typed navigation for apps,
+  desktop settings and services, screenshots, system actions, and a public
+  `menu open|close|toggle|summon` IPC surface. Opening the menu moves the
+  pointer into its search field to preserve keyboard focus under DWM.
+
 - Install Gear Lever from a user-scoped Flathub remote by default with the
   recommended/full desktop and both Fedora image variants.
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ INSTALL_COMMANDS = \
 	scripts/dwm-quickshell-controls \
 	scripts/dwm-quickshell-controlcenter \
 	scripts/dwm-quickshell-network \
+	scripts/dwm-quickshell-pointer \
 	scripts/dwm-quickshell-state \
 	scripts/dwm-quickshell-version-check \
 	scripts/dwm-status \
@@ -312,10 +313,10 @@ release: dwm
 	echo "==> Created ${RELEASE_ARCHIVE}"
 
 check-shell:
-	shellcheck install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-quickshell-version-check scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/install-herdr scripts/quickshell-qmllint scripts/run-tests scripts/*.sh tests/*.sh
+	shellcheck install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-pointer scripts/dwm-quickshell-state scripts/dwm-quickshell-version-check scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/install-herdr scripts/quickshell-qmllint scripts/run-tests scripts/*.sh tests/*.sh
 
 check-format:
-	shfmt -d install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-state scripts/dwm-quickshell-version-check scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/install-herdr scripts/quickshell-qmllint scripts/run-tests scripts/*.sh tests/*.sh
+	shfmt -d install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-pointer scripts/dwm-quickshell-state scripts/dwm-quickshell-version-check scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/install-herdr scripts/quickshell-qmllint scripts/run-tests scripts/*.sh tests/*.sh
 
 check-session-guards:
 	tests/test-autostart.sh
@@ -386,6 +387,9 @@ check-quickshell-design-system:
 
 check-quickshell-panel-menus:
 	tests/test-quickshell-panel-menus.sh
+
+check-quickshell-command-menu:
+	tests/test-quickshell-command-menu.sh
 
 check-quickshell-notifications:
 	tests/test-quickshell-notifications.sh
@@ -535,6 +539,7 @@ check:
 	$(MAKE) check-quickshell-controlcenter
 	$(MAKE) check-quickshell-design-system
 	$(MAKE) check-quickshell-panel-menus
+	$(MAKE) check-quickshell-command-menu
 	$(MAKE) check-quickshell-qml
 	$(MAKE) check-quickshell-notifications
 	$(MAKE) check-quickshell-tray
@@ -561,5 +566,5 @@ check:
 	check-display-profile check-display-setup check-fedora-iso-builder check-fedora-packages check-fedora-platform check-format check-install \
 	check-gearlever-install check-herdr-install check-install-manifest check-install-preservation check-kickstart check-lock \
 	check-session-guards check-session-migration check-screenshot check-release-helper check-shell check-diagnostics check-status check-system-health check-settings \
-	check-quickshell-launcher check-quickshell-controls check-quickshell-controlcenter check-quickshell-design-system check-quickshell-panel-menus check-quickshell-notifications check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-qml check-lightdm-config check-terminal check-xvfb-runtime install install-system install-user \
+	check-quickshell-launcher check-quickshell-controls check-quickshell-controlcenter check-quickshell-design-system check-quickshell-panel-menus check-quickshell-command-menu check-quickshell-notifications check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-qml check-lightdm-config check-terminal check-xvfb-runtime install install-system install-user \
 	install-cursors native release release-check uninstall

--- a/config/quickshell/core/Commands.qml
+++ b/config/quickshell/core/Commands.qml
@@ -31,6 +31,10 @@ Singleton {
         return helperCommand("dwm-quickshell-network", action, args, false);
     }
 
+    function pointerHelperCommand(action) {
+        return helperCommand("dwm-quickshell-pointer", action, [], true);
+    }
+
     function controlsHelperCommand(action, args) {
         return helperCommand("dwm-quickshell-controls", action, args, true);
     }
@@ -41,6 +45,10 @@ Singleton {
 
     function lockHelperCommand() {
         return helperCommand("dwm-lock", undefined, [], true);
+    }
+
+    function screenshotHelperCommand(action) {
+        return helperCommand("dwm-screenshot", action, [], true);
     }
 
     function systemHealthHelperCommand(action, args) {

--- a/config/quickshell/launcher/CommandMenuCatalog.js
+++ b/config/quickshell/launcher/CommandMenuCatalog.js
@@ -1,0 +1,160 @@
+.pragma library
+
+var menus = {
+    "root": [
+        { "id": "apps", "label": "Apps", "detail": "Browse installed applications", "kind": "submenu", "target": "apps", "provider": "applications", "keywords": "applications launch programs", "enabled": true, "current": false },
+        { "id": "settings", "label": "Settings", "detail": "Open desktop settings", "kind": "action", "actionType": "ipc", "target": "settings", "action": "open", "argument": "", "keywords": "preferences configuration", "enabled": true, "current": false },
+        { "id": "display-input", "label": "Display / Input", "detail": "Monitors, keyboard, pointer, and touchpad", "kind": "submenu", "target": "display-input", "keywords": "screen monitor mouse keyboard touchpad", "enabled": true, "current": false },
+        { "id": "network", "label": "Network", "detail": "Wi-Fi and wired connections", "kind": "action", "actionType": "ipc", "target": "network", "action": "open", "argument": "", "keywords": "wifi ethernet vpn connections", "enabled": true, "current": false },
+        { "id": "bluetooth", "label": "Bluetooth", "detail": "Adapters and paired devices", "kind": "action", "actionType": "ipc", "target": "bluetooth", "action": "open", "argument": "", "keywords": "wireless devices paired", "enabled": true, "current": false },
+        { "id": "audio", "label": "Audio", "detail": "Volume, microphone, and media", "kind": "action", "actionType": "ipc", "target": "controls", "action": "open", "argument": "", "keywords": "sound volume microphone media", "enabled": true, "current": false },
+        { "id": "health", "label": "System Health", "detail": "Desktop diagnostics and status", "kind": "action", "actionType": "ipc", "target": "systemhealth", "action": "open", "argument": "", "keywords": "diagnostics status services", "enabled": true, "current": false },
+        { "id": "keybindings", "label": "Keybindings", "detail": "Search the active keyboard shortcuts", "kind": "action", "actionType": "ipc", "target": "controlcenter", "action": "keybindings", "argument": "", "keywords": "hotkeys shortcuts keys", "enabled": true, "current": false },
+        { "id": "screenshots", "label": "Screenshots", "detail": "Capture a monitor, desktop, or region", "kind": "submenu", "target": "screenshots", "keywords": "capture image clipboard", "enabled": true, "current": false },
+        { "id": "system", "label": "System", "detail": "Lock, power, and system settings", "kind": "submenu", "target": "system", "keywords": "lock logout reboot shutdown power", "enabled": true, "current": false }
+    ],
+    "apps": [],
+    "display-input": [
+        { "id": "displays", "label": "Displays", "detail": "Layouts, modes, rotation, and profiles", "kind": "action", "actionType": "ipc", "target": "settings", "action": "select", "argument": "displays", "keywords": "screen monitor resolution refresh", "enabled": true, "current": false },
+        { "id": "input", "label": "Input", "detail": "Keyboard, pointer, and touchpad settings", "kind": "action", "actionType": "ipc", "target": "settings", "action": "select", "argument": "input", "keywords": "mouse keyboard touchpad acceleration", "enabled": true, "current": false }
+    ],
+    "screenshots": [
+        { "id": "screenshot-screen", "label": "Active Monitor", "detail": "Save the monitor containing the pointer", "kind": "action", "actionType": "helper", "target": "screenshot", "action": "screen", "argument": "", "keywords": "capture screen file", "enabled": true, "current": false },
+        { "id": "screenshot-full", "label": "All Monitors", "detail": "Save the complete X11 desktop", "kind": "action", "actionType": "helper", "target": "screenshot", "action": "full", "argument": "", "keywords": "capture desktop file", "enabled": true, "current": false },
+        { "id": "screenshot-region", "label": "Select Region to File", "detail": "Draw a region and save it", "kind": "action", "actionType": "helper", "target": "screenshot", "action": "gui", "argument": "", "keywords": "capture selection area file", "enabled": true, "current": false },
+        { "id": "screenshot-clipboard", "label": "Select Region to Clipboard", "detail": "Draw a region and copy it as PNG", "kind": "action", "actionType": "helper", "target": "screenshot", "action": "clip", "argument": "", "keywords": "capture selection area copy", "enabled": true, "current": false }
+    ],
+    "system": [
+        { "id": "lock", "label": "Lock", "detail": "Secure this session", "kind": "action", "actionType": "helper", "target": "lock", "action": "run", "argument": "", "keywords": "secure session", "enabled": true, "current": false },
+        { "id": "power-menu", "label": "Power Menu", "detail": "Lock, log out, reboot, or shut down", "kind": "action", "actionType": "ipc", "target": "power", "action": "open", "argument": "", "keywords": "logout reboot shutdown", "enabled": true, "current": false },
+        { "id": "power-settings", "label": "Power Settings", "detail": "DPMS, locking, and session policy", "kind": "action", "actionType": "ipc", "target": "settings", "action": "select", "argument": "power", "keywords": "sleep display dpms", "enabled": true, "current": false },
+        { "id": "system-settings", "label": "System Settings", "detail": "Health and administration capabilities", "kind": "action", "actionType": "ipc", "target": "settings", "action": "select", "argument": "system", "keywords": "administration capabilities", "enabled": true, "current": false }
+    ]
+};
+
+var menuLabels = {
+    "root": "Commands",
+    "apps": "Apps",
+    "display-input": "Display / Input",
+    "screenshots": "Screenshots",
+    "system": "System"
+};
+
+function copyEntry(entry) {
+    var copy = {};
+    var keys = Object.keys(entry);
+
+    for (var index = 0; index < keys.length; index++) {
+        copy[keys[index]] = entry[keys[index]];
+    }
+
+    return copy;
+}
+
+function entriesFor(menuId) {
+    var source = menus[menuId] || [];
+    var entries = [];
+
+    for (var index = 0; index < source.length; index++) {
+        entries.push(copyEntry(source[index]));
+    }
+
+    return entries;
+}
+
+function searchableEntries() {
+    var entries = [];
+    var menuIds = Object.keys(menus);
+
+    for (var menuIndex = 0; menuIndex < menuIds.length; menuIndex++) {
+        var menuEntries = menus[menuIds[menuIndex]];
+        for (var entryIndex = 0; entryIndex < menuEntries.length; entryIndex++) {
+            entries.push(copyEntry(menuEntries[entryIndex]));
+        }
+    }
+
+    return entries;
+}
+
+function textScore(text, query) {
+    if (query.length === 0) return 1;
+    if (text === query) return 10000;
+    if (text.indexOf(query) === 0) return 5000;
+
+    var words = text.split(/[\s._/-]+/);
+    for (var wordIndex = 0; wordIndex < words.length; wordIndex++) {
+        if (words[wordIndex].indexOf(query) === 0) return 3000;
+    }
+
+    if (text.indexOf(query) >= 0) return 1000;
+
+    var offset = 0;
+    for (var queryIndex = 0; queryIndex < query.length; queryIndex++) {
+        offset = text.indexOf(query.charAt(queryIndex), offset);
+        if (offset < 0) return 0;
+        offset++;
+    }
+
+    return 250;
+}
+
+function score(entry, query) {
+    var needle = query.trim().toLowerCase();
+    var label = String(entry.label || "").toLowerCase();
+    var detail = String(entry.detail || "").toLowerCase();
+    var keywords = String(entry.keywords || "").toLowerCase();
+
+    return Math.max(
+        textScore(label, needle),
+        textScore(detail, needle) * 0.65,
+        textScore(keywords, needle) * 0.55
+    );
+}
+
+function filterAndSort(entries, query) {
+    var matches = [];
+    var needle = query.trim().toLowerCase();
+
+    for (var index = 0; index < entries.length; index++) {
+        var entry = copyEntry(entries[index]);
+        entry.menuScore = score(entry, needle);
+        if (entry.menuScore > 0) matches.push(entry);
+    }
+
+    matches.sort(function(left, right) {
+        if (right.menuScore !== left.menuScore) return right.menuScore - left.menuScore;
+        return String(left.label || "").localeCompare(String(right.label || ""));
+    });
+
+    return matches;
+}
+
+function isSelectable(entry) {
+    return entry && entry.enabled !== false && entry.kind !== "status";
+}
+
+function nextSelectable(entries, start, delta) {
+    if (entries.length === 0) return 0;
+
+    var direction = delta < 0 ? -1 : 1;
+    var index = start;
+
+    for (var count = 0; count < entries.length; count++) {
+        index = (index + direction + entries.length) % entries.length;
+        if (isSelectable(entries[index])) return index;
+    }
+
+    return Math.max(0, Math.min(start, entries.length - 1));
+}
+
+function firstSelectable(entries) {
+    for (var index = 0; index < entries.length; index++) {
+        if (isSelectable(entries[index])) return index;
+    }
+
+    return 0;
+}
+
+function breadcrumb(menuId) {
+    return menuId === "root" ? menuLabels.root : menuLabels.root + " / " + (menuLabels[menuId] || menuId);
+}

--- a/config/quickshell/launcher/CommandMenuModel.qml
+++ b/config/quickshell/launcher/CommandMenuModel.qml
@@ -1,0 +1,241 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.core
+import "CommandMenuCatalog.js" as Catalog
+
+Scope {
+    id: root
+
+    required property var launcherModel
+
+    property bool visible: false
+    property string query: ""
+    property string activeMenu: "root"
+    property var targetScreen: null
+    property var rows: []
+    property var currentEntryIds: []
+    property int selectedIndex: 0
+    readonly property string breadcrumb: Catalog.breadcrumb(root.activeMenu)
+    readonly property string selectedLabel: root.rows.length > 0
+        && root.selectedIndex >= 0
+        && root.selectedIndex < root.rows.length
+        ? root.rows[root.selectedIndex].label : ""
+
+    signal ipcActionRequested(string target, string action, string argument, var screen)
+
+    function applicationEntry(app) {
+        return {
+            "id": "application:" + app.desktopFile,
+            "label": app.name,
+            "detail": app.generic.length > 0 ? app.generic : app.comment,
+            "kind": "application",
+            "actionType": "application",
+            "target": "launcher",
+            "action": "launch",
+            "argument": app.desktopFile,
+            "keywords": [app.generic, app.comment, app.keywords, app.categories, app.startupWmClass, app.exec].join(" "),
+            "enabled": true,
+            "current": false,
+            "app": app
+        };
+    }
+
+    function applicationEntries() {
+        const entries = [];
+
+        for (const app of root.launcherModel.apps) {
+            entries.push(root.applicationEntry(app));
+        }
+
+        return entries;
+    }
+
+    function placeholderEntry() {
+        const loading = root.launcherModel.status === "Loading applications...";
+        return {
+            "id": loading ? "apps-loading" : "apps-empty",
+            "label": loading ? "Loading applications..." : "No applications found",
+            "detail": loading ? "Reading XDG desktop entries" : "No launchable desktop entries matched",
+            "kind": "status",
+            "enabled": false,
+            "current": false
+        };
+    }
+
+    function applyCurrentStates(entries) {
+        for (let index = 0; index < entries.length; index++) {
+            entries[index].current = root.currentEntryIds.indexOf(entries[index].id) >= 0;
+        }
+
+        return entries;
+    }
+
+    function refreshRows() {
+        if (!root.visible) {
+            root.rows = [];
+            root.selectedIndex = 0;
+            return;
+        }
+
+        let entries;
+        if (root.query.trim().length > 0) {
+            entries = Catalog.searchableEntries().concat(root.applicationEntries());
+            entries = Catalog.filterAndSort(entries, root.query);
+        } else if (root.activeMenu === "apps") {
+            entries = root.applicationEntries();
+            if (entries.length === 0) entries = [root.placeholderEntry()];
+        } else {
+            entries = Catalog.entriesFor(root.activeMenu);
+        }
+
+        root.rows = root.applyCurrentStates(entries);
+        root.selectedIndex = Catalog.firstSelectable(entries);
+    }
+
+    function openWindow() {
+        const wasVisible = root.visible;
+
+        root.visible = true;
+        root.query = "";
+        root.activeMenu = "root";
+        root.selectedIndex = 0;
+        if (!wasVisible) root.launcherModel.acquireApplications();
+        root.refreshRows();
+    }
+
+    function open() {
+        root.targetScreen = null;
+        root.openWindow();
+    }
+
+    function openOnScreen(screen) {
+        root.targetScreen = screen;
+        root.openWindow();
+    }
+
+    function close() {
+        const wasVisible = root.visible;
+
+        root.visible = false;
+        root.query = "";
+        root.activeMenu = "root";
+        root.rows = [];
+        root.selectedIndex = 0;
+        if (wasVisible) root.launcherModel.releaseApplications();
+    }
+
+    function toggle() {
+        if (root.visible) root.close(); else root.open();
+    }
+
+    function toggleOnScreen(screen) {
+        if (root.visible) root.close(); else root.openOnScreen(screen);
+    }
+
+    function setQuery(value) {
+        root.query = value;
+        root.refreshRows();
+    }
+
+    function selectRelative(delta) {
+        if (root.rows.length === 0 || delta === 0) return;
+
+        const direction = delta < 0 ? -1 : 1;
+        const steps = Math.abs(delta);
+        let index = root.selectedIndex;
+
+        for (let step = 0; step < steps; step++) {
+            index = Catalog.nextSelectable(root.rows, index, direction);
+        }
+
+        root.selectedIndex = index;
+    }
+
+    function selectAbsolute(index) {
+        if (root.rows.length === 0) return;
+
+        let candidate = Math.max(0, Math.min(index, root.rows.length - 1));
+        if (!Catalog.isSelectable(root.rows[candidate])) {
+            candidate = Catalog.nextSelectable(root.rows, candidate, 1);
+        }
+        root.selectedIndex = candidate;
+    }
+
+    function openSubmenu(menuId) {
+        root.activeMenu = menuId;
+        root.query = "";
+        root.refreshRows();
+    }
+
+    function navigateBack() {
+        if (root.query.length > 0) {
+            root.setQuery("");
+            return true;
+        }
+        if (root.activeMenu !== "root") {
+            root.activeMenu = "root";
+            root.refreshRows();
+            return true;
+        }
+        return false;
+    }
+
+    function runHelper(entry) {
+        if (actionProcess.running) return;
+
+        if (entry.target === "screenshot") {
+            actionProcess.command = Commands.screenshotHelperCommand(entry.action);
+        } else if (entry.target === "lock") {
+            actionProcess.command = Commands.lockHelperCommand();
+        } else {
+            return;
+        }
+
+        root.close();
+        actionProcess.running = true;
+    }
+
+    function activate(entry) {
+        if (!Catalog.isSelectable(entry)) return;
+
+        if (entry.kind === "submenu") {
+            root.openSubmenu(entry.target);
+        } else if (entry.actionType === "application") {
+            root.launcherModel.launchApp(entry.app);
+            root.close();
+        } else if (entry.actionType === "helper") {
+            root.runHelper(entry);
+        } else if (entry.actionType === "ipc") {
+            const actionScreen = root.targetScreen;
+            root.close();
+            root.ipcActionRequested(entry.target, entry.action, entry.argument || "", actionScreen);
+        }
+    }
+
+    function activateSelected() {
+        if (root.selectedIndex < 0 || root.selectedIndex >= root.rows.length) return;
+        root.activate(root.rows[root.selectedIndex]);
+    }
+
+    Connections {
+        target: root.launcherModel
+
+        function onAppsChanged() {
+            root.refreshRows();
+        }
+
+        function onStatusChanged() {
+            if (root.activeMenu === "apps") root.refreshRows();
+        }
+    }
+
+    onCurrentEntryIdsChanged: root.refreshRows()
+
+    Process {
+        id: actionProcess
+
+        command: ["true"]
+        running: false
+    }
+}

--- a/config/quickshell/launcher/CommandMenuRow.qml
+++ b/config/quickshell/launcher/CommandMenuRow.qml
@@ -1,0 +1,97 @@
+import QtQuick
+import QtQuick.Layouts
+import Quickshell.Widgets
+import qs.core
+
+Rectangle {
+    id: root
+
+    required property int index
+    required property var modelData
+    required property bool selected
+    required property var commandMenuModel
+
+    height: Theme.controlRowHeight + Theme.spacingHuge
+    radius: Theme.controlRadius
+    color: root.selected
+        ? Theme.menuSelectedBackground
+        : mouseArea.containsMouse ? Theme.menuHoverBackground : Theme.transparent
+    opacity: root.modelData.enabled === false ? 0.55 : 1.0
+
+    MouseArea {
+        id: mouseArea
+
+        anchors.fill: parent
+        hoverEnabled: true
+        cursorShape: root.modelData.enabled === false ? Qt.ArrowCursor : Qt.PointingHandCursor
+        onEntered: {
+            if (root.modelData.enabled !== false) root.commandMenuModel.selectAbsolute(root.index);
+        }
+        onClicked: root.commandMenuModel.activate(root.modelData)
+    }
+
+    RowLayout {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.leftMargin: Theme.controlPaddingX + Theme.spacingSm
+        anchors.rightMargin: Theme.controlPaddingX + Theme.spacingSm
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: Theme.rowSpacing
+
+        Item {
+            Layout.preferredWidth: Theme.iconSize
+            Layout.preferredHeight: Theme.iconSize
+            Layout.alignment: Qt.AlignVCenter
+
+            IconImage {
+                anchors.fill: parent
+                source: root.modelData.kind === "application"
+                    ? Icons.launcherIcon(root.modelData.app.icon) : ""
+                visible: root.modelData.kind === "application"
+            }
+
+            Text {
+                anchors.centerIn: parent
+                text: root.modelData.kind === "submenu" ? ">" : root.modelData.current ? "*" : "-"
+                visible: root.modelData.kind !== "application"
+                color: root.selected ? Theme.menuSelectedText : Theme.menuActionText
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.bodyFontSize
+                font.bold: true
+            }
+        }
+
+        Column {
+            Layout.fillWidth: true
+            spacing: Theme.tightSpacing
+
+            Text {
+                width: parent.width
+                text: root.modelData.label
+                color: root.selected ? Theme.menuSelectedText : Theme.menuText
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.bodyFontSize
+                font.bold: root.selected || root.modelData.current
+                elide: Text.ElideRight
+            }
+
+            Text {
+                width: parent.width
+                text: root.modelData.detail || ""
+                color: root.selected ? Theme.menuSelectedText : Theme.menuMutedText
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.smallFontSize
+                elide: Text.ElideRight
+                visible: text.length > 0
+            }
+        }
+
+        Text {
+            Layout.alignment: Qt.AlignVCenter
+            text: root.modelData.kind === "submenu" ? ">" : root.modelData.current ? "Current" : ""
+            color: root.selected ? Theme.menuSelectedText : Theme.menuMutedText
+            font.family: Theme.fontFamily
+            font.pixelSize: Theme.smallFontSize
+        }
+    }
+}

--- a/config/quickshell/launcher/CommandMenuWindow.qml
+++ b/config/quickshell/launcher/CommandMenuWindow.qml
@@ -1,0 +1,181 @@
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Io
+import qs.core
+
+pragma ComponentBehavior: Bound
+
+FloatingWindow {
+    id: root
+
+    required property var commandMenuModel
+
+    title: "dwm menu"
+    visible: commandMenuModel.visible
+    screen: commandMenuModel.targetScreen
+    implicitWidth: 720
+    implicitHeight: 600
+    color: Theme.transparent
+
+    function focusSearch() {
+        commandSearch.text = root.commandMenuModel.query;
+        commandSearch.forceActiveFocus();
+        commandSearch.cursorPosition = commandSearch.text.length;
+        pointerWarpProcess.running = false;
+        pointerWarpProcess.running = true;
+    }
+
+    onVisibleChanged: {
+        if (visible) Qt.callLater(root.focusSearch);
+    }
+
+    Process {
+        id: pointerWarpProcess
+
+        command: Commands.pointerHelperCommand("command-menu")
+    }
+
+    ShellSurface {
+        anchors.fill: parent
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: Theme.popupSpacing
+
+            RowLayout {
+                Layout.fillWidth: true
+
+                Text {
+                    Layout.fillWidth: true
+                    text: root.commandMenuModel.breadcrumb
+                    color: Theme.text
+                    font.family: Theme.fontFamily
+                    font.pixelSize: Theme.titleFontSize
+                    font.bold: true
+                    elide: Text.ElideRight
+                }
+
+                Text {
+                    text: root.commandMenuModel.rows.length === 1
+                        ? "1 item" : root.commandMenuModel.rows.length + " items"
+                    color: Theme.textMuted
+                    font.family: Theme.fontFamily
+                    font.pixelSize: Theme.smallFontSize
+                }
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 42
+                color: Theme.controlNormalFill
+                border.color: commandSearch.activeFocus ? Theme.controlFocusBorder : Theme.controlNormalBorder
+                border.width: commandSearch.activeFocus ? Theme.controlFocusBorderWidth : Theme.controlBorderWidth
+                radius: Theme.controlRadius
+
+                TextInput {
+                    id: commandSearch
+
+                    anchors.fill: parent
+                    anchors.leftMargin: Theme.controlPaddingX + Theme.spacingSm
+                    anchors.rightMargin: Theme.controlPaddingX + Theme.spacingSm
+                    verticalAlignment: TextInput.AlignVCenter
+                    color: Theme.textStrong
+                    selectionColor: Theme.accent
+                    selectedTextColor: Theme.accentText
+                    font.family: Theme.fontFamily
+                    font.pixelSize: Theme.inputFontSize
+                    clip: true
+
+                    onTextChanged: {
+                        if (text !== root.commandMenuModel.query) root.commandMenuModel.setQuery(text);
+                    }
+
+                    Keys.onPressed: function(event) {
+                        const ctrl = event.modifiers & Qt.ControlModifier;
+
+                        if (event.key === Qt.Key_Down || (event.key === Qt.Key_N && ctrl)) {
+                            root.commandMenuModel.selectRelative(1);
+                            event.accepted = true;
+                        } else if (event.key === Qt.Key_Up || (event.key === Qt.Key_P && ctrl)) {
+                            root.commandMenuModel.selectRelative(-1);
+                            event.accepted = true;
+                        } else if (event.key === Qt.Key_PageDown) {
+                            root.commandMenuModel.selectRelative(8);
+                            event.accepted = true;
+                        } else if (event.key === Qt.Key_PageUp) {
+                            root.commandMenuModel.selectRelative(-8);
+                            event.accepted = true;
+                        } else if (event.key === Qt.Key_Home) {
+                            root.commandMenuModel.selectAbsolute(0);
+                            event.accepted = true;
+                        } else if (event.key === Qt.Key_End) {
+                            root.commandMenuModel.selectAbsolute(root.commandMenuModel.rows.length - 1);
+                            event.accepted = true;
+                        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                            root.commandMenuModel.activateSelected();
+                            event.accepted = true;
+                        } else if ((event.key === Qt.Key_Left || event.key === Qt.Key_Backspace) && text.length === 0) {
+                            event.accepted = root.commandMenuModel.navigateBack();
+                        } else if (event.key === Qt.Key_Escape) {
+                            root.commandMenuModel.close();
+                            event.accepted = true;
+                        }
+                    }
+                }
+
+                Text {
+                    anchors.left: parent.left
+                    anchors.leftMargin: Theme.controlPaddingX + Theme.spacingSm
+                    anchors.verticalCenter: parent.verticalCenter
+                    visible: commandSearch.text.length === 0
+                    text: "Type to search commands and applications"
+                    color: Theme.placeholder
+                    font.family: Theme.fontFamily
+                    font.pixelSize: Theme.inputFontSize
+                }
+            }
+
+            ListView {
+                id: commandResults
+
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                clip: true
+                spacing: Theme.listSpacing
+                model: root.commandMenuModel.rows
+
+                Connections {
+                    target: root.commandMenuModel
+
+                    function onQueryChanged() {
+                        if (commandSearch.text !== root.commandMenuModel.query) {
+                            commandSearch.text = root.commandMenuModel.query;
+                        }
+                    }
+
+                    function onSelectedIndexChanged() {
+                        if (root.commandMenuModel.rows.length > 0) {
+                            commandResults.positionViewAtIndex(root.commandMenuModel.selectedIndex, ListView.Contain);
+                        }
+                    }
+                }
+
+                delegate: CommandMenuRow {
+                    width: commandResults.width
+                    selected: index === root.commandMenuModel.selectedIndex
+                    commandMenuModel: root.commandMenuModel
+                }
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: "Enter select  |  Left/Backspace back  |  Esc close"
+                color: Theme.textMuted
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.smallFontSize
+                horizontalAlignment: Text.AlignRight
+            }
+        }
+    }
+}

--- a/config/quickshell/launcher/LauncherModel.qml
+++ b/config/quickshell/launcher/LauncherModel.qml
@@ -14,6 +14,8 @@ Scope {
     property var apps: []
     property var categories: []
     property var filteredApps: []
+    property int applicationConsumers: 0
+    readonly property bool applicationIndexActive: root.visible || root.applicationConsumers > 0
 
     function categoryLabel(category) {
         const labels = {
@@ -132,6 +134,11 @@ Scope {
     }
 
     function parseApps(text) {
+        if (!root.applicationIndexActive) {
+            root.clearApplicationIndex();
+            return;
+        }
+
         const apps = [];
         const categoryCounts = {};
         const lines = text.trim().length > 0 ? text.trim().split("\n") : [];
@@ -185,6 +192,41 @@ Scope {
         root.refreshFilteredApps();
     }
 
+    function clearApplicationIndex() {
+        root.apps = [];
+        root.categories = [];
+        root.filteredApps = [];
+        root.status = "Loading applications...";
+        root.selectedIndex = 0;
+    }
+
+    function ensureApplicationIndex() {
+        if (root.apps.length === 0 && !indexProcess.running) {
+            root.status = "Loading applications...";
+            indexProcess.running = true;
+        }
+    }
+
+    function refreshApplicationIndex() {
+        if (indexProcess.running) return;
+
+        root.status = "Loading applications...";
+        indexProcess.running = true;
+    }
+
+    function acquireApplications() {
+        root.applicationConsumers++;
+        root.ensureApplicationIndex();
+    }
+
+    function releaseApplications() {
+        root.applicationConsumers = Math.max(0, root.applicationConsumers - 1);
+        if (!root.applicationIndexActive) {
+            indexProcess.running = false;
+            root.clearApplicationIndex();
+        }
+    }
+
     function openWindow() {
         root.visible = true;
         root.query = "";
@@ -192,9 +234,7 @@ Scope {
         root.selectedIndex = 0;
         root.status = "Loading applications...";
         root.refreshFilteredApps();
-        if (!indexProcess.running) {
-            indexProcess.running = true;
-        }
+        root.refreshApplicationIndex();
     }
 
     function open() {
@@ -213,6 +253,10 @@ Scope {
         root.category = "all";
         root.filteredApps = [];
         root.selectedIndex = 0;
+        if (!root.applicationIndexActive) {
+            indexProcess.running = false;
+            root.clearApplicationIndex();
+        }
     }
 
     function toggle() {

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -34,12 +34,69 @@ ShellRoot {
             return;
         }
 
+        commandMenuModel.close();
         if (popupId !== "bluetooth") bluetoothModel.close();
         if (popupId !== "controlcenter") controlCenterModel.close();
         if (popupId !== "controls") controlsModel.close();
         if (popupId !== "network") networkModel.close();
         if (popupId !== "power") powerMenuModel.close();
         root.selectedPanelWindow = panel;
+    }
+
+    function openCommandMenu(screen) {
+        networkModel.close();
+        bluetoothModel.close();
+        controlCenterModel.close();
+        controlsModel.close();
+        powerMenuModel.close();
+        launcherModel.close();
+        if (screen) commandMenuModel.openOnScreen(screen); else commandMenuModel.open();
+    }
+
+    function toggleCommandMenu(screen) {
+        if (commandMenuModel.visible) {
+            commandMenuModel.close();
+        } else {
+            root.openCommandMenu(screen);
+        }
+    }
+
+    function panelForScreen(screen) {
+        if (screen) {
+            for (const panel of panelVariants.instances) {
+                if (panel.screen === screen || (panel.screen && panel.screen.name === screen.name)) {
+                    return panel;
+                }
+            }
+        }
+
+        return root.activePanelWindow;
+    }
+
+    function runCommandMenuAction(target, action, argument, requestedScreen) {
+        const panel = root.panelForScreen(requestedScreen);
+        const screen = requestedScreen || (panel ? panel.screen : root.activePanelScreen);
+
+        if (target === "settings" && (action === "open" || action === "select")) {
+            settingsModel.openOnScreen(screen);
+            if (action === "select") settingsModel.selectSection(argument);
+        } else if (target === "network" && action === "open") {
+            if (panel) root.selectPanelPopup(panel, "network");
+            networkModel.open();
+        } else if (target === "bluetooth" && action === "open") {
+            if (panel) root.selectPanelPopup(panel, "bluetooth");
+            bluetoothModel.open();
+        } else if (target === "controls" && action === "open") {
+            if (panel) root.selectPanelPopup(panel, "controls");
+            controlsModel.open();
+        } else if (target === "systemhealth" && action === "open") {
+            systemHealthModel.openOnScreen(screen);
+        } else if (target === "controlcenter" && action === "keybindings") {
+            controlCenterModel.openKeybindsOnScreen(screen);
+        } else if (target === "power" && action === "open") {
+            if (panel) root.selectPanelPopup(panel, "power");
+            powerMenuModel.open("panel");
+        }
     }
 
     DwmState {
@@ -54,6 +111,44 @@ ShellRoot {
 
     LauncherModel {
         id: launcherModel
+
+        onVisibleChanged: {
+            if (visible) commandMenuModel.close();
+        }
+    }
+
+    CommandMenuModel {
+        id: commandMenuModel
+        launcherModel: launcherModel
+        currentEntryIds: {
+            const ids = [];
+
+            if (settingsModel.visible) {
+                ids.push("settings");
+                if (settingsModel.selectedSectionId === "displays" || settingsModel.selectedSectionId === "input") {
+                    ids.push(settingsModel.selectedSectionId);
+                    ids.push("display-input");
+                } else if (settingsModel.selectedSectionId === "power") {
+                    ids.push("system");
+                    ids.push("power-settings");
+                } else if (settingsModel.selectedSectionId === "system") {
+                    ids.push("system");
+                    ids.push("system-settings");
+                }
+            }
+            if (networkModel.visible) ids.push("network");
+            if (bluetoothModel.visible) ids.push("bluetooth");
+            if (controlsModel.visible) ids.push("audio");
+            if (systemHealthModel.visible) ids.push("health");
+            if (controlCenterModel.utilityVisible && controlCenterModel.utilityPage === "keybinds") ids.push("keybindings");
+            if (powerMenuModel.visible) {
+                ids.push("system");
+                ids.push("power-menu");
+            }
+
+            return ids;
+        }
+        onIpcActionRequested: (target, action, argument, screen) => root.runCommandMenuAction(target, action, argument, screen)
     }
 
     PowerMenuModel {
@@ -102,8 +197,16 @@ ShellRoot {
     IpcHandler {
         target: "launcher"
 
+        function applicationConsumers(): int {
+            return launcherModel.applicationConsumers;
+        }
+
         function close(): void {
             launcherModel.close();
+        }
+
+        function indexCount(): int {
+            return launcherModel.apps.length;
         }
 
         function open(): void {
@@ -112,6 +215,38 @@ ShellRoot {
 
         function toggle(): void {
             launcherModel.toggle();
+        }
+    }
+
+    IpcHandler {
+        target: "menu"
+
+        function activeMenu(): string {
+            return commandMenuModel.activeMenu;
+        }
+
+        function close(): void {
+            commandMenuModel.close();
+        }
+
+        function open(): void {
+            root.openCommandMenu(null);
+        }
+
+        function resultCount(): int {
+            return commandMenuModel.rows.length;
+        }
+
+        function selectedLabel(): string {
+            return commandMenuModel.selectedLabel;
+        }
+
+        function summon(): void {
+            root.openCommandMenu(dwmState.focusedScreen());
+        }
+
+        function toggle(): void {
+            root.toggleCommandMenu(null);
         }
     }
 
@@ -390,6 +525,10 @@ ShellRoot {
 
     LauncherWindow {
         launcherModel: launcherModel
+    }
+
+    CommandMenuWindow {
+        commandMenuModel: commandMenuModel
     }
 
     PowerMenuWindow {

--- a/config/quickshell/state/DwmState.qml
+++ b/config/quickshell/state/DwmState.qml
@@ -5,6 +5,7 @@ Scope {
     id: root
 
     property int currentWorkspace: 0
+    property int focusedMonitorIndex: -1
     property var monitorWorkspaceRows: []
     property var workspaceNames: ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     property var occupiedWorkspaces: []
@@ -49,6 +50,10 @@ Scope {
                     });
                 }
                 root.monitorWorkspaceRows = rows;
+            } else if (key === "focused_monitor") {
+                const parsed = parseInt(value, 10);
+
+                root.focusedMonitorIndex = isNaN(parsed) ? -1 : parsed;
             } else if (key === "names") {
                 root.workspaceNames = value.length > 0 ? value.split("|") : [];
             } else if (key === "occupied") {
@@ -107,6 +112,43 @@ Scope {
         }
 
         return 0;
+    }
+
+    function screenForMonitorIndex(monitorIndex) {
+        if (monitorIndex < 0 || monitorIndex >= root.monitorWorkspaceRows.length) {
+            return Quickshell.screens.length > 0 ? Quickshell.screens[0] : null;
+        }
+
+        const row = root.monitorWorkspaceRows[monitorIndex];
+        for (let screenIndex = 0; screenIndex < Quickshell.screens.length; screenIndex++) {
+            const screen = Quickshell.screens[screenIndex];
+            const pixelRatio = screen.devicePixelRatio > 0 ? screen.devicePixelRatio : 1;
+            const logicalMatch = row.x === screen.x && row.y === screen.y
+                && row.width === screen.width && row.height === screen.height;
+            const pixelMatch = row.x === Math.round(screen.x) && row.y === Math.round(screen.y)
+                && row.width === Math.round(screen.width * pixelRatio)
+                && row.height === Math.round(screen.height * pixelRatio);
+
+            if (logicalMatch || pixelMatch) return screen;
+        }
+
+        return monitorIndex < Quickshell.screens.length
+            ? Quickshell.screens[monitorIndex]
+            : (Quickshell.screens.length > 0 ? Quickshell.screens[0] : null);
+    }
+
+    function focusedScreen() {
+        if (root.focusedMonitorIndex >= 0) {
+            return root.screenForMonitorIndex(root.focusedMonitorIndex);
+        }
+
+        for (let index = 0; index < root.monitorWorkspaceRows.length; index++) {
+            if (root.monitorWorkspaceRows[index].desktop === root.currentWorkspace) {
+                return root.screenForMonitorIndex(index);
+            }
+        }
+
+        return Quickshell.screens.length > 0 ? Quickshell.screens[0] : null;
     }
 
     function workspaceIndexes(screen) {

--- a/config/window-rules.toml
+++ b/config/window-rules.toml
@@ -36,6 +36,7 @@ rules = [
   # PopupWindow surfaces are override-redirect transients and are stacked by
   # dwm directly. Managed FloatingWindow surfaces still use their titles.
   { title="dwm launcher",             isfloating=1, alwaysontop=1 },
+  { title="dwm menu",                 isfloating=1, alwaysontop=1 },
   { title="dwm network password",     isfloating=1, alwaysontop=1 },
   { title="dwm control center utility", isfloating=1, alwaysontop=1 },
   { title="dwm system health",        isfloating=1, alwaysontop=1 },

--- a/docs/OMARCHY-UI-ADAPTATION.md
+++ b/docs/OMARCHY-UI-ADAPTATION.md
@@ -77,10 +77,56 @@ The static design-system check rejects Wayland and Hyprland dependencies in
 the managed shell. The Quickshell lint and X11 runtime checks remain the
 authoritative syntax and integration gates.
 
+## Command Menu Contract
+
+The command menu is a DWM-owned navigation surface, not an Omarchy service
+port. Its root taxonomy is Apps, Settings, Display / Input, Network,
+Bluetooth, Audio, System Health, Keybindings, Screenshots, and System.
+Submenus and actions are typed data. Actions may call an allowlisted shell IPC
+operation, a fixed helper argument vector, or the existing XDG application
+launcher provider; catalog entries cannot contain executable command text.
+
+The `menu` IPC target provides `open`, `close`, `toggle`, and `summon`.
+`summon` targets the focused DWM screen, while `open` preserves the normal
+floating-window screen selection. The existing `launcher` IPC target and
+Super+r binding remain unchanged for compatibility.
+
+Open the menu on the focused DWM screen from a terminal or a user-defined
+hotkey:
+
+```sh
+quickshell ipc --path "${XDG_CONFIG_HOME:-$HOME/.config}/quickshell/shell.qml" call menu summon
+```
+
+Apps enters the shared XDG application provider. Display / Input,
+Screenshots, and System enter focused submenus; the other root rows open their
+existing dwm-titus surface directly. Type to search commands and applications
+across the catalog.
+
+Existing `window-rules.toml` files remain user-owned and are preserved during
+upgrades. If the file predates the command menu, add this entry inside its
+`rules` array so the managed window floats above tiled clients:
+
+```toml
+{ title="dwm menu", isfloating=1, alwaysontop=1 },
+```
+
+Saving the file applies the rule through DWM's normal hot reload. A customized
+rule with the same title can be retained instead.
+
+The application index is shared only while either surface is open. Closing
+the launcher and command menu releases its parsed desktop-entry data so the
+new menu does not add a hidden resident application model. Keyboard behavior
+includes type-to-search, arrows, Page Up/Down, Home/End, Enter, Left or empty
+Backspace to return, and Escape to close. Opening the menu moves the pointer
+into its search field so DWM's pointer-following focus cannot immediately hand
+keyboard input back to the window that was previously under the pointer.
+
 Run the focused source contract with:
 
 ```sh
 make check-quickshell-design-system
+make check-quickshell-command-menu
 ```
 
 It is also part of the repository-wide `make check` gate. QML changes still

--- a/dwm.c
+++ b/dwm.c
@@ -84,7 +84,7 @@ enum { NetSupported, NetWMName, NetWMState, NetWMCheck,
        NetWMWindowTypeMenu, NetWMWindowTypePopupMenu, NetWMWindowTypeDropdownMenu,
        NetWMWindowTypeCombo, NetWMWindowTypeDnd,
        NetClientList, NetDesktopNames, NetDesktopViewport, NetNumberOfDesktops, NetCurrentDesktop,
-       NetWMDesktop, NetDwmMonitorDesktops, NetLast }; /* EWMH atoms */
+       NetWMDesktop, NetDwmMonitorDesktops, NetDwmSelectedMonitor, NetLast }; /* EWMH atoms */
 enum { WMProtocols, WMDelete, WMState, WMTakeFocus, WMLast }; /* default atoms */
 enum { ClkTagBar, ClkLtSymbol, ClkStatusText, ClkWinTitle,
        ClkClientWin, ClkRootWin, ClkLast }; /* clicks */
@@ -336,6 +336,7 @@ static void setdesktopnames(void);
 static void setnumdesktops(void);
 static void setviewport(void);
 static void updatecurrentdesktop(void);
+static void updateselectedmonitor(void);
 
 /* External dock and systray declarations */
 static void managealtbar(Window win, XWindowAttributes *wa);
@@ -412,6 +413,8 @@ static xcb_connection_t *xcon;
 static Window *clientlistcache;
 static unsigned long clientlistcachelen;
 static int clientlistcachevalid;
+static int selectedmonitorcache;
+static int selectedmonitorcachevalid;
 static Atom dwmfullscreenmonitorsatom, dwmtagupdateatom;
 static unsigned long tagupdatesequence;
 
@@ -1043,6 +1046,7 @@ configurenotify(XEvent *e)
 		sw = ev->width;
 		sh = ev->height;
 		if (updategeom() || dirty) {
+			selectedmonitorcachevalid = 0;
 			reconcilemonitortags();
 			drw_resize(drw, sw, bh);
 			updatebars();
@@ -1373,6 +1377,7 @@ focus(Client *c)
 		ewmh_clear_active_window();
 	}
 	selmon->sel = c;
+	updateselectedmonitor();
 	drawbars();
 }
 
@@ -4081,6 +4086,7 @@ setup(void)
 	netatom[NetDesktopNames] = XInternAtom(dpy, "_NET_DESKTOP_NAMES", False);
 	netatom[NetWMDesktop] = XInternAtom(dpy, "_NET_WM_DESKTOP", False);
 	netatom[NetDwmMonitorDesktops] = XInternAtom(dpy, "_DWM_MONITOR_DESKTOPS", False);
+	netatom[NetDwmSelectedMonitor] = XInternAtom(dpy, "_DWM_SELECTED_MONITOR", False);
 	dwmfullscreenmonitorsatom = XInternAtom(dpy, "_DWM_FULLSCREEN_MONITORS", False);
 	dwmtagupdateatom = XInternAtom(dpy, "DWM_TAG_UPDATE", False);
 	/* init cursors */
@@ -4897,7 +4903,26 @@ updatecurrentdesktop(void)
 	XChangeProperty(dpy, root, netatom[NetDwmMonitorDesktops], XA_INTEGER, 32,
 		PropModeReplace, (unsigned char *)monitor_desktops, count * 5);
 	free(monitor_desktops);
+	updateselectedmonitor();
 	updatefullscreenmonitors();
+}
+
+void
+updateselectedmonitor(void)
+{
+	long data[] = { 0 };
+	int logicalindex;
+
+	if (!selmon)
+		return;
+	logicalindex = getmonlogicalindex(selmon);
+	if (logicalindex < 0
+	|| (selectedmonitorcachevalid && logicalindex == selectedmonitorcache))
+		return;
+	data[0] = logicalindex;
+	ewmh_replace_root_cardinal(netatom[NetDwmSelectedMonitor], data, 1);
+	selectedmonitorcache = logicalindex;
+	selectedmonitorcachevalid = 1;
 }
 
 #if SHOWWINICON

--- a/scripts/dwm-quickshell-pointer
+++ b/scripts/dwm-quickshell-pointer
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -eu
+
+case ${1:-} in
+command-menu)
+	window_name='^dwm menu$'
+	pointer_x=360
+	pointer_y=85
+	;;
+*)
+	printf 'usage: %s command-menu\n' "$0" >&2
+	exit 2
+	;;
+esac
+
+command -v xdotool >/dev/null 2>&1 || {
+	printf '%s: xdotool is required\n' "$0" >&2
+	exit 1
+}
+
+attempt=0
+while [ "$attempt" -lt 40 ]; do
+	if xdotool search --onlyvisible --name "$window_name" \
+		mousemove --window %@ "$pointer_x" "$pointer_y" >/dev/null 2>&1; then
+		exit 0
+	fi
+	attempt=$((attempt + 1))
+	sleep 0.025
+done
+
+printf '%s: command menu window did not become visible\n' "$0" >&2
+exit 1

--- a/scripts/dwm-quickshell-state
+++ b/scripts/dwm-quickshell-state
@@ -164,9 +164,11 @@ show_state() {
 			tr -d '[:space:]'
 	)
 	monitor_desktops=${monitor_desktops:-$current}
+	focused_monitor=$(root_property_value _DWM_SELECTED_MONITOR | awk '{ print $1; exit }')
 
 	printf 'current=%s\n' "$current"
 	printf 'monitor_desktops=%s\n' "$monitor_desktops"
+	printf 'focused_monitor=%s\n' "$focused_monitor"
 	printf 'count=%s\n' "$count"
 	printf 'names=%s\n' "$names"
 	printf 'occupied=%s\n' "$occupied"
@@ -186,6 +188,7 @@ watch_state() {
 		xprop -root -spy \
 			DWM_TAG_UPDATE \
 			_DWM_MONITOR_DESKTOPS \
+			_DWM_SELECTED_MONITOR \
 			_NET_NUMBER_OF_DESKTOPS \
 			_NET_DESKTOP_NAMES \
 			_NET_ACTIVE_WINDOW \

--- a/tests/quickshell-command-menu-catalog.qml
+++ b/tests/quickshell-command-menu-catalog.qml
@@ -1,0 +1,48 @@
+import QtQml
+import "../config/quickshell/launcher/CommandMenuCatalog.js" as Catalog
+
+QtObject {
+    function require(condition, message) {
+        if (!condition) throw new Error(message);
+    }
+
+    Component.onCompleted: {
+        try {
+            const rootEntries = Catalog.entriesFor("root");
+            require(rootEntries.length === 10, "root taxonomy must contain ten entries");
+            require(rootEntries[0].label === "Apps", "Apps must lead the root menu");
+            require(rootEntries[0].provider === "applications", "Apps must declare its dynamic provider");
+            require(Catalog.entriesFor(rootEntries[0].target).length === 0, "dynamic Apps submenu must resolve in the catalog");
+            require(rootEntries[9].label === "System", "System must close the root menu");
+
+            const screenshotEntries = Catalog.entriesFor("screenshots");
+            require(screenshotEntries.length === 4, "all screenshot modes must be exposed");
+            require(screenshotEntries[0].actionType === "helper", "screenshots must use typed helpers");
+
+            const searchable = Catalog.searchableEntries().concat([{
+                "id": "application:firefox.desktop",
+                "label": "Firefox",
+                "detail": "Web Browser",
+                "keywords": "internet network",
+                "kind": "application",
+                "enabled": true
+            }]);
+            const matches = Catalog.filterAndSort(searchable, "fire");
+            require(matches.length > 0 && matches[0].label === "Firefox", "application search must rank prefix matches first");
+
+            const disabledRows = [
+                { "label": "Loading", "kind": "status", "enabled": false },
+                { "label": "Network", "kind": "action", "enabled": true }
+            ];
+            require(Catalog.firstSelectable(disabledRows) === 1, "disabled rows must not receive selection");
+            require(Catalog.nextSelectable(disabledRows, 1, 1) === 1, "navigation must skip disabled rows");
+            require(Catalog.breadcrumb("screenshots") === "Commands / Screenshots", "submenu breadcrumb must be stable");
+        } catch (error) {
+            console.error("Command menu catalog test failed: " + error);
+            Qt.exit(1);
+            return;
+        }
+
+        Qt.exit(0);
+    }
+}

--- a/tests/test-monitor-tag-switching.sh
+++ b/tests/test-monitor-tag-switching.sh
@@ -161,6 +161,14 @@ reconcile_body=$(sed -n '/^reconcilemonitortags(void)/,/^}$/p' "$repo_dir/dwm.c"
 printf '%s\n' "$reconcile_body" | grep -q 'dwmfullscreenmonitorsatom != None'
 printf '%s\n' "$reconcile_body" | grep -q 'updatefullscreenmonitors();'
 grep -q 'XInternAtom(dpy, "_DWM_FULLSCREEN_MONITORS", False)' "$repo_dir/dwm.c"
+grep -q 'XInternAtom(dpy, "_DWM_SELECTED_MONITOR", False)' "$repo_dir/dwm.c"
+focus_body=$(sed -n '/^focus(Client \*c)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$focus_body" | grep -q 'updateselectedmonitor();'
+selected_monitor_body=$(sed -n '/^updateselectedmonitor(void)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$selected_monitor_body" | grep -q 'selectedmonitorcachevalid && logicalindex == selectedmonitorcache'
+printf '%s\n' "$selected_monitor_body" | grep -q 'selectedmonitorcachevalid = 1;'
+configure_notify_body=$(sed -n '/^configurenotify(XEvent \*e)/,/^}$/p' "$repo_dir/dwm.c")
+printf '%s\n' "$configure_notify_body" | grep -q 'selectedmonitorcachevalid = 0;'
 grep -q 'XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_COMBO", False)' "$repo_dir/dwm.c"
 
 mkdir -p "$work/bin"
@@ -177,6 +185,13 @@ case $* in
 *"_DWM_MONITOR_DESKTOPS"*)
 	if [ "${DWM_TEST_MONITOR_DESKTOPS+x}" = x ]; then
 		printf '_DWM_MONITOR_DESKTOPS(CARDINAL) = %s\n' "$DWM_TEST_MONITOR_DESKTOPS"
+	else
+		exit 1
+	fi
+	;;
+*"_DWM_SELECTED_MONITOR"*)
+	if [ "${DWM_TEST_SELECTED_MONITOR+x}" = x ]; then
+		printf '_DWM_SELECTED_MONITOR(CARDINAL) = %s\n' "$DWM_TEST_SELECTED_MONITOR"
 	else
 		exit 1
 	fi
@@ -198,9 +213,11 @@ chmod +x "$work/bin/xprop" "$work/bin/xdotool"
 
 DWM_TEST_FULLSCREEN_MONITORS='0, 1' \
 	DWM_TEST_MONITOR_DESKTOPS='2560, 0, 2560, 1440, 0, 0, 0, 2560, 1440, 4' \
+	DWM_TEST_SELECTED_MONITOR=1 \
 	PATH="$work/bin:$PATH" \
 	"$repo_dir/scripts/dwm-quickshell-state" state >"$work/state.out"
 grep -Fqx 'monitor_desktops=2560,0,2560,1440,0,0,0,2560,1440,4' "$work/state.out"
+grep -Fqx 'focused_monitor=1' "$work/state.out"
 grep -Fqx 'fullscreen_monitors=0|1' "$work/state.out"
 
 PATH="$work/bin:$PATH" \

--- a/tests/test-quickshell-command-menu.sh
+++ b/tests/test-quickshell-command-menu.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+set -eu
+
+repo=$(
+	unset CDPATH
+	cd -- "$(dirname -- "$0")/.." && pwd
+)
+
+catalog=$repo/config/quickshell/launcher/CommandMenuCatalog.js
+model=$repo/config/quickshell/launcher/CommandMenuModel.qml
+window=$repo/config/quickshell/launcher/CommandMenuWindow.qml
+shell=$repo/config/quickshell/shell.qml
+
+for label in Apps Settings 'Display / Input' Network Bluetooth Audio \
+	'System Health' Keybindings Screenshots System; do
+	grep -Fq "\"label\": \"$label\"" "$catalog"
+done
+
+grep -Fq '"actionType": "ipc"' "$catalog"
+grep -Fq '"actionType": "helper"' "$catalog"
+grep -Fq '"kind": "application"' "$model"
+grep -Fq 'Commands.screenshotHelperCommand(entry.action)' "$model"
+grep -Fq 'Commands.lockHelperCommand()' "$model"
+grep -Fq 'Commands.pointerHelperCommand("command-menu")' "$window"
+grep -Fq 'pointerWarpProcess.running = true;' "$window"
+[ -x "$repo/scripts/dwm-quickshell-pointer" ]
+grep -Fq 'target: "menu"' "$shell"
+menu_handler=$(awk '
+	/target: "menu"/ { in_menu = 1; seen_menu = 1 }
+	in_menu && seen_menu && /^    IpcHandler \{/ { exit }
+	in_menu { print }
+' "$shell")
+for action in close open toggle summon; do
+	printf '%s\n' "$menu_handler" | grep -Fq "function $action(): void"
+done
+grep -Fq 'title: "dwm menu"' "$window"
+grep -Fq 'title="dwm menu"' "$repo/config/window-rules.toml"
+grep -Fq 'dwmState.focusedScreen()' "$shell"
+grep -Fq 'function panelForScreen(screen)' "$shell"
+grep -Fq 'const panel = root.panelForScreen(requestedScreen)' "$shell"
+grep -Fq 'ipcActionRequested(string target, string action, string argument, var screen)' "$model"
+grep -Fq 'function focusedScreen()' "$repo/config/quickshell/state/DwmState.qml"
+grep -Fq 'property int focusedMonitorIndex: -1' "$repo/config/quickshell/state/DwmState.qml"
+grep -Fq 'root.focusedMonitorIndex >= 0' "$repo/config/quickshell/state/DwmState.qml"
+grep -Fq 'if (visible) commandMenuModel.close();' "$shell"
+select_panel_popup_body=$(sed -n '/function selectPanelPopup(panel, popupId)/,/^    }$/p' "$shell")
+printf '%s\n' "$select_panel_popup_body" | grep -Fq 'commandMenuModel.close();'
+open_menu_body=$(sed -n '/function openCommandMenu(screen)/,/^    }$/p' "$shell")
+for popup_model in networkModel bluetoothModel controlCenterModel controlsModel powerMenuModel; do
+	printf '%s\n' "$open_menu_body" | grep -Fq "$popup_model.close();"
+done
+grep -Fq 'function refreshApplicationIndex()' "$repo/config/quickshell/launcher/LauncherModel.qml"
+grep -Fq 'root.refreshApplicationIndex()' "$repo/config/quickshell/launcher/LauncherModel.qml"
+grep -Fq '{ title="dwm menu", isfloating=1, alwaysontop=1 },' "$repo/docs/OMARCHY-UI-ADAPTATION.md"
+grep -Fq 'menu open|close|toggle|summon' "$repo/CHANGELOG.md"
+grep -Fq 'target: "launcher"' "$shell"
+grep -Eq 'key="r".*call launcher toggle' "$repo/config/hotkeys.toml"
+if grep -Eq 'call menu (open|toggle|summon)' "$repo/config/hotkeys.toml"; then
+	printf '%s\n' 'Command menu unexpectedly replaced or added a default hotkey.' >&2
+	exit 1
+fi
+
+if grep -REn \
+	-e 'Quickshell\.(Wayland|Hyprland)' \
+	-e 'WlrLayershell' \
+	-e '(^|[^[:alnum:]_-])(hyprctl|uwsm-app|wl-copy|wl-paste)([^[:alnum:]_-]|$)' \
+	-e '"command"[[:space:]]*:' \
+	"$catalog"; then
+	printf '%s\n' 'Command catalog contains a compositor-specific or raw command backend.' >&2
+	exit 1
+fi
+
+qml_runner=
+for candidate in /usr/lib64/qt6/bin/qml /usr/lib/qt6/bin/qml qml6 qml; do
+	if command -v "$candidate" >/dev/null 2>&1; then
+		candidate_path=$(command -v "$candidate")
+		if [ "$candidate" = qml ]; then
+			candidate_version=$("$candidate_path" --version 2>&1 || true)
+			case $candidate_version in
+			*' 6.'* | *'Qt 6'*) ;;
+			*) continue ;;
+			esac
+		fi
+		qml_runner=$candidate_path
+		break
+	fi
+done
+
+if [ -n "$qml_runner" ]; then
+	QT_QPA_PLATFORM=offscreen "$qml_runner" "$repo/tests/quickshell-command-menu-catalog.qml"
+	printf '%s\n' 'Quickshell command menu: PASS'
+else
+	printf '%s\n' 'SKIP: Qt 6 qml runner is unavailable; catalog runtime assertions were not run.'
+fi

--- a/tests/test-quickshell-health-xvfb.sh
+++ b/tests/test-quickshell-health-xvfb.sh
@@ -44,6 +44,7 @@ grep -Fqx '  { title="dwm control center",         isfloating=1, alwaysontop=1 }
 cp "$repo/scripts/dwm-system-health" "$repo/scripts/dwm-diagnostics" \
 	"$repo/scripts/dwm-quickshell-controlcenter" "$repo/scripts/dwm-quickshell-controls" \
 	"$repo/scripts/dwm-quickshell-launcher" "$repo/scripts/dwm-quickshell-network" \
+	"$repo/scripts/dwm-quickshell-pointer" \
 	"$data_home/dwm-titus/scripts/"
 
 Xvfb "$display" -screen 0 1024x768x24 -nolisten tcp -extension GLX >"$work/xvfb.log" 2>&1 &
@@ -323,6 +324,134 @@ while [ "$i" -lt 100 ]; do
 done
 if DISPLAY=$display xdotool search --onlyvisible --name '^dwm launcher$' >/dev/null 2>&1; then
 	printf 'Launcher did not close on Escape\n' >&2
+	exit 1
+fi
+
+# The DWM-owned command menu keeps the legacy launcher intact while sharing
+# its XDG application index only for the lifetime of an open surface.
+DISPLAY=$display xdotool mousemove 5 5
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home XDG_RUNTIME_DIR=$runtime \
+	quickshell ipc --path "$config" call menu summon >/dev/null
+
+menu_window=
+i=0
+while [ "$i" -lt 200 ]; do
+	menu_window=$(DISPLAY=$display xdotool search --onlyvisible --name '^dwm menu$' 2>/dev/null | head -1 || true)
+	[ -n "$menu_window" ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+if [ -z "$menu_window" ]; then
+	printf 'Command menu did not open\n' >&2
+	tail -40 "$work/quickshell.log" >&2
+	exit 1
+fi
+
+[ "$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home XDG_RUNTIME_DIR=$runtime \
+	quickshell ipc --path "$config" call menu resultCount)" = 10 ]
+[ "$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home XDG_RUNTIME_DIR=$runtime \
+	quickshell ipc --path "$config" call menu selectedLabel)" = Apps ]
+[ "$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home XDG_RUNTIME_DIR=$runtime \
+	quickshell ipc --path "$config" call launcher applicationConsumers)" = 1 ]
+
+geometry=$(DISPLAY=$display xdotool getwindowgeometry --shell "$menu_window")
+width=$(printf '%s\n' "$geometry" | awk -F= '$1 == "WIDTH" { print $2 }')
+height=$(printf '%s\n' "$geometry" | awk -F= '$1 == "HEIGHT" { print $2 }')
+[ "$width" = 720 ]
+[ "$height" = 600 ]
+
+pointer_window=
+i=0
+while [ "$i" -lt 100 ]; do
+	pointer_window=$(DISPLAY=$display xdotool getmouselocation --shell |
+		awk -F= '$1 == "WINDOW" { print $2 }')
+	[ "$pointer_window" = "$menu_window" ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$pointer_window" = "$menu_window" ]
+[ "$(DISPLAY=$display xdotool getwindowfocus)" = "$menu_window" ]
+
+DISPLAY=$display xdotool key Return
+i=0
+while [ "$i" -lt 100 ]; do
+	active_menu=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home XDG_RUNTIME_DIR=$runtime \
+		quickshell ipc --path "$config" call menu activeMenu)
+	[ "$active_menu" = apps ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$active_menu" = apps ]
+
+DISPLAY=$display xdotool key BackSpace
+i=0
+while [ "$i" -lt 100 ]; do
+	active_menu=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home XDG_RUNTIME_DIR=$runtime \
+		quickshell ipc --path "$config" call menu activeMenu)
+	[ "$active_menu" = root ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$active_menu" = root ]
+
+DISPLAY=$display xdotool type --delay 10 'system health'
+i=0
+while [ "$i" -lt 100 ]; do
+	selected_label=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home XDG_RUNTIME_DIR=$runtime \
+		quickshell ipc --path "$config" call menu selectedLabel)
+	[ "$selected_label" = 'System Health' ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$selected_label" = 'System Health' ]
+DISPLAY=$display xdotool key Return
+
+health_window=
+i=0
+while [ "$i" -lt 200 ]; do
+	health_window=$(DISPLAY=$display xdotool search --onlyvisible --name '^dwm system health$' 2>/dev/null | head -1 || true)
+	[ -n "$health_window" ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+if [ -z "$health_window" ]; then
+	printf 'Command menu did not dispatch the System Health IPC action\n' >&2
+	tail -40 "$work/quickshell.log" >&2
+	exit 1
+fi
+if DISPLAY=$display xdotool search --onlyvisible --name '^dwm menu$' >/dev/null 2>&1; then
+	printf 'Command menu remained visible after dispatch\n' >&2
+	exit 1
+fi
+[ "$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home XDG_RUNTIME_DIR=$runtime \
+	quickshell ipc --path "$config" call launcher applicationConsumers)" = 0 ]
+[ "$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home XDG_RUNTIME_DIR=$runtime \
+	quickshell ipc --path "$config" call launcher indexCount)" = 0 ]
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home XDG_RUNTIME_DIR=$runtime \
+	quickshell ipc --path "$config" call systemhealth close >/dev/null
+
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home XDG_RUNTIME_DIR=$runtime \
+	quickshell ipc --path "$config" call menu toggle >/dev/null
+i=0
+while [ "$i" -lt 200 ]; do
+	menu_window=$(DISPLAY=$display xdotool search --onlyvisible --name '^dwm menu$' 2>/dev/null | head -1 || true)
+	[ -n "$menu_window" ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ -n "$menu_window" ]
+DISPLAY=$display xdotool windowactivate --sync "$menu_window"
+DISPLAY=$display xdotool key Escape
+i=0
+while [ "$i" -lt 100 ]; do
+	if ! DISPLAY=$display xdotool search --onlyvisible --name '^dwm menu$' >/dev/null 2>&1; then
+		break
+	fi
+	i=$((i + 1))
+	sleep 0.05
+done
+if DISPLAY=$display xdotool search --onlyvisible --name '^dwm menu$' >/dev/null 2>&1; then
+	printf 'Command menu did not close on Escape\n' >&2
 	exit 1
 fi
 

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -555,9 +555,11 @@ dwm_pid=$!
 wait_for_root_property _NET_SUPPORTED
 wait_for_root_property _NET_NUMBER_OF_DESKTOPS
 wait_for_root_property _DWM_MONITOR_DESKTOPS
+wait_for_root_property _DWM_SELECTED_MONITOR
 wait_for_root_property _DWM_FULLSCREEN_MONITORS
 wait_for_current_desktop 0
 wait_for_monitor_desktops 0,0,1024,768,0
+DISPLAY=$display xprop -root _DWM_SELECTED_MONITOR | grep -Eq '= 0$'
 wait_for_fullscreen_monitors ''
 DISPLAY=$display xprop -root _NET_SUPPORTED | grep -q _NET_WM_STATE_ABOVE
 DISPLAY=$display xprop -root _NET_SUPPORTED | grep -q _NET_WM_STATE_STAYS_ON_TOP


### PR DESCRIPTION
## Summary

PR #158 was merged into its feature base (`codex/quickshell-design-system`) rather than `main`, so the reviewed X11 command-menu work never reached the default branch. This corrective PR applies the exact PR #158 squash tree on top of current `main`, which already contains PR #159.

The result is the intended unified experience:

- Omarchy-inspired X11 command menu with DWM monitor targeting and pointer-to-menu focus
- restyled DWM panel and Audio, Bluetooth, Network, Control Center, and Power menus
- existing DWM, Fedora helpers, Quickshell IPC, X11 focus, monitor, tray, and click-away contracts preserved

## Conflict resolution

The two mechanical cherry-pick conflicts retained both phases:

- `Makefile` runs and publishes both the command-menu and panel-menu checks
- the nested-X11 health fixture installs controls, network, pointer, launcher, and control-center helpers

No PR #159 code is duplicated in this diff.

## Validation

- `make check-quickshell-command-menu check-quickshell-panel-menus check-quickshell-qml check-quickshell-health-xvfb`
- `scripts/run-tests make clean all`
- `scripts/run-tests`
- `git diff --check origin/main...HEAD`

The nested Fedora X11 run validates the combined command menu, pointer/focus path, panel popups, Escape dismissal, click-away behavior, tray ownership, and managed shell lifecycle.

## Review notes

- Request hosted Codex review against the corrective exact head.
- If CodeRabbit auto-runs, resolve its comments but do not use it as a waiting gate.
