### PR TITLE
Plan integrated Omarchy UI phase 4

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,11 +28,75 @@ when optional components fail.
 ## Planning Rules
 
 `SPEC.md` defines the durable product contract. This roadmap defines ordered
-outcomes. `TASKS.md` contains detailed work only for the active phase.
+outcomes. `TASKS.md` contains detailed work only for the active numbered
+product phase and may order that phase into multiple reviewable pull-request
+slices.
 
 A phase may advance only when its exit criteria are validated and remaining
 limitations are recorded. Completed implementation belongs in `CHANGELOG.md`
 and release history rather than in a permanent checked-off task list.
+
+## Integrated Omarchy-Inspired X11 UI Delivery
+
+Status: Integrated into the numbered roadmap; `P3-UI4` is the next pull-request
+slice after this planning change merges
+
+The Omarchy-inspired overhaul is not a second roadmap. Its visual and
+interaction work is folded into the existing Fedora product phases while DWM,
+X11, Fedora providers, helpers, IPC, and session policy remain authoritative.
+The `UI-1` through `UI-6` names identify the approved review boundaries from
+the design plan; the `P3-UI4` form identifies where a slice belongs in the
+product roadmap.
+
+- UI-1, semantic theme tokens and shared controls: Phase 3 prerequisite,
+  complete in PR #157.
+- UI-2, DWM command menu and shared launcher model: Phase 3 prerequisite,
+  complete in PR #158 and corrective PR #160.
+- UI-3, panel and existing quick panels: Phase 3 prerequisite, complete in
+  PR #159.
+- P3-UI4, Settings, System Health, notifications, and launcher: first active
+  Phase 3 pull-request slice, ready to start.
+- UI-5, optional X11-native experiences: planned for Phase 5 personalization
+  and accessibility; split backend-heavy work when needed.
+- UI-6, whole-shell integration hardening: planned for Phase 7 image and
+  release qualification, with no major features.
+
+### Integrated Boundaries
+
+- Reuse `themes.toml`, root-scoped state models, installed helpers, IPC names,
+  window titles, X11 surface types, and the existing 30px panel contract.
+- Do not ship Wayland, Hyprland, layer-shell, UWSM, `wl-*`, or Omarchy service
+  and plugin backends.
+- Keep `P3-UI4` visual and interaction focused. The Phase 3 provider and action
+  tasks remain later, separate pull-request slices in the same active phase.
+- Keep lock, polkit, idle, power, and background policy on the existing X11 and
+  Fedora implementations.
+- Treat an event-driven clipboard-history backend as a separate review boundary
+  if UI-5 adopts it.
+
+### Integrated Delivery Order
+
+UI-1 is the merged foundation. UI-2 and UI-3 were parallel children and are
+now unified on `main`. `P3-UI4` begins from that combined state and establishes
+the shared large-surface language used by the remaining Phase 3 work and the
+later power, defaults, personalization, accessibility, and system-management
+phases. Phase 3 still requires its connectivity and audio provider slices and
+validation before product Phase 4 can begin. UI-5 is delivered with Phase 5,
+and UI-6 closes the desktop during Phase 7 release qualification.
+
+### UI Overhaul Exit Criteria
+
+- Every converted surface preserves its backend, lifecycle, IPC, X11 focus,
+  click-away, stacking, and monitor-selection behavior.
+- Managed QML contains no Wayland or Hyprland runtime dependency.
+- Focused source checks, Quickshell lint, nested-X11 interaction tests, the full
+  managed repository suite, and real-session manual checks pass.
+- Closed surfaces leave no resident list models, scans, duplicate subscriptions,
+  or overlapping helper commands, and the mean idle CPU delta remains within
+  0.5 percentage points of one CPU.
+- The final approved revision is synchronized through
+  `scripts/dev-sync-install.sh`, with installed parity and any required
+  logout/login activation gate recorded.
 
 ## Phase 1: Settings Platform Foundation
 
@@ -141,7 +205,8 @@ Make common monitor and input changes available from the Settings application.
 
 ## Phase 3: Connectivity and Audio
 
-Status: Ready to start (2026-08-15)
+Status: Active (2026-08-21). The next review boundary is `P3-UI4`; connectivity
+and audio provider work follows in separate Phase 3 pull requests.
 
 ### Objective
 
@@ -155,12 +220,17 @@ Provide desktop-grade network, Bluetooth, and sound management.
 - Output and input device selection, volume, mute, per-application streams, and
   microphone visibility through PipeWire/WirePlumber-compatible interfaces.
 - Event-driven updates with bounded command execution and no overlapping polls.
+- Omarchy-inspired large-surface styling for Settings, System Health,
+  notifications, and the application launcher, using the merged design system
+  without changing their providers or X11 contracts.
 
 ### Exit Criteria
 
 - Common connection and audio workflows no longer require a terminal.
 - Authentication cancellation and service unavailability fail safely.
 - Existing panel quick controls remain synchronized with Settings.
+- The converted large surfaces preserve their existing IPC, focus, lifecycle,
+  privilege, and backend behavior in real and nested X11 sessions.
 
 ## Phase 4: Power, Session, and Defaults
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -5,7 +5,62 @@ file contains implementation work only for the active roadmap phase. Phase 2
 completion evidence is recorded in `ROADMAP.md`, `CHANGELOG.md`, and
 `docs/SETTINGS-PLATFORM.md`.
 
-## Active Phase: Connectivity and Audio
+## Active Phase: Connectivity, Audio, and Large-Surface Integration
+
+The Omarchy-inspired UI plan is integrated into this phase rather than tracked
+as a competing roadmap. `P3-UI4` is the next pull-request boundary. The
+connectivity and audio tasks remain required after that visual slice; none of
+them becomes complete merely because an existing surface is restyled.
+
+### P3-UI4: Large-Surface Visual Integration (Next PR)
+
+- [ ] Capture before-change screenshots and X11 geometry for Settings, System
+  Health, notification popups/history, and the application launcher on the
+  active two-monitor session and a lower-resolution nested X11 session.
+- [ ] Reuse the merged semantic tokens and panel/menu interaction language.
+  Add a presentation-only shared component only when at least two converted
+  surfaces use it; visual components must not own providers or processes.
+- [ ] Restyle Settings navigation, search, capability cards, status states, and
+  the existing Displays/Input panes without changing section IDs, provider
+  records, preview/rollback flows, or unsupported-state behavior.
+- [ ] Restyle System Health summary tiles, categories, check cards, evidence
+  actions, and repair confirmations without changing scan lifecycle,
+  authorization, repair allowlists, or bounded evidence behavior.
+- [ ] Restyle notification cards, popups, and history while preserving urgency,
+  dismiss, sender-close, action, timeout, overflow, and history semantics.
+- [ ] Restyle the application launcher while preserving the application model
+  shared with the command menu, type-to-search, keyboard/mouse activation,
+  terminal-entry fallback, close-on-launch, and closed-model release behavior.
+- [ ] Preserve the existing `settings`, `systemhealth`, `notifications`, and
+  `launcher` IPC targets, stable X11 window titles, monitor selection, focus,
+  stacking, click-away, Escape, and fullscreen precedence.
+- [ ] Add a focused large-surface source contract and expand nested-X11 tests
+  to exercise keyboard navigation, pointer activation, dismissal, monitor
+  placement, notification actions, and health/settings lifecycle.
+- [ ] Record before/after screenshots for review and document any intentional
+  visual deviation from the shared Omarchy-inspired language.
+
+Acceptance:
+
+- The pull request contains only `P3-UI4`; it does not begin `CONN-001`,
+  `NET-001`, `BT-001`, `AUDIO-001`, `AUDIO-002`, or optional UI-5 features.
+- No provider, helper argument contract, IPC name, keybinding, privilege
+  boundary, 30px panel geometry, X11 surface type, or window title changes.
+- Managed QML adds no `Quickshell.Wayland`, `Quickshell.Hyprland`,
+  `WlrLayershell`, `hyprctl`, `uwsm-app`, `wl-copy`, or `wl-paste` dependency.
+- Closing each converted surface releases section-owned work and leaves no
+  duplicate scans, subscriptions, application models, or helper commands.
+- Focused source checks, `scripts/quickshell-qmllint --root config/quickshell`,
+  applicable nested-X11 suites, `scripts/run-tests make clean all`, and
+  `scripts/run-tests` pass.
+- Real Fedora X11 checks cover both active monitors, keyboard and mouse paths,
+  notification delivery/history, Settings preview cancellation, System Health
+  scan cancellation, tray ownership, and real-fullscreen precedence. The mean
+  Quickshell CPU delta between a 30-second closed baseline and a 30-second
+  post-open/close sample is no more than 0.5 percentage points of one CPU.
+- The ready-for-review PR records screenshots, exact automated and manual
+  evidence, skipped checks, and limitations. Live synchronization waits for
+  approval and uses `scripts/dev-sync-install.sh`.
 
 ### CONN-001: Connectivity Provider Contract
 

--- a/docs/OMARCHY-UI-ADAPTATION.md
+++ b/docs/OMARCHY-UI-ADAPTATION.md
@@ -77,6 +77,55 @@ The static design-system check rejects Wayland and Hyprland dependencies in
 the managed shell. The Quickshell lint and X11 runtime checks remain the
 authoritative syntax and integration gates.
 
+## Integrated Six-Slice Delivery Plan
+
+The adaptation is delivered as six review and rollback boundaries inside the
+existing Fedora roadmap. The UI identifiers preserve the approved design-plan
+sequence; a product-phase prefix, such as `P3-UI4`, records where that work is
+scheduled in `ROADMAP.md`.
+
+- UI-1, design-system foundation: Phase 3 prerequisite, complete in PR #157.
+- UI-2, DWM command menu and shared launcher model: Phase 3 prerequisite,
+  complete in PR #158 and corrective PR #160.
+- UI-3, bar and existing quick panels: Phase 3 prerequisite, complete in
+  PR #159.
+- P3-UI4, Settings, System Health, notifications, and launcher: next Phase 3
+  pull request from unified `main`.
+- UI-5, optional X11-native experiences: planned for Phase 5 personalization
+  and accessibility; split backend-heavy work when needed.
+- UI-6, integration hardening and approved rollout: planned for Phase 7 release
+  qualification, with no major features.
+
+UI-2 and UI-3 were the only parallel branches because they owned mostly
+separate surfaces after UI-1 established shared tokens. `P3-UI4` must reuse the
+merged components and interaction decisions from both. The remaining
+Connectivity and Audio tasks then build on those surfaces as separate Phase 3
+pull requests. UI-5 remains optional and must not make `P3-UI4` depend on a new
+service. UI-6 is a stabilization slice, not a feature catch-all.
+
+### P3-UI4 Boundary
+
+`P3-UI4` converts the large resident and on-demand shell surfaces:
+
+- Settings navigation, search, capability cards, and current interactive panes;
+- System Health summary, category navigation, check cards, evidence actions,
+  and repair confirmations;
+- notification popups, cards, and history;
+- the application launcher while retaining the application model shared with
+  the command menu.
+
+The slice may add presentation-only shared components when at least two of
+these surfaces use them. It must not add a network, Bluetooth, audio, power,
+notification, health, application, or Settings provider; change an IPC target,
+window title, helper argument contract, privilege boundary, or keybinding; or
+fold UI-5 features into the review.
+
+`TASKS.md` combines `P3-UI4` with the remaining Connectivity and Audio work in
+one active Phase 3 plan. Only the `P3-UI4` section belongs in the next pull
+request. Completing that visual conversion does not complete Phase 3 or
+authorize product Phase 4; the provider, workflow, hardware, and validation
+gates must pass first.
+
 ## Command Menu Contract
 
 The command menu is a DWM-owned navigation surface, not an Omarchy service
@@ -95,7 +144,9 @@ Open the menu on the focused DWM screen from a terminal or a user-defined
 hotkey:
 
 ```sh
-quickshell ipc --path "${XDG_CONFIG_HOME:-$HOME/.config}/quickshell/shell.qml" call menu summon
+quickshell ipc \
+  --path "${XDG_CONFIG_HOME:-$HOME/.config}/quickshell/shell.qml" \
+  call menu summon
 ```
 
 Apps enters the shared XDG application provider. Display / Input,


### PR DESCRIPTION
## Summary

- integrate the approved six-slice Omarchy-inspired UI overhaul into the existing Fedora roadmap instead of maintaining a competing phase sequence
- record UI-1 through UI-3 as merged prerequisites and make P3-UI4 the next isolated Phase 3 pull-request boundary
- preserve every unfinished connectivity and audio provider, workflow, hardware, and validation task behind that visual slice
- define P3-UI4 scope and acceptance for Settings, System Health, notifications, and the application launcher

## Important boundaries

P3-UI4 is the fourth UI-overhaul slice, but it remains part of active product Phase 3. Completing it does not complete Connectivity and Audio or authorize product Phase 4. The next implementation PR must not change providers, helpers, IPC names, keybindings, privilege boundaries, X11 surface types, window titles, or panel geometry.

## Validation

- `scripts/run-tests make clean all`
- `scripts/run-tests`
- `make check-quickshell-design-system`
- `make check-quickshell-command-menu`
- `make check-quickshell-panel-menus`
- `git diff --check`
- CodeRabbit uncommitted review: 0 findings
- `codex review --uncommitted`: no actionable findings

## Manual testing

Not applicable for this planning-only change. P3-UI4 itself requires documented before/after screenshots, nested and real Fedora X11 checks, both active monitors, keyboard/mouse flows, lifecycle checks, fullscreen precedence, and idle CPU evidence.

## Known limitations

The current roadmap repeats subsection headings such as `Objective`, `Outcomes`, and `Exit Criteria`; default markdownlint reports those pre-existing MD024 findings. The changed Markdown adds no other markdownlint findings.
