### PR TITLE
Harden Phase 3 prerequisite contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ versions from `config.mk`.
   fixtures while retaining the Fedora-only boundary test that proves an
   unsupported installer cannot perform package or system mutations.
 
+### Fixed
+
+- Require root-owned, non-writable parent directories for installed health
+  helpers and report administrative authorization available only when polkit
+  or noninteractive sudo can actually authorize the operation.
+- Preserve command-menu selection when asynchronous application state refreshes
+  and tolerate bounded slow X11 window mapping before pointer-focus fallback.
+
 ## [0.6.1] - 2026-08-17
 
 ### Added

--- a/config/quickshell/launcher/CommandMenuCatalog.js
+++ b/config/quickshell/launcher/CommandMenuCatalog.js
@@ -155,6 +155,16 @@ function firstSelectable(entries) {
     return 0;
 }
 
+function restoredSelection(entries, previousId) {
+    if (previousId) {
+        for (var index = 0; index < entries.length; index++) {
+            if (entries[index].id === previousId && isSelectable(entries[index])) return index;
+        }
+    }
+
+    return firstSelectable(entries);
+}
+
 function breadcrumb(menuId) {
     return menuId === "root" ? menuLabels.root : menuLabels.root + " / " + (menuLabels[menuId] || menuId);
 }

--- a/config/quickshell/launcher/CommandMenuModel.qml
+++ b/config/quickshell/launcher/CommandMenuModel.qml
@@ -78,6 +78,9 @@ Scope {
             return;
         }
 
+        const previousId = root.selectedIndex >= 0 && root.selectedIndex < root.rows.length
+            ? root.rows[root.selectedIndex].id : "";
+
         let entries;
         if (root.query.trim().length > 0) {
             entries = Catalog.searchableEntries().concat(root.applicationEntries());
@@ -90,7 +93,7 @@ Scope {
         }
 
         root.rows = root.applyCurrentStates(entries);
-        root.selectedIndex = Catalog.firstSelectable(entries);
+        root.selectedIndex = Catalog.restoredSelection(root.rows, previousId);
     }
 
     function openWindow() {
@@ -135,6 +138,7 @@ Scope {
 
     function setQuery(value) {
         root.query = value;
+        root.selectedIndex = -1;
         root.refreshRows();
     }
 
@@ -165,6 +169,7 @@ Scope {
     function openSubmenu(menuId) {
         root.activeMenu = menuId;
         root.query = "";
+        root.selectedIndex = -1;
         root.refreshRows();
     }
 
@@ -175,6 +180,7 @@ Scope {
         }
         if (root.activeMenu !== "root") {
             root.activeMenu = "root";
+            root.selectedIndex = -1;
             root.refreshRows();
             return true;
         }

--- a/scripts/dwm-quickshell-pointer
+++ b/scripts/dwm-quickshell-pointer
@@ -20,13 +20,13 @@ command -v xdotool >/dev/null 2>&1 || {
 }
 
 attempt=0
-while [ "$attempt" -lt 40 ]; do
+while [ "$attempt" -lt 100 ]; do
 	if xdotool search --onlyvisible --name "$window_name" \
 		mousemove --window %@ "$pointer_x" "$pointer_y" >/dev/null 2>&1; then
 		exit 0
 	fi
 	attempt=$((attempt + 1))
-	sleep 0.025
+	sleep 0.05
 done
 
 printf '%s: command menu window did not become visible\n' "$0" >&2

--- a/scripts/dwm-settings-provider
+++ b/scripts/dwm-settings-provider
@@ -107,10 +107,7 @@ trusted_health_helper() {
 	path_candidate=$(command -v dwm-system-health 2>/dev/null || true)
 	for candidate in "$path_candidate" /usr/local/bin/dwm-system-health /usr/bin/dwm-system-health; do
 		[ -n "$candidate" ] || continue
-		[ -f "$candidate" ] || continue
-		[ ! -L "$candidate" ] || continue
-		[ "$(stat -c %u -- "$candidate" 2>/dev/null || printf 1)" = 0 ] || continue
-		find "$candidate" -maxdepth 0 -type f ! -perm /022 -print -quit 2>/dev/null | grep -q . || continue
+		trusted_installed_file "$candidate" || continue
 		return 0
 	done
 	return 1
@@ -272,7 +269,10 @@ discover() {
 		emit_capability system health 'System health' unavailable read-only dwm-system-health \
 			'Install the dwm-system-health helper'
 	fi
-	if trusted_health_helper && { provider_available pkexec || provider_available sudo; }; then
+	if trusted_health_helper && {
+		provider_available pkexec ||
+			{ provider_available sudo && run_bounded_probe sudo -n -v; }
+	}; then
 		emit_capability system authorization 'Administrative authorization' available privileged polkit \
 			'A trusted installed helper and authorization tool are available'
 	else

--- a/scripts/dwm-system-health
+++ b/scripts/dwm-system-health
@@ -195,10 +195,27 @@ trusted_system_command() {
 	case $resolved in
 	"${HOME:-/nonexistent}"/* | "${XDG_DATA_HOME:-${HOME:-/nonexistent}/.local/share}"/* | "${XDG_CONFIG_HOME:-${HOME:-/nonexistent}/.config}"/*) return 1 ;;
 	esac
+	trusted_parent_chain "$resolved" || return 1
 	owner=$(stat -c %u -- "$resolved" 2>/dev/null || printf 1)
 	[[ $owner == 0 ]] || return 1
 	find "$resolved" -maxdepth 0 -type f ! -perm /022 -print -quit 2>/dev/null | grep -q . || return 1
 	printf '%s\n' "$resolved"
+}
+
+trusted_parent_chain() {
+	local candidate=$1
+	local parent=${candidate%/*}
+	local owner
+
+	while :; do
+		[[ -d $parent && ! -L $parent ]] || return 1
+		owner=$(stat -c %u -- "$parent" 2>/dev/null || printf 1)
+		[[ $owner == 0 ]] || return 1
+		find "$parent" -maxdepth 0 -type d ! -perm /022 -print -quit 2>/dev/null | grep -q . || return 1
+		[[ $parent == / ]] && return 0
+		parent=${parent%/*}
+		[[ -n $parent ]] || parent=/
+	done
 }
 
 privilege_mode() {
@@ -772,6 +789,7 @@ trusted_system_helper() {
 		case $resolved in
 		"${HOME:-/nonexistent}"/* | "${XDG_DATA_HOME:-${HOME:-/nonexistent}/.local/share}"/* | "${XDG_CONFIG_HOME:-${HOME:-/nonexistent}/.config}"/*) continue ;;
 		esac
+		trusted_parent_chain "$resolved" || continue
 		owner=$(stat -c %u -- "$resolved" 2>/dev/null || printf 1)
 		[[ $owner == 0 ]] || continue
 		find "$resolved" -maxdepth 0 -type f ! -perm /022 -print -quit 2>/dev/null | grep -q . || continue

--- a/tests/quickshell-command-menu-catalog.qml
+++ b/tests/quickshell-command-menu-catalog.qml
@@ -36,6 +36,14 @@ QtObject {
             ];
             require(Catalog.firstSelectable(disabledRows) === 1, "disabled rows must not receive selection");
             require(Catalog.nextSelectable(disabledRows, 1, 1) === 1, "navigation must skip disabled rows");
+            const refreshedRows = [
+                { "id": "network", "kind": "action", "enabled": true },
+                { "id": "audio", "kind": "action", "enabled": true }
+            ];
+            require(Catalog.restoredSelection(refreshedRows, "audio") === 1,
+                "refresh must preserve a selectable entry by stable id");
+            require(Catalog.restoredSelection(refreshedRows, "missing") === 0,
+                "refresh must fall back when the prior entry disappeared");
             require(Catalog.breadcrumb("screenshots") === "Commands / Screenshots", "submenu breadcrumb must be stable");
         } catch (error) {
             console.error("Command menu catalog test failed: " + error);

--- a/tests/test-quickshell-command-menu.sh
+++ b/tests/test-quickshell-command-menu.sh
@@ -24,6 +24,9 @@ grep -Fq 'Commands.lockHelperCommand()' "$model"
 grep -Fq 'Commands.pointerHelperCommand("command-menu")' "$window"
 grep -Fq 'pointerWarpProcess.running = true;' "$window"
 [ -x "$repo/scripts/dwm-quickshell-pointer" ]
+grep -Fq "while [ \"\$attempt\" -lt 100 ]; do" "$repo/scripts/dwm-quickshell-pointer"
+grep -Fq 'sleep 0.05' "$repo/scripts/dwm-quickshell-pointer"
+grep -Fq 'Catalog.restoredSelection(root.rows, previousId)' "$model"
 grep -Fq 'target: "menu"' "$shell"
 menu_handler=$(awk '
 	/target: "menu"/ { in_menu = 1; seen_menu = 1 }

--- a/tests/test-settings.sh
+++ b/tests/test-settings.sh
@@ -181,6 +181,8 @@ if grep -Eq '^[[:space:]]*(sudo|pkexec)([[:space:]]|$)' "$provider"; then
 	printf 'Settings discovery must not execute an elevation tool.\n' >&2
 	exit 1
 fi
+grep -Fq "trusted_installed_file \"\$candidate\"" "$provider"
+grep -Fq 'provider_available sudo && run_bounded_probe sudo -n -v' "$provider"
 
 if "$repo/scripts/dwm-settings-display-root" rollback 2>"$work/root-helper.err"; then
 	printf 'Privileged display helper ran without root authorization.\n' >&2

--- a/tests/test-system-health.sh
+++ b/tests/test-system-health.sh
@@ -190,4 +190,7 @@ if "$HELPER" repair-system 'example.service' 2>"$work/system-repair.err"; then
 fi
 grep -Fq 'unsupported system repair' "$work/system-repair.err"
 
+grep -Fq "trusted_parent_chain \"\$resolved\" || return 1" "$HELPER"
+grep -Fq "trusted_parent_chain \"\$resolved\" || continue" "$HELPER"
+
 printf 'System health helper: PASS\n'


### PR DESCRIPTION
## Summary

- require canonical root-owned, non-writable helper parent chains before health elevation
- report Settings administrative authorization available only for polkit or usable noninteractive sudo
- preserve command-menu selection through asynchronous application/status refreshes
- extend the bounded X11 pointer-focus discovery window

## Validation

- focused Settings, System Health, command-menu, QML, and nested-X11 checks
- ShellCheck and shfmt on changed shell files
- `scripts/run-tests make clean all`
- `scripts/run-tests`
- `codex review --uncommitted`: no actionable defects
- CodeRabbit CLI: zero findings

## Scope

This clears inherited Phase 1 and UI-2 review findings before the active Phase 3 P3-UI4 slice. It makes no provider protocol, IPC, keybinding, panel geometry, or platform-scope change.