### PR TITLE
feat(settings): add Phase 3 connectivity workflows

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -40,7 +40,7 @@ jobs:
           mapfile -t qml_packages < <(dwm_packages fedora qml-validation | awk 'NF' | sort -u)
           dnf install -y --setopt=install_weak_deps=False \
             "${required_packages[@]}" "${qml_packages[@]}" \
-            diffutils dbus-daemon \
+            diffutils dbus-daemon jq \
             pkgconf-pkg-config ShellCheck shfmt pykickstart \
             xorg-x11-server-Xvfb
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versions from `config.mk`.
 
 ### Added
 
+- Add shared, versioned NetworkManager and BlueZ provider models and Settings
+  panes for Ethernet, Wi-Fi, saved profiles, VPN status, bounded discovery,
+  pairing, trust, connection, and removal workflows. Fixed actions preserve
+  stable identities, secured Wi-Fi secrets use ephemeral mode-0600 password
+  files, and advanced editing remains delegated to trusted platform tools.
+
 - Add a focused large-surface source contract, a private nested-X11
   interaction and screenshot harness, and checked-in before/after review
   evidence for P3-UI4.
@@ -51,6 +57,10 @@ versions from `config.mk`.
   unsupported installer cannot perform package or system mutations.
 
 ### Fixed
+
+- Bind long-lived NetworkManager and media watcher children to the originating
+  Quickshell process identity so an ungraceful shell exit cannot leave orphaned
+  subscriptions behind.
 
 - Require root-owned, non-writable parent directories for installed health
   helpers and report administrative authorization available only when polkit

--- a/Makefile
+++ b/Makefile
@@ -376,6 +376,9 @@ check-quickshell-launcher:
 check-quickshell-network:
 	tests/test-quickshell-network.sh
 
+check-quickshell-connectivity:
+	tests/test-quickshell-connectivity.sh
+
 check-quickshell-controls:
 	tests/test-quickshell-controls.sh
 
@@ -556,6 +559,7 @@ check:
 	$(MAKE) check-system-health
 	$(MAKE) check-settings
 	$(MAKE) check-quickshell-network
+	$(MAKE) check-quickshell-connectivity
 	$(MAKE) check-terminal
 	$(MAKE) check-gearlever-install
 	$(MAKE) check-herdr-install
@@ -576,5 +580,5 @@ check:
 	check-display-profile check-display-setup check-fedora-iso-builder check-fedora-packages check-fedora-platform check-format check-install \
 	check-gearlever-install check-herdr-install check-install-manifest check-install-preservation check-kickstart check-lock \
 	check-session-guards check-session-migration check-screenshot check-release-helper check-shell check-diagnostics check-status check-system-health check-settings \
-	check-quickshell-launcher check-quickshell-controls check-quickshell-controlcenter check-quickshell-design-system check-quickshell-large-surfaces check-quickshell-large-surfaces-xvfb check-quickshell-panel-menus check-quickshell-command-menu check-quickshell-notifications check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-qml check-lightdm-config check-terminal check-xvfb-runtime install install-system install-user \
+	check-quickshell-launcher check-quickshell-controls check-quickshell-controlcenter check-quickshell-design-system check-quickshell-large-surfaces check-quickshell-large-surfaces-xvfb check-quickshell-panel-menus check-quickshell-command-menu check-quickshell-notifications check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-connectivity check-quickshell-qml check-lightdm-config check-terminal check-xvfb-runtime install install-system install-user \
 	install-cursors native release release-check uninstall

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -204,8 +204,9 @@ Make common monitor and input changes available from the Settings application.
 
 ## Phase 3: Connectivity and Audio
 
-Status: Active (2026-08-21). `P3-UI4` is complete in PR #163; the next review
-boundary is `CONN-001`, followed by Network/VPN, Bluetooth, and audio slices.
+Status: Active (2026-08-21). `P3-UI4` is complete in PR #163. The connectivity,
+NetworkManager, and BlueZ slices are complete; the next review boundary is
+`AUDIO-001`, followed by the Phase 3 validation and closeout.
 
 ### Objective
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -8,10 +8,9 @@ completion evidence is recorded in `ROADMAP.md`, `CHANGELOG.md`, and
 ## Active Phase: Connectivity, Audio, and Large-Surface Integration
 
 The Omarchy-inspired UI plan is integrated into this phase rather than tracked
-as a competing roadmap. `P3-UI4` is complete in PR #163, and `CONN-001` is the
-next pull-request boundary. The connectivity and audio tasks remain required
-after that visual slice; none of them becomes complete merely because an
-existing surface is restyled.
+as a competing roadmap. `P3-UI4` is complete in PR #163. The connectivity
+provider, NetworkManager, and BlueZ slices are complete in the current review
+boundary; `AUDIO-001` is next.
 
 ### P3-UI4: Large-Surface Visual Integration (PR #163)
 
@@ -65,15 +64,15 @@ Acceptance:
 
 ### CONN-001: Connectivity Provider Contract
 
-- [ ] Define versioned machine-readable records for network, VPN, Bluetooth,
+- [x] Define versioned machine-readable records for network, VPN, Bluetooth,
   and provider availability without parsing human-oriented status output.
-- [ ] Define required fields for a protocol-version header and each record;
+- [x] Define required fields for a protocol-version header and each record;
   consumers reject a missing or incompatible major version, reject records
   missing required fields, and ignore documented trailing fields and unknown
   record types for append-only compatibility.
-- [ ] Reuse the existing NetworkManager and BlueZ helpers where their output,
+- [x] Reuse the existing NetworkManager and BlueZ helpers where their output,
   lifecycle, and failure contracts are already suitable.
-- [ ] Separate read-only state, user-session actions, delegated authorization,
+- [x] Separate read-only state, user-session actions, delegated authorization,
   and unsupported capabilities in provider and QML state.
 
 Acceptance:
@@ -87,14 +86,14 @@ Acceptance:
 
 ### NET-001: Network and VPN Workflows
 
-- [ ] Add Ethernet, Wi-Fi, saved connection, active connection, and VPN status
+- [x] Add Ethernet, Wi-Fi, saved connection, active connection, and VPN status
   to Settings using NetworkManager-owned interfaces.
-- [ ] Add scan, saved-profile activation, Wi-Fi connection, disconnect, and
+- [x] Add scan, saved-profile activation, Wi-Fi connection, disconnect, and
   forget actions with explicit progress and failure states. Bound scans to 10
   seconds, activation and connection to 90 seconds, and disconnect or forget
   to 15 seconds; cancellation terminates the owning helper, cleans temporary
   state, and performs no automatic retry.
-- [ ] Delegate advanced, hidden, enterprise, and VPN editing to a trusted
+- [x] Delegate advanced, hidden, enterprise, and VPN editing to a trusted
   NetworkManager tool when the workflow is not safely owned by Settings.
 
 Acceptance:
@@ -111,13 +110,13 @@ Acceptance:
 
 ### BT-001: Bluetooth Workflows
 
-- [ ] Add adapter power, bounded discovery, known-device, paired, trusted, and
+- [x] Add adapter power, bounded discovery, known-device, paired, trusted, and
   connected state using BlueZ-owned interfaces.
-- [ ] Add pair, trust, connect, disconnect, and remove actions with per-device
+- [x] Add pair, trust, connect, disconnect, and remove actions with per-device
   progress and attributed failures.
-- [ ] Carry one validated canonical device address or stable BlueZ object path
+- [x] Carry one validated canonical device address or stable BlueZ object path
   through every request, progress record, completion callback, and error.
-- [ ] Report adapter, daemon, hardware, and operation support separately.
+- [x] Report adapter, daemon, hardware, and operation support separately.
 
 Acceptance:
 

--- a/config/quickshell/controls/BluetoothModel.qml
+++ b/config/quickshell/controls/BluetoothModel.qml
@@ -1,3 +1,4 @@
+import QtQuick
 import Quickshell
 import Quickshell.Io
 import qs.core
@@ -6,12 +7,27 @@ Scope {
     id: root
 
     property bool visible: false
+    property bool settingsVisible: false
     property bool busy: false
     property string statusText: "BT unavailable"
+    property string providerState: "idle"
+    property string providerDetail: ""
+    property string daemonState: "unknown"
+    property string adapterState: "unknown"
+    property string operationState: "unavailable"
+    property var adapters: []
     property var devices: []
     property string message: ""
+    property string actionOrigin: ""
+    property string actionName: ""
+    property string actionAddress: ""
+    property string snapshotOrigin: ""
+    property string scanOrigin: ""
+    property bool actionFailed: false
     readonly property bool available: statusText !== "BT unavailable"
     readonly property bool powered: available && statusText !== "BT off"
+    readonly property bool actionsAvailable: operationState === "delegated"
+    readonly property bool active: true
 
     function open() {
         root.visible = true;
@@ -21,18 +37,97 @@ Scope {
     function close() {
         root.visible = false;
         root.message = "";
+        root.stopUnownedWork("panel");
+    }
+
+    function openSettings() {
+        root.settingsVisible = true;
+        root.refresh(false, "settings");
+    }
+
+    function closeSettings() {
+        root.settingsVisible = false;
+        root.stopUnownedWork("settings");
+    }
+
+    function stopUnownedWork(origin) {
+        if (root.actionOrigin === origin && actionProcess.running) actionProcess.running = false;
+        if (root.snapshotOrigin === origin && snapshotProcess.running) snapshotProcess.running = false;
+        if (root.scanOrigin === origin && scanProcess.running) scanProcess.running = false;
     }
 
     function toggle() {
         if (root.visible) root.close(); else root.open();
     }
 
-    function refresh(scan) {
-        if (!statusProcess.running) statusProcess.running = true;
-        if (!devicesProcess.running) {
-            devicesProcess.command = Commands.controlsHelperCommand(scan ? "bluetooth-scan" : "bluetooth-devices");
-            devicesProcess.running = true;
+    function refresh(scan, origin) {
+        if (!root.active) return;
+        if (scan) {
+            if (!scanProcess.running) {
+                root.scanOrigin = origin || (root.visible ? "panel" : "shared");
+                scanProcess.running = true;
+            }
+            return;
         }
+        if (!snapshotProcess.running) {
+            root.snapshotOrigin = origin || (root.visible ? "panel" : "shared");
+            snapshotProcess.running = true;
+        }
+    }
+
+    function parseSnapshot(text) {
+        const adapters = [];
+        const devices = [];
+        let protocolValid = false;
+        let providerSeen = false;
+        let malformed = false;
+        root.daemonState = "unknown";
+        root.adapterState = "unknown";
+        root.operationState = "unavailable";
+
+        for (const line of text.trim().split("\n")) {
+            if (line.length === 0) continue;
+            const fields = line.split("\t");
+            if (fields[0] === "connectivity-protocol") {
+                protocolValid = fields.length >= 3 && fields[1] === "1";
+            } else if (fields[0] === "provider") {
+                if (fields.length < 5 || fields[1] !== "bluetooth") { malformed = true; continue; }
+                providerSeen = true;
+                root.providerState = fields[2];
+                root.providerDetail = fields[4];
+            } else if (fields[0] === "bluetooth-adapter") {
+                if (fields.length < 7) { malformed = true; continue; }
+                adapters.push({ "path": fields[1], "address": fields[2], "name": fields[3] === "-" ? "" : fields[3],
+                    "powered": fields[4] === "yes", "discovering": fields[5] === "yes", "pairable": fields[6] === "yes" });
+            } else if (fields[0] === "bluetooth-support") {
+                if (fields.length < 4) { malformed = true; continue; }
+                if (fields[1] === "daemon") root.daemonState = fields[2];
+                else if (fields[1] === "adapter") root.adapterState = fields[2];
+                else if (fields[1] === "operations") root.operationState = fields[2];
+            } else if (fields[0] === "bluetooth-device") {
+                if (fields.length < 8) { malformed = true; continue; }
+                devices.push({ "path": fields[1], "address": fields[2], "name": fields[3] === "-" ? "" : fields[3],
+                    "paired": fields[4] === "yes", "trusted": fields[5] === "yes",
+                    "connected": fields[6] === "yes", "adapterPath": fields[7] === "-" ? "" : fields[7] });
+            }
+        }
+
+        if (!protocolValid || !providerSeen || malformed) {
+            root.providerState = "failure";
+            root.providerDetail = !protocolValid ? "Unsupported connectivity protocol" : "Malformed Bluetooth provider record";
+            root.statusText = "BT unavailable";
+            root.message = root.providerDetail;
+            root.adapters = [];
+            root.devices = [];
+            return;
+        }
+
+        root.adapters = adapters;
+        root.devices = devices;
+        if (root.providerState !== "available" || adapters.length === 0) root.statusText = "BT unavailable";
+        else if (!adapters[0].powered) root.statusText = "BT off";
+        else root.statusText = "BT " + devices.filter(function(device) { return device.connected; }).length;
+        if (root.providerState !== "available") root.message = root.providerDetail;
     }
 
     function parseDevices(text) {
@@ -46,12 +141,58 @@ Scope {
         root.devices = rows;
     }
 
-    function action(name, args) {
+    function action(name, args, origin) {
         if (root.busy) return;
+        const actionArgs = args || [];
+        const address = actionArgs.length > 0 && name !== "bluetooth-power" ? actionArgs[0] : "";
+        if (address.length > 0 && !/^[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}$/.test(address)) {
+            root.message = "Invalid Bluetooth device address";
+            return;
+        }
         root.busy = true;
-        root.message = "Working...";
-        actionProcess.command = Commands.controlsHelperCommand(name, args || []);
+        root.actionFailed = false;
+        root.actionOrigin = origin || "panel";
+        root.actionName = name;
+        root.actionAddress = address;
+        root.message = address.length > 0 ? name.replace("bluetooth-", "") + " " + address : "Updating adapter...";
+        actionProcess.command = Commands.controlsHelperCommand(name, actionArgs);
         actionProcess.running = true;
+    }
+
+    Process {
+        id: snapshotProcess
+        command: Commands.controlsHelperCommand("bluetooth-snapshot")
+        stdout: StdioCollector { onStreamFinished: root.parseSnapshot(this.text) }
+        stderr: StdioCollector { onStreamFinished: { const error = this.text.trim(); if (error.length > 0) root.message = error; } }
+        onRunningChanged: if (!running) root.snapshotOrigin = ""
+    }
+
+    Process {
+        id: scanProcess
+        command: Commands.controlsHelperCommand("bluetooth-scan")
+        stderr: StdioCollector {
+            onStreamFinished: if (this.text.trim().length > 0) root.message = "Bluetooth discovery failed"
+        }
+        onRunningChanged: if (!running) {
+            const completedOrigin = root.scanOrigin;
+            if (root.active && !snapshotProcess.running) {
+                root.snapshotOrigin = completedOrigin;
+                snapshotProcess.running = true;
+            }
+            root.scanOrigin = "";
+        }
+    }
+
+    Process {
+        command: ["sh", "-c", "command -v busctl >/dev/null 2>&1 && exec busctl --system monitor org.bluez"]
+        running: true
+        stdout: SplitParser { onRead: monitorSettleTimer.restart() }
+    }
+
+    Timer {
+        id: monitorSettleTimer
+        interval: 600
+        onTriggered: root.refresh(false, "shared")
     }
 
     Process {
@@ -72,8 +213,22 @@ Scope {
         onRunningChanged: {
             if (!running && root.busy) {
                 root.busy = false;
-                root.message = "";
+                if (!root.actionFailed) root.message = "";
                 root.refresh(false);
+                root.actionOrigin = "";
+                root.actionName = "";
+                root.actionAddress = "";
+            }
+        }
+
+        stderr: StdioCollector {
+            onStreamFinished: {
+                const error = this.text.trim();
+                if (error.length > 0) {
+                    root.actionFailed = true;
+                    root.message = root.actionName.replace("bluetooth-", "")
+                        + (root.actionAddress.length > 0 ? " failed for " + root.actionAddress : " failed");
+                }
             }
         }
     }

--- a/config/quickshell/controls/BluetoothWindow.qml
+++ b/config/quickshell/controls/BluetoothWindow.qml
@@ -49,14 +49,15 @@ ClickAwayPopup {
 
                 ShellButton {
                     label: "Scan"
-                    enabled: root.bluetoothModel.powered && !root.bluetoothModel.busy
+                    enabled: root.bluetoothModel.powered && root.bluetoothModel.actionsAvailable
+                        && !root.bluetoothModel.busy
                     onActivated: root.bluetoothModel.refresh(true)
                 }
 
                 PanelToggleSwitch {
                     checked: root.bluetoothModel.powered
                     busy: root.bluetoothModel.busy
-                    enabled: root.bluetoothModel.available
+                    enabled: root.bluetoothModel.available && root.bluetoothModel.actionsAvailable
                     onToggled: root.bluetoothModel.action("bluetooth-power", [checked ? "off" : "on"])
                 }
             }
@@ -116,7 +117,7 @@ ClickAwayPopup {
                         }
                         ShellButton {
                             label: deviceRow.modelData.connected ? "Disconnect" : (deviceRow.modelData.paired ? "Connect" : "Pair")
-                            enabled: !root.bluetoothModel.busy
+                            enabled: root.bluetoothModel.actionsAvailable && !root.bluetoothModel.busy
                             onActivated: root.bluetoothModel.action(deviceRow.modelData.connected ? "bluetooth-disconnect" : (deviceRow.modelData.paired ? "bluetooth-connect" : "bluetooth-pair"), [deviceRow.modelData.address])
                         }
                     }

--- a/config/quickshell/network/NetworkModel.qml
+++ b/config/quickshell/network/NetworkModel.qml
@@ -6,14 +6,23 @@ Scope {
     id: root
 
     property bool visible: false
+    property bool settingsVisible: false
     property bool busy: false
     property bool editorAvailable: false
     property bool actionUsesPasswordStdin: false
     property bool wifiPasswordPromptVisible: false
+    property string wifiPasswordPromptOrigin: ""
     property int selectedIndex: 0
     property int selectedWifiIndex: -1
     property string statusText: "NET offline"
     property string message: ""
+    property string providerState: "idle"
+    property string providerDetail: ""
+    property string operationState: "read-only"
+    property string actionOrigin: ""
+    property string actionLabel: ""
+    property string snapshotOrigin: ""
+    property bool actionFailed: false
     property string wifiPassword: ""
     property var devices: []
     property var connections: []
@@ -25,9 +34,18 @@ Scope {
     readonly property var savedProfiles: root.connections.filter(function(profile) {
         return !profile.active && root.isSupportedProfile(profile.type);
     })
+    readonly property bool active: true
+    readonly property bool actionsAvailable: (providerState === "available" || providerState === "restricted")
+        && operationState === "delegated"
 
     function isSupportedProfile(type) {
         return type === "802-3-ethernet" || type === "ethernet" || type === "802-11-wireless" || type === "wifi" || type === "vpn";
+    }
+
+    function supportsFixedWifiSecurity(security) {
+        const value = (security || "").toUpperCase();
+        return value.indexOf("802.1X") < 0 && value.indexOf("EAP") < 0
+            && value.indexOf("ENTERPRISE") < 0;
     }
 
     function open() {
@@ -40,8 +58,29 @@ Scope {
         root.selectedIndex = 0;
         root.selectedWifiIndex = -1;
         root.wifiPasswordPromptVisible = false;
+        root.wifiPasswordPromptOrigin = "";
         root.message = "";
         root.wifiPassword = "";
+        root.stopUnownedWork("panel");
+    }
+
+    function openSettings() {
+        root.settingsVisible = true;
+        root.refresh(false, "settings");
+    }
+
+    function closeSettings() {
+        root.settingsVisible = false;
+        root.selectedWifiIndex = -1;
+        root.wifiPasswordPromptVisible = false;
+        root.wifiPasswordPromptOrigin = "";
+        root.wifiPassword = "";
+        root.stopUnownedWork("settings");
+    }
+
+    function stopUnownedWork(origin) {
+        if (root.actionOrigin === origin && actionProcess.running) actionProcess.running = false;
+        if (root.snapshotOrigin === origin && snapshotProcess.running) snapshotProcess.running = false;
     }
 
     function toggle() {
@@ -52,27 +91,77 @@ Scope {
         }
     }
 
-    function refresh(rescanWifi) {
-        if (!statusProcess.running) {
-            statusProcess.running = true;
-        }
-        if (!devicesProcess.running) {
-            devicesProcess.running = true;
-        }
-        if (!connectionsProcess.running) {
-            connectionsProcess.running = true;
-        }
-        root.refreshWifi(rescanWifi === true);
+    function refresh(rescanWifi, origin) {
+        if (!root.active || snapshotProcess.running) return;
+        root.providerState = "loading";
+        root.snapshotOrigin = origin || (root.visible ? "panel" : "shared");
+        snapshotProcess.command = Commands.networkHelperCommand("snapshot", ["--rescan", rescanWifi ? "yes" : "no"]);
+        snapshotProcess.running = true;
         if (!editorCheckProcess.running) {
             editorCheckProcess.running = true;
         }
     }
 
-    function refreshWifi(rescan) {
-        if (!wifiScanProcess.running) {
-            wifiScanProcess.command = Commands.networkHelperCommand("wifi-scan", rescan ? ["--rescan", "yes"] : ["--rescan", "no"]);
-            wifiScanProcess.running = true;
+    function refreshWifi(rescan, origin) {
+        root.refresh(rescan === true, origin);
+    }
+
+    function parseSnapshot(text) {
+        const devices = [];
+        const connections = [];
+        const wifiNetworks = [];
+        let protocolValid = false;
+        let providerSeen = false;
+        let malformed = false;
+        let connectedDevice = "";
+        root.operationState = "read-only";
+
+        for (const line of text.trim().split("\n")) {
+            if (line.length === 0) continue;
+            const fields = line.split("\t");
+            if (fields[0] === "connectivity-protocol") {
+                protocolValid = fields.length >= 3 && fields[1] === "1";
+            } else if (fields[0] === "provider") {
+                if (fields.length < 5 || fields[1] !== "network") { malformed = true; continue; }
+                providerSeen = true;
+                root.providerState = fields[2];
+                root.operationState = fields[3];
+                root.providerDetail = fields[4];
+            } else if (fields[0] === "network-device") {
+                if (fields.length < 5) { malformed = true; continue; }
+                devices.push({ "device": fields[1], "type": fields[2], "state": fields[3], "connection": fields[4] === "-" ? "" : fields[4] });
+                if (connectedDevice.length === 0 && fields[3] === "connected") connectedDevice = fields[1];
+            } else if (fields[0] === "network-profile") {
+                if (fields.length < 6) { malformed = true; continue; }
+                connections.push({ "name": fields[1], "uuid": fields[2], "type": fields[3], "active": fields[4] === "yes", "device": fields[5] === "-" ? "" : fields[5] });
+            } else if (fields[0] === "wifi-network") {
+                if (fields.length < 8) { malformed = true; continue; }
+                const security = fields[5] === "--" ? "" : fields[5];
+                wifiNetworks.push({ "active": fields[1] === "*", "bssid": fields[2], "ssid": fields[3],
+                    "signal": fields[4], "security": security, "channel": fields[6], "device": fields[7], "secured": security.length > 0 });
+            }
         }
+
+        if (!protocolValid || !providerSeen || malformed) {
+            root.providerState = "failure";
+            root.providerDetail = !protocolValid ? "Unsupported connectivity protocol" : "Malformed network provider record";
+            root.statusText = "NET unavailable";
+            root.devices = [];
+            root.connections = [];
+            root.wifiNetworks = [];
+            root.message = root.providerDetail;
+            return;
+        }
+
+        root.devices = devices;
+        root.connections = connections;
+        root.wifiNetworks = wifiNetworks;
+        const stateReadable = root.providerState === "available" || root.providerState === "restricted";
+        root.statusText = stateReadable ? (connectedDevice.length > 0 ? "NET " + connectedDevice : "NET offline") : "NET unavailable";
+        if (root.providerState !== "available") root.message = root.providerDetail;
+        else if (!root.actionFailed && !root.busy) root.message = "";
+        if (root.selectedIndex >= connections.length) root.selectedIndex = Math.max(0, connections.length - 1);
+        if (root.selectedWifiIndex >= wifiNetworks.length) root.selectedWifiIndex = -1;
     }
 
     function parseDevices(text) {
@@ -189,16 +278,23 @@ Scope {
 
     function cancelWifiPasswordPrompt() {
         root.wifiPasswordPromptVisible = false;
+        root.wifiPasswordPromptOrigin = "";
         root.selectedWifiIndex = -1;
         root.wifiPassword = "";
         root.message = "";
     }
 
-    function connectWifi(network) {
+    function connectWifi(network, origin) {
         if (!network || network.device.length === 0 || network.bssid.length === 0 || network.ssid.length === 0) {
             return;
         }
-        if (root.busy || actionProcess.running) {
+        if (!root.actionsAvailable || root.busy || actionProcess.running) {
+            return;
+        }
+
+        if (!root.supportsFixedWifiSecurity(network.security)) {
+            root.message = "Enterprise Wi-Fi opens in Advanced NetworkManager settings";
+            root.openEditor();
             return;
         }
 
@@ -210,6 +306,7 @@ Scope {
                 }
             }
             root.wifiPasswordPromptVisible = true;
+            root.wifiPasswordPromptOrigin = origin || "panel";
             root.message = "";
             return;
         }
@@ -221,44 +318,66 @@ Scope {
         }
 
         root.busy = true;
+        root.actionFailed = false;
+        root.actionOrigin = origin || "panel";
+        root.actionLabel = "connect Wi-Fi";
         root.actionUsesPasswordStdin = network.secured;
         root.wifiPasswordPromptVisible = false;
+        root.wifiPasswordPromptOrigin = "";
         root.message = "Connecting " + network.ssid;
         actionProcess.command = Commands.networkHelperCommand("wifi-connect", args);
         actionProcess.running = true;
     }
 
-    function connectSelectedWifi() {
-        root.connectWifi(root.selectedWifiNetwork());
+    function connectSelectedWifi(origin) {
+        root.connectWifi(root.selectedWifiNetwork(), origin);
     }
 
-    function connectProfile(profile) {
+    function connectProfile(profile, origin) {
         if (!profile || profile.uuid.length === 0) {
             return;
         }
-        if (root.busy || actionProcess.running) {
+        if (!root.actionsAvailable || root.busy || actionProcess.running) {
             return;
         }
 
         root.busy = true;
+        root.actionFailed = false;
+        root.actionOrigin = origin || "panel";
+        root.actionLabel = "activate profile";
         root.actionUsesPasswordStdin = false;
         root.message = "Connecting " + profile.name;
         actionProcess.command = Commands.networkHelperCommand("connect", [profile.uuid]);
         actionProcess.running = true;
     }
 
-    function disconnectDevice(device) {
+    function disconnectDevice(device, origin) {
         if (!device || device.length === 0) {
             return;
         }
-        if (root.busy || actionProcess.running) {
+        if (!root.actionsAvailable || root.busy || actionProcess.running) {
             return;
         }
 
         root.busy = true;
+        root.actionFailed = false;
+        root.actionOrigin = origin || "panel";
+        root.actionLabel = "disconnect device";
         root.actionUsesPasswordStdin = false;
         root.message = "Disconnecting " + device;
         actionProcess.command = Commands.networkHelperCommand("disconnect", [device]);
+        actionProcess.running = true;
+    }
+
+    function forgetProfile(profile, origin) {
+        if (!root.actionsAvailable || !profile || profile.uuid.length === 0 || root.busy || actionProcess.running) return;
+        root.busy = true;
+        root.actionFailed = false;
+        root.actionOrigin = origin || "panel";
+        root.actionLabel = "forget profile";
+        root.actionUsesPasswordStdin = false;
+        root.message = "Forgetting " + profile.name;
+        actionProcess.command = Commands.networkHelperCommand("forget", [profile.uuid]);
         actionProcess.running = true;
     }
 
@@ -268,6 +387,25 @@ Scope {
         }
 
         editorProcess.running = true;
+    }
+
+    Process {
+        id: snapshotProcess
+
+        command: Commands.networkHelperCommand("snapshot", ["--rescan", "no"])
+        running: false
+        stdout: StdioCollector { onStreamFinished: root.parseSnapshot(this.text) }
+        stderr: StdioCollector {
+            onStreamFinished: {
+                const error = this.text.trim();
+                if (error.length > 0) {
+                    root.providerState = "failure";
+                    root.providerDetail = error;
+                    root.message = error;
+                }
+            }
+        }
+        onRunningChanged: if (!running) root.snapshotOrigin = ""
     }
 
     Process {
@@ -327,8 +465,20 @@ Scope {
                 root.busy = false;
                 root.actionUsesPasswordStdin = false;
                 root.wifiPassword = "";
-                root.message = "";
+                if (!root.actionFailed) root.message = "";
                 root.refresh(false);
+                root.actionOrigin = "";
+                root.actionLabel = "";
+            }
+        }
+
+        stderr: StdioCollector {
+            onStreamFinished: {
+                const error = this.text.trim();
+                if (error.length > 0) {
+                    root.actionFailed = true;
+                    root.message = root.actionLabel + " failed: " + error;
+                }
             }
         }
     }

--- a/config/quickshell/network/NetworkProfileRow.qml
+++ b/config/quickshell/network/NetworkProfileRow.qml
@@ -7,6 +7,7 @@ Rectangle {
 
     required property var profile
     property bool active: false
+    property bool actionsEnabled: true
     signal connectRequested(var profile)
     signal disconnectRequested(string device)
 
@@ -56,6 +57,7 @@ Rectangle {
         ShellButton {
             Layout.preferredHeight: Theme.chipHeight
             label: root.active ? "Disconnect" : "Connect"
+            enabled: root.actionsEnabled
             onActivated: root.active ? root.disconnectRequested(root.profile.device) : root.connectRequested(root.profile)
         }
     }

--- a/config/quickshell/network/NetworkWifiRow.qml
+++ b/config/quickshell/network/NetworkWifiRow.qml
@@ -8,6 +8,8 @@ Rectangle {
     required property var network
     property bool selected: false
     property bool busy: false
+    property bool actionsEnabled: true
+    property bool delegated: false
     signal selectedRequested
     signal connectRequested(var network)
 
@@ -69,8 +71,8 @@ Rectangle {
 
         ShellButton {
             Layout.preferredHeight: Theme.chipHeight
-            label: root.busy ? "Connecting..." : "Connect"
-            enabled: !root.busy
+            label: root.delegated ? "Advanced" : root.busy ? "Connecting..." : "Connect"
+            enabled: root.actionsEnabled && !root.busy
             onActivated: root.connectRequested(root.network)
         }
     }

--- a/config/quickshell/network/NetworkWindow.qml
+++ b/config/quickshell/network/NetworkWindow.qml
@@ -100,6 +100,7 @@ ClickAwayPopup {
                     width: ListView.view.width
                     profile: modelData
                     active: true
+                    actionsEnabled: root.networkModel.actionsAvailable && !root.networkModel.busy
                     onDisconnectRequested: device => root.networkModel.disconnectDevice(device)
                 }
             }
@@ -132,6 +133,8 @@ ClickAwayPopup {
                     network: modelData
                     selected: index === root.networkModel.selectedWifiIndex
                     busy: root.networkModel.busy
+                    actionsEnabled: root.networkModel.actionsAvailable
+                    delegated: !root.networkModel.supportsFixedWifiSecurity(modelData.security)
                     onSelectedRequested: root.networkModel.selectWifi(index)
                     onConnectRequested: network => {
                         root.networkModel.selectWifi(index);
@@ -166,6 +169,7 @@ ClickAwayPopup {
                     width: ListView.view.width
                     profile: modelData
                     active: false
+                    actionsEnabled: root.networkModel.actionsAvailable && !root.networkModel.busy
                     onConnectRequested: profile => root.networkModel.connectProfile(profile)
                 }
             }
@@ -197,6 +201,7 @@ ClickAwayPopup {
             title: "dwm network password"
             screen: root.panelWindow ? root.panelWindow.screen : null
             visible: root.networkModel.wifiPasswordPromptVisible
+                && root.networkModel.wifiPasswordPromptOrigin === "panel"
             implicitWidth: 440
             implicitHeight: 210
             color: Theme.transparent

--- a/config/quickshell/settings/BluetoothSettingsPane.qml
+++ b/config/quickshell/settings/BluetoothSettingsPane.qml
@@ -1,0 +1,145 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.core
+
+pragma ComponentBehavior: Bound
+
+ColumnLayout {
+    id: root
+
+    required property var bluetoothModel
+    property string pendingRemoveAddress: ""
+    spacing: Theme.spacingLg
+
+    onVisibleChanged: if (!visible) pendingRemoveAddress = ""
+
+    RowLayout {
+        Layout.fillWidth: true
+
+        UiText {
+            Layout.fillWidth: true
+            text: root.bluetoothModel.providerState === "available"
+                ? root.bluetoothModel.statusText + " / BlueZ"
+                : root.bluetoothModel.providerDetail
+            color: root.bluetoothModel.providerState === "available" ? Theme.menuText : Theme.warning
+            font.bold: true
+            elide: Text.ElideRight
+        }
+
+        ShellButton {
+            label: root.bluetoothModel.powered ? "Power Off" : "Power On"
+            enabled: root.bluetoothModel.available && root.bluetoothModel.actionsAvailable
+                && !root.bluetoothModel.busy
+            onActivated: root.bluetoothModel.action("bluetooth-power",
+                [root.bluetoothModel.powered ? "off" : "on"], "settings")
+        }
+
+        ShellButton {
+            label: "Discover"
+            enabled: root.bluetoothModel.powered && root.bluetoothModel.actionsAvailable
+                && !root.bluetoothModel.busy
+            onActivated: root.bluetoothModel.refresh(true, "settings")
+        }
+    }
+
+    UiText {
+        Layout.fillWidth: true
+        visible: root.bluetoothModel.message.length > 0
+        text: root.bluetoothModel.message
+        color: root.bluetoothModel.providerState === "failure" ? Theme.danger : Theme.menuMutedText
+        elide: Text.ElideRight
+    }
+
+    SectionLabel { label: "Known and discovered devices" }
+
+    ListView {
+        id: deviceList
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        clip: true
+        spacing: Theme.spacingSm
+        model: root.bluetoothModel.devices
+
+        delegate: Rectangle {
+            id: deviceRow
+            required property var modelData
+            readonly property bool thisBusy: root.bluetoothModel.busy
+                && root.bluetoothModel.actionAddress === modelData.address
+            width: deviceList.width
+            height: 68
+            color: Theme.controlNormalFill
+            border.color: thisBusy ? Theme.accent : Theme.controlNormalBorder
+            border.width: Theme.controlBorderWidth
+            radius: Theme.controlRadius
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.margins: Theme.spacingSm
+                spacing: Theme.spacingSm
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: Theme.spacingXxs
+
+                    UiText {
+                        Layout.fillWidth: true
+                        text: deviceRow.modelData.name || deviceRow.modelData.address
+                        color: Theme.controlNormalText
+                        font.bold: true
+                        elide: Text.ElideRight
+                    }
+
+                    UiText {
+                        Layout.fillWidth: true
+                        text: deviceRow.thisBusy ? "Working on " + deviceRow.modelData.address
+                            : deviceRow.modelData.address + " / "
+                                + (deviceRow.modelData.connected ? "connected"
+                                    : deviceRow.modelData.paired ? "paired" : "not paired")
+                                + (deviceRow.modelData.trusted ? " / trusted" : "")
+                        color: Theme.menuMutedText
+                        font.pixelSize: Theme.fontCaptionSize
+                        elide: Text.ElideRight
+                    }
+                }
+
+                ShellButton {
+                    label: !deviceRow.modelData.paired ? "Pair"
+                        : !deviceRow.modelData.trusted ? "Trust"
+                        : deviceRow.modelData.connected ? "Disconnect" : "Connect"
+                    enabled: root.bluetoothModel.actionsAvailable && !root.bluetoothModel.busy
+                    onActivated: {
+                        const action = !deviceRow.modelData.paired ? "bluetooth-pair"
+                            : !deviceRow.modelData.trusted ? "bluetooth-trust"
+                            : deviceRow.modelData.connected ? "bluetooth-disconnect" : "bluetooth-connect";
+                        root.bluetoothModel.action(action, [deviceRow.modelData.address], "settings");
+                    }
+                }
+
+                ShellButton {
+                    label: root.pendingRemoveAddress === deviceRow.modelData.address ? "Confirm Remove" : "Remove"
+                    danger: true
+                    visible: deviceRow.modelData.paired
+                    enabled: root.bluetoothModel.actionsAvailable && !root.bluetoothModel.busy
+                    onActivated: {
+                        if (root.pendingRemoveAddress === deviceRow.modelData.address) {
+                            root.pendingRemoveAddress = "";
+                            root.bluetoothModel.action("bluetooth-remove",
+                                [deviceRow.modelData.address], "settings");
+                        } else {
+                            root.pendingRemoveAddress = deviceRow.modelData.address;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    UiText {
+        Layout.fillWidth: true
+        visible: root.bluetoothModel.devices.length === 0
+        text: root.bluetoothModel.powered ? "No Bluetooth devices are known or visible"
+            : "Turn Bluetooth on to discover devices"
+        color: Theme.menuMutedText
+        horizontalAlignment: Text.AlignHCenter
+    }
+}

--- a/config/quickshell/settings/NetworkSettingsPane.qml
+++ b/config/quickshell/settings/NetworkSettingsPane.qml
@@ -1,0 +1,201 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.core
+import qs.network
+
+pragma ComponentBehavior: Bound
+
+ColumnLayout {
+    id: root
+
+    required property var networkModel
+    property string pendingForgetUuid: ""
+    spacing: Theme.spacingLg
+
+    onVisibleChanged: if (!visible) pendingForgetUuid = ""
+
+    RowLayout {
+        Layout.fillWidth: true
+
+        UiText {
+            Layout.fillWidth: true
+            text: root.networkModel.providerState === "available"
+                ? root.networkModel.statusText + " / NetworkManager"
+                : root.networkModel.providerDetail
+            color: root.networkModel.providerState === "available" ? Theme.menuText : Theme.warning
+            font.bold: true
+            elide: Text.ElideRight
+        }
+
+        ShellButton {
+            label: "Scan"
+            enabled: !root.networkModel.busy && root.networkModel.actionsAvailable
+            onActivated: root.networkModel.refresh(true, "settings")
+        }
+
+        ShellButton {
+            label: "Advanced"
+            visible: root.networkModel.editorAvailable && root.networkModel.actionsAvailable
+            onActivated: root.networkModel.openEditor()
+        }
+    }
+
+    UiText {
+        Layout.fillWidth: true
+        visible: root.networkModel.message.length > 0
+        text: root.networkModel.message
+        color: root.networkModel.providerState === "failure" ? Theme.danger : Theme.menuMutedText
+        elide: Text.ElideRight
+    }
+
+    SectionLabel { label: "Active connections" }
+
+    ListView {
+        id: activeList
+        Layout.fillWidth: true
+        Layout.preferredHeight: Math.min(92, Math.max(40, contentHeight))
+        clip: true
+        spacing: Theme.spacingSm
+        model: root.networkModel.activeConnections
+
+        delegate: NetworkProfileRow {
+            required property var modelData
+            width: activeList.width
+            profile: modelData
+            active: true
+            actionsEnabled: root.networkModel.actionsAvailable && !root.networkModel.busy
+            onDisconnectRequested: device => root.networkModel.disconnectDevice(device, "settings")
+        }
+    }
+
+    SectionLabel { label: "Wi-Fi networks" }
+
+    ListView {
+        id: wifiList
+        Layout.fillWidth: true
+        Layout.preferredHeight: 142
+        clip: true
+        spacing: Theme.spacingSm
+        model: root.networkModel.wifiNetworks
+
+        delegate: NetworkWifiRow {
+            required property int index
+            required property var modelData
+            width: wifiList.width
+            network: modelData
+            selected: index === root.networkModel.selectedWifiIndex
+            busy: root.networkModel.busy
+            actionsEnabled: root.networkModel.actionsAvailable
+            delegated: !root.networkModel.supportsFixedWifiSecurity(modelData.security)
+            onSelectedRequested: root.networkModel.selectWifi(index)
+            onConnectRequested: network => {
+                root.networkModel.selectWifi(index);
+                root.networkModel.connectWifi(network, "settings");
+            }
+        }
+    }
+
+    RowLayout {
+        Layout.fillWidth: true
+        visible: root.networkModel.wifiPasswordPromptVisible
+            && root.networkModel.wifiPasswordPromptOrigin === "settings"
+        spacing: Theme.spacingSm
+
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: Theme.largeSurfaceSearchHeight
+            color: Theme.controlNormalFill
+            border.color: passwordInput.activeFocus ? Theme.controlFocusBorder : Theme.controlNormalBorder
+            border.width: Theme.controlBorderWidth
+            radius: Theme.controlRadius
+
+            TextInput {
+                id: passwordInput
+                anchors.fill: parent
+                anchors.margins: Theme.spacingSm
+                echoMode: TextInput.Password
+                color: Theme.controlNormalText
+                verticalAlignment: TextInput.AlignVCenter
+                text: root.networkModel.wifiPassword
+                onTextChanged: root.networkModel.wifiPassword = text
+                onAccepted: root.networkModel.connectSelectedWifi("settings")
+
+                Connections {
+                    target: root.networkModel
+
+                    function onWifiPasswordChanged() {
+                        if (root.networkModel.wifiPassword.length === 0 && passwordInput.text.length > 0) {
+                            passwordInput.clear();
+                        }
+                    }
+                }
+            }
+        }
+
+        ShellButton {
+            label: "Connect"
+            enabled: passwordInput.text.length > 0 && root.networkModel.actionsAvailable
+                && !root.networkModel.busy
+            onActivated: root.networkModel.connectSelectedWifi("settings")
+        }
+
+        ShellButton {
+            label: "Cancel"
+            onActivated: root.networkModel.cancelWifiPasswordPrompt()
+        }
+    }
+
+    SectionLabel { label: "Saved Ethernet, Wi-Fi, and VPN profiles" }
+
+    ListView {
+        id: savedList
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        clip: true
+        spacing: Theme.spacingSm
+        model: root.networkModel.savedProfiles
+
+        delegate: Rectangle {
+            id: profileRow
+            required property var modelData
+            width: savedList.width
+            height: 48
+            color: Theme.controlNormalFill
+            border.color: Theme.controlNormalBorder
+            border.width: Theme.controlBorderWidth
+            radius: Theme.controlRadius
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.margins: Theme.spacingSm
+
+                UiText {
+                    Layout.fillWidth: true
+                    text: profileRow.modelData.name + " / " + profileRow.modelData.type
+                    color: Theme.controlNormalText
+                    elide: Text.ElideRight
+                }
+
+                ShellButton {
+                    label: "Connect"
+                    enabled: root.networkModel.actionsAvailable && !root.networkModel.busy
+                    onActivated: root.networkModel.connectProfile(profileRow.modelData, "settings")
+                }
+
+                ShellButton {
+                    label: root.pendingForgetUuid === profileRow.modelData.uuid ? "Confirm Forget" : "Forget"
+                    danger: true
+                    enabled: root.networkModel.actionsAvailable && !root.networkModel.busy
+                    onActivated: {
+                        if (root.pendingForgetUuid === profileRow.modelData.uuid) {
+                            root.pendingForgetUuid = "";
+                            root.networkModel.forgetProfile(profileRow.modelData, "settings");
+                        } else {
+                            root.pendingForgetUuid = profileRow.modelData.uuid;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/config/quickshell/settings/SettingsModel.qml
+++ b/config/quickshell/settings/SettingsModel.qml
@@ -16,6 +16,8 @@ Scope {
     property string platformFamily: "unknown"
     property string platformName: "Unknown Linux"
     property var targetScreen: null
+    property var networkModel: null
+    property var bluetoothModel: null
     property var capabilities: []
     property int selectedIndex: 0
     property var displayOutputs: []
@@ -91,6 +93,16 @@ Scope {
         displayWatchProcess.running = id === "displays" && root.visible;
         inputWatchProcess.running = id === "input" && root.visible;
 			if (id !== "input") inputSettleTimer.stop();
+        if (root.networkModel) {
+            const wantNetwork = id === "network" && root.visible;
+            if (wantNetwork && !root.networkModel.settingsVisible) root.networkModel.openSettings();
+            else if (!wantNetwork && root.networkModel.settingsVisible) root.networkModel.closeSettings();
+        }
+        if (root.bluetoothModel) {
+            const wantBluetooth = id === "bluetooth" && root.visible;
+            if (wantBluetooth && !root.bluetoothModel.settingsVisible) root.bluetoothModel.openSettings();
+            else if (!wantBluetooth && root.bluetoothModel.settingsVisible) root.bluetoothModel.closeSettings();
+        }
         if (id === "displays") root.refreshDisplays();
         if (id === "input") root.refreshInput();
     }
@@ -471,6 +483,8 @@ Scope {
         inputDiscoverProcess.running = false;
         displayWatchProcess.running = false;
         inputWatchProcess.running = false;
+		if (root.networkModel) root.networkModel.closeSettings();
+		if (root.bluetoothModel) root.bluetoothModel.closeSettings();
 			inputSettleTimer.stop();
         root.visible = false;
         root.busy = false;

--- a/config/quickshell/settings/SettingsWindow.qml
+++ b/config/quickshell/settings/SettingsWindow.qml
@@ -9,6 +9,8 @@ FloatingWindow {
     id: root
 
     required property var settingsModel
+    required property var networkModel
+    required property var bluetoothModel
 
     title: "dwm settings"
     visible: settingsModel.visible
@@ -330,6 +332,20 @@ FloatingWindow {
                                 settingsModel: root.settingsModel
                             }
 
+                            NetworkSettingsPane {
+                                Layout.fillWidth: true
+                                Layout.fillHeight: true
+                                visible: root.settingsModel.selectedSectionId === "network"
+                                networkModel: root.networkModel
+                            }
+
+                            BluetoothSettingsPane {
+                                Layout.fillWidth: true
+                                Layout.fillHeight: true
+                                visible: root.settingsModel.selectedSectionId === "bluetooth"
+                                bluetoothModel: root.bluetoothModel
+                            }
+
                             ListView {
                                 id: capabilityList
 
@@ -337,6 +353,8 @@ FloatingWindow {
                                 Layout.fillHeight: true
                                 visible: root.settingsModel.selectedSectionId !== "displays"
                                     && root.settingsModel.selectedSectionId !== "input"
+                                    && root.settingsModel.selectedSectionId !== "network"
+                                    && root.settingsModel.selectedSectionId !== "bluetooth"
                                 clip: true
                                 spacing: Theme.spacingLg
                                 model: root.settingsModel.capabilitiesForSection(root.settingsModel.selectedSectionId)

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -177,6 +177,8 @@ ShellRoot {
 
     SettingsModel {
         id: settingsModel
+        networkModel: networkModel
+        bluetoothModel: bluetoothModel
     }
 
     LazyLoader {
@@ -185,6 +187,7 @@ ShellRoot {
         component: Item {
             Component.onCompleted: {
                 networkModel.refresh();
+                bluetoothModel.refresh();
                 controlsModel.refresh();
             }
         }
@@ -465,6 +468,22 @@ ShellRoot {
             return settingsModel.inputState;
         }
 
+        function networkProviderStatus(): string {
+            return networkModel.providerState;
+        }
+
+        function networkDeviceCount(): int {
+            return networkModel.devices.length;
+        }
+
+        function bluetoothProviderStatus(): string {
+            return bluetoothModel.providerState;
+        }
+
+        function bluetoothDeviceCount(): int {
+            return bluetoothModel.devices.length;
+        }
+
         function open(): void {
             settingsModel.open();
         }
@@ -601,5 +620,7 @@ ShellRoot {
 
     SettingsWindow {
         settingsModel: settingsModel
+        networkModel: networkModel
+        bluetoothModel: bluetoothModel
     }
 }

--- a/docs/CONNECTIVITY-PROTOCOL.md
+++ b/docs/CONNECTIVITY-PROTOCOL.md
@@ -1,0 +1,68 @@
+# Connectivity Provider Protocol
+
+The shared Network and Bluetooth models consume tab-separated, append-only
+records from `dwm-quickshell-network snapshot` and
+`dwm-quickshell-controls bluetooth-snapshot`. The first record must be:
+
+```text
+connectivity-protocol<TAB>1<TAB>minor
+```
+
+Consumers require major version `1`, ignore the minor version, ignore unknown
+record types, and ignore trailing fields. They reject a missing header, another
+major version, or a known record missing a required field. Empty required
+fields use `-`; record text must not contain tabs or newlines.
+
+## Common record
+
+`provider` requires domain, availability, capability class, and detail:
+
+```text
+provider<TAB>network|bluetooth<TAB>available|restricted|unavailable<TAB>read-only|delegated<TAB>detail
+```
+
+Availability describes readable state. The capability class independently
+states whether Settings is only reading state or may request a fixed action.
+A provider failure affects only its owning Settings section.
+
+## Network records
+
+- `network-device`: interface, type, state, active connection.
+- `network-profile`: name, UUID, NetworkManager type, active yes/no, interface.
+- `wifi-network`: active marker, BSSID, SSID, signal, security, channel,
+  interface.
+
+NetworkManager state uses explicit `nmcli --terse --escape yes -f ...` fields.
+Wi-Fi scans are bounded to 10 seconds, profile and Wi-Fi activation to 90
+seconds, and disconnect/forget to 15 seconds. Hidden, enterprise, advanced, and
+VPN editing remains delegated to `nm-connection-editor`.
+
+Secured Wi-Fi secrets cross the QML/helper boundary only on stdin. The helper
+creates a mode-0600 `nmcli --passwd-file`, clears the QML value after writing,
+and removes the file on success, failure, timeout, cancellation, or signal.
+
+## Bluetooth records
+
+- `bluetooth-support`: daemon, adapter, or operations; state; detail.
+- `bluetooth-adapter`: object path, address, alias, powered, discovering,
+  pairable.
+- `bluetooth-device`: object path, canonical address, alias, paired, trusted,
+  connected, adapter object path.
+
+Bluetooth state comes from BlueZ `ObjectManager.GetManagedObjects` through
+`busctl --json=short`; `jq` transforms that D-Bus JSON into the protocol. Fixed
+actions use `bluetoothctl`, validate a canonical device address, and preserve
+that identity through progress and failure state. Discovery is bounded and
+always requests `scan off` during normal exit, failure, cancellation, or a
+signal.
+
+## Lifecycle
+
+The panel and Settings receive the same root-scoped Network and Bluetooth
+models. One root NetworkManager monitor and one root BlueZ D-Bus monitor drive
+shared refreshes. Settings does not add another long-lived monitor. Closing a
+Settings section terminates only its own scan or action; closing the shell also
+terminates the root subscriptions. The long-lived shell helpers bind their
+child commands to the originating Quickshell process identity (PID plus process
+start time), so even an ungraceful shell exit cannot leave an `nmcli monitor`
+or media subscription behind.

--- a/docs/P3-CONNECTIVITY-EVIDENCE.md
+++ b/docs/P3-CONNECTIVITY-EVIDENCE.md
@@ -1,0 +1,54 @@
+# Phase 3 Connectivity Evidence
+
+## Scope
+
+This evidence qualifies `CONN-001`, `NET-001`, and `BT-001` on Fedora Linux 44
+x86_64 in the active managed X11 session. Network and Bluetooth state is shared
+between the panel and Settings by one root-scoped model per provider. No
+Settings pane owns a duplicate long-lived monitor.
+
+## Automated Validation
+
+The connectivity suites cover protocol compatibility, malformed and unavailable
+providers, action failures, stable Bluetooth identities, bounded commands,
+secret-file cleanup, and Settings lifecycle. The full repository build and test
+commands passed from a clean managed test workspace before merge.
+
+The monitor lifecycle test kills the owning shell process and verifies that the
+helper and its `nmcli monitor` child both terminate. The same parent-bound
+lifecycle is used by the media watcher.
+
+## Live Network Qualification
+
+NetworkManager reported the active Ethernet connection
+`3519b659-6ec0-47e0-aa59-aa566e5bcaae` on `enp6s0`, plus the externally managed
+`virbr0` bridge. Opening Network Settings exposed three devices and the saved
+profiles through the shared model. A bounded rescan completed without changing
+the active connection set.
+
+This machine has no Wi-Fi adapter. The real Wi-Fi scan therefore completed with
+an empty result, and Wi-Fi association, password authentication, and cancellation
+could only be qualified by fixtures and helper tests. Enterprise, hidden, and
+VPN editing remains explicitly delegated to NetworkManager's trusted editor.
+
+## Live Bluetooth Qualification
+
+BlueZ exposed adapter `/org/bluez/hci0` at `08:B4:D2:6A:D9:8D`. A bounded
+eight-second discovery completed successfully and left the adapter with
+`Discovering=false`. The paired and trusted Xbox Wireless Controller retained
+canonical address `68:6C:E6:6E:D6:8A` and remained disconnected. Discovery also
+found transient nearby devices without changing their paired or trusted state.
+
+The real adapter, discovery, and known-device paths are qualified. Pairing a new
+device and recovering a failed pairing were not performed because no sacrificial
+device was available; those paths remain covered by stable-identity fixtures and
+action-failure tests.
+
+## Process and Live-Install Qualification
+
+The final development synchronization created rollback backup
+`20260821T214412Z-756866` and verified every managed file before restarting the
+managed Quickshell instance. A subsequent deliberate restart removed the former
+NetworkManager and media watcher children and created exactly one current
+`nmcli monitor` and one current `playerctl --follow` child. No discovery process
+or scan remained after closing the owning operation.

--- a/docs/P3-CONNECTIVITY-EVIDENCE.md
+++ b/docs/P3-CONNECTIVITY-EVIDENCE.md
@@ -20,11 +20,11 @@ lifecycle is used by the media watcher.
 
 ## Live Network Qualification
 
-NetworkManager reported the active Ethernet connection
-`3519b659-6ec0-47e0-aa59-aa566e5bcaae` on `enp6s0`, plus the externally managed
-`virbr0` bridge. Opening Network Settings exposed three devices and the saved
-profiles through the shared model. A bounded rescan completed without changing
-the active connection set.
+NetworkManager reported the active Ethernet connection on `enp6s0`, plus the
+externally managed `virbr0` bridge. The private connection UUID is retained in
+local qualification records and intentionally redacted here. Opening Network
+Settings exposed three devices and the saved profiles through the shared model.
+A bounded rescan completed without changing the active connection set.
 
 This machine has no Wi-Fi adapter. The real Wi-Fi scan therefore completed with
 an empty result, and Wi-Fi association, password authentication, and cancellation
@@ -33,11 +33,12 @@ VPN editing remains explicitly delegated to NetworkManager's trusted editor.
 
 ## Live Bluetooth Qualification
 
-BlueZ exposed adapter `/org/bluez/hci0` at `08:B4:D2:6A:D9:8D`. A bounded
-eight-second discovery completed successfully and left the adapter with
+BlueZ exposed adapter `/org/bluez/hci0`. Adapter and device addresses are
+retained in local qualification records and intentionally redacted here. A
+bounded eight-second discovery completed successfully and left the adapter with
 `Discovering=false`. The paired and trusted Xbox Wireless Controller retained
-canonical address `68:6C:E6:6E:D6:8A` and remained disconnected. Discovery also
-found transient nearby devices without changing their paired or trusted state.
+its stable canonical identity and remained disconnected. Discovery also found
+transient nearby devices without changing their paired or trusted state.
 
 The real adapter, discovery, and known-device paths are qualified. Pairing a new
 device and recovering a failed pairing were not performed because no sacrificial

--- a/docs/SETTINGS-CAPABILITIES.md
+++ b/docs/SETTINGS-CAPABILITIES.md
@@ -90,12 +90,12 @@ action.
 
 | Operations | Owner and interface | Class | Failure and lifecycle behavior |
 | --- | --- | --- | --- |
-| Network status, devices, profiles, Wi-Fi scan | `dwm-quickshell-network` machine-oriented `nmcli` fields | Read-only | Missing NetworkManager tooling yields unavailable state without affecting other sections. |
+| Network status, devices, profiles, Wi-Fi scan | Versioned `dwm-quickshell-network snapshot` records from machine-oriented `nmcli` fields | Read-only | Missing NetworkManager tooling yields unavailable state without affecting other sections. |
 | Network change notifications | `dwm-quickshell-network monitor` using `nmcli monitor` | Read-only | The existing shared monitor serves the always-visible panel. A Settings-only watch must stop when its section closes. |
 | Connect saved profile, connect Wi-Fi, disconnect device | Fixed `nmcli connection` and `device` actions | Delegated | NetworkManager owns policy and secrets. QML clears passwords after passing them over helper stdin; the helper selects WPA, WPA3, or WEP settings from scan data, uses a mode-0600 temporary `passwd-file`, removes it after activation, and never puts the secret on argv. |
 | Hidden, enterprise, and advanced network editing | `nm-connection-editor` | Delegated | Hide the entry point when the tool is absent. |
-| Bluetooth status and known device list | `dwm-quickshell-controls bluetooth-status` and `bluetooth-devices` | Read-only | Missing `bluetoothctl`, daemon, or adapter is an unavailable capability. |
-| Scan, adapter power, pair/trust/connect, disconnect | Fixed `bluetoothctl` actions | Delegated | BlueZ owns device policy. Scan is bounded to eight seconds; failures must be attributed to the requested device/action. |
+| Bluetooth status and known device list | Versioned `bluetooth-snapshot` records from BlueZ ObjectManager D-Bus JSON | Read-only | Daemon, adapter, and operation support are reported separately. |
+| Scan, adapter power, pair/trust/connect, disconnect, remove | Fixed `bluetoothctl` actions | Delegated | BlueZ owns device policy. Scan is bounded to eight seconds and explicitly stopped; failures retain the canonical requested address. |
 
 ### Audio and Media
 
@@ -148,7 +148,7 @@ duplicate Fedora package lists.
 | Quickshell Settings frontend | `fedora:desktop` | Missing Quickshell makes the Settings UI unavailable. |
 | X11 display state | `fedora:x11` | Missing RandR tools disable display controls. TearFree and NVIDIA composition remain driver-dependent. |
 | NetworkManager | `fedora:desktop-optional`; enabled by the Fedora image | Missing service reports unavailable while other sections continue. |
-| BlueZ | `fedora:desktop` plus the image service/package set | Adapter absence is a runtime unsupported state. |
+| BlueZ and D-Bus JSON parsing | `bluez`, `systemd`, and `jq` from `fedora:desktop` plus the image service/package set | Adapter absence is a runtime unsupported state. |
 | PipeWire/WirePlumber and controls | `fedora:desktop`; included by the image | Missing session services report unavailable. |
 | DPMS and auto-lock | X11 tools plus `fedora:desktop` | Missing schemas or locker disable only lock controls. |
 | Defaults | `fedora:runtime-required` | Missing XDG utilities disable default-application controls. |

--- a/dwm-fedora-nvidia.ks
+++ b/dwm-fedora-nvidia.ks
@@ -100,6 +100,7 @@ mate-polkit
 alsa-utils
 brightnessctl
 pulseaudio-utils
+jq
 pipewire
 pipewire-pulseaudio
 wireplumber

--- a/dwm-fedora.ks
+++ b/dwm-fedora.ks
@@ -99,6 +99,7 @@ mate-polkit
 alsa-utils
 brightnessctl
 pulseaudio-utils
+jq
 pipewire
 pipewire-pulseaudio
 wireplumber

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -128,6 +128,7 @@ else
 	MISSING=$((MISSING + 1))
 fi
 check_cmd "amixer"
+check_cmd "jq"
 check_cmd "bluetoothctl"
 check_cmd "blueman-applet"
 echo ""

--- a/scripts/dwm-packages.sh
+++ b/scripts/dwm-packages.sh
@@ -24,7 +24,7 @@ dwm_packages() {
 		# desktop transaction; the Fedora package-map check proves availability.
 		printf '%s\n' \
 			quickshell picom feh dex-autostart mate-polkit \
-			alsa-utils brightnessctl pulseaudio-utils pipewire pavucontrol \
+			alsa-utils brightnessctl jq pulseaudio-utils pipewire pavucontrol \
 			pipewire-pulseaudio wireplumber libnotify light-locker xorg-x11-drv-libinput \
 			bluez blueman playerctl flatpak xdg-desktop-portal-gtk
 		;;

--- a/scripts/dwm-quickshell-controls
+++ b/scripts/dwm-quickshell-controls
@@ -628,8 +628,8 @@ bluetooth_power() {
 bluetooth_pair() {
 	[ "$#" -eq 1 ] || usage
 	validate_bluetooth_address "$1"
-	run_bounded 90 bluetoothctl pair "$1"
-	run_bounded 15 bluetoothctl trust "$1"
+	run_bounded 90 bluetoothctl pair "$1" || return $?
+	run_bounded 15 bluetoothctl trust "$1" || return $?
 	run_bounded 90 bluetoothctl connect "$1"
 }
 

--- a/scripts/dwm-quickshell-controls
+++ b/scripts/dwm-quickshell-controls
@@ -2,8 +2,55 @@
 set -eu
 
 usage() {
-	printf '%s\n' "usage: dwm-quickshell-controls volume-status|volume-watch|volume-up [step]|volume-down [step]|volume-set <percent>|volume-toggle-mute|output-status|output-devices|output-set-default <sink>|mic-status|media-status|media-watch|media-play-pause|media-next|media-previous|bluetooth-status|bluetooth-devices|bluetooth-scan|bluetooth-power <on|off>|bluetooth-pair <address>|bluetooth-connect <address>|bluetooth-disconnect <address>" >&2
+	printf '%s\n' "usage: dwm-quickshell-controls volume-status|volume-watch|volume-up [step]|volume-down [step]|volume-set <percent>|volume-toggle-mute|output-status|output-devices|output-set-default <sink>|mic-status|media-status|media-watch|media-play-pause|media-next|media-previous|bluetooth-snapshot|bluetooth-status|bluetooth-devices|bluetooth-scan|bluetooth-power <on|off>|bluetooth-pair <address>|bluetooth-trust <address>|bluetooth-connect <address>|bluetooth-disconnect <address>|bluetooth-remove <address>" >&2
 	exit 2
+}
+
+run_bounded() {
+	duration=$1
+	shift
+	status=0
+	timeout --signal=TERM --kill-after=2 "$duration" "$@" || status=$?
+	if [ "$status" -eq 124 ]; then
+		printf 'operation timed out after %s seconds\n' "$duration" >&2
+	fi
+	return "$status"
+}
+
+run_parent_bound() {
+	parent_pid=$PPID
+	parent_identity=$(sed 's/^.*) //' "/proc/$parent_pid/stat" 2>/dev/null |
+		awk '{ print $1 " " $20 }') || return 1
+	case $parent_identity in
+	Z\ *) return 1 ;;
+	esac
+	"$@" &
+	child_pid=$!
+
+	cleanup_parent_bound() {
+		kill -TERM "$child_pid" 2>/dev/null || :
+		kill -TERM "${watchdog_pid:-}" 2>/dev/null || :
+	}
+	trap cleanup_parent_bound EXIT HUP INT TERM
+	(
+		while :; do
+			current_identity=$(sed 's/^.*) //' "/proc/$parent_pid/stat" 2>/dev/null |
+				awk '{ print $1 " " $20 }' || true)
+			[ "$current_identity" = "$parent_identity" ] || {
+				kill -TERM "$child_pid" 2>/dev/null || :
+				exit 0
+			}
+			sleep 0.25
+		done
+	) &
+	watchdog_pid=$!
+
+	status=0
+	wait "$child_pid" || status=$?
+	kill -TERM "$watchdog_pid" 2>/dev/null || :
+	wait "$watchdog_pid" 2>/dev/null || :
+	trap - EXIT HUP INT TERM
+	return "$status"
 }
 
 volume_step() {
@@ -411,7 +458,7 @@ media_watch() {
 	fi
 
 	format=$(printf '{{playerName}}\t{{status}}\t{{artist}}\t{{title}}')
-	if ! playerctl --follow metadata --format "$format" 2>/dev/null; then
+	if ! run_parent_bound playerctl --follow metadata --format "$format"; then
 		printf '%s\n' "MEDIA none"
 	fi
 }
@@ -425,6 +472,86 @@ playerctl_action() {
 	fi
 
 	playerctl "$1"
+}
+
+bluetooth_snapshot() {
+	printf 'connectivity-protocol\t1\t0\n'
+
+	if ! command -v busctl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+		printf 'provider\tbluetooth\tunavailable\tread-only\tbusctl and jq are required for BlueZ state\n'
+		printf 'bluetooth-support\tdaemon\tunknown\tD-Bus state tooling is unavailable\n'
+		printf 'bluetooth-support\tadapter\tunknown\tAdapter state cannot be read\n'
+		printf 'bluetooth-support\toperations\tunavailable\tBluetooth actions are disabled\n'
+		return 0
+	fi
+
+	bluez_json=$(run_bounded 5 busctl --system --json=short call org.bluez / \
+		org.freedesktop.DBus.ObjectManager GetManagedObjects 2>/dev/null) || {
+		printf 'provider\tbluetooth\tunavailable\tread-only\tBlueZ daemon is unavailable\n'
+		printf 'bluetooth-support\tdaemon\tunavailable\tBlueZ ObjectManager is unreachable\n'
+		printf 'bluetooth-support\tadapter\tunknown\tAdapter state cannot be read\n'
+		printf 'bluetooth-support\toperations\tunavailable\tBluetooth actions are disabled\n'
+		return 0
+	}
+
+	if ! adapter_count=$(printf '%s\n' "$bluez_json" |
+		jq -er 'select(.data[0] | type == "object") | [.data[0] | to_entries[] | select(.value["org.bluez.Adapter1"] != null)] | length'); then
+		printf 'provider\tbluetooth\tunavailable\tread-only\tBlueZ returned an invalid ObjectManager response\n'
+		printf 'bluetooth-support\tdaemon\tunknown\tBlueZ response could not be validated\n'
+		printf 'bluetooth-support\tadapter\tunknown\tAdapter state cannot be read\n'
+		printf 'bluetooth-support\toperations\tunavailable\tBluetooth actions are disabled\n'
+		return 0
+	fi
+	if [ "$adapter_count" -eq 0 ]; then
+		printf 'provider\tbluetooth\trestricted\tread-only\tBlueZ is available but no adapter is present\n'
+		printf 'bluetooth-support\tdaemon\tavailable\tBlueZ ObjectManager is reachable\n'
+		printf 'bluetooth-support\tadapter\tunavailable\tNo BlueZ adapter object is present\n'
+		printf 'bluetooth-support\toperations\tunavailable\tNo adapter can accept operations\n'
+		return 0
+	fi
+
+	if command -v bluetoothctl >/dev/null 2>&1; then
+		printf 'provider\tbluetooth\tavailable\tdelegated\tBlueZ state and user-authorized device actions\n'
+		operation_state=delegated
+		operation_detail='Fixed bluetoothctl actions are available'
+	else
+		printf 'provider\tbluetooth\tavailable\tread-only\tBlueZ state is readable but bluetoothctl actions are unavailable\n'
+		operation_state=unavailable
+		operation_detail='bluetoothctl is not installed'
+	fi
+	printf 'bluetooth-support\tdaemon\tavailable\tBlueZ ObjectManager is reachable\n'
+	printf 'bluetooth-support\tadapter\tavailable\tA BlueZ adapter object is present\n'
+	printf 'bluetooth-support\toperations\t%s\t%s\n' "$operation_state" "$operation_detail"
+	printf '%s\n' "$bluez_json" | jq -r '
+		def clean: tostring | gsub("[\\t\\r\\n]"; " ");
+		def field: clean | if . == "" then "-" else . end;
+		.data[0] | to_entries[] |
+		select(.value["org.bluez.Adapter1"] != null) |
+		.value["org.bluez.Adapter1"] as $adapter |
+		["bluetooth-adapter", .key,
+		 ($adapter.Address.data // "" | field),
+		 ($adapter.Alias.data // $adapter.Name.data // "" | field),
+		 (if ($adapter.Powered.data // false) then "yes" else "no" end),
+		 (if ($adapter.Discovering.data // false) then "yes" else "no" end),
+		 (if ($adapter.Pairable.data // false) then "yes" else "no" end)] | @tsv'
+	printf '%s\n' "$bluez_json" | jq -r '
+		def clean: tostring | gsub("[\\t\\r\\n]"; " ");
+		def field: clean | if . == "" then "-" else . end;
+		.data[0] | to_entries[] |
+		select(.value["org.bluez.Device1"] != null) |
+		.value["org.bluez.Device1"] as $device |
+		["bluetooth-device", .key,
+		 ($device.Address.data // "" | field),
+		 ($device.Alias.data // $device.Name.data // $device.Address.data // "" | field),
+		 (if ($device.Paired.data // false) then "yes" else "no" end),
+		 (if ($device.Trusted.data // false) then "yes" else "no" end),
+		 (if ($device.Connected.data // false) then "yes" else "no" end),
+		 ($device.Adapter.data // "" | field)] | @tsv'
+}
+
+validate_bluetooth_address() {
+	[ "$#" -eq 1 ] || usage
+	printf '%s\n' "$1" | grep -Eq '^[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}$' || usage
 }
 
 bluetooth_status() {
@@ -472,28 +599,62 @@ bluetooth_devices() {
 
 bluetooth_scan() {
 	command -v bluetoothctl >/dev/null 2>&1 || return 1
-	bluetoothctl --timeout 8 scan on >/dev/null 2>&1 || true
+	scan_pid=
+	cleanup_bluetooth_scan() {
+		if [ -n "$scan_pid" ]; then
+			kill -TERM "$scan_pid" 2>/dev/null || :
+			wait "$scan_pid" 2>/dev/null || :
+		fi
+		bluetoothctl scan off >/dev/null 2>&1 || :
+	}
+	trap cleanup_bluetooth_scan EXIT
+	trap 'cleanup_bluetooth_scan; exit 1' HUP INT TERM
+	run_bounded 10 bluetoothctl --timeout 8 scan on >/dev/null 2>&1 &
+	scan_pid=$!
+	status=0
+	wait "$scan_pid" || status=$?
+	scan_pid=
+	bluetoothctl scan off >/dev/null 2>&1 || :
+	trap - EXIT HUP INT TERM
+	[ "$status" -eq 0 ] || return "$status"
 	bluetooth_devices
 }
 
 bluetooth_power() {
 	[ "$#" -eq 1 ] || usage
-	case $1 in on | off) bluetoothctl power "$1" ;; *) usage ;; esac
+	case $1 in on | off) run_bounded 15 bluetoothctl power "$1" ;; *) usage ;; esac
 }
 
 bluetooth_pair() {
 	[ "$#" -eq 1 ] || usage
-	bluetoothctl pair "$1" && bluetoothctl trust "$1" && bluetoothctl connect "$1"
+	validate_bluetooth_address "$1"
+	run_bounded 90 bluetoothctl pair "$1"
+	run_bounded 15 bluetoothctl trust "$1"
+	run_bounded 90 bluetoothctl connect "$1"
+}
+
+bluetooth_trust() {
+	[ "$#" -eq 1 ] || usage
+	validate_bluetooth_address "$1"
+	run_bounded 15 bluetoothctl trust "$1"
 }
 
 bluetooth_connect() {
 	[ "$#" -eq 1 ] || usage
-	bluetoothctl connect "$1"
+	validate_bluetooth_address "$1"
+	run_bounded 90 bluetoothctl connect "$1"
 }
 
 bluetooth_disconnect() {
 	[ "$#" -eq 1 ] || usage
-	bluetoothctl disconnect "$1"
+	validate_bluetooth_address "$1"
+	run_bounded 15 bluetoothctl disconnect "$1"
+}
+
+bluetooth_remove() {
+	[ "$#" -eq 1 ] || usage
+	validate_bluetooth_address "$1"
+	run_bounded 15 bluetoothctl remove "$1"
 }
 
 [ "$#" -ge 1 ] || usage
@@ -566,6 +727,10 @@ bluetooth-status)
 	[ "$#" -eq 0 ] || usage
 	bluetooth_status
 	;;
+bluetooth-snapshot)
+	[ "$#" -eq 0 ] || usage
+	bluetooth_snapshot
+	;;
 bluetooth-devices)
 	[ "$#" -eq 0 ] || usage
 	bluetooth_devices
@@ -580,11 +745,17 @@ bluetooth-power)
 bluetooth-pair)
 	bluetooth_pair "$@"
 	;;
+bluetooth-trust)
+	bluetooth_trust "$@"
+	;;
 bluetooth-connect)
 	bluetooth_connect "$@"
 	;;
 bluetooth-disconnect)
 	bluetooth_disconnect "$@"
+	;;
+bluetooth-remove)
+	bluetooth_remove "$@"
 	;;
 *)
 	usage

--- a/scripts/dwm-quickshell-controls
+++ b/scripts/dwm-quickshell-controls
@@ -21,6 +21,7 @@ run_parent_bound() {
 	parent_pid=$PPID
 	parent_identity=$(sed 's/^.*) //' "/proc/$parent_pid/stat" 2>/dev/null |
 		awk '{ print $1 " " $20 }') || return 1
+	[ -n "$parent_identity" ] || return 1
 	case $parent_identity in
 	Z\ *) return 1 ;;
 	esac

--- a/scripts/dwm-quickshell-network
+++ b/scripts/dwm-quickshell-network
@@ -2,8 +2,55 @@
 set -eu
 
 usage() {
-	printf '%s\n' "usage: dwm-quickshell-network status|devices|connections|wifi-scan [--rescan yes|no] [ifname]|wifi-connect <ifname> <bssid> <ssid> [--password-stdin <security>]|connect <uuid>|disconnect <device>|monitor|editor" >&2
+	printf '%s\n' "usage: dwm-quickshell-network snapshot [--rescan yes|no]|status|devices|connections|wifi-scan [--rescan yes|no] [ifname]|wifi-connect <ifname> <bssid> <ssid> [--password-stdin <security>]|connect <uuid>|disconnect <device>|forget <uuid>|monitor|editor" >&2
 	exit 2
+}
+
+run_bounded() {
+	duration=$1
+	shift
+	status=0
+	timeout --signal=TERM --kill-after=2 "$duration" "$@" || status=$?
+	if [ "$status" -eq 124 ]; then
+		printf 'operation timed out after %s seconds\n' "$duration" >&2
+	fi
+	return "$status"
+}
+
+run_parent_bound() {
+	parent_pid=$PPID
+	parent_identity=$(sed 's/^.*) //' "/proc/$parent_pid/stat" 2>/dev/null |
+		awk '{ print $1 " " $20 }') || return 1
+	case $parent_identity in
+	Z\ *) return 1 ;;
+	esac
+	"$@" &
+	child_pid=$!
+
+	cleanup_parent_bound() {
+		kill -TERM "$child_pid" 2>/dev/null || :
+		kill -TERM "${watchdog_pid:-}" 2>/dev/null || :
+	}
+	trap cleanup_parent_bound EXIT HUP INT TERM
+	(
+		while :; do
+			current_identity=$(sed 's/^.*) //' "/proc/$parent_pid/stat" 2>/dev/null |
+				awk '{ print $1 " " $20 }' || true)
+			[ "$current_identity" = "$parent_identity" ] || {
+				kill -TERM "$child_pid" 2>/dev/null || :
+				exit 0
+			}
+			sleep 0.25
+		done
+	) &
+	watchdog_pid=$!
+
+	status=0
+	wait "$child_pid" || status=$?
+	kill -TERM "$watchdog_pid" 2>/dev/null || :
+	wait "$watchdog_pid" 2>/dev/null || :
+	trap - EXIT HUP INT TERM
+	return "$status"
 }
 
 need_nmcli() {
@@ -13,9 +60,8 @@ need_nmcli() {
 	fi
 }
 
-nmcli_tab() {
-	nmcli --terse --escape yes "$@" |
-		awk '
+nmcli_tab_from_stdin() {
+	awk '
 			{
 				field = ""
 				output = ""
@@ -41,11 +87,16 @@ nmcli_tab() {
 		'
 }
 
+nmcli_tab() {
+	output=$(nmcli --terse --escape yes "$@") || return
+	printf '%s' "$output" | nmcli_tab_from_stdin
+}
+
 status() {
 	need_nmcli
 
-	nmcli_tab -f DEVICE,TYPE,STATE device status 2>/dev/null |
-		awk -F '\t' '
+	output=$(nmcli_tab -f DEVICE,TYPE,STATE device status 2>/dev/null) || return
+	printf '%s\n' "$output" | awk -F '\t' '
 			$2 != "loopback" && $3 == "connected" {
 				print "NET " $1
 				found = 1
@@ -61,19 +112,22 @@ status() {
 
 devices() {
 	need_nmcli
-	nmcli_tab -f DEVICE,TYPE,STATE,CONNECTION device status |
-		awk -F '\t' '$2 != "loopback"'
+	output=$(nmcli_tab -f DEVICE,TYPE,STATE,CONNECTION device status) || return
+	printf '%s\n' "$output" | awk -F '\t' '$2 != "loopback"'
 }
 
 connections() {
 	need_nmcli
 
 	active=$(mktemp "${TMPDIR:-/tmp}/dwm-network-active.XXXXXX")
-	trap 'rm -f "$active"' EXIT
+	saved=$(mktemp "${TMPDIR:-/tmp}/dwm-network-saved.XXXXXX")
 
-	nmcli_tab -f NAME,UUID,TYPE,DEVICE connection show --active >"$active"
-	nmcli_tab -f NAME,UUID,TYPE connection show |
-		awk -F '\t' -v OFS='\t' '
+	if ! nmcli_tab -f NAME,UUID,TYPE,DEVICE connection show --active >"$active" ||
+		! nmcli_tab -f NAME,UUID,TYPE connection show >"$saved"; then
+		rm -f "$active" "$saved"
+		return 1
+	fi
+	awk -F '\t' -v OFS='\t' '
 			NR == FNR {
 				active[$2] = 1
 				device[$2] = $4
@@ -82,7 +136,10 @@ connections() {
 			$3 != "loopback" {
 				print $1, $2, $3, (active[$2] ? "yes" : "no"), device[$2]
 			}
-		' "$active" -
+		' "$active" "$saved"
+	status=$?
+	rm -f "$active" "$saved"
+	return "$status"
 }
 
 wifi_scan() {
@@ -114,10 +171,13 @@ wifi_scan() {
 	done
 
 	if [ -n "$ifname" ]; then
-		nmcli_tab -f IN-USE,BSSID,SSID,SIGNAL,SECURITY,CHAN,DEVICE device wifi list ifname "$ifname" --rescan "$rescan"
+		output=$(run_bounded 10 nmcli --terse --escape yes -f IN-USE,BSSID,SSID,SIGNAL,SECURITY,CHAN,DEVICE \
+			device wifi list ifname "$ifname" --rescan "$rescan") || return
 	else
-		nmcli_tab -f IN-USE,BSSID,SSID,SIGNAL,SECURITY,CHAN,DEVICE device wifi list --rescan "$rescan"
+		output=$(run_bounded 10 nmcli --terse --escape yes -f IN-USE,BSSID,SSID,SIGNAL,SECURITY,CHAN,DEVICE \
+			device wifi list --rescan "$rescan") || return
 	fi
+	printf '%s' "$output" | nmcli_tab_from_stdin
 }
 
 wifi_connect() {
@@ -137,6 +197,12 @@ wifi_connect() {
 	if [ "$#" -eq 5 ]; then
 		[ "$4" = "--password-stdin" ] || usage
 		security=$5
+		case $security in
+		*802.1X* | *802.1x* | *EAP* | *Enterprise*)
+			printf '%s\n' "enterprise Wi-Fi must be configured in the delegated NetworkManager editor" >&2
+			exit 2
+			;;
+		esac
 		key_mgmt=wpa-psk
 		secret_property=802-11-wireless-security.psk
 		wep_key_type=
@@ -156,8 +222,14 @@ wifi_connect() {
 		umask 077
 		password_file=$(mktemp "${TMPDIR:-/tmp}/dwm-network-password.XXXXXX")
 		connection_uuid=
-		trap 'rm -f "$password_file"' EXIT
-		trap 'rm -f "$password_file"; if [ -n "$connection_uuid" ]; then nmcli connection delete uuid "$connection_uuid" >/dev/null 2>&1 || :; fi; exit 1' HUP INT TERM
+		cleanup_wifi_connect() {
+			rm -f "$password_file"
+			if [ -n "$connection_uuid" ]; then
+				nmcli connection delete uuid "$connection_uuid" >/dev/null 2>&1 || :
+			fi
+		}
+		trap cleanup_wifi_connect EXIT
+		trap 'cleanup_wifi_connect; exit 1' HUP INT TERM
 
 		if ! IFS= read -r password || [ -z "$password" ]; then
 			printf '%s\n' "Wi-Fi password required on stdin" >&2
@@ -192,9 +264,9 @@ wifi_connect() {
 			set -- "$@" wifi-sec.wep-key-type "$wep_key_type"
 		fi
 		set -- "$@" connection.uuid "$connection_uuid"
-		nmcli "$@" >/dev/null
+		run_bounded 90 nmcli "$@" >/dev/null
 
-		if nmcli connection up uuid "$connection_uuid" ifname "$ifname" ap "$bssid" \
+		if run_bounded 90 nmcli connection up uuid "$connection_uuid" ifname "$ifname" ap "$bssid" \
 			passwd-file "$password_file"; then
 			trap - HUP INT TERM
 			connection_uuid=
@@ -207,29 +279,58 @@ wifi_connect() {
 		connection_uuid=
 		return "$status"
 	else
-		nmcli device wifi connect "$ssid" ifname "$ifname" bssid "$bssid"
+		run_bounded 90 nmcli device wifi connect "$ssid" ifname "$ifname" bssid "$bssid"
 	fi
 }
 
 connect_uuid() {
 	need_nmcli
 	[ "$#" -eq 1 ] || usage
-	nmcli connection up uuid "$1"
+	run_bounded 90 nmcli connection up uuid "$1"
 }
 
 disconnect_device() {
 	need_nmcli
 	[ "$#" -eq 1 ] || usage
-	nmcli device disconnect "$1"
+	run_bounded 15 nmcli device disconnect "$1"
+}
+
+forget_uuid() {
+	need_nmcli
+	[ "$#" -eq 1 ] || usage
+	run_bounded 15 nmcli connection delete uuid "$1"
+}
+
+snapshot() {
+	printf 'connectivity-protocol\t1\t0\n'
+
+	if ! command -v nmcli >/dev/null 2>&1; then
+		printf 'provider\tnetwork\tunavailable\tread-only\tnmcli is not installed\n'
+		return 0
+	fi
+
+	work=$(mktemp -d "${TMPDIR:-/tmp}/dwm-network-snapshot.XXXXXX")
+	trap 'rm -rf "$work"' EXIT HUP INT TERM
+	if ! devices >"$work/devices" 2>"$work/error" ||
+		! connections >"$work/connections" 2>>"$work/error"; then
+		printf 'provider\tnetwork\tunavailable\tread-only\tNetworkManager service is unavailable\n'
+		return 0
+	fi
+
+	if wifi_scan "$@" >"$work/wifi" 2>>"$work/error"; then
+		printf 'provider\tnetwork\tavailable\tdelegated\tNetworkManager state and user-authorized actions\n'
+	else
+		: >"$work/wifi"
+		printf 'provider\tnetwork\trestricted\tdelegated\tWi-Fi scanning is unavailable; other NetworkManager state remains readable\n'
+	fi
+	awk -F '\t' -v OFS='\t' 'NF >= 3 { connection = $4 != "" ? $4 : "-"; print "network-device", $1, $2, $3, connection }' "$work/devices"
+	awk -F '\t' -v OFS='\t' 'NF >= 4 { device = $5 != "" ? $5 : "-"; print "network-profile", $1, $2, $3, $4, device }' "$work/connections"
+	awk -F '\t' -v OFS='\t' 'NF >= 7 && $3 != "" { active = $1 != "" ? $1 : "-"; print "wifi-network", active, $2, $3, $4, $5, $6, $7 }' "$work/wifi"
 }
 
 monitor() {
 	need_nmcli
-
-	nmcli monitor |
-		while IFS= read -r _event; do
-			printf '%s\n' changed
-		done
+	run_parent_bound nmcli monitor
 }
 
 editor() {
@@ -247,6 +348,9 @@ command=$1
 shift
 
 case "$command" in
+snapshot)
+	snapshot "$@"
+	;;
 status)
 	[ "$#" -eq 0 ] || usage
 	status
@@ -270,6 +374,9 @@ connect)
 	;;
 disconnect)
 	disconnect_device "$@"
+	;;
+forget)
+	forget_uuid "$@"
 	;;
 monitor)
 	[ "$#" -eq 0 ] || usage

--- a/scripts/dwm-quickshell-network
+++ b/scripts/dwm-quickshell-network
@@ -21,6 +21,7 @@ run_parent_bound() {
 	parent_pid=$PPID
 	parent_identity=$(sed 's/^.*) //' "/proc/$parent_pid/stat" 2>/dev/null |
 		awk '{ print $1 " " $20 }') || return 1
+	[ -n "$parent_identity" ] || return 1
 	case $parent_identity in
 	Z\ *) return 1 ;;
 	esac

--- a/tests/test-quickshell-connectivity.sh
+++ b/tests/test-quickshell-connectivity.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -eu
+
+repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+network_model=$repo/config/quickshell/network/NetworkModel.qml
+bluetooth_model=$repo/config/quickshell/controls/BluetoothModel.qml
+settings_model=$repo/config/quickshell/settings/SettingsModel.qml
+settings_window=$repo/config/quickshell/settings/SettingsWindow.qml
+network_pane=$repo/config/quickshell/settings/NetworkSettingsPane.qml
+bluetooth_pane=$repo/config/quickshell/settings/BluetoothSettingsPane.qml
+
+grep -Fq 'run_parent_bound nmcli monitor' "$repo/scripts/dwm-quickshell-network"
+grep -Fq 'run_parent_bound playerctl --follow' "$repo/scripts/dwm-quickshell-controls"
+
+for pattern in \
+	'fields[0] === "connectivity-protocol"' \
+	'fields[1] === "1"' \
+	'!protocolValid || !providerSeen || malformed' \
+	'fields.length < 5' \
+	'root.providerState = "failure"'; do
+	grep -Fq "$pattern" "$network_model"
+	grep -Fq "$pattern" "$bluetooth_model"
+done
+
+grep -Fq 'else if (fields[0] === "network-profile")' "$network_model"
+grep -Fq 'else if (fields[0] === "wifi-network")' "$network_model"
+grep -Fq 'else if (fields[0] === "bluetooth-adapter")' "$bluetooth_model"
+grep -Fq 'else if (fields[0] === "bluetooth-device")' "$bluetooth_model"
+
+grep -Fq 'function openSettings()' "$network_model"
+grep -Fq 'property string wifiPasswordPromptOrigin: ""' "$network_model"
+grep -Fq 'function supportsFixedWifiSecurity(security)' "$network_model"
+grep -Fq 'function closeSettings()' "$network_model"
+grep -Fq 'function openSettings()' "$bluetooth_model"
+grep -Fq 'function closeSettings()' "$bluetooth_model"
+grep -Fq 'root.actionOrigin === origin && actionProcess.running' "$network_model"
+grep -Fq 'root.scanOrigin === origin && scanProcess.running' "$bluetooth_model"
+grep -Fq 'operationState === "delegated"' "$bluetooth_model"
+grep -Fq 'root.connections = []' "$network_model"
+grep -Fq 'root.operationState = "unavailable"' "$bluetooth_model"
+
+if grep -Fq 'repeat: true' "$network_model" || grep -Fq 'repeat: true' "$bluetooth_model"; then
+	printf 'Connectivity models must not poll.\n' >&2
+	exit 1
+fi
+grep -Fq 'stdout: SplitParser { onRead: monitorSettleTimer.restart() }' "$bluetooth_model"
+
+grep -Fq 'networkModel: networkModel' "$repo/config/quickshell/shell.qml"
+grep -Fq 'bluetoothModel: bluetoothModel' "$repo/config/quickshell/shell.qml"
+grep -Fq 'root.networkModel.openSettings()' "$settings_model"
+grep -Fq 'root.bluetoothModel.openSettings()' "$settings_model"
+grep -Fq 'NetworkSettingsPane {' "$settings_window"
+grep -Fq 'BluetoothSettingsPane {' "$settings_window"
+
+grep -Fq 'connectSelectedWifi("settings")' "$network_pane"
+grep -Fq 'function onWifiPasswordChanged()' "$network_pane"
+grep -Fq 'passwordInput.clear()' "$network_pane"
+grep -Fq 'Confirm Forget' "$network_pane"
+grep -Fq 'root.networkModel.wifiPasswordPromptOrigin === "settings"' "$network_pane"
+grep -Fq 'delegated: !root.networkModel.supportsFixedWifiSecurity(modelData.security)' "$network_pane"
+grep -Fq 'forgetProfile(profileRow.modelData, "settings")' "$network_pane"
+grep -Fq 'bluetooth-trust' "$bluetooth_pane"
+grep -Fq 'bluetooth-remove' "$bluetooth_pane"
+grep -Fq 'Confirm Remove' "$bluetooth_pane"
+grep -Fq 'actionAddress === modelData.address' "$bluetooth_pane"
+
+printf 'Quickshell connectivity contract: PASS\n'

--- a/tests/test-quickshell-connectivity.sh
+++ b/tests/test-quickshell-connectivity.sh
@@ -28,6 +28,8 @@ grep -Fq 'else if (fields[0] === "bluetooth-adapter")' "$bluetooth_model"
 grep -Fq 'else if (fields[0] === "bluetooth-device")' "$bluetooth_model"
 
 grep -Fq 'function openSettings()' "$network_model"
+grep -Fq "[ -n \"\$parent_identity\" ] || return 1" "$repo/scripts/dwm-quickshell-network"
+grep -Fq "[ -n \"\$parent_identity\" ] || return 1" "$repo/scripts/dwm-quickshell-controls"
 grep -Fq 'property string wifiPasswordPromptOrigin: ""' "$network_model"
 grep -Fq 'function supportsFixedWifiSecurity(security)' "$network_model"
 grep -Fq 'function closeSettings()' "$network_model"

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -404,7 +404,7 @@ grep -Fq 'onDismissed: controlCenterModel.close()' "$repo/config/quickshell/cont
 grep -Fq 'grabFocus: true' "$repo/config/quickshell/core/ClickAwayPopup.qml"
 grep -Fq 'function applyThemes(themeText)' "$repo/config/quickshell/core/Theme.qml"
 grep -Fq 'root.text = value("normfgcolor", root.text)' "$repo/config/quickshell/core/Theme.qml"
-grep -Fq 'label: root.busy ? "Connecting..." : "Connect"' "$repo/config/quickshell/network/NetworkWifiRow.qml"
+grep -Fq 'label: root.delegated ? "Advanced" : root.busy ? "Connecting..." : "Connect"' "$repo/config/quickshell/network/NetworkWifiRow.qml"
 grep -Fq 'property bool wifiPasswordPromptVisible: false' "$repo/config/quickshell/network/NetworkModel.qml"
 grep -Fq 'root.wifiPasswordPromptVisible = true;' "$repo/config/quickshell/network/NetworkModel.qml"
 grep -Fq 'root.networkModel.cancelWifiPasswordPrompt()' "$repo/config/quickshell/network/NetworkWindow.qml"
@@ -453,7 +453,7 @@ grep -Fq 'root.wifiPasswordPromptVisible && root.selectedWifiIndex < 0' "$repo/c
 grep -Fq 'args.push("--password-stdin");' "$repo/config/quickshell/network/NetworkModel.qml"
 grep -Fq 'args.push(network.security);' "$repo/config/quickshell/network/NetworkModel.qml"
 grep -Fq 'stdinEnabled: true' "$repo/config/quickshell/network/NetworkModel.qml"
-test "$(grep -Fc 'if (root.busy || actionProcess.running) {' "$repo/config/quickshell/network/NetworkModel.qml")" -eq 3
+test "$(grep -Fc 'root.busy || actionProcess.running' "$repo/config/quickshell/network/NetworkModel.qml")" -eq 4
 if grep -Fq 'args.push(root.wifiPassword)' "$repo/config/quickshell/network/NetworkModel.qml"; then
 	exit 1
 fi

--- a/tests/test-quickshell-controls.sh
+++ b/tests/test-quickshell-controls.sh
@@ -166,8 +166,12 @@ devices)
 	printf 'scan\n' >>"$DWM_TEST_BLUETOOTHCTL_LOG"
 	;;
 "power on" | "power off" | "pair AA:BB:CC:DD:EE:02" | "trust AA:BB:CC:DD:EE:02" | \
-	"connect AA:BB:CC:DD:EE:02" | "disconnect AA:BB:CC:DD:EE:01")
+	"disconnect AA:BB:CC:DD:EE:01" | "remove AA:BB:CC:DD:EE:02" | "scan off")
 	printf '%s\n' "$*" >>"$DWM_TEST_BLUETOOTHCTL_LOG"
+	;;
+"connect AA:BB:CC:DD:EE:02")
+	printf '%s\n' "$*" >>"$DWM_TEST_BLUETOOTHCTL_LOG"
+	[ "${DWM_TEST_BT_ACTION_FAIL:-0}" != 1 ] || exit 5
 	;;
 *)
 	printf 'unexpected bluetoothctl call: %s\n' "$*" >&2
@@ -176,6 +180,29 @@ devices)
 esac
 SH
 chmod +x "$work/bin/bluetoothctl"
+
+cat >"$work/bin/busctl" <<'SH'
+#!/bin/sh
+set -eu
+
+case "${DWM_TEST_BLUEZ_MODE:-available}" in
+available)
+	cat <<'JSON'
+{"type":"a{oa{sa{sv}}}","data":[{"/org/bluez/hci0":{"org.bluez.Adapter1":{"Address":{"type":"s","data":"00:11:22:33:44:55"},"Alias":{"type":"s","data":"Test Adapter"},"Powered":{"type":"b","data":true},"Discovering":{"type":"b","data":false},"Pairable":{"type":"b","data":true}}},"/org/bluez/hci0/dev_AA_BB_CC_DD_EE_02":{"org.bluez.Device1":{"Address":{"type":"s","data":"AA:BB:CC:DD:EE:02"},"Alias":{"type":"s","data":"Keyboard"},"Paired":{"type":"b","data":true},"Trusted":{"type":"b","data":false},"Connected":{"type":"b","data":false},"Adapter":{"type":"o","data":"/org/bluez/hci0"}}}}]}
+JSON
+	;;
+restricted)
+	printf '%s\n' '{"type":"a{oa{sa{sv}}}","data":[{"/org/bluez":{}}]}'
+	;;
+unavailable)
+	exit 1
+	;;
+malformed)
+	printf '%s\n' '{not-json'
+	;;
+esac
+SH
+chmod +x "$work/bin/busctl"
 
 if PATH="$work/bin:$PATH" "$repo/scripts/dwm-quickshell-controls" 2>"$work/usage.out"; then
 	printf 'Control helper accepted a missing subcommand.\n' >&2
@@ -269,6 +296,38 @@ DWM_TEST_BT_MODE=none \
 	"$repo/scripts/dwm-quickshell-controls" bluetooth-status >"$work/bluetooth-none.out"
 grep -Fqx "BT unavailable" "$work/bluetooth-none.out"
 
+PATH="$work/bin:$PATH" "$repo/scripts/dwm-quickshell-controls" bluetooth-snapshot >"$work/bluetooth-snapshot.out"
+grep -Fqx "connectivity-protocol	1	0" "$work/bluetooth-snapshot.out"
+grep -Fqx "provider	bluetooth	available	delegated	BlueZ state and user-authorized device actions" "$work/bluetooth-snapshot.out"
+grep -Fqx "bluetooth-support	daemon	available	BlueZ ObjectManager is reachable" "$work/bluetooth-snapshot.out"
+grep -Fqx "bluetooth-support	adapter	available	A BlueZ adapter object is present" "$work/bluetooth-snapshot.out"
+grep -Fqx "bluetooth-support	operations	delegated	Fixed bluetoothctl actions are available" "$work/bluetooth-snapshot.out"
+grep -Fqx "bluetooth-adapter	/org/bluez/hci0	00:11:22:33:44:55	Test Adapter	yes	no	yes" "$work/bluetooth-snapshot.out"
+grep -Fqx "bluetooth-device	/org/bluez/hci0/dev_AA_BB_CC_DD_EE_02	AA:BB:CC:DD:EE:02	Keyboard	yes	no	no	/org/bluez/hci0" "$work/bluetooth-snapshot.out"
+
+mkdir -p "$work/read-only-bin"
+ln -s "$work/bin/busctl" "$work/read-only-bin/busctl"
+for command_name in cat jq timeout; do
+	ln -s "$(command -v "$command_name")" "$work/read-only-bin/$command_name"
+done
+PATH="$work/read-only-bin" "$repo/scripts/dwm-quickshell-controls" bluetooth-snapshot >"$work/bluetooth-read-only.out"
+grep -Fqx "provider	bluetooth	available	read-only	BlueZ state is readable but bluetoothctl actions are unavailable" "$work/bluetooth-read-only.out"
+grep -Fqx "bluetooth-support	operations	unavailable	bluetoothctl is not installed" "$work/bluetooth-read-only.out"
+
+DWM_TEST_BLUEZ_MODE=restricted PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" bluetooth-snapshot >"$work/bluetooth-restricted.out"
+grep -Fqx "provider	bluetooth	restricted	read-only	BlueZ is available but no adapter is present" "$work/bluetooth-restricted.out"
+grep -Fqx "bluetooth-support	adapter	unavailable	No BlueZ adapter object is present" "$work/bluetooth-restricted.out"
+
+DWM_TEST_BLUEZ_MODE=unavailable PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" bluetooth-snapshot >"$work/bluetooth-unavailable.out"
+grep -Fqx "provider	bluetooth	unavailable	read-only	BlueZ daemon is unavailable" "$work/bluetooth-unavailable.out"
+grep -Fqx "bluetooth-support	daemon	unavailable	BlueZ ObjectManager is unreachable" "$work/bluetooth-unavailable.out"
+
+DWM_TEST_BLUEZ_MODE=malformed PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" bluetooth-snapshot >"$work/bluetooth-malformed.out" 2>/dev/null
+grep -Fqx "provider	bluetooth	unavailable	read-only	BlueZ returned an invalid ObjectManager response" "$work/bluetooth-malformed.out"
+
 PATH="$work/bin:$PATH" "$repo/scripts/dwm-quickshell-controls" bluetooth-devices >"$work/bluetooth-devices.out"
 grep -Fqx "$(printf 'AA:BB:CC:DD:EE:01\tHeadphones\tyes\tyes')" "$work/bluetooth-devices.out"
 grep -Fqx "$(printf 'AA:BB:CC:DD:EE:02\tKeyboard\tno\tno')" "$work/bluetooth-devices.out"
@@ -291,12 +350,29 @@ DWM_TEST_BLUETOOTHCTL_LOG="$work/bluetoothctl.log" PATH="$work/bin:$PATH" \
 	"$repo/scripts/dwm-quickshell-controls" bluetooth-connect AA:BB:CC:DD:EE:02
 DWM_TEST_BLUETOOTHCTL_LOG="$work/bluetoothctl.log" PATH="$work/bin:$PATH" \
 	"$repo/scripts/dwm-quickshell-controls" bluetooth-disconnect AA:BB:CC:DD:EE:01
+DWM_TEST_BLUETOOTHCTL_LOG="$work/bluetoothctl.log" PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" bluetooth-trust AA:BB:CC:DD:EE:02
+DWM_TEST_BLUETOOTHCTL_LOG="$work/bluetoothctl.log" PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" bluetooth-remove AA:BB:CC:DD:EE:02
 grep -Fqx "power on" "$work/bluetoothctl.log"
 grep -Fqx "power off" "$work/bluetoothctl.log"
 grep -Fqx "pair AA:BB:CC:DD:EE:02" "$work/bluetoothctl.log"
 grep -Fqx "trust AA:BB:CC:DD:EE:02" "$work/bluetoothctl.log"
 grep -Fqx "connect AA:BB:CC:DD:EE:02" "$work/bluetoothctl.log"
 grep -Fqx "disconnect AA:BB:CC:DD:EE:01" "$work/bluetoothctl.log"
+grep -Fqx "trust AA:BB:CC:DD:EE:02" "$work/bluetoothctl.log"
+grep -Fqx "remove AA:BB:CC:DD:EE:02" "$work/bluetoothctl.log"
+
+if DWM_TEST_BT_ACTION_FAIL=1 DWM_TEST_BLUETOOTHCTL_LOG="$work/bluetoothctl.log" PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" bluetooth-connect AA:BB:CC:DD:EE:02; then
+	printf 'Bluetooth helper hid an attributed action failure.\n' >&2
+	exit 1
+fi
+if DWM_TEST_BLUETOOTHCTL_LOG="$work/bluetoothctl.log" PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" bluetooth-connect not-an-address 2>"$work/bluetooth-address.err"; then
+	printf 'Bluetooth helper accepted a non-canonical device address.\n' >&2
+	exit 1
+fi
 
 DWM_TEST_PACTL_LOG="$work/pactl.log" \
 	PATH="$work/bin:$PATH" \

--- a/tests/test-quickshell-controls.sh
+++ b/tests/test-quickshell-controls.sh
@@ -165,7 +165,11 @@ devices)
 "--timeout 8 scan on")
 	printf 'scan\n' >>"$DWM_TEST_BLUETOOTHCTL_LOG"
 	;;
-"power on" | "power off" | "pair AA:BB:CC:DD:EE:02" | "trust AA:BB:CC:DD:EE:02" | \
+"pair AA:BB:CC:DD:EE:02")
+	printf '%s\n' "$*" >>"$DWM_TEST_BLUETOOTHCTL_LOG"
+	[ "${DWM_TEST_BT_PAIR_FAIL:-0}" != 1 ] || exit 6
+	;;
+"power on" | "power off" | "trust AA:BB:CC:DD:EE:02" | \
 	"disconnect AA:BB:CC:DD:EE:01" | "remove AA:BB:CC:DD:EE:02" | "scan off")
 	printf '%s\n' "$*" >>"$DWM_TEST_BLUETOOTHCTL_LOG"
 	;;
@@ -362,6 +366,17 @@ grep -Fqx "connect AA:BB:CC:DD:EE:02" "$work/bluetoothctl.log"
 grep -Fqx "disconnect AA:BB:CC:DD:EE:01" "$work/bluetoothctl.log"
 grep -Fqx "trust AA:BB:CC:DD:EE:02" "$work/bluetoothctl.log"
 grep -Fqx "remove AA:BB:CC:DD:EE:02" "$work/bluetoothctl.log"
+
+: >"$work/bluetoothctl.log"
+if DWM_TEST_BT_PAIR_FAIL=1 DWM_TEST_BLUETOOTHCTL_LOG="$work/bluetoothctl.log" PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" bluetooth-pair AA:BB:CC:DD:EE:02; then
+	printf 'Bluetooth helper continued after a pair failure.\n' >&2
+	exit 1
+fi
+grep -Fqx "pair AA:BB:CC:DD:EE:02" "$work/bluetoothctl.log"
+if grep -Eq '^(trust|connect) ' "$work/bluetoothctl.log"; then
+	exit 1
+fi
 
 if DWM_TEST_BT_ACTION_FAIL=1 DWM_TEST_BLUETOOTHCTL_LOG="$work/bluetoothctl.log" PATH="$work/bin:$PATH" \
 	"$repo/scripts/dwm-quickshell-controls" bluetooth-connect AA:BB:CC:DD:EE:02; then

--- a/tests/test-quickshell-network.sh
+++ b/tests/test-quickshell-network.sh
@@ -36,6 +36,22 @@ while [ "$#" -gt 0 ]; do
 	esac
 done
 
+if [ "${DWM_TEST_NMCLI_CONNECTION_FAIL:-0}" = 1 ]; then
+	case "$*" in
+	"connection show" | "connection show --active") exit 11 ;;
+	esac
+fi
+if [ "${DWM_TEST_NMCLI_EMPTY_CONNECTIONS:-0}" = 1 ]; then
+	case "$*" in
+	"connection show" | "connection show --active") exit 0 ;;
+	esac
+fi
+if [ "${DWM_TEST_WIFI_SCAN_FAIL:-0}" = 1 ]; then
+	case "$*" in
+	"device wifi list "*) exit 12 ;;
+	esac
+fi
+
 case "$*" in
 "device status")
 	case "${DWM_TEST_NMCLI_MODE:-wired}" in
@@ -47,6 +63,9 @@ case "$*" in
 	offline)
 		printf 'enp6s0:ethernet:disconnected:--\n'
 		printf 'lo:loopback:connected:lo\n'
+		;;
+	service-fail)
+		exit 10
 		;;
 	esac
 	;;
@@ -146,6 +165,10 @@ case "$*" in
 	printf 'disconnect enp6s0\n' >>"$DWM_TEST_NMCLI_LOG"
 	;;
 "monitor")
+	if [ "${DWM_TEST_MONITOR_HOLD:-0}" = 1 ]; then
+		printf '%s\n' "$$" >"$DWM_TEST_MONITOR_CHILD"
+		while :; do sleep 1; done
+	fi
 	printf 'wlan0: connected\n'
 	printf 'Networkmanager is now connected\n'
 	;;
@@ -186,6 +209,42 @@ grep -Fqx "	AA:BB:CC:DD:EE:02	Guest WiFi	61	--	11	wlan0" "$work/wifi-scan.out"
 grep -Fqx "	AA:BB:CC:DD:EE:03	Cafe:WiFi	50	WPA3	149	wlan0" "$work/wifi-scan.out"
 grep -Fqx "	AA:BB:CC:DD:EE:06	Legacy WiFi	42	WEP	3	wlan0" "$work/wifi-scan.out"
 
+PATH="$work/bin:$PATH" "$repo/scripts/dwm-quickshell-network" snapshot --rescan no >"$work/snapshot.out"
+[ "$(grep -Fxc "connectivity-protocol	1	0" "$work/snapshot.out")" -eq 1 ]
+grep -Fqx "provider	network	available	delegated	NetworkManager state and user-authorized actions" "$work/snapshot.out"
+grep -Fqx "network-device	enp6s0	ethernet	connected	Wired connection 1" "$work/snapshot.out"
+grep -Fqx "network-profile	Work VPN	uuid-vpn	vpn	no	-" "$work/snapshot.out"
+grep -Fqx "wifi-network	*	AA:BB:CC:DD:EE:01	Cafe:WiFi	83	WPA2	6	wlan0" "$work/snapshot.out"
+
+DWM_TEST_WIFI_SCAN_FAIL=1 PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-network" snapshot --rescan no >"$work/snapshot-wifi-restricted.out"
+grep -Fqx "provider	network	restricted	delegated	Wi-Fi scanning is unavailable; other NetworkManager state remains readable" "$work/snapshot-wifi-restricted.out"
+grep -Fqx "network-device	enp6s0	ethernet	connected	Wired connection 1" "$work/snapshot-wifi-restricted.out"
+grep -Fqx "network-profile	Work VPN	uuid-vpn	vpn	no	-" "$work/snapshot-wifi-restricted.out"
+if grep -Fq "wifi-network	" "$work/snapshot-wifi-restricted.out"; then
+	exit 1
+fi
+
+DWM_TEST_NMCLI_MODE=service-fail PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-network" snapshot --rescan no >"$work/snapshot-unavailable.out"
+grep -Fqx "provider	network	unavailable	read-only	NetworkManager service is unavailable" "$work/snapshot-unavailable.out"
+
+DWM_TEST_NMCLI_CONNECTION_FAIL=1 PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-network" snapshot --rescan no >"$work/snapshot-connection-failure.out"
+grep -Fqx "provider	network	unavailable	read-only	NetworkManager service is unavailable" "$work/snapshot-connection-failure.out"
+if grep -Fq "network-profile	" "$work/snapshot-connection-failure.out"; then
+	printf 'Snapshot emitted incomplete profiles after a connection query failure.\n' >&2
+	exit 1
+fi
+
+DWM_TEST_NMCLI_EMPTY_CONNECTIONS=1 PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-network" snapshot --rescan no >"$work/snapshot-empty-connections.out"
+grep -Fqx "provider	network	available	delegated	NetworkManager state and user-authorized actions" "$work/snapshot-empty-connections.out"
+if grep -Fq "network-profile	" "$work/snapshot-empty-connections.out"; then
+	printf 'Snapshot serialized a false profile from empty NetworkManager output.\n' >&2
+	exit 1
+fi
+
 PATH="$work/bin:$PATH" "$repo/scripts/dwm-quickshell-network" wifi-scan --rescan yes >"$work/wifi-rescan.out"
 grep -Fqx "	AA:BB:CC:DD:EE:04	New WiFi	74	WPA2	1	wlan0" "$work/wifi-rescan.out"
 
@@ -207,6 +266,17 @@ grep -Fqx "wifi-secured" "$work/nmcli.log"
 password_file=$(sed -n 's/^password-file //p' "$work/nmcli.log")
 [ -n "$password_file" ]
 [ ! -e "$password_file" ]
+
+if printf '%s\n' "enterprise secret" |
+	PATH="$work/bin:$PATH" \
+		"$repo/scripts/dwm-quickshell-network" wifi-connect wlan0 AA:BB:CC:DD:EE:09 "Enterprise WiFi" --password-stdin "WPA2 802.1X" \
+		2>"$work/enterprise.err"; then
+	exit 1
+fi
+grep -Fqx "enterprise Wi-Fi must be configured in the delegated NetworkManager editor" "$work/enterprise.err"
+if grep -Fq "Enterprise WiFi" "$work/nmcli.log"; then
+	exit 1
+fi
 if grep -Fq "correct horse battery staple" "$work/nmcli-argv.log"; then
 	exit 1
 fi
@@ -275,7 +345,43 @@ password_file=$(sed -n 's/^password-file //p' "$work/nmcli.log")
 [ ! -e "$password_file" ]
 
 PATH="$work/bin:$PATH" "$repo/scripts/dwm-quickshell-network" monitor >"$work/monitor.out"
-grep -Fqx changed "$work/monitor.out"
+grep -Fqx "wlan0: connected" "$work/monitor.out"
+grep -Fqx "Networkmanager is now connected" "$work/monitor.out"
+
+DWM_TEST_MONITOR_HOLD=1 DWM_TEST_MONITOR_CHILD="$work/monitor-child.pid" \
+	PATH="$work/bin:$PATH" sh -c '"$1" monitor & echo $! >"$2"; wait' sh \
+	"$repo/scripts/dwm-quickshell-network" "$work/monitor-helper.pid" &
+monitor_owner=$!
+i=0
+while [ "$i" -lt 100 ]; do
+	[ -s "$work/monitor-helper.pid" ] && [ -s "$work/monitor-child.pid" ] && break
+	i=$((i + 1))
+	sleep 0.02
+done
+[ -s "$work/monitor-helper.pid" ]
+[ -s "$work/monitor-child.pid" ]
+monitor_helper=$(cat "$work/monitor-helper.pid")
+monitor_child=$(cat "$work/monitor-child.pid")
+pid_running() {
+	[ -r "/proc/$1/stat" ] || return 1
+	state=$(sed 's/^.*) //' "/proc/$1/stat" | awk '{ print $1 }')
+	[ "$state" != Z ]
+}
+kill -KILL "$monitor_owner"
+wait "$monitor_owner" 2>/dev/null || :
+i=0
+while [ "$i" -lt 100 ]; do
+	if ! pid_running "$monitor_helper" && ! pid_running "$monitor_child"; then
+		break
+	fi
+	i=$((i + 1))
+	sleep 0.02
+done
+if pid_running "$monitor_helper" || pid_running "$monitor_child"; then
+	printf 'Parent-bound NetworkManager monitor survived its owner.\n' >&2
+	kill -TERM "$monitor_helper" "$monitor_child" 2>/dev/null || :
+	exit 1
+fi
 
 DWM_TEST_NMCLI_LOG="$work/nmcli.log" \
 	PATH="$work/bin:$PATH" \
@@ -287,6 +393,12 @@ DWM_TEST_NMCLI_LOG="$work/nmcli.log" \
 	PATH="$work/bin:$PATH" \
 	"$repo/scripts/dwm-quickshell-network" disconnect enp6s0
 grep -Fqx "disconnect enp6s0" "$work/nmcli.log"
+
+: >"$work/nmcli.log"
+DWM_TEST_NMCLI_LOG="$work/nmcli.log" \
+	PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-network" forget uuid-wifi
+grep -Fqx "profile-delete connection delete uuid uuid-wifi" "$work/nmcli.log"
 
 if PATH="$work/bin" "$repo/scripts/dwm-quickshell-network" editor 2>"$work/editor.err"; then
 	exit 1

--- a/tests/test-quickshell-settings-xvfb.sh
+++ b/tests/test-quickshell-settings-xvfb.sh
@@ -169,6 +169,31 @@ section=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME
 	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings currentSection)
 [ "$section" = network ]
 
+i=0
+while [ "$i" -lt 100 ]; do
+	network_status=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings networkProviderStatus 2>/dev/null || true)
+	[ "$network_status" = available ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$network_status" = available ]
+network_count=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings networkDeviceCount)
+[ "$network_count" -ge 1 ]
+
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select bluetooth >/dev/null
+i=0
+while [ "$i" -lt 100 ]; do
+	bluetooth_status=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings bluetoothProviderStatus 2>/dev/null || true)
+	[ "$bluetooth_status" = available ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$bluetooth_status" = available ]
+
 # IPC selection clears a search that hides the requested section.
 DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
 	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select audio >/dev/null
@@ -192,6 +217,17 @@ fi
 
 if pgrep -f '[d]wm-settings-provider discover$' >/dev/null; then
 	printf 'Settings capability provider remained active after close\n' >&2
+	exit 1
+fi
+
+if pgrep -af '[d]wm-quickshell-network (snapshot|wifi-scan|wifi-connect|connect|disconnect|forget)' |
+	grep -F "$data_home/dwm-titus/scripts/dwm-quickshell-network" >/dev/null; then
+	printf 'Settings-owned network work remained active after close\n' >&2
+	exit 1
+fi
+if pgrep -af '[d]wm-quickshell-controls (bluetooth-snapshot|bluetooth-scan|bluetooth-power|bluetooth-pair|bluetooth-trust|bluetooth-connect|bluetooth-disconnect|bluetooth-remove)' |
+	grep -F "$data_home/dwm-titus/scripts/dwm-quickshell-controls" >/dev/null; then
+	printf 'Settings-owned Bluetooth work remained active after close\n' >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary
- add versioned shared NetworkManager and BlueZ providers with Settings panes
- add bounded network, Wi-Fi, Bluetooth discovery and stable-identity actions
- preserve secrets through stdin and ephemeral mode-0600 nmcli password files
- bind long-lived shell watcher children to the owning Quickshell lifetime
- record live Fedora X11 qualification and explicit Wi-Fi/pairing limitations

## Validation
- `scripts/run-tests make clean all`
- `scripts/run-tests`
- real NetworkManager Ethernet snapshot and bounded rescan with unchanged active connection
- real BlueZ adapter and 8-second discovery, ending with `Discovering=false`
- deliberate Quickshell restart leaves exactly one current `nmcli monitor` and one current media watcher
- `scripts/dev-sync-install.sh` (rollback backup `20260821T214412Z-756866`)

## Limitations
- This host has no Wi-Fi adapter, so real association/authentication is fixture-qualified only.
- No sacrificial Bluetooth device was available for new-device pairing recovery; the real adapter, discovery, and paired-device state paths were exercised.
- The final CodeRabbit CLI invocation was rate-limited after earlier review/fix loops; hosted review remains required before merge.
