### PR TITLE
fix: close Phase 4 and address late review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ versions from `config.mk`.
 
 ### Changed
 
+- Complete Phase 4 Power, Session, Defaults, and XDG autostart integration.
+  Fresh Fedora 44 LightDM activation now runs the installed DWM and one managed
+  Quickshell shell with one panel per active monitor; unavailable battery, lid,
+  destructive power, repeated-login, and real `startx` paths remain explicitly
+  qualified instead of overstated.
+
 - Make the Bash-based status publisher single-instance per user and X display
   using exact resolved command-path matching instead of its interpreter process
   name. Track and reap subscription children so repeated session startup cannot

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,8 +78,9 @@ product roadmap.
 UI-1 is the merged foundation. UI-2 and UI-3 were parallel children and are
 now unified on `main`. `P3-UI4` established the shared large-surface language
 used by the completed Phase 3 provider work and the later power, defaults,
-personalization, accessibility, and system-management phases. Phase 3 is
-complete and product Phase 4 is active. UI-5 is delivered with Phase 5, and
+personalization, accessibility, and system-management phases. Phases 3 and 4
+are complete and product Phase 5 is active. UI-5 candidates are evaluated in
+Phase 5 and approved experiences are delivered as separate review boundaries;
 UI-6 closes the desktop during Phase 7 release qualification.
 
 ### UI Overhaul Exit Criteria
@@ -251,7 +252,7 @@ Provide desktop-grade network, Bluetooth, and sound management.
 
 ## Phase 4: Power, Session, and Defaults
 
-Status: Active (2026-08-21)
+Status: Complete (2026-08-22)
 
 ### Objective
 
@@ -273,7 +274,30 @@ Unify normal session behavior and application defaults.
 - Destructive power actions keep confirmation and authorization boundaries.
 - Defaults are visible through standard XDG inspection tools.
 
+### Completion Evidence
+
+- PR #168 delivered the shared Power and session-action models, transactional
+  default-application management, XDG autostart controls, event-driven provider
+  lifecycle, and Fedora package/install integration.
+- The clean build, full managed repository suite, Quickshell lint, focused shell
+  checks, nested-X11 workflows, and exact-head hosted checks passed. Reversible
+  live power, browser, file-manager, MIME, and autostart mutations converged and
+  restored their recorded baselines.
+- After installation, a fresh Fedora 44 LightDM X11 login ran the installed DWM
+  byte-for-byte, launched one managed Quickshell instance with one panel per
+  active monitor and tray clients, and passed user acceptance of the Phase 4
+  Settings and confirmation surfaces. The observed upgrade login reached DWM
+  and Quickshell without retries or duplicate processes; the active DWM now
+  owns the bounded completion-aware logout path.
+- Battery and lid transitions remain fixture-qualified because this workstation
+  has neither device. Actual suspend, reboot, and shutdown were not executed;
+  their confirmation, authorization-denial, fixed-command, and failure paths are
+  automated. Real `startx` and repeated destructive login cycles also remain
+  fixture-qualified.
+
 ## Phase 5: Personalization and Accessibility
+
+Status: Active (2026-08-22)
 
 ### Objective
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -657,13 +657,12 @@ In a real or nested X11 session:
 The existing desktop provides dwm, a managed Quickshell panel and launcher,
 notifications, quick controls, power actions, network and Bluetooth surfaces,
 display helpers, a system-health dashboard, and the unified Settings platform.
-Settings now includes the completed Phase 2 display and input mutation surface
-with preview, rollback, persistence, and capability reporting, plus the Phase 3
-NetworkManager, BlueZ, PipeWire, and media workflows. It does not yet provide
-the remaining settings mutation surface in Section 5.10. Phase 4 POWER-001 is
-complete with a shared UPower, Power Profiles, logind, DPMS, and automatic-lock
-provider plus its Settings pane. Session, defaults, and autostart work remains
-sequenced in `ROADMAP.md` and defined in `TASKS.md`.
+Settings includes the completed Phase 2 display and input mutation surface,
+Phase 3 NetworkManager, BlueZ, PipeWire, and media workflows, and Phase 4 power,
+session-action, default-application, MIME, and XDG autostart workflows. The
+remaining Settings mutation surface in Section 5.10 begins with Phase 5 themes,
+wallpaper, fonts, cursors, toolkit integration, notifications, and practical X11
+accessibility controls, sequenced in `ROADMAP.md` and defined in `TASKS.md`.
 
 The installer contains a Fedora-only package map and rejects other systems.
 The build uses `pkg-config`, supports staged installation with `DESTDIR`, and

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,147 +1,137 @@
 # Active Project Tasks
 
 `SPEC.md` is the product contract and `ROADMAP.md` defines phase order. This
-file contains implementation work only for the active roadmap phase. Phase 3
+file contains implementation work only for the active roadmap phase. Phase 4
 completion evidence is recorded in `ROADMAP.md`, `CHANGELOG.md`,
-`docs/P3-UI4-EVIDENCE.md`, `docs/P3-CONNECTIVITY-EVIDENCE.md`, and
-`docs/P3-AUDIO-EVIDENCE.md`.
+`docs/P4-EVIDENCE.md`, and the four detailed Phase 4 evidence records.
 
-## Active Phase: Power, Session, and Defaults
+## Active Phase: Personalization and Accessibility
 
-Phase 4 begins from the merged Settings, connectivity, and audio architecture.
-Keep the existing panel Power menu, confirmation boundaries, DWM session
-lifecycle, user configuration, and XDG overrides compatible while adding the
-full-screen Settings workflows below.
+Phase 5 begins from the merged Settings platform and semantic theme adapter.
+Keep DWM, X11, Fedora providers, runtime TOML files, existing keybindings, panel
+geometry, and user-owned configuration compatible while adding the workflows
+below. Do not begin Phase 6 system-management work in Phase 5 changes.
 
-### POWER-001: Power Provider and Settings Workflows
+### THEME-001: Shared Appearance Provider and Safe Theme Changes
 
-- [x] Define versioned machine-readable records for battery state, external
-  power, available power profiles, active profile, DPMS, idle timing,
-  automatic locking, suspend support, and lid-policy capability.
-- [x] Reuse the standard Power Profiles D-Bus provider, UPower, logind, `xset`,
-  and the existing Control Center helper only through stable machine
-  interfaces. Dedicated images select `power-profiles-daemon`; the
-  existing-system installer retains any compatible `ppd-service` provider
-  already installed. Consume UPower
-  battery property-change signals; allow bounded sampling only for a documented
-  fallback with no event source, and keep every service subscription
-  event-driven.
-- [x] Add a Power Settings pane for available profile selection, DPMS, lock and
-  idle timeouts, and supported suspend/lid behavior. Hide or explain unsupported
-  hardware without disabling readable state.
-- [x] Separate read-only battery state, user-session DPMS/lock changes,
-  delegated logind actions, and privileged persistent system policy.
-- [x] Preserve the existing user `power.conf`, panel Power menu, confirmation
-  dialogs, and service authorization behavior. Failed writes must not be shown
-  as saved.
+- [ ] Define a versioned machine-readable provider for the active theme,
+  available themes, semantic colors, toolkit state, and per-capability errors.
+- [ ] Add one root-scoped appearance model shared by Settings and existing shell
+  surfaces without duplicating the `Theme.qml` or `themes.toml` ownership path.
+- [ ] Add a Settings Appearance pane with theme preview, apply, reset, and
+  recovery behavior. Preserve comments, custom themes, file mode, and unrelated
+  user configuration.
+- [ ] Make partial GTK, Qt, terminal, cursor, or compositor application failures
+  visible without reporting the selected theme as fully applied.
 
 Acceptance:
 
-- Missing batteries, profile services, X11 DPMS, lock providers, or lid
-  hardware fail only the owning capability and leave Settings usable.
-- Timeout and numeric arguments are bounded; suspend and policy changes retain
-  explicit confirmation and authorization boundaries.
-- Panel power state and Settings converge without duplicate providers or idle
-  polling, and section-owned work stops on close.
+- Invalid, missing, duplicate, or incomplete theme records cannot prevent DWM,
+  Quickshell, Settings, or an existing theme from loading.
+- Preview is bounded and rolls back automatically unless confirmed. Apply and
+  reset are transactional, attributed, and converge through hot reload.
+- Existing Control Center theme selection remains compatible with the shared
+  provider until its presentation can be migrated without behavior drift.
 
-### SESSION-001: Session Actions and Recovery Contract
+### APPEARANCE-001: Wallpaper, Fonts, Cursors, Icons, and Toolkit Integration
 
-- [x] Define one shared root-scoped session action model for lock, logout,
-  suspend, reboot, and shutdown that reuses the existing Power menu backend.
-- [x] Attribute action progress and failures to the initiating surface, reject
-  overlapping session-ending requests, and retain confirmation for every
-  destructive action.
-- [x] Preserve both display-manager and `startx` startup, D-Bus session setup,
-  graphical-session target ownership, autostop cleanup, tray startup order,
-  and optional-component failure tolerance.
-- [x] Document recovery paths for a failed locker, denied logind action,
-  incomplete graphical-session startup, and deferred installed-DWM activation.
-
-Acceptance:
-
-- Authorization denial or service loss cannot be reported as success and does
-  not terminate unrelated shell providers.
-- Lock, logout, suspend, reboot, and shutdown remain reachable from the panel;
-  Settings uses the same action and confirmation contracts.
-- Repeated login/logout does not leave duplicate Quickshell, locker, portal,
-  status, watcher, or XDG autostart processes.
-
-### DEFAULTS-001: Default Application Management
-
-- [x] Define versioned records for default browser, terminal, file manager,
-  supported MIME handlers, candidate desktop entries, and provider availability
-  using XDG interfaces rather than parsing human-oriented launcher output.
-- [x] Extend the existing `dwm-default-apps` contract for validated terminal,
-  file-manager, browser, and MIME mutations while preserving current hotkeys
-  and safe unavailable behavior.
-- [x] Add a Defaults Settings pane with explicit current values, candidate
-  selection, per-MIME changes, reset/recovery behavior, and attributed partial
-  failures.
-- [x] Preserve user desktop files and existing MIME associations not selected
-  for change. Never invent a default when XDG state is absent or malformed.
+- [ ] Define event-driven inventory and state contracts for wallpaper, supported
+  fonts, cursors, icons, GTK, Qt, and compositor integration using stable Fedora
+  or X11 interfaces.
+- [ ] Add wallpaper selection, fit mode, preview, reset, and missing-file
+  recovery without scanning while the Appearance pane is closed.
+- [ ] Add bounded user-session controls for supported font, text-size, cursor,
+  icon, GTK, and Qt choices. Delegate advanced toolkit editing to a trusted
+  Fedora tool where a narrow project contract would be incomplete.
+- [ ] Move the existing in-memory panel-widget visibility controls onto shared,
+  versioned user state with Settings integration, safe defaults, and migration
+  that preserves the current Control Center behavior.
+- [ ] Preserve optional-component behavior: missing Picom, Feh, toolkit themes,
+  wallpaper directories, or delegated tools must fail only their capability.
 
 Acceptance:
 
-- Changes are visible through `xdg-settings` or `xdg-mime`, survive a fresh
-  session, and affect only the selected default or MIME type.
-- Invalid or missing desktop entries are rejected before mutation. Missing XDG
-  tools fail only Defaults and keep readable state where possible.
-- Existing browser and terminal hotkeys resolve through the newly selected
-  defaults without changing DWM keybinding contracts.
+- Selected appearance state persists through a fresh session and follows the
+  shared theme where appropriate without overwriting unrelated toolkit files.
+- Panel-widget visibility persists through a fresh session, stays consistent on
+  every active monitor, and does not duplicate panel models or providers.
+- Preview, apply, interruption, rollback, reset, missing-asset, and external-
+  change paths converge with explicit status and no orphaned watcher.
+- Visible shell surfaces remain opaque, X11-native, correctly stacked, and
+  usable at the existing panel and popup geometry contracts.
 
-### AUTOSTART-001: User-Visible XDG Autostart Controls
+### ACCESSIBILITY-001: Practical X11 Accessibility and Notification Policy
 
-- [x] Define versioned records for system and user XDG autostart entries,
-  effective enabled state, origin, desktop visibility, and unsupported entries.
-- [x] Add enable and disable actions by creating or updating a user override;
-  never edit or delete vendor desktop files.
-- [x] Validate desktop IDs and resolved paths, reject symlink escapes, preserve
-  unrelated keys, and back up an existing user override before a material
-  rewrite.
-- [x] Add searchable Defaults Settings controls with clear vendor/user origin,
-  confirmation where disabling a session component risks loss of desktop
-  functionality, and reset-to-vendor behavior.
+- [ ] Define capability records for text scaling, contrast, reduced motion,
+  notification policy, and practical keyboard or pointer accessibility features
+  available through supported Fedora/X11 interfaces.
+- [ ] Add accessible Settings controls with keyboard navigation, visible focus,
+  usable common display sizes, explanatory unavailable states, and reset.
+- [ ] Apply reduced-motion and contrast choices consistently to managed
+  Quickshell surfaces without introducing a Wayland, compositor, or polling
+  dependency.
+- [ ] Add notification behavior controls that preserve the existing D-Bus owner,
+  history lifecycle, urgency semantics, and safe failure isolation.
 
 Acceptance:
 
-- Enable, disable, and reset survive logout/login and match the effective XDG
-  autostart state without duplicate launches.
-- Existing dwm-scoped overrides for the locker, compositor, and polkit agent
-  remain preserved unless the user explicitly changes that exact entry.
-- Malformed, missing, hidden, or non-applicable entries degrade per item and do
-  not break the Defaults pane or session startup.
+- Accessibility state persists and is observable through the owning platform or
+  managed interface after a fresh session.
+- Missing X11 extensions or optional tools degrade per capability and never make
+  Settings, notifications, or the shell unavailable.
+- Keyboard-only navigation, text scaling, contrast, reduced motion, notification
+  delivery/history, and reset behavior pass nested-X11 and real-session checks.
 
-### P4-VALIDATE: Phase 4 Validation
+### P5-UI5: Optional X11-Native Experience Integration
 
-- [x] Run focused shell, provider, QML, helper, and nested-X11 tests for power,
-  session, defaults, and autostart workflows.
-- [x] Exercise available battery/profile/DPMS/lock paths and record exact absent
-  hardware or services rather than claiming them verified.
-- [ ] Exercise default browser, terminal, file manager, representative MIME,
-  and XDG autostart changes in an isolated user environment and a real Fedora
-  session, restoring the original values afterward.
-- [ ] Qualify display-manager and `startx` startup, repeated logout/login,
-  destructive-action confirmation, authorization denial, and process cleanup.
-- [x] Compare a 30-second closed baseline with a 30-second sample after opening
-  and closing every Phase 4 Settings workflow; the mean Quickshell CPU delta
+- [ ] Inventory UI-5 candidates, beginning with event-driven clipboard history,
+  and record an adopt, defer, or reject decision for each candidate.
+- [ ] Evaluate every adopted UI-5 experience as an independent review boundary
+  with an event-driven provider, explicit data ownership, bounded lifecycle,
+  privacy model, and Fedora package impact before implementation.
+- [ ] Integrate only approved X11-native experiences into the existing semantic
+  design system and command surfaces; do not copy Wayland, Hyprland, layer-shell,
+  UWSM, or Omarchy service/plugin backends.
+- [ ] Preserve current IPC names, X11 focus/click-away/stacking behavior, monitor
+  selection, and closed-surface near-idle behavior.
+
+Acceptance:
+
+- Every inventoried candidate has a recorded adopt, defer, or reject decision.
+- Every adopted experience has focused source, helper, lifecycle, nested-X11,
+  package/install, and privacy tests.
+- Closing a surface leaves no resident scan, duplicate subscription, helper,
+  sensitive history owner, or overlapping process.
+
+### P5-VALIDATE: Phase 5 Validation
+
+- [ ] Run focused parser, helper, QML, lifecycle, rollback, and nested-X11 tests
+  for every Phase 5 workflow.
+- [ ] Exercise reversible appearance and accessibility changes on Fedora 44,
+  restore exact original state, and record unavailable toolkit or X11 paths.
+- [ ] Compare a 30-second closed baseline with a 30-second sample after opening
+  and closing every Phase 5 Settings workflow; the mean Quickshell CPU delta
   must be no more than 0.5 percentage points of one CPU.
-- [ ] Run the full Fedora repository validation, staged install, and installed
-  runtime checks, and record every untested hardware or reboot path.
+- [ ] Run the clean build, full managed repository suite, Quickshell lint,
+  ShellCheck, shfmt, staged install, repeated install, and installed-runtime
+  parity checks.
+- [ ] Qualify a fresh LightDM login, fixture or real `startx`, multi-monitor and
+  common display-size rendering, optional-component loss, and recovery after an
+  invalid theme or missing asset.
 
 Acceptance:
 
-- Every Phase 4 exit criterion maps to automated evidence or a named manual
-  check with Fedora release, hardware, session, restoration, and limitations.
-- Settings and panel workflows share providers, fail safely, persist through a
-  fresh session where required, and leave no duplicate services or autostarts.
-- No power, lid, battery, display-manager, or reboot path is described as
-  verified when its required environment was unavailable.
+- Every Phase 5 exit criterion maps to automated evidence or a named manual
+  check with Fedora release, session, restoration, and limitations.
+- Invalid themes or missing assets cannot prevent login or shell startup.
+- Accessibility choices persist, remain keyboard-usable, and do not add idle
+  polling, duplicate providers, or orphaned work.
 
 ## Phase Completion
 
-When all Phase 4 acceptance criteria pass:
+When all Phase 5 acceptance criteria pass:
 
 1. Record delivered behavior and validation in `CHANGELOG.md`.
-2. Update the Phase 4 status and limitations in `ROADMAP.md`.
-3. Replace this file's active task set with Phase 5 tasks.
+2. Update the Phase 5 status and limitations in `ROADMAP.md`.
+3. Replace this file's active task set with Phase 6 tasks.
 4. Preserve incomplete or deferred work as explicit roadmap limitations.

--- a/docs/P4-AUTOSTART-EVIDENCE.md
+++ b/docs/P4-AUTOSTART-EVIDENCE.md
@@ -126,5 +126,7 @@ package and installed-runtime validation must independently require it.
 Search, confirmation, origin rendering, action attribution, pane-owned watcher
 lifecycle, package/Kickstart/install symmetry, restored live mutation, repeated
 display-manager and `startx` fixtures, full repository tests, and the 30-second
-CPU comparison are integrated. Real repeated logout/login remains an explicit
-active-workstation limitation in `P4-EVIDENCE.md`.
+CPU comparison are integrated. A fresh real display-manager login activated one
+managed shell and the expected tray applications without duplicate autostarts.
+Repeated real logout/login remains an explicit workstation limitation in
+`P4-EVIDENCE.md`.

--- a/docs/P4-EVIDENCE.md
+++ b/docs/P4-EVIDENCE.md
@@ -1,6 +1,6 @@
 # Phase 4 Integration Evidence
 
-Date: 2026-08-21
+Date: 2026-08-22
 
 ## Qualification Scope
 
@@ -98,6 +98,33 @@ absence of false-success records.
   original session-owned publisher remained, and the guard plus direct-child
   teardown regression prevents recurrence.
 
+## Final Activation and Manual Acceptance
+
+- PR #168 merged as `7b4b64e8da8abbb280580c36f99e43f15faecc4f` after
+  exact-head validate, Quickshell QML, CodeQL, documentation, and CodeRabbit
+  checks passed. Three actionable review threads posted after merge were
+  corrected and regression-tested in the Phase 4 closeout.
+- `scripts/dev-sync-install.sh` synchronized the final closeout and reported
+  every managed file current. After a
+  fresh LightDM login, `/proc/529804/exe`, `/usr/local/bin/dwm`, and the checkout
+  DWM all had SHA-256
+  `63b7edf38b957f9659a8b66831065c3ffcca0bb71820cc474885fbf8766882c1`.
+- The active Fedora 44 X11 session had one managed Quickshell instance, two
+  visible 30-pixel panels for the two active monitors, six registered tray
+  items, an available Power provider, and no Defaults or autostart watcher
+  workspace after Settings closed. The user manually accepted the visible
+  panel, Settings, Power menu, confirmation, and normal-launch behavior.
+- LightDM authentication and Xauthority setup succeeded without retry or error.
+  The observed login reached DWM and Quickshell within about three seconds and
+  completed `graphical-session.target` without a retry, timeout, or duplicate
+  shell process. The journal records the previous target stopping before the
+  new session completed, but one login does not establish that ordering as the
+  cause of the perceived delay or prove its future recurrence.
+- The final helper-only synchronization replaced the on-disk DWM inode while
+  the accepted session remained active. The running deleted inode, installed
+  binary, and checkout still had the same SHA-256 above; no DWM or QML source
+  changed in the closeout, so a second disruptive logout was not required.
+
 ## Explicit Limitations
 
 - This workstation has no battery or lid hardware, so those transitions remain
@@ -107,14 +134,12 @@ absence of false-success records.
   helper, confirmation, denial, and failure paths are automated.
 - No sacrificial real locker was available; lock/unlock remains nested- and
   failure-fixture-qualified.
-- Repeated display-manager logout/login and reboot persistence are not claimed.
-  Automated fixtures qualify repeated autostart execution and graceful nested
-  DWM logout; one fresh real display-manager login remains the final activation
-  gate after the reviewed tree is installed.
+- An actual reboot and repeated real display-manager cycles are not claimed.
+  Persistent file state, startup replay, repeated display-manager and `startx`
+  autostart execution, process cleanup, and graceful nested DWM logout are
+  fixture-qualified; one fresh real display-manager login completed the
+  installed activation gate.
 - The live terminal setting is read-only while the user file remains a symlink.
 - `startx` preserves its TTY scope by design. Exact path, UID, and display
   matching prevents repeated-start duplication, but an abandoned publisher
   from an abnormal X-server loss may require scoped cleanup in a future phase.
-- The final installed DWM binary requires one logout/login before its graceful
-  logout endpoint can be observed in the active session. Installed-file parity
-  and the post-login panel/process check are recorded at final synchronization.

--- a/docs/P4-POWER-EVIDENCE.md
+++ b/docs/P4-POWER-EVIDENCE.md
@@ -2,14 +2,14 @@
 
 ## Scope and Status
 
-This record qualifies POWER-001 on Fedora Linux 44 x86_64. It does not claim a
-completed Phase 4, SESSION-001 power actions, or hardware paths unavailable on
-the host.
+This feature record qualifies POWER-001 on Fedora Linux 44 x86_64. Integrated
+Phase 4 completion and SESSION-001 power actions are recorded in
+`P4-EVIDENCE.md`; unavailable hardware paths remain explicit below.
 
-POWER-001 implementation, automated gates, nested-X11 lifecycle checks, and
-available live Fedora service mutations are complete. The remaining limits are
-physical hardware, destructive suspend/resume, and current-login activation of
-the newly installed managed DWM and Quickshell code.
+POWER-001 implementation, automated gates, nested-X11 lifecycle checks,
+available live Fedora service mutations, and fresh-login activation are
+complete. The remaining limits are physical hardware and destructive
+suspend/resume.
 
 ## Host and Service Evidence
 
@@ -82,8 +82,9 @@ restored the fixture baseline. A 30-second closed baseline used 0.100 percent
 CPU; the post-Power-workflow sample used 0.033 percent, a 0.067 percentage-point
 delta against the 0.5-point limit.
 
-The managed installation matches this checkout. The active login intentionally
-retains its previously loaded DWM/Quickshell code until logout/login so tray
-startup order is not disturbed. Actual battery and lid transitions remain
-unavailable. Suspend/resume and lid-policy mutation remain deferred to
-SESSION-001 and an appropriate destructive-action qualification environment.
+The managed installation matches this checkout. A fresh Fedora 44 LightDM X11
+login activated the installed DWM and managed Quickshell tree with one shell,
+one panel per active monitor, and registered tray clients. Actual battery and
+lid transitions remain unavailable. Suspend/resume and lid-policy mutation
+remain limited to their automated contracts and an appropriate destructive-
+action or hardware qualification environment.

--- a/docs/P4-SESSION-EVIDENCE.md
+++ b/docs/P4-SESSION-EVIDENCE.md
@@ -45,6 +45,11 @@ worktree. The final exact-commit CI status is recorded on the pull request.
 Panel and Settings rendering, the five fixed actions, confirmation, failed
 locker, denied logind, cross-display isolation, duplicate startup, nested DWM
 logout, autostop completion, and the Phase-wide CPU comparison are automated.
-Actual lock/unlock, suspend/resume, reboot, shutdown, and repeated destructive
-login cycles were not run on the active workstation and remain explicitly
-limited in `P4-EVIDENCE.md`.
+The reviewed installation was activated through a fresh real Fedora 44 LightDM
+X11 login. The installed DWM hash matched the running process, one managed
+Quickshell instance mapped both panels and hosted the tray, and the user accepted
+the visible session and confirmation behavior. DWM and Quickshell started within
+about three seconds without a retry, timeout, or duplicate process; the single
+login does not establish the cause of the perceived delay. Actual lock/unlock,
+suspend/resume, reboot, shutdown, and repeated destructive login cycles were not
+run on the active workstation and remain explicitly limited in `P4-EVIDENCE.md`.

--- a/scripts/autostop.sh
+++ b/scripts/autostop.sh
@@ -101,6 +101,8 @@ stop_scoped_status() {
 	remove_scoped_status_identity
 }
 
+stop_scoped_status
+
 # A nested X server inherits the parent login's logind and XDG session IDs.
 # Refuse to clean up that login unless this dwm instance is attached to the
 # display that logind records for it. Accept an explicit X11 screen suffix,
@@ -113,8 +115,6 @@ x11:user:?*)
 	esac
 	;;
 esac
-
-stop_scoped_status
 
 # The systemd user manager and its graphical targets are shared across all
 # sessions for this user. Leave them active when another graphical login still

--- a/scripts/dwm-default-apps
+++ b/scripts/dwm-default-apps
@@ -1569,6 +1569,19 @@ watch_defaults() {
 				;;
 			control)
 				restart=0
+				if [[ $config_watch_mode == config ]]; then
+					if [[ ! -d $config_watch_target || -L $config_watch_target ]] ||
+						! path_has_no_symlink_components "$config_watch_target"; then
+						restart=1
+					fi
+				elif [[ -d $config_watch_target && ! -L $config_watch_target ]] &&
+					path_has_no_symlink_components "$config_watch_target"; then
+					restart=1
+				elif [[ $config_watch_mode == ancestor ]]; then
+					new_parent=$(deepest_existing_watch_parent \
+						"$config_watch_target" 2>/dev/null || true)
+					[[ $new_parent == "$config_watch_parent" ]] || restart=1
+				fi
 				break
 				;;
 			esac

--- a/scripts/dwm-default-apps
+++ b/scripts/dwm-default-apps
@@ -291,20 +291,19 @@ desktop_usable() {
 		else
 			command -v "$try_exec" >/dev/null 2>&1 || return 1
 		fi
+	fi
+	exec_value=$desktop_parsed_exec
+	[[ -n $exec_value ]] || return 1
+	if [[ $exec_value =~ ^\"([^\"]+)\"([[:space:]]|$) ]]; then
+		exec_command=${BASH_REMATCH[1]}
 	else
-		exec_value=$desktop_parsed_exec
-		[[ -n $exec_value ]] || return 1
-		if [[ $exec_value =~ ^\"([^\"]+)\"([[:space:]]|$) ]]; then
-			exec_command=${BASH_REMATCH[1]}
-		else
-			exec_command=${exec_value%%[[:space:]]*}
-		fi
-		[[ -n $exec_command && $exec_command != env ]] || return 1
-		if [[ $exec_command == */* ]]; then
-			[[ -x $exec_command ]] || return 1
-		else
-			command -v "$exec_command" >/dev/null 2>&1 || return 1
-		fi
+		exec_command=${exec_value%%[[:space:]]*}
+	fi
+	[[ -n $exec_command && $exec_command != env ]] || return 1
+	if [[ $exec_command == */* ]]; then
+		[[ -x $exec_command ]] || return 1
+	else
+		command -v "$exec_command" >/dev/null 2>&1 || return 1
 	fi
 }
 
@@ -1396,7 +1395,7 @@ watch_defaults() {
 			path_has_no_symlink_components "$config_home"; then
 			# Continue observing safe top-level MIME changes even when the
 			# nested hotkeys path is currently unsafe.
-			config_watch_mode=config
+			config_watch_mode=root
 			config_watch_parent=$config_home
 		fi
 		if [[ $config_watch_mode == ancestor ]]; then
@@ -1445,7 +1444,13 @@ watch_defaults() {
 		)
 		if [[ -n $config_watch_parent ]]; then
 			if [[ $config_watch_mode == config ]]; then
-				inotifywait "${common_args[@]}" -r --format $'config\t%e\t%f' \
+				inotifywait "${common_args[@]}" --format $'config-root\t%e\t%f' \
+					-- "$config_watch_parent" >"$fifo" &
+				defaults_watch_children+=("$!")
+				inotifywait "${common_args[@]}" --format $'config-managed\t%e\t%f' \
+					-- "$config_watch_target" >"$fifo" &
+			elif [[ $config_watch_mode == root ]]; then
+				inotifywait "${common_args[@]}" --format $'config-root\t%e\t%f' \
 					-- "$config_watch_parent" >"$fifo" &
 			else
 				inotifywait "${common_args[@]}" --format $'config\t%e\t%f' \
@@ -1522,6 +1527,42 @@ watch_defaults() {
 				fi
 				case $event_name in
 				mimeapps.list | *-mimeapps.list | hotkeys.toml)
+					printf '%s:%s\n' "$event_type" "$event_name"
+					;;
+				esac
+				;;
+			config-root)
+				if [[ ! -d $config_home || -L $config_home ]] ||
+					! path_has_no_symlink_components "$config_home"; then
+					printf '%s:%s\n' "$event_type" "$event_name"
+					restart=1
+					break
+				fi
+				case $event_name in
+				mimeapps.list | *-mimeapps.list)
+					printf '%s:%s\n' "$event_type" "$event_name"
+					;;
+				dwm-titus)
+					case ,$event_type, in
+					*,CREATE,* | *,DELETE,* | *,MOVED_TO,* | *,MOVED_FROM,*)
+						printf '%s:%s\n' "$event_type" "$event_name"
+						restart=1
+						break
+						;;
+					esac
+					;;
+				esac
+				;;
+			config-managed)
+				case ,$event_type, in
+				*,DELETE_SELF,* | *,MOVE_SELF,*)
+					printf '%s:%s\n' "$event_type" "${event_name:-dwm-titus}"
+					restart=1
+					break
+					;;
+				esac
+				case $event_name in
+				hotkeys.toml)
 					printf '%s:%s\n' "$event_type" "$event_name"
 					;;
 				esac

--- a/tests/test-autostop.sh
+++ b/tests/test-autostop.sh
@@ -317,13 +317,38 @@ if grep -q '^systemctl \|^loginctl terminate-session ' "$work/mismatched_session
 	exit 1
 fi
 
-run_case mismatched_display env XDG_SESSION_ID=48 DISPLAY=:150
+DISPLAY=:150 XDG_RUNTIME_DIR="$work/status-runtime" \
+	TEST_STATUS_READY="$work/status-nested.ready" "$work/bin/dwm-status" &
+nested_status_pid=$!
+track_status_pid "$nested_status_pid"
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+	[ -e "$work/status-nested.ready" ] && break
+	sleep 0.02
+done
+nested_status_starttime=$(awk '{ line = $0; sub(/^.*\) /, "", line); split(line, fields, " "); print fields[20] }' "/proc/$nested_status_pid/stat")
+nested_status_key=$(printf '%s' :150 | sha256sum | awk '{ print $1 }')
+nested_status_identity_file=$work/status-runtime/dwm-titus/dwm-status.$nested_status_key.identity
+printf '%s:%s\n' "$nested_status_pid" "$nested_status_starttime" >"$nested_status_identity_file"
+
+run_case mismatched_display env XDG_SESSION_ID=48 DISPLAY=:150 \
+	XDG_RUNTIME_DIR="$work/status-runtime"
 grep -Fqx 'loginctl show-session 48 -p Name -p Type -p Class -p Active -p Display' \
 	"$work/mismatched_display.log"
 if grep -q '^systemctl \|^loginctl terminate-session ' "$work/mismatched_display.log"; then
 	printf '%s\n' 'autostop must not clean up a login from a nested X display' >&2
 	exit 1
 fi
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+	status_identity_is_live "$nested_status_pid:$nested_status_starttime" || break
+	sleep 0.05
+done
+if status_identity_is_live "$nested_status_pid:$nested_status_starttime"; then
+	printf '%s\n' 'autostop left the nested display status process running' >&2
+	exit 1
+fi
+wait "$nested_status_pid" 2>/dev/null || true
+forget_status_pid "$nested_status_pid"
+[ ! -e "$nested_status_identity_file" ]
 
 run_case screen_suffix env XDG_SESSION_ID=48 DISPLAY=:0.1
 grep -Fqx 'loginctl terminate-session 48' "$work/screen_suffix.log"

--- a/tests/test-dwm-default-apps.sh
+++ b/tests/test-dwm-default-apps.sh
@@ -6,6 +6,7 @@ HELPER="$ROOT_DIR/scripts/dwm-default-apps"
 BASH_BIN=${BASH:-/usr/bin/bash}
 REAL_MV=$(command -v mv)
 REAL_CHMOD=$(command -v chmod)
+REAL_INOTIFYWAIT=$(command -v inotifywait || true)
 
 work=$(mktemp -d)
 watch_pid=
@@ -62,7 +63,36 @@ case $target in
 esac
 exec "${DWM_TEST_REAL_CHMOD:?}" "$@"
 SCRIPT
-chmod +x "$work/fail-bin/mv" "$work/fail-bin/chmod"
+
+cat >"$work/fail-bin/inotifywait" <<'SCRIPT'
+#!/bin/sh
+set -eu
+if [ -n "${DWM_TEST_WATCH_SETUP_TARGET:-}" ]; then
+	for argument do
+		if [ "$argument" = "$DWM_TEST_WATCH_SETUP_TARGET" ] &&
+			[ ! -e "${DWM_TEST_WATCH_SETUP_MARKER:?}" ]; then
+			mv -- "$DWM_TEST_WATCH_SETUP_TARGET" \
+				"$DWM_TEST_WATCH_SETUP_TARGET.removed"
+			: >"$DWM_TEST_WATCH_SETUP_MARKER"
+			exit 1
+		fi
+	done
+	for argument do
+		if [ "$argument" = "${DWM_TEST_WATCH_SETUP_ROOT:?}" ] &&
+			[ ! -e "${DWM_TEST_WATCH_SETUP_ROOT_PID:?}" ]; then
+			printf '%s\n' "$$" >"${DWM_TEST_WATCH_SETUP_ROOT_PID:?}"
+			while [ ! -e "${DWM_TEST_WATCH_SETUP_MARKER:?}" ]; do
+				sleep 0.01
+			done
+			while :; do
+				sleep 0.1
+			done
+		fi
+	done
+fi
+exec "${DWM_TEST_REAL_INOTIFYWAIT:-/usr/bin/inotifywait}" "$@"
+SCRIPT
+chmod +x "$work/fail-bin/mv" "$work/fail-bin/chmod" "$work/fail-bin/inotifywait"
 
 cat >"$work/data/applications/firefox.desktop" <<'DESKTOP'
 [Desktop Entry]
@@ -975,6 +1005,61 @@ if command -v inotifywait >/dev/null 2>&1; then
 			exit 1
 		fi
 	done
+
+	raced_config=$work/watch-setup-race
+	mkdir -p "$raced_config/dwm-titus"
+	printf '[vars]\nterminal = "alacritty"\n' >"$raced_config/dwm-titus/hotkeys.toml"
+	setup_marker=$work/watch-setup-race.marker
+	setup_root_pid_file=$work/watch-setup-root.pid
+	env "${env_common[@]}" XDG_CONFIG_HOME="$raced_config" \
+		PATH="$work/fail-bin:$work/bin:/usr/bin:/bin" \
+		DWM_TEST_REAL_MV="$REAL_MV" \
+		DWM_TEST_REAL_INOTIFYWAIT="$REAL_INOTIFYWAIT" \
+		DWM_TEST_WATCH_SETUP_TARGET="$raced_config/dwm-titus" \
+		DWM_TEST_WATCH_SETUP_ROOT="$raced_config" \
+		DWM_TEST_WATCH_SETUP_ROOT_PID="$setup_root_pid_file" \
+		DWM_TEST_WATCH_SETUP_MARKER="$setup_marker" \
+		"$BASH_BIN" "$HELPER" watch >"$work/watch-setup-race.out" \
+		2>"$work/watch-setup-race.err" &
+	watch_pid=$!
+	for _ in {1..100}; do
+		[[ -e $setup_marker && -s $setup_root_pid_file ]] && break
+		sleep 0.02
+	done
+	[[ -e $setup_marker && -s $setup_root_pid_file ]]
+	setup_initial_root_pid=$(<"$setup_root_pid_file")
+	process_identity_is_live "$(process_identity "$watch_pid")"
+	for _ in {1..100}; do
+		setup_generation_child=$(watch_child_for_path "$watch_pid" "$raced_config" \
+			2>/dev/null || true)
+		[[ -n $setup_generation_child &&
+			$setup_generation_child != "$setup_initial_root_pid" ]] && break
+		sleep 0.02
+	done
+	[[ -n $setup_generation_child &&
+		$setup_generation_child != "$setup_initial_root_pid" ]]
+	if watch_child_has_argument "$setup_generation_child" -r; then
+		printf 'Setup-race recovery watch was recursive\n' >&2
+		exit 1
+	fi
+	mkdir "$raced_config/dwm-titus"
+	setup_managed_child=
+	for _ in {1..100}; do
+		setup_managed_child=$(watch_child_for_path "$watch_pid" \
+			"$raced_config/dwm-titus" 2>/dev/null || true)
+		[[ -n $setup_managed_child ]] && break
+		sleep 0.02
+	done
+	[[ -n $setup_managed_child ]]
+	printf '[vars]\nterminal = "kitty"\n' >"$raced_config/dwm-titus/hotkeys.toml"
+	for _ in {1..100}; do
+		grep -Fq hotkeys.toml "$work/watch-setup-race.out" 2>/dev/null && break
+		sleep 0.02
+	done
+	grep -Fq hotkeys.toml "$work/watch-setup-race.out"
+	kill "$watch_pid"
+	wait "$watch_pid" 2>/dev/null || true
+	watch_pid=
 
 	owner_pid_file=$work/watch-owner.pid
 	# shellcheck disable=SC2016 # Positional parameters are expanded by the child shell.

--- a/tests/test-dwm-default-apps.sh
+++ b/tests/test-dwm-default-apps.sh
@@ -145,6 +145,16 @@ MimeType=text/html;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/
 Exec=/usr/bin/missing-dwm-test-chromium %U
 DESKTOP
 
+cat >"$work/data/applications/tryexec-stale.desktop" <<'DESKTOP'
+[Desktop Entry]
+Type=Application
+Name=Stale TryExec Browser
+Categories=Network;WebBrowser;
+MimeType=text/html;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/https;
+TryExec=sh
+Exec=/usr/bin/missing-dwm-test-tryexec %U
+DESKTOP
+
 cat >"$work/data/applications/duplicate.desktop" <<'DESKTOP'
 [Desktop Entry]
 Type=Application
@@ -402,7 +412,7 @@ grep -Fqx $'role\tfile-manager\tavailable\torg.example.Files.desktop\tFiles\txdg
 grep -Fqx $'candidate\tbrowser\tfirefox.desktop\tFirefox\tavailable\t\tInstalled desktop entry' <<<"$snapshot"
 grep -Fqx $'candidate\tterminal\tkitty.desktop\tkitty\tavailable\tkitty\tInstalled desktop entry' <<<"$snapshot"
 grep -Fqx $'mime-candidate\ttext/plain\torg.example.Editor.desktop\tEditor\tavailable\tInstalled desktop entry' <<<"$snapshot"
-for rejected_id in hidden.desktop not-an-app.desktop chromium.desktop duplicate.desktop \
+for rejected_id in hidden.desktop not-an-app.desktop chromium.desktop tryexec-stale.desktop duplicate.desktop \
 	oversized.desktop control.desktop linked-escaped.desktop linked-leaf.desktop st.desktop; do
 	if grep -Fq "$rejected_id" <<<"$snapshot"; then
 		printf 'Rejected desktop entry was emitted as a candidate: %s\n' "$rejected_id" >&2
@@ -562,6 +572,7 @@ expect_status 1 run_helper set-mime application/x-unsupported org.example.Editor
 expect_status 1 run_helper set-mime text/plain firefox.desktop
 expect_status 1 run_helper set-role browser '../../evil.desktop'
 expect_status 1 run_helper set-role browser chromium.desktop
+expect_status 1 run_helper set-role browser tryexec-stale.desktop
 expect_status 1 run_helper set-role browser duplicate.desktop
 expect_status 1 run_helper set-role browser oversized.desktop
 expect_status 1 run_helper set-role browser control.desktop
@@ -918,32 +929,52 @@ if command -v inotifywait >/dev/null 2>&1; then
 	done
 	grep -Fq mimeapps.list "$work/watch-absent.out"
 	mkdir "$absent_config/dwm-titus"
-	fourth_child=
+	config_root_child=
+	config_managed_child=
 	for _ in {1..100}; do
-		fourth_child=$(watch_child_for_path "$watch_pid" "$absent_config" 2>/dev/null || true)
-		[[ -n $fourth_child && $fourth_child != "$third_child" ]] && break
+		config_root_child=$(watch_child_for_path "$watch_pid" "$absent_config" 2>/dev/null || true)
+		config_managed_child=$(watch_child_for_path "$watch_pid" \
+			"$absent_config/dwm-titus" 2>/dev/null || true)
+		[[ -n $config_root_child && -n $config_managed_child &&
+			$config_root_child != "$third_child" ]] && break
 		sleep 0.02
 	done
-	[[ -n $fourth_child && $fourth_child != "$third_child" ]]
-	watch_child_has_argument "$fourth_child" -r
+	[[ -n $config_root_child && -n $config_managed_child &&
+		$config_root_child != "$third_child" ]]
+	if watch_child_has_argument "$config_root_child" -r ||
+		watch_child_has_argument "$config_managed_child" -r; then
+		printf 'Steady defaults config watches must be nonrecursive\n' >&2
+		exit 1
+	fi
+	steady_output_size=$(stat -c %s "$work/watch-absent.out")
+	mkdir -p "$absent_config/browser/deep"
+	printf 'unrelated\n' >"$absent_config/browser/deep/file"
+	sleep 0.1
+	[[ $(stat -c %s "$work/watch-absent.out") -eq $steady_output_size ]]
 	printf '[vars]\nterminal = "alacritty"\n' >"$absent_config/dwm-titus/hotkeys.toml"
 	for _ in {1..100}; do
 		grep -Fq hotkeys.toml "$work/watch-absent.out" 2>/dev/null && break
 		sleep 0.02
 	done
 	grep -Fq hotkeys.toml "$work/watch-absent.out"
-	fourth_identity=$(process_identity "$fourth_child")
+	config_root_identity=$(process_identity "$config_root_child")
+	config_managed_identity=$(process_identity "$config_managed_child")
 	kill "$watch_pid"
 	wait "$watch_pid" 2>/dev/null || true
 	watch_pid=
 	for _ in {1..100}; do
-		process_identity_is_live "$fourth_identity" || break
+		if ! process_identity_is_live "$config_root_identity" &&
+			! process_identity_is_live "$config_managed_identity"; then
+			break
+		fi
 		sleep 0.02
 	done
-	if process_identity_is_live "$fourth_identity"; then
-		printf 'Defaults watch child survived helper exit: %s\n' "$fourth_identity" >&2
-		exit 1
-	fi
+	for config_identity in "$config_root_identity" "$config_managed_identity"; do
+		if process_identity_is_live "$config_identity"; then
+			printf 'Defaults watch child survived helper exit: %s\n' "$config_identity" >&2
+			exit 1
+		fi
+	done
 
 	owner_pid_file=$work/watch-owner.pid
 	# shellcheck disable=SC2016 # Positional parameters are expanded by the child shell.
@@ -969,10 +1000,10 @@ if command -v inotifywait >/dev/null 2>&1; then
 			descendant_identity=$(process_identity "$descendant_pid" 2>/dev/null || true)
 			[[ -z $descendant_identity ]] || descendant_identities+=("$descendant_identity")
 		done < <(pgrep -P "$watch_pid" 2>/dev/null || true)
-		((${#descendant_identities[@]} == 5)) && break
+		((${#descendant_identities[@]} == 6)) && break
 		sleep 0.02
 	done
-	((${#descendant_identities[@]} == 5))
+	((${#descendant_identities[@]} == 6))
 	kill -KILL "$watch_owner_pid"
 	wait "$watch_owner_pid" 2>/dev/null || true
 	watch_owner_pid=


### PR DESCRIPTION
## Summary

- fix late post-merge review findings in default-app validation, watcher scope, and nested-display status cleanup
- record final Phase 4 activation evidence and explicit unavailable hardware/destructive-session limits
- mark Phase 4 complete and replace the active task plan with objectively closeable Phase 5 work

## Validation

- `scripts/run-tests make clean all`
- `scripts/run-tests`
- `scripts/run-tests scripts/quickshell-qmllint --root config/quickshell`
- `shellcheck install.sh scripts/*.sh tests/*.sh`
- `shfmt -d install.sh scripts/*.sh tests/*.sh`
- `mdbook build docs`
- local CodeRabbit review: no new findings
- independent multi-agent code, evidence, and planning reviews: clean
- live sync: all managed files match; one Quickshell, two panels, six tray clients; running/installed/checkout DWM hashes are identical

## Explicit limitations

Battery and lid transitions remain fixture-qualified on this workstation. Actual suspend, reboot, shutdown, repeated destructive display-manager cycles, and real `startx` were not run; their automated contracts and the precise live limits are recorded in `docs/P4-EVIDENCE.md`.
