### PR TITLE
Complete Phase 3 audio workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versions from `config.mk`.
 
 ### Added
 
+- Add a native-first PipeWire audio model and Settings pane for output and input
+  selection, volume, mute, microphone visibility, and per-application streams.
+  A versioned bounded snapshot protocol supplies inventories, while one
+  generation-checked fallback subscription is used only when native state does
+  not initialize or disconnects.
+
 - Add shared, versioned NetworkManager and BlueZ provider models and Settings
   panes for Ethernet, Wi-Fi, saved profiles, VPN status, bounded discovery,
   pairing, trust, connection, and removal workflows. Fixed actions preserve
@@ -57,6 +63,10 @@ versions from `config.mk`.
   unsupported installer cannot perform package or system mutations.
 
 ### Fixed
+
+- Restart unexpectedly exited parent-bound NetworkManager and media
+  subscriptions after a bounded delay, preserving one live subscription per
+  shared root model without polling.
 
 - Bind long-lived NetworkManager and media watcher children to the originating
   Quickshell process identity so an ungraceful shell exit cannot leave orphaned

--- a/Makefile
+++ b/Makefile
@@ -382,6 +382,9 @@ check-quickshell-connectivity:
 check-quickshell-controls:
 	tests/test-quickshell-controls.sh
 
+check-quickshell-audio:
+	tests/test-quickshell-audio.sh
+
 check-quickshell-controlcenter:
 	tests/test-quickshell-controlcenter.sh
 
@@ -547,6 +550,7 @@ check:
 	$(MAKE) check-monitor-tags
 	$(MAKE) check-quickshell-launcher
 	$(MAKE) check-quickshell-controls
+	$(MAKE) check-quickshell-audio
 	$(MAKE) check-quickshell-controlcenter
 	$(MAKE) check-quickshell-design-system
 	$(MAKE) check-quickshell-large-surfaces
@@ -580,5 +584,5 @@ check:
 	check-display-profile check-display-setup check-fedora-iso-builder check-fedora-packages check-fedora-platform check-format check-install \
 	check-gearlever-install check-herdr-install check-install-manifest check-install-preservation check-kickstart check-lock \
 	check-session-guards check-session-migration check-screenshot check-release-helper check-shell check-diagnostics check-status check-system-health check-settings \
-	check-quickshell-launcher check-quickshell-controls check-quickshell-controlcenter check-quickshell-design-system check-quickshell-large-surfaces check-quickshell-large-surfaces-xvfb check-quickshell-panel-menus check-quickshell-command-menu check-quickshell-notifications check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-connectivity check-quickshell-qml check-lightdm-config check-terminal check-xvfb-runtime install install-system install-user \
+	check-quickshell-launcher check-quickshell-controls check-quickshell-audio check-quickshell-controlcenter check-quickshell-design-system check-quickshell-large-surfaces check-quickshell-large-surfaces-xvfb check-quickshell-panel-menus check-quickshell-command-menu check-quickshell-notifications check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-connectivity check-quickshell-qml check-lightdm-config check-terminal check-xvfb-runtime install install-system install-user \
 	install-cursors native release release-check uninstall

--- a/TASKS.md
+++ b/TASKS.md
@@ -8,9 +8,10 @@ completion evidence is recorded in `ROADMAP.md`, `CHANGELOG.md`, and
 ## Active Phase: Connectivity, Audio, and Large-Surface Integration
 
 The Omarchy-inspired UI plan is integrated into this phase rather than tracked
-as a competing roadmap. `P3-UI4` is complete in PR #163. The connectivity
-provider, NetworkManager, and BlueZ slices are complete in the current review
-boundary; `AUDIO-001` is next.
+as a competing roadmap. `P3-UI4` is complete in PR #163 and the connectivity
+slices are complete in PR #164. Audio implementation and Phase 3 validation are
+complete in the current review boundary; phase activation occurs only after the
+review is merged and the final installed-state check passes.
 
 ### P3-UI4: Large-Surface Visual Integration (PR #163)
 
@@ -129,17 +130,17 @@ Acceptance:
 
 ### AUDIO-001: PipeWire and WirePlumber Provider
 
-- [ ] Define event-driven output, input, stream, volume, mute, default-device,
+- [x] Define event-driven output, input, stream, volume, mute, default-device,
   and microphone-visibility records using PipeWire/WirePlumber-compatible
   interfaces.
-- [ ] Reuse native Quickshell PipeWire signals where stable and provide one
+- [x] Reuse native Quickshell PipeWire signals where stable and provide one
   documented bounded fallback when native state is unavailable.
-- [ ] Start one fallback subscription only after native initialization fails or
+- [x] Start one fallback subscription only after native initialization fails or
   disconnects within three seconds. Increment a source generation on every
   transition, ignore events from older generations, terminate the fallback on
   section close or native recovery, and hand new snapshots back to native state
   without overlapping subscriptions.
-- [ ] Keep audio and media provider failures independent.
+- [x] Keep audio and media provider failures independent.
 
 Acceptance:
 
@@ -152,13 +153,13 @@ Acceptance:
 
 ### AUDIO-002: Audio Controls and Panel Synchronization
 
-- [ ] Add output and input selection, volume, mute, per-application stream, and
+- [x] Add output and input selection, volume, mute, per-application stream, and
   microphone controls only when reported by the provider.
-- [ ] Make one root-scoped audio service model authoritative for the panel and
+- [x] Make one root-scoped audio service model authoritative for the panel and
   Settings. Tag mutations with an origin and monotonic generation, reject stale
   generations, and suppress echoed events at their originating surface so both
   consumers converge without feedback loops.
-- [ ] Add bounded value validation, partial-failure reporting, and reset or
+- [x] Add bounded value validation, partial-failure reporting, and reset or
   recovery behavior for disappearing devices and streams.
 
 Acceptance:
@@ -172,19 +173,19 @@ Acceptance:
 
 ### CA-VALIDATE: Phase 3 Validation
 
-- [ ] Run focused shell, QML, provider, helper, and nested-X11 tests for all
+- [x] Run focused shell, QML, provider, helper, and nested-X11 tests for all
   connectivity and audio interactions.
-- [ ] Exercise NetworkManager workflows with a real Fedora Ethernet or Wi-Fi
+- [x] Exercise NetworkManager workflows with a real Fedora Ethernet or Wi-Fi
   connection, including cancellation and service-unavailable recovery.
-- [ ] Exercise BlueZ workflows with a real adapter and device, or record the
+- [x] Exercise BlueZ workflows with a real adapter and device, or record the
   exact hardware path that remains unqualified.
-- [ ] Exercise PipeWire/WirePlumber outputs, inputs, application streams, and
+- [x] Exercise PipeWire/WirePlumber outputs, inputs, application streams, and
   microphone state in a real Fedora session.
-- [ ] Verify closed Settings sections leave no scans, duplicate subscriptions,
+- [x] Verify closed Settings sections leave no scans, duplicate subscriptions,
   or overlapping commands. Compare a 30-second closed baseline with a
   30-second sample after opening and closing each section; the mean Quickshell
   CPU delta must be no more than 0.5 percentage points of one CPU.
-- [ ] Run the full Fedora repository validation and record untested hardware
+- [x] Run the full Fedora repository validation and record untested hardware
   paths.
 
 Acceptance:

--- a/config/quickshell/controls/ControlsModel.qml
+++ b/config/quickshell/controls/ControlsModel.qml
@@ -8,12 +8,15 @@ Scope {
     id: root
 
     property bool visible: false
+    property bool settingsVisible: false
     property bool busy: false
     property string volumeText: "VOL unavailable"
     property int volumePercent: 0
     property bool volumeMuted: false
     property string volumeDisplayText: volumeText + (outputDeviceDescription.length > 0 ? " - " + outputDeviceDescription : "")
     property var outputDevices: []
+    property var inputDevices: []
+    property var audioStreams: []
     property string outputDeviceName: ""
     property string outputDeviceDescription: ""
     property string micText: "MIC unavailable"
@@ -24,8 +27,47 @@ Scope {
     property string mediaTitle: ""
     property string bluetoothText: "BT unavailable"
     property string message: ""
+    property string audioProviderState: "idle"
+    property string audioProviderDetail: ""
+    property string audioSourceKind: "none"
+    property int audioSourceGeneration: 0
+    property int fallbackProcessGeneration: 0
+    property int mutationGeneration: 0
+    property int appliedMutationGeneration: 0
+    property int actionProcessGeneration: 0
+    property string mutationOrigin: ""
     readonly property var audioSink: Pipewire.defaultAudioSink
     readonly property var audioSource: Pipewire.defaultAudioSource
+
+    function nativeAudioReady() {
+        return root.audioSink !== null && root.audioSink.ready && root.audioSink.audio !== null;
+    }
+
+    function selectAudioSource() {
+        if (root.nativeAudioReady()) {
+            nativeGraceTimer.stop();
+            if (fallbackWatchProcess.running) fallbackWatchProcess.running = false;
+            if (root.audioSourceKind !== "native") {
+                root.audioSourceGeneration++;
+                root.audioSourceKind = "native";
+            }
+        } else if ((root.visible || root.settingsVisible) && !nativeGraceTimer.running
+                && root.audioSourceKind !== "fallback") {
+            nativeGraceTimer.restart();
+        }
+    }
+
+    function openSettings() {
+        root.settingsVisible = true;
+        root.refresh();
+        root.selectAudioSource();
+    }
+
+    function closeSettings() {
+        root.settingsVisible = false;
+        if (!root.visible && fallbackWatchProcess.running) fallbackWatchProcess.running = false;
+        if (!root.visible) nativeGraceTimer.stop();
+    }
 
     function refreshAudioStatus() {
         const sink = root.audioSink;
@@ -45,6 +87,7 @@ Scope {
                 volumeStatusProcess.running = true;
             }
         }
+        root.selectAudioSource();
 
         const source = root.audioSource;
         if (source !== null && source.ready && source.audio !== null) {
@@ -60,11 +103,14 @@ Scope {
     function open() {
         root.visible = true;
         root.refresh();
+        root.selectAudioSource();
     }
 
     function close() {
         root.visible = false;
         root.message = "";
+        if (!root.settingsVisible && fallbackWatchProcess.running) fallbackWatchProcess.running = false;
+        if (!root.settingsVisible) nativeGraceTimer.stop();
     }
 
     function toggle() {
@@ -77,7 +123,7 @@ Scope {
 
     function refresh() {
         root.refreshAudioStatus();
-        root.refreshOutputDevices();
+        root.refreshAudioInventory();
         if (!mediaStatusProcess.running) {
             mediaStatusProcess.running = true;
         }
@@ -86,9 +132,84 @@ Scope {
         }
     }
 
-    function refreshOutputDevices() {
-        if (!outputDevicesProcess.running) {
-            outputDevicesProcess.running = true;
+    function refreshAudioInventory() {
+        if (!audioSnapshotProcess.running) audioSnapshotProcess.running = true;
+    }
+
+    function parseAudioSnapshot(text) {
+        const outputs = [];
+        const inputs = [];
+        const streams = [];
+        let protocolValid = false;
+        let providerSeen = false;
+        let malformed = false;
+        let defaultOutput = null;
+        let defaultInput = null;
+        for (const line of text.trim().split("\n")) {
+            if (line.length === 0) continue;
+            const fields = line.split("\t");
+            if (fields[0] === "audio-protocol") {
+                protocolValid = fields.length >= 3 && fields[1] === "1";
+            } else if (fields[0] === "provider") {
+                if (fields.length < 5 || fields[1] !== "audio") { malformed = true; continue; }
+                providerSeen = true;
+                root.audioProviderState = fields[2];
+                root.audioProviderDetail = fields[4];
+            } else if (fields[0] === "audio-output" && fields.length >= 6) {
+                const percent = Number(fields[5]);
+                if ((fields[3] !== "yes" && fields[3] !== "no")
+                        || (fields[4] !== "yes" && fields[4] !== "no")
+                        || !isFinite(percent) || percent < 0 || percent > 100) {
+                    malformed = true;
+                    continue;
+                }
+                const item = { "name": fields[1], "description": fields[2], "isDefault": fields[3] === "yes",
+                    "muted": fields[4] === "yes", "volume": Math.round(percent) };
+                outputs.push(item);
+                if (item.isDefault) defaultOutput = item;
+            } else if (fields[0] === "audio-input" && fields.length >= 6) {
+                const percent = Number(fields[5]);
+                if ((fields[3] !== "yes" && fields[3] !== "no")
+                        || (fields[4] !== "yes" && fields[4] !== "no")
+                        || !isFinite(percent) || percent < 0 || percent > 100) {
+                    malformed = true;
+                    continue;
+                }
+                const item = { "name": fields[1], "description": fields[2], "isDefault": fields[3] === "yes",
+                    "muted": fields[4] === "yes", "volume": Math.round(percent) };
+                inputs.push(item);
+                if (item.isDefault) defaultInput = item;
+            } else if (fields[0] === "audio-stream" && fields.length >= 6) {
+                const percent = Number(fields[5]);
+                if ((fields[4] !== "yes" && fields[4] !== "no")
+                        || !isFinite(percent) || percent < 0 || percent > 100) {
+                    malformed = true;
+                    continue;
+                }
+                streams.push({ "index": fields[1], "application": fields[2], "description": fields[3],
+                    "muted": fields[4] === "yes", "volume": Math.round(percent) });
+            }
+        }
+        if (!protocolValid || !providerSeen || malformed) {
+            root.outputDevices = [];
+            root.inputDevices = [];
+            root.audioStreams = [];
+            root.audioProviderState = "failure";
+            root.audioProviderDetail = !protocolValid ? "Unsupported audio protocol" : "Malformed audio provider record";
+            return;
+        }
+        root.outputDevices = outputs;
+        root.inputDevices = inputs;
+        root.audioStreams = streams;
+        if (defaultOutput !== null && root.audioSourceKind === "fallback") {
+            root.volumePercent = defaultOutput.volume;
+            root.volumeMuted = defaultOutput.muted;
+            root.volumeText = (defaultOutput.muted ? "VOL muted " : "VOL ") + defaultOutput.volume + "%";
+            root.outputDeviceName = defaultOutput.name;
+            root.outputDeviceDescription = defaultOutput.description;
+        }
+        if (defaultInput !== null && root.audioSourceKind === "fallback") {
+            root.micText = defaultInput.muted ? "MIC muted" : "MIC on";
         }
     }
 
@@ -189,12 +310,15 @@ Scope {
         return Math.max(0, Math.min(100, number));
     }
 
-    function runAction(action, args) {
+    function runAction(action, args, origin) {
         if (root.busy) {
             return;
         }
 
         root.busy = true;
+        root.mutationGeneration++;
+        root.actionProcessGeneration = root.mutationGeneration;
+        root.mutationOrigin = origin || "panel";
         root.message = "";
         actionProcess.command = Commands.controlsHelperCommand(action, args || []);
         actionProcess.running = true;
@@ -216,13 +340,23 @@ Scope {
         root.runAction("volume-set", [root.clampPercent(percent).toString() + "%"]);
     }
 
-    function outputSetDefault(name) {
+    function outputSetDefault(name, origin) {
         if (name.length === 0 || name === root.outputDeviceName) {
             return;
         }
 
-        root.runAction("output-set-default", [name]);
+        root.runAction("output-set-default", [name], origin);
     }
+
+    function inputSetDefault(name, origin) { root.runAction("input-set-default", [name], origin); }
+    function inputVolumeSet(name, percent, origin) {
+        root.runAction("input-volume-set", [name, root.clampPercent(percent).toString() + "%"], origin);
+    }
+    function inputToggleMute(name, origin) { root.runAction("input-toggle-mute", [name], origin); }
+    function streamVolumeSet(index, percent, origin) {
+        root.runAction("stream-volume-set", [index, root.clampPercent(percent).toString() + "%"], origin);
+    }
+    function streamToggleMute(index, origin) { root.runAction("stream-toggle-mute", [index], origin); }
 
     function mediaPlayPause() {
         root.runAction("media-play-pause");
@@ -245,7 +379,7 @@ Scope {
 
         function onDefaultAudioSinkChanged() {
             root.refreshAudioStatus();
-            root.refreshOutputDevices();
+            root.refreshAudioInventory();
         }
 
         function onDefaultAudioSourceChanged() {
@@ -261,14 +395,14 @@ Scope {
         target: Pipewire.nodes
 
         function onObjectInsertedPost(object, index) {
-            if (root.visible) {
-                root.refreshOutputDevices();
+            if (root.visible || root.settingsVisible) {
+                root.refreshAudioInventory();
             }
         }
 
         function onObjectRemovedPost(object, index) {
-            if (root.visible) {
-                root.refreshOutputDevices();
+            if (root.visible || root.settingsVisible) {
+                root.refreshAudioInventory();
             }
         }
     }
@@ -309,6 +443,59 @@ Scope {
         }
     }
 
+    Timer {
+        id: nativeGraceTimer
+        interval: 3000
+        repeat: false
+        onTriggered: {
+            if (!root.nativeAudioReady() && (root.visible || root.settingsVisible)) {
+                root.audioSourceGeneration++;
+                root.audioSourceKind = "fallback";
+                root.fallbackProcessGeneration = root.audioSourceGeneration;
+                root.refreshAudioInventory();
+                fallbackWatchProcess.running = true;
+            }
+        }
+    }
+
+    Process {
+        id: audioSnapshotProcess
+        command: Commands.controlsHelperCommand("audio-snapshot")
+        running: false
+        stdout: StdioCollector { onStreamFinished: root.parseAudioSnapshot(this.text) }
+    }
+
+    Process {
+        id: fallbackWatchProcess
+        command: Commands.controlsHelperCommand("audio-watch")
+        running: false
+        stdout: SplitParser {
+            onRead: function(data) {
+                if (root.audioSourceKind === "fallback"
+                        && root.fallbackProcessGeneration === root.audioSourceGeneration) {
+                    root.refreshAudioInventory();
+                }
+            }
+        }
+        onRunningChanged: {
+            if (!running && root.audioSourceKind === "fallback"
+                    && (root.visible || root.settingsVisible)) fallbackRestartTimer.restart();
+        }
+    }
+
+    Timer {
+        id: fallbackRestartTimer
+        interval: 3000
+        repeat: false
+        onTriggered: {
+            if (root.audioSourceKind === "fallback" && !fallbackWatchProcess.running
+                    && (root.visible || root.settingsVisible)) {
+                root.fallbackProcessGeneration = root.audioSourceGeneration;
+                fallbackWatchProcess.running = true;
+            }
+        }
+    }
+
     Process {
         id: volumeStatusProcess
 
@@ -343,17 +530,6 @@ Scope {
     }
 
     Process {
-        id: outputDevicesProcess
-
-        command: Commands.controlsHelperCommand("output-devices")
-        running: false
-
-        stdout: StdioCollector {
-            onStreamFinished: root.parseOutputDevices(this.text)
-        }
-    }
-
-    Process {
         id: mediaStatusProcess
 
         command: Commands.controlsHelperCommand("media-status")
@@ -365,6 +541,7 @@ Scope {
     }
 
     Process {
+        id: mediaWatchProcess
         command: Commands.controlsHelperCommand("media-watch")
         running: true
 
@@ -372,6 +549,18 @@ Scope {
             onRead: function(data) {
                 root.parseMedia(data);
             }
+        }
+        onRunningChanged: {
+            if (!running) mediaWatchRestartTimer.restart();
+        }
+    }
+
+    Timer {
+        id: mediaWatchRestartTimer
+        interval: 3000
+        repeat: false
+        onTriggered: {
+            if (!mediaWatchProcess.running) mediaWatchProcess.running = true;
         }
     }
 
@@ -398,8 +587,19 @@ Scope {
 
         onRunningChanged: {
             if (!running) {
+                if (root.actionProcessGeneration !== root.mutationGeneration) return;
                 root.busy = false;
+                root.appliedMutationGeneration = root.mutationGeneration;
                 root.refresh();
+            }
+        }
+
+        stderr: StdioCollector {
+            onStreamFinished: {
+                const error = this.text.trim();
+                if (error.length > 0 && root.actionProcessGeneration === root.mutationGeneration) {
+                    root.message = error;
+                }
             }
         }
     }

--- a/config/quickshell/network/NetworkModel.qml
+++ b/config/quickshell/network/NetworkModel.qml
@@ -1,3 +1,4 @@
+import QtQuick
 import Quickshell
 import Quickshell.Io
 import qs.core
@@ -495,11 +496,24 @@ Scope {
     }
 
     Process {
+        id: networkMonitorProcess
         command: Commands.networkHelperCommand("monitor")
         running: true
 
         stdout: SplitParser {
             onRead: root.refresh(false)
+        }
+        onRunningChanged: {
+            if (!running) networkMonitorRestartTimer.restart();
+        }
+    }
+
+    Timer {
+        id: networkMonitorRestartTimer
+        interval: 3000
+        repeat: false
+        onTriggered: {
+            if (!networkMonitorProcess.running) networkMonitorProcess.running = true;
         }
     }
 

--- a/config/quickshell/settings/AudioSettingsPane.qml
+++ b/config/quickshell/settings/AudioSettingsPane.qml
@@ -1,0 +1,161 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.core
+
+pragma ComponentBehavior: Bound
+
+Flickable {
+    id: root
+
+    required property var controlsModel
+    contentWidth: width
+    contentHeight: content.implicitHeight
+    clip: true
+
+    ColumnLayout {
+        id: content
+        width: root.width
+        spacing: Theme.spacingLg
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            UiText {
+                Layout.fillWidth: true
+                text: root.controlsModel.audioProviderState === "available"
+                    ? "PipeWire / " + root.controlsModel.audioSourceKind
+                    : root.controlsModel.audioProviderDetail
+                color: root.controlsModel.audioProviderState === "available" ? Theme.menuText : Theme.warning
+                font.bold: true
+                elide: Text.ElideRight
+            }
+
+            ShellButton {
+                label: "Refresh"
+                enabled: !root.controlsModel.busy
+                onActivated: root.controlsModel.refresh()
+            }
+        }
+
+        UiText {
+            Layout.fillWidth: true
+            visible: root.controlsModel.message.length > 0
+            text: root.controlsModel.message
+            color: Theme.danger
+            wrapMode: Text.WordWrap
+        }
+
+        SectionLabel { label: "Output devices" }
+
+        Repeater {
+            model: root.controlsModel.outputDevices
+            delegate: Rectangle {
+                id: outputRow
+                required property var modelData
+                Layout.fillWidth: true
+                Layout.preferredHeight: 46
+                color: Theme.controlNormalFill
+                border.color: outputRow.modelData.isDefault ? Theme.controlSelectedBorder : Theme.controlNormalBorder
+                border.width: Theme.controlBorderWidth
+                radius: Theme.controlRadius
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.margins: Theme.spacingSm
+                    UiText { Layout.fillWidth: true; text: outputRow.modelData.description; elide: Text.ElideRight }
+                    ShellButton {
+                        label: outputRow.modelData.isDefault ? "Default" : "Set Default"
+                        enabled: !outputRow.modelData.isDefault && !root.controlsModel.busy
+                        onActivated: root.controlsModel.outputSetDefault(outputRow.modelData.name, "settings")
+                    }
+                }
+            }
+        }
+
+        SectionLabel { label: "Input devices and microphone" }
+
+        Repeater {
+            model: root.controlsModel.inputDevices
+            delegate: Rectangle {
+                id: inputRow
+                required property var modelData
+                Layout.fillWidth: true
+                Layout.preferredHeight: 72
+                color: Theme.controlNormalFill
+                border.color: inputRow.modelData.isDefault ? Theme.controlSelectedBorder : Theme.controlNormalBorder
+                border.width: Theme.controlBorderWidth
+                radius: Theme.controlRadius
+                ColumnLayout {
+                    anchors.fill: parent
+                    anchors.margins: Theme.spacingSm
+                    RowLayout {
+                        Layout.fillWidth: true
+                        UiText { Layout.fillWidth: true; text: inputRow.modelData.description; elide: Text.ElideRight }
+                        ShellButton {
+                            label: inputRow.modelData.isDefault ? "Default" : "Set"
+                            enabled: !inputRow.modelData.isDefault && !root.controlsModel.busy
+                            onActivated: root.controlsModel.inputSetDefault(inputRow.modelData.name, "settings")
+                        }
+                        ShellButton {
+                            label: inputRow.modelData.muted ? "Unmute" : "Mute"
+                            enabled: !root.controlsModel.busy
+                            onActivated: root.controlsModel.inputToggleMute(inputRow.modelData.name, "settings")
+                        }
+                    }
+                    PanelSlider {
+                        Layout.fillWidth: true
+                        value: inputRow.modelData.volume
+                        muted: inputRow.modelData.muted
+                        enabled: !root.controlsModel.busy
+                        onValueCommitted: value => root.controlsModel.inputVolumeSet(inputRow.modelData.name, value, "settings")
+                    }
+                }
+            }
+        }
+
+        SectionLabel { label: "Application streams" }
+
+        UiText {
+            visible: root.controlsModel.audioStreams.length === 0
+            text: "No active application streams"
+            color: Theme.menuMutedText
+        }
+
+        Repeater {
+            model: root.controlsModel.audioStreams
+            delegate: Rectangle {
+                id: streamRow
+                required property var modelData
+                Layout.fillWidth: true
+                Layout.preferredHeight: 72
+                color: Theme.controlNormalFill
+                border.color: Theme.controlNormalBorder
+                border.width: Theme.controlBorderWidth
+                radius: Theme.controlRadius
+                ColumnLayout {
+                    anchors.fill: parent
+                    anchors.margins: Theme.spacingSm
+                    RowLayout {
+                        Layout.fillWidth: true
+                        UiText {
+                            Layout.fillWidth: true
+                            text: streamRow.modelData.application + " / " + streamRow.modelData.description
+                            elide: Text.ElideRight
+                        }
+                        ShellButton {
+                            label: streamRow.modelData.muted ? "Unmute" : "Mute"
+                            enabled: !root.controlsModel.busy
+                            onActivated: root.controlsModel.streamToggleMute(streamRow.modelData.index, "settings")
+                        }
+                    }
+                    PanelSlider {
+                        Layout.fillWidth: true
+                        value: streamRow.modelData.volume
+                        muted: streamRow.modelData.muted
+                        enabled: !root.controlsModel.busy
+                        onValueCommitted: value => root.controlsModel.streamVolumeSet(streamRow.modelData.index, value, "settings")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/config/quickshell/settings/SettingsModel.qml
+++ b/config/quickshell/settings/SettingsModel.qml
@@ -18,6 +18,7 @@ Scope {
     property var targetScreen: null
     property var networkModel: null
     property var bluetoothModel: null
+    property var controlsModel: null
     property var capabilities: []
     property int selectedIndex: 0
     property var displayOutputs: []
@@ -102,6 +103,11 @@ Scope {
             const wantBluetooth = id === "bluetooth" && root.visible;
             if (wantBluetooth && !root.bluetoothModel.settingsVisible) root.bluetoothModel.openSettings();
             else if (!wantBluetooth && root.bluetoothModel.settingsVisible) root.bluetoothModel.closeSettings();
+        }
+        if (root.controlsModel) {
+            const wantAudio = id === "audio" && root.visible;
+            if (wantAudio && !root.controlsModel.settingsVisible) root.controlsModel.openSettings();
+            else if (!wantAudio && root.controlsModel.settingsVisible) root.controlsModel.closeSettings();
         }
         if (id === "displays") root.refreshDisplays();
         if (id === "input") root.refreshInput();
@@ -485,6 +491,7 @@ Scope {
         inputWatchProcess.running = false;
 		if (root.networkModel) root.networkModel.closeSettings();
 		if (root.bluetoothModel) root.bluetoothModel.closeSettings();
+		if (root.controlsModel) root.controlsModel.closeSettings();
 			inputSettleTimer.stop();
         root.visible = false;
         root.busy = false;

--- a/config/quickshell/settings/SettingsWindow.qml
+++ b/config/quickshell/settings/SettingsWindow.qml
@@ -11,6 +11,7 @@ FloatingWindow {
     required property var settingsModel
     required property var networkModel
     required property var bluetoothModel
+    required property var controlsModel
 
     title: "dwm settings"
     visible: settingsModel.visible
@@ -346,6 +347,13 @@ FloatingWindow {
                                 bluetoothModel: root.bluetoothModel
                             }
 
+                            AudioSettingsPane {
+                                Layout.fillWidth: true
+                                Layout.fillHeight: true
+                                visible: root.settingsModel.selectedSectionId === "audio"
+                                controlsModel: root.controlsModel
+                            }
+
                             ListView {
                                 id: capabilityList
 
@@ -355,6 +363,7 @@ FloatingWindow {
                                     && root.settingsModel.selectedSectionId !== "input"
                                     && root.settingsModel.selectedSectionId !== "network"
                                     && root.settingsModel.selectedSectionId !== "bluetooth"
+                                    && root.settingsModel.selectedSectionId !== "audio"
                                 clip: true
                                 spacing: Theme.spacingLg
                                 model: root.settingsModel.capabilitiesForSection(root.settingsModel.selectedSectionId)

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -179,6 +179,7 @@ ShellRoot {
         id: settingsModel
         networkModel: networkModel
         bluetoothModel: bluetoothModel
+        controlsModel: controlsModel
     }
 
     LazyLoader {
@@ -484,6 +485,26 @@ ShellRoot {
             return bluetoothModel.devices.length;
         }
 
+        function audioProviderStatus(): string {
+            return controlsModel.audioProviderState;
+        }
+
+        function audioSourceKind(): string {
+            return controlsModel.audioSourceKind;
+        }
+
+        function audioOutputCount(): int {
+            return controlsModel.outputDevices.length;
+        }
+
+        function audioInputCount(): int {
+            return controlsModel.inputDevices.length;
+        }
+
+        function audioStreamCount(): int {
+            return controlsModel.audioStreams.length;
+        }
+
         function open(): void {
             settingsModel.open();
         }
@@ -622,5 +643,6 @@ ShellRoot {
         settingsModel: settingsModel
         networkModel: networkModel
         bluetoothModel: bluetoothModel
+        controlsModel: controlsModel
     }
 }

--- a/docs/AUDIO-PROTOCOL.md
+++ b/docs/AUDIO-PROTOCOL.md
@@ -1,0 +1,54 @@
+# Audio Provider Protocol
+
+## Purpose
+
+`dwm-quickshell-controls audio-snapshot` provides a bounded, versioned snapshot
+of the PipeWire PulseAudio compatibility interface for the root-scoped
+Quickshell controls model. Native `Quickshell.Services.Pipewire` signals remain
+authoritative for the default output, default input, volume, and mute state.
+The snapshot supplies the output, non-monitor input, and application-stream
+inventories used by Settings.
+
+## Records
+
+Records are tab-separated. Descriptions are normalized so embedded tabs and
+newlines cannot create additional fields. Consumers require the protocol major
+version and required fields, ignore unknown record types and trailing fields,
+and clear the owning inventory when required records are malformed.
+
+```text
+audio-protocol  1  0
+provider        audio  STATE  ACCESS  DETAIL
+audio-output    NAME   DESCRIPTION  DEFAULT  MUTED  PERCENT
+audio-input     NAME   DESCRIPTION  DEFAULT  MUTED  PERCENT
+audio-stream    INDEX  APPLICATION  DESCRIPTION  MUTED  PERCENT
+```
+
+`STATE` is `available`, `restricted`, or `unavailable`. `ACCESS` describes the
+read-only or delegated user-session boundary. Boolean fields use `yes` or `no`,
+and percentages are bounded to 0 through 100. Monitor sources are excluded from
+the input inventory. Provider and action commands use three- or fifteen-second
+bounds respectively.
+
+## Event and Fallback Contract
+
+The shared controls model uses native PipeWire signals whenever its default
+sink is ready. If native initialization has not completed after one non-repeating
+three-second grace period while the panel or Audio Settings is open, it starts
+one parent-bound `pactl subscribe` fallback. Every source transition increments
+a generation; events from an older generation are ignored. Native recovery
+stops the fallback, and closing the last consumer stops its grace timer and
+fallback process. A stopped fallback is retried after a bounded three-second
+delay rather than by polling.
+
+All mutations are serialized, tagged with their UI origin and a monotonic
+generation, and applied only when the completing generation is current. Model
+updates do not invoke actions, so echoed native events update both surfaces
+without feeding a second mutation back to PipeWire.
+
+## Failure Boundaries
+
+Missing `pactl` or `jq`, a service loss, timeout, or malformed JSON produces an
+audio-only unavailable record. Malformed protocol values clear audio inventory
+instead of retaining stale success. Media and Bluetooth state use independent
+provider paths and remain available when audio fails.

--- a/docs/P3-AUDIO-EVIDENCE.md
+++ b/docs/P3-AUDIO-EVIDENCE.md
@@ -1,0 +1,61 @@
+# Phase 3 Audio Evidence
+
+## Scope
+
+This evidence qualifies `AUDIO-001`, `AUDIO-002`, and the audio portion of
+`CA-VALIDATE` on Fedora Linux 44 x86_64 in the active managed X11 session.
+Hardware serials and stable device identifiers are intentionally omitted.
+
+## Automated Validation
+
+The helper fixtures cover multiple outputs, a non-monitor input, monitor-source
+filtering, an application stream, no-audio state, malformed JSON, bounded
+percentages, action arguments, and subscription startup. The source contract
+covers native-first selection, the one-shot three-second fallback grace period,
+source and mutation generations, fallback recovery, one shared root model, and
+Settings lifecycle.
+
+The following gates passed from managed disposable workspaces:
+
+- `scripts/run-tests make clean all`
+- `scripts/run-tests`
+- ShellCheck and shfmt for the changed helper and tests
+- `scripts/quickshell-qmllint --root config/quickshell`
+
+QML lint retained only the existing `PanelTooltip` incomplete-type and
+`RunningAppsArea` property warnings. The full suite passed its nested-X11,
+packaging, staged-install, preservation, and release checks.
+
+## Live PipeWire Qualification
+
+Native `Quickshell.Services.Pipewire` initialized successfully. Audio Settings
+reported three outputs, four non-monitor inputs, and no stream before playback.
+Changing the default output volume externally from 30 to 31 percent updated the
+panel model without reopening Settings; the value then returned to the exact
+30-percent baseline. The default microphone was muted and unmuted through the
+fixed helper, and both the Settings model and panel returned to the original
+unmuted state.
+
+A temporary silent FFmpeg playback stream appeared in Settings. Its fixed
+stream identity accepted a 42-percent volume change and mute action, after which
+the exact process was terminated and the stream count returned to zero. No
+audio fallback subscription was present while native PipeWire was healthy.
+
+## Lifecycle and Idle Qualification
+
+After a managed Quickshell restart, the shell held exactly one parent-bound
+NetworkManager monitor and one parent-bound media subscription. Every Settings
+section was opened in sequence and the window was closed. There were no scans,
+audio fallback subscriptions, or application streams left afterward.
+
+The 30-second closed baseline and the 30-second sample after the complete
+open/close cycle each measured 0.000 percent of one CPU for Quickshell, for a
+0.000 percentage-point delta against the 0.5-point limit.
+
+## Remaining Hardware Limits
+
+The active host has no Wi-Fi adapter, so real association and authentication
+remain fixture-qualified. The real Bluetooth adapter and discovery paths were
+qualified, but pairing recovery remains fixture-qualified because no
+sacrificial device was available. These limitations are connectivity hardware
+limits and do not reduce the completed real PipeWire audio qualification.

--- a/scripts/dwm-quickshell-controls
+++ b/scripts/dwm-quickshell-controls
@@ -2,7 +2,7 @@
 set -eu
 
 usage() {
-	printf '%s\n' "usage: dwm-quickshell-controls volume-status|volume-watch|volume-up [step]|volume-down [step]|volume-set <percent>|volume-toggle-mute|output-status|output-devices|output-set-default <sink>|mic-status|media-status|media-watch|media-play-pause|media-next|media-previous|bluetooth-snapshot|bluetooth-status|bluetooth-devices|bluetooth-scan|bluetooth-power <on|off>|bluetooth-pair <address>|bluetooth-trust <address>|bluetooth-connect <address>|bluetooth-disconnect <address>|bluetooth-remove <address>" >&2
+	printf '%s\n' "usage: dwm-quickshell-controls audio-snapshot|audio-watch|volume-status|volume-watch|volume-up [step]|volume-down [step]|volume-set <percent>|volume-toggle-mute|output-status|output-devices|output-set-default <sink>|input-set-default <source>|input-volume-set <source> <percent>|input-toggle-mute <source>|stream-volume-set <index> <percent>|stream-toggle-mute <index>|mic-status|media-status|media-watch|media-play-pause|media-next|media-previous|bluetooth-snapshot|bluetooth-status|bluetooth-devices|bluetooth-scan|bluetooth-power <on|off>|bluetooth-pair <address>|bluetooth-trust <address>|bluetooth-connect <address>|bluetooth-disconnect <address>|bluetooth-remove <address>" >&2
 	exit 2
 }
 
@@ -358,6 +358,7 @@ move_sink_inputs_pactl() {
 
 output_set_default() {
 	[ "$#" -eq 1 ] || usage
+	validate_audio_name "$1"
 
 	if command -v pactl >/dev/null 2>&1; then
 		if pactl set-default-sink "$1"; then
@@ -438,6 +439,97 @@ output_status() {
 	else
 		printf '%s\n' "Output unavailable"
 	fi
+}
+
+validate_audio_name() {
+	[ "$#" -eq 1 ] && [ -n "$1" ] || usage
+	case $1 in
+	*[!A-Za-z0-9_.:-]*) usage ;;
+	esac
+}
+
+validate_audio_index() {
+	[ "$#" -eq 1 ] || usage
+	case $1 in '' | *[!0-9]*) usage ;; esac
+}
+
+audio_snapshot() {
+	printf 'audio-protocol\t1\t0\n'
+	if ! command -v pactl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+		printf 'provider\taudio\tunavailable\tread-only\tpactl and jq are required\n'
+		return 0
+	fi
+
+	work=$(mktemp -d "${TMPDIR:-/tmp}/dwm-audio-snapshot.XXXXXX")
+	trap 'rm -rf "$work"' EXIT HUP INT TERM
+	if ! run_bounded 3 pactl --format=json info >"$work/info" ||
+		! run_bounded 3 pactl --format=json list sinks >"$work/sinks" ||
+		! run_bounded 3 pactl --format=json list sources >"$work/sources" ||
+		! run_bounded 3 pactl --format=json list sink-inputs >"$work/streams"; then
+		printf 'provider\taudio\tunavailable\tread-only\tPipeWire PulseAudio interface is unavailable\n'
+		return 0
+	fi
+	if ! jq -e . "$work/info" "$work/sinks" "$work/sources" "$work/streams" >/dev/null 2>&1; then
+		printf 'provider\taudio\tunavailable\tread-only\tMalformed audio provider response\n'
+		return 0
+	fi
+
+	default_sink=$(jq -r '.default_sink_name // ""' "$work/info")
+	default_source=$(jq -r '.default_source_name // ""' "$work/info")
+	printf 'provider\taudio\tavailable\tdelegated\tPipeWire state and user-session actions\n'
+	jq -r --arg default "$default_sink" '
+		def clean: tostring | gsub("[\\t\\r\\n]"; " ");
+	def percent: ([.volume[]?.value_percent | sub("%$"; "") | tonumber] | max // 0 | round) as $p |
+		if $p < 0 then 0 elif $p > 100 then 100 else $p end;
+		.[] | ["audio-output", (.name|clean), (.description // .properties["device.description"] // .name|clean),
+			(if .name == $default then "yes" else "no" end), (if .mute then "yes" else "no" end), (percent|tostring)] | @tsv' "$work/sinks"
+	jq -r --arg default "$default_source" '
+		def clean: tostring | gsub("[\\t\\r\\n]"; " ");
+	def percent: ([.volume[]?.value_percent | sub("%$"; "") | tonumber] | max // 0 | round) as $p |
+		if $p < 0 then 0 elif $p > 100 then 100 else $p end;
+		.[] | select(.name | endswith(".monitor") | not) |
+		["audio-input", (.name|clean), (.description // .properties["device.description"] // .name|clean),
+			(if .name == $default then "yes" else "no" end), (if .mute then "yes" else "no" end), (percent|tostring)] | @tsv' "$work/sources"
+	jq -r '
+		def clean: tostring | gsub("[\\t\\r\\n]"; " ");
+	def percent: ([.volume[]?.value_percent | sub("%$"; "") | tonumber] | max // 0 | round) as $p |
+		if $p < 0 then 0 elif $p > 100 then 100 else $p end;
+		.[] | ["audio-stream", (.index|tostring), (.properties["application.name"] // .name // "Application"|clean),
+			(.properties["media.name"] // .name // "Audio stream"|clean), (if .mute then "yes" else "no" end), (percent|tostring)] | @tsv' "$work/streams"
+}
+
+audio_watch() {
+	command -v pactl >/dev/null 2>&1 || return 127
+	run_parent_bound pactl subscribe
+}
+
+input_set_default() {
+	validate_audio_name "$1"
+	run_bounded 15 pactl set-default-source "$1"
+}
+
+input_volume_set() {
+	[ "$#" -eq 2 ] || usage
+	validate_audio_name "$1"
+	percent=$(volume_percent "$2")
+	run_bounded 15 pactl set-source-volume "$1" "$percent"
+}
+
+input_toggle_mute() {
+	validate_audio_name "$1"
+	run_bounded 15 pactl set-source-mute "$1" toggle
+}
+
+stream_volume_set() {
+	[ "$#" -eq 2 ] || usage
+	validate_audio_index "$1"
+	percent=$(volume_percent "$2")
+	run_bounded 15 pactl set-sink-input-volume "$1" "$percent"
+}
+
+stream_toggle_mute() {
+	validate_audio_index "$1"
+	run_bounded 15 pactl set-sink-input-mute "$1" toggle
 }
 
 media_status() {
@@ -664,6 +756,14 @@ command=$1
 shift
 
 case "$command" in
+audio-snapshot)
+	[ "$#" -eq 0 ] || usage
+	audio_snapshot
+	;;
+audio-watch)
+	[ "$#" -eq 0 ] || usage
+	audio_watch
+	;;
 volume-status)
 	[ "$#" -eq 0 ] || usage
 	volume_status
@@ -695,6 +795,24 @@ output-devices)
 output-set-default)
 	[ "$#" -eq 1 ] || usage
 	output_set_default "$1"
+	;;
+input-set-default)
+	[ "$#" -eq 1 ] || usage
+	input_set_default "$1"
+	;;
+input-volume-set)
+	input_volume_set "$@"
+	;;
+input-toggle-mute)
+	[ "$#" -eq 1 ] || usage
+	input_toggle_mute "$1"
+	;;
+stream-volume-set)
+	stream_volume_set "$@"
+	;;
+stream-toggle-mute)
+	[ "$#" -eq 1 ] || usage
+	stream_toggle_mute "$1"
 	;;
 mic-status)
 	[ "$#" -eq 0 ] || usage

--- a/tests/test-quickshell-audio.sh
+++ b/tests/test-quickshell-audio.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+repo=$(
+	unset CDPATH
+	cd -- "$(dirname -- "$0")/.." && pwd
+)
+model=$repo/config/quickshell/controls/ControlsModel.qml
+pane=$repo/config/quickshell/settings/AudioSettingsPane.qml
+settings=$repo/config/quickshell/settings/SettingsModel.qml
+shell=$repo/config/quickshell/shell.qml
+
+grep -Fq 'property int audioSourceGeneration: 0' "$model"
+grep -Fq 'property int mutationGeneration: 0' "$model"
+grep -Fq 'property int appliedMutationGeneration: 0' "$model"
+grep -Fq 'root.actionProcessGeneration !== root.mutationGeneration' "$model"
+grep -Fq 'property string mutationOrigin: ""' "$model"
+grep -Fq 'interval: 3000' "$model"
+grep -Fq 'repeat: false' "$model"
+grep -Fq 'root.fallbackProcessGeneration === root.audioSourceGeneration' "$model"
+grep -Fq 'fallbackRestartTimer.restart()' "$model"
+grep -Fq 'if (fallbackWatchProcess.running) fallbackWatchProcess.running = false;' "$model"
+[ "$(grep -Fc 'Commands.controlsHelperCommand("audio-watch")' "$model")" -eq 1 ]
+if grep -Fq 'repeat: true' "$model"; then
+	exit 1
+fi
+grep -Fq 'function parseAudioSnapshot(text)' "$model"
+grep -Fq 'fields[3] !== "yes" && fields[3] !== "no"' "$model"
+grep -Fq 'fields[4] !== "yes" && fields[4] !== "no"' "$model"
+grep -Fq 'function inputSetDefault(name, origin)' "$model"
+grep -Fq 'function streamVolumeSet(index, percent, origin)' "$model"
+grep -Fq 'property var controlsModel: null' "$settings"
+grep -Fq 'root.controlsModel.openSettings()' "$settings"
+grep -Fq 'root.controlsModel.closeSettings()' "$settings"
+grep -Fq 'controlsModel: controlsModel' "$shell"
+grep -Fq 'root.controlsModel.inputSetDefault' "$pane"
+grep -Fq 'root.controlsModel.inputToggleMute' "$pane"
+grep -Fq 'root.controlsModel.streamVolumeSet' "$pane"
+grep -Fq 'root.controlsModel.streamToggleMute' "$pane"
+
+printf 'Quickshell audio provider and Settings contract: PASS\n'

--- a/tests/test-quickshell-connectivity.sh
+++ b/tests/test-quickshell-connectivity.sh
@@ -11,6 +11,7 @@ bluetooth_pane=$repo/config/quickshell/settings/BluetoothSettingsPane.qml
 
 grep -Fq 'run_parent_bound nmcli monitor' "$repo/scripts/dwm-quickshell-network"
 grep -Fq 'run_parent_bound playerctl --follow' "$repo/scripts/dwm-quickshell-controls"
+grep -Fq 'networkMonitorRestartTimer.restart()' "$network_model"
 
 for pattern in \
 	'fields[0] === "connectivity-protocol"' \

--- a/tests/test-quickshell-controls.sh
+++ b/tests/test-quickshell-controls.sh
@@ -15,6 +15,23 @@ cat >"$work/bin/pactl" <<'SH'
 set -eu
 
 case "$*" in
+"--format=json info")
+	if [ "${DWM_TEST_AUDIO_MALFORMED:-0}" = 1 ]; then
+		printf '%s\n' '{not-json'
+	else
+		printf '%s\n' '{"default_sink_name":"sink.one","default_source_name":"source.one"}'
+	fi
+	;;
+"--format=json list sinks")
+	output_volume=${DWM_TEST_AUDIO_OUTPUT_VOLUME:-40}
+	printf '[{"name":"sink.one","description":"Speakers","mute":false,"volume":{"left":{"value_percent":"%s%%"}}},{"name":"sink.two","description":"Headphones","mute":true,"volume":{"left":{"value_percent":"55%%"}}}]\n' "$output_volume"
+	;;
+"--format=json list sources")
+	printf '%s\n' '[{"name":"source.one","description":"Microphone","mute":false,"volume":{"mono":{"value_percent":"70%"}}},{"name":"sink.one.monitor","description":"Monitor","mute":false,"volume":{"mono":{"value_percent":"100%"}}}]'
+	;;
+"--format=json list sink-inputs")
+	printf '%s\n' '[{"index":21,"name":"Playback","mute":false,"volume":{"left":{"value_percent":"65%"}},"properties":{"application.name":"Browser","media.name":"Video"}}]'
+	;;
 "get-sink-mute @DEFAULT_SINK@")
 	printf 'Mute: %s\n' "${DWM_TEST_SINK_MUTE:-no}"
 	;;
@@ -63,6 +80,9 @@ list\ short\ sink-inputs)
 	;;
 set-default-sink\ *)
 	printf 'default sink %s\n' "$2" >>"$DWM_TEST_PACTL_LOG"
+	;;
+set-default-source\ * | set-source-volume\ * | set-source-mute\ * | set-sink-input-volume\ * | set-sink-input-mute\ *)
+	printf '%s\n' "$*" >>"$DWM_TEST_PACTL_LOG"
 	;;
 move-sink-input\ *)
 	printf 'move sink input %s %s\n' "$2" "$3" >>"$DWM_TEST_PACTL_LOG"
@@ -207,6 +227,43 @@ malformed)
 esac
 SH
 chmod +x "$work/bin/busctl"
+
+PATH="$work/bin:$PATH" "$repo/scripts/dwm-quickshell-controls" audio-snapshot >"$work/audio-snapshot.out"
+grep -Fqx "audio-protocol	1	0" "$work/audio-snapshot.out"
+grep -Fqx "provider	audio	available	delegated	PipeWire state and user-session actions" "$work/audio-snapshot.out"
+grep -Fqx "audio-output	sink.one	Speakers	yes	no	40" "$work/audio-snapshot.out"
+grep -Fqx "audio-input	source.one	Microphone	yes	no	70" "$work/audio-snapshot.out"
+grep -Fqx "audio-stream	21	Browser	Video	no	65" "$work/audio-snapshot.out"
+if grep -Fq "sink.one.monitor" "$work/audio-snapshot.out"; then
+	exit 1
+fi
+DWM_TEST_AUDIO_OUTPUT_VOLUME=140 PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" audio-snapshot >"$work/audio-bounded.out"
+grep -Fqx "audio-output	sink.one	Speakers	yes	no	100" "$work/audio-bounded.out"
+DWM_TEST_AUDIO_MALFORMED=1 PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" audio-snapshot >"$work/audio-malformed.out"
+grep -Fqx "provider	audio	unavailable	read-only	Malformed audio provider response" "$work/audio-malformed.out"
+
+DWM_TEST_SUBSCRIBE_MARKER="$work/audio-subscribed" PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" audio-watch
+[ -e "$work/audio-subscribed" ]
+
+: >"$work/pactl.log"
+DWM_TEST_PACTL_LOG="$work/pactl.log" PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" input-set-default source.one
+DWM_TEST_PACTL_LOG="$work/pactl.log" PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" input-volume-set source.one 72%
+DWM_TEST_PACTL_LOG="$work/pactl.log" PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" input-toggle-mute source.one
+DWM_TEST_PACTL_LOG="$work/pactl.log" PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" stream-volume-set 21 64%
+DWM_TEST_PACTL_LOG="$work/pactl.log" PATH="$work/bin:$PATH" \
+	"$repo/scripts/dwm-quickshell-controls" stream-toggle-mute 21
+grep -Fqx "set-default-source source.one" "$work/pactl.log"
+grep -Fqx "set-source-volume source.one 72%" "$work/pactl.log"
+grep -Fqx "set-source-mute source.one toggle" "$work/pactl.log"
+grep -Fqx "set-sink-input-volume 21 64%" "$work/pactl.log"
+grep -Fqx "set-sink-input-mute 21 toggle" "$work/pactl.log"
 
 if PATH="$work/bin:$PATH" "$repo/scripts/dwm-quickshell-controls" 2>"$work/usage.out"; then
 	printf 'Control helper accepted a missing subcommand.\n' >&2
@@ -498,5 +555,7 @@ chmod +x "$work/bin/wpctl"
 
 PATH="$work/bin:/usr/bin:/bin" "$repo/scripts/dwm-quickshell-controls" volume-status >"$work/unavailable.out"
 grep -Fqx "VOL unavailable" "$work/unavailable.out"
+PATH="$work/bin:/usr/bin:/bin" "$repo/scripts/dwm-quickshell-controls" audio-snapshot >"$work/audio-unavailable.out"
+grep -Fqx "provider	audio	unavailable	read-only	PipeWire PulseAudio interface is unavailable" "$work/audio-unavailable.out"
 
 printf 'Quickshell controls helper: PASS\n'


### PR DESCRIPTION
## Summary

- add a native-first root-scoped PipeWire audio model and Settings pane for outputs, inputs, mute, volume, microphone state, and per-application streams
- add a bounded versioned audio snapshot protocol with generation-checked fallback subscription and malformed-state clearing
- harden NetworkManager and media subscriptions with bounded restart after unexpected exit
- record Fedora X11 audio, lifecycle, idle, and hardware-limitation evidence

## Validation

- `scripts/run-tests make clean all`
- `scripts/run-tests`
- ShellCheck and shfmt for changed shell/tests
- `scripts/quickshell-qmllint --root config/quickshell` (only documented pre-existing warnings)
- real Fedora 44 X11: 3 outputs, 4 non-monitor inputs, external 30% -> 31% -> 30% convergence, microphone mute/unmute restore, silent application-stream 42%/mute action and teardown
- 30-second closed baseline: 0.000% Quickshell CPU
- 30-second post-all-Settings-sections sample: 0.000% Quickshell CPU
- exactly one parent-bound NetworkManager watcher and one media watcher; no native-overlapping audio fallback
- CodeRabbit local review: one malformed-boolean finding fixed; re-review clean

## Limitations

- no Wi-Fi adapter was present, so association/authentication remain fixture-qualified
- no sacrificial Bluetooth device was available, so pairing recovery remains fixture-qualified
