### PR TITLE
feat(settings): begin Phase 5 appearance provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ versions from `config.mk`.
 
 ### Changed
 
+- Make DWM's hot-reloaded TOML paths honor `XDG_CONFIG_HOME` and
+  `XDG_DATA_HOME`, matching the managed shell and appearance provider.
+
 - Complete Phase 4 Power, Session, Defaults, and XDG autostart integration.
   Fresh Fedora 44 LightDM activation now runs the installed DWM and one managed
   Quickshell shell with one panel per active monitor; unavailable battery, lid,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ versions from `config.mk`.
 
 ### Added
 
+- Begin Phase 5 with a versioned, read-only appearance provider that validates
+  the active and available themes, resolves a safe recovery theme, exposes the
+  shared semantic palette, and reports GTK, Qt, cursor, terminal, and compositor
+  integration failures without modifying user configuration.
+
 - Add one shared session-action model for Lock, Log Out, Suspend, Reboot, and
   Shutdown across the panel and Settings. Fixed helper actions require exact
   accepted records, preserve destructive confirmations, attribute failures to

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ INSTALL_COMMANDS = \
 	scripts/dwm-settings \
 	scripts/dwm-settings-display \
 	scripts/dwm-settings-input \
+	scripts/dwm-settings-appearance \
 	scripts/dwm-settings-provider \
 	scripts/dwm-terminal \
 	scripts/dwm-utils.sh \
@@ -314,10 +315,10 @@ release: dwm
 	echo "==> Created ${RELEASE_ARCHIVE}"
 
 check-shell:
-	shellcheck install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-pointer scripts/dwm-quickshell-state scripts/dwm-quickshell-version-check scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/dwm-xdg-autostart scripts/install-herdr scripts/quickshell-qmllint scripts/run-tests scripts/*.sh tests/*.sh
+	shellcheck install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-pointer scripts/dwm-quickshell-state scripts/dwm-quickshell-version-check scripts/dwm-settings scripts/dwm-settings-appearance scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/dwm-xdg-autostart scripts/install-herdr scripts/quickshell-qmllint scripts/run-tests scripts/*.sh tests/*.sh
 
 check-format:
-	shfmt -d install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-pointer scripts/dwm-quickshell-state scripts/dwm-quickshell-version-check scripts/dwm-settings scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/dwm-xdg-autostart scripts/install-herdr scripts/quickshell-qmllint scripts/run-tests scripts/*.sh tests/*.sh
+	shfmt -d install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-pointer scripts/dwm-quickshell-state scripts/dwm-quickshell-version-check scripts/dwm-settings scripts/dwm-settings-appearance scripts/dwm-settings-provider scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/dwm-xdg-autostart scripts/install-herdr scripts/quickshell-qmllint scripts/run-tests scripts/*.sh tests/*.sh
 
 check-session-guards:
 	tests/test-autostart.sh
@@ -441,6 +442,9 @@ check-system-health:
 check-settings:
 	tests/test-settings.sh
 	tests/test-settings-input.sh
+
+check-appearance:
+	tests/test-dwm-settings-appearance.sh
 
 check-quickshell-settings-xvfb: all
 	tests/test-quickshell-settings-xvfb.sh
@@ -586,6 +590,7 @@ check:
 	$(MAKE) check-quickshell-tray
 	$(MAKE) check-system-health
 	$(MAKE) check-settings
+	$(MAKE) check-appearance
 	$(MAKE) check-quickshell-network
 	$(MAKE) check-quickshell-connectivity
 	$(MAKE) check-terminal
@@ -604,7 +609,7 @@ check:
 	$(MAKE) check-lightdm-config
 	$(MAKE) release-check
 
-.PHONY: clean all check check-build-config check-build-deps check-default-apps check-xdg-autostart check-dev-sync-install \
+.PHONY: clean all check check-appearance check-build-config check-build-deps check-default-apps check-xdg-autostart check-dev-sync-install \
 	check-test-runner \
 	check-display-profile check-display-setup check-fedora-iso-builder check-fedora-packages check-fedora-platform check-format check-install \
 	check-gearlever-install check-herdr-install check-install-manifest check-install-preservation check-kickstart check-lock \

--- a/TASKS.md
+++ b/TASKS.md
@@ -12,9 +12,20 @@ Keep DWM, X11, Fedora providers, runtime TOML files, existing keybindings, panel
 geometry, and user-owned configuration compatible while adding the workflows
 below. Do not begin Phase 6 system-management work in Phase 5 changes.
 
+Keep Phase 5 reviewable through these ordered pull-request boundaries. Finish,
+validate, and merge each boundary before starting the next one:
+
+1. Read-only appearance inventory and validation protocol.
+2. Transactional theme preview, apply, reset, and recovery helper.
+3. Shared root appearance model and Settings theme pane.
+4. Wallpaper, toolkit, font, cursor, icon, and panel-widget persistence slices,
+   split further when one slice cannot remain independently reviewable.
+5. Accessibility and notification policy, with UI-5 candidates kept in their
+   own later review boundaries.
+
 ### THEME-001: Shared Appearance Provider and Safe Theme Changes
 
-- [ ] Define a versioned machine-readable provider for the active theme,
+- [x] Define a versioned machine-readable provider for the active theme,
   available themes, semantic colors, toolkit state, and per-capability errors.
 - [ ] Add one root-scoped appearance model shared by Settings and existing shell
   surfaces without duplicating the `Theme.qml` or `themes.toml` ownership path.

--- a/docs/SETTINGS-CAPABILITIES.md
+++ b/docs/SETTINGS-CAPABILITIES.md
@@ -141,7 +141,8 @@ resolved; partial snapshots and isolated integration failures return status 0.
 Inventory enforces the DWM parser's 512-entry ceiling and the exact section
 header grammar shared by the current QML and toolkit consumers. A trailing
 comment on a section header is therefore a typed compatibility error until all
-live consumers support it consistently.
+live consumers support it consistently. Arrays and inline tables are rejected
+conservatively because they are outside the appearance snapshot grammar.
 
 ```text
 appearance-protocol<TAB>major<TAB>minor

--- a/docs/SETTINGS-CAPABILITIES.md
+++ b/docs/SETTINGS-CAPABILITIES.md
@@ -44,7 +44,7 @@ provider work still required.
 | Audio and media | Native `Quickshell.Services.Pipewire` signals with a versioned `pactl` inventory fallback; `playerctl --follow` for media | Output/input defaults, volume and mute, application streams, and MPRIS media actions | Read-only, user-session | Native signals remain authoritative; audio inventory, media, and Bluetooth fail independently | `make check-quickshell-controls check-quickshell-audio`; live PipeWire and MPRIS exercise |
 | Power and session | Shared Power and session-action models over versioned helper records, UPower, Power Profiles D-Bus, logind, `xset`, `gsettings`, and light-locker | Delegated profile and session actions; user `power.conf`, DPMS, and lock policy; cleanup-aware DWM logout | Read-only, user-session, delegated | Capabilities fail independently; destructive actions share confirmation, origin attribution, overlap rejection, and exact accepted-result checks | `make check-quickshell-power check-quickshell-session-actions check-quickshell-controlcenter check-lock check-quickshell-settings-xvfb`; real X11 and available hardware/service checks |
 | Defaults and autostart | Versioned `dwm-default-apps` and `dwm-xdg-autostart` providers over XDG tools and desktop entries | Browser, terminal, file-manager, MIME, and next-login autostart overrides with verified recovery | Read-only, user-session | Invalid entries fail per item; mutations reject unsafe paths, preserve unrelated state, verify convergence, and never edit vendor files | `make check-default-apps check-terminal check-xdg-autostart check-quickshell-defaults-model check-quickshell-settings-xvfb` |
-| Appearance and accessibility | `themes.toml`, `Theme.qml`, `dwm-quickshell-controlcenter`, `theme-apply.sh`, `feh`, and delegated `nwg-look` | User theme files and toolkit config; session wallpaper; external GTK tool | Read-only, user-session, delegated, unsupported | Missing themes/tools affect only their controls; fonts, cursors, notifications, wallpaper selection, and accessibility still need settings contracts | `make check-quickshell-controlcenter check-quickshell-qml`; live theme reload |
+| Appearance and accessibility | Versioned `dwm-settings-appearance` inventory over `themes.toml`; `Theme.qml`, `dwm-quickshell-controlcenter`, `theme-apply.sh`, `feh`, and delegated `nwg-look` | User theme files and toolkit config; session wallpaper; external GTK tool | Read-only, user-session, delegated, unsupported | Invalid theme records and missing integrations are attributed per capability; preview/apply/reset, fonts, notifications, wallpaper selection, and accessibility still need settings contracts | `make check-appearance check-quickshell-controlcenter check-quickshell-qml`; live theme reload |
 | System and diagnostics | `dwm-system-health` structured snapshots and the full-screen health window | Allowlisted user repairs; installed-helper privileged repairs; selected trusted-tool entry points | Read-only, user-session, privileged, delegated, unsupported | Authorization denial produces a restricted partial report; high-risk administration stays delegated or unsupported | `make check-system-health check-quickshell-health-xvfb` |
 
 ## Existing Operation Inventory
@@ -122,11 +122,37 @@ action.
 | Browser, terminal, file-manager, and MIME state/candidates | `dwm-default-apps snapshot` version 1.0 | Read-only | Missing tools and invalid desktop entries fail per role or MIME without inventing defaults. |
 | Set or restore an application default | Fixed `set-role`, `set-mime`, `reset-role`, and `reset-mime` actions | User-session | Exact selected associations or the terminal variable change transactionally; recovery refuses to overwrite later external edits. |
 | XDG autostart entries | `dwm-xdg-autostart` version 1.0 snapshot/watch and fixed set/reset actions | Read-only and user-session | Vendor files are immutable; user overrides are revision-checked, backed up, atomic, and next-login only. Session-critical changes require confirmation. |
-| Theme list and active theme | `themes.toml`, `Theme.qml`, and Control Center helper records | Read-only | Missing or invalid user state falls back to managed defaults without overwriting the user file. |
+| Theme list and active theme | `dwm-settings-appearance snapshot` version 1.0 over `themes.toml`; `Theme.qml` remains the live shell adapter | Read-only | Missing, duplicate, malformed, or incomplete themes produce typed errors and a deterministic valid recovery theme without modifying the user file. |
 | Select theme and apply toolkit/terminal/cursor settings | `theme-set`, hot reload, and `theme-apply.sh` user-file writes | User-session | A future contract must report partial toolkit failures and define preview/reset behavior. |
 | Random wallpaper | Fixed `feh` action over the user wallpaper directory | User-session | Missing tools, directory, or images are isolated failures. A selected-wallpaper provider is not yet available. |
 | GTK configuration tool | `nwg-look` | Delegated | Optional entry point only. |
 | Fonts, icons, notification policy, and accessibility | No settings-ready provider contract | Unsupported | Add by Phase 5 with explicit preview, reset, and rollback behavior. |
+
+The Phase 5 appearance snapshot is append-only within protocol version 1. It
+starts with `appearance-protocol<TAB>1<TAB>0` and emits provider, source,
+active-theme, theme, semantic-color, integration, and capability-scoped error
+records. It is read-only. The active record distinguishes the user's selected
+theme from the resolved recovery theme, so later UI work can explain invalid
+state without overwriting comments, custom themes, file mode, or unrelated
+configuration. GTK, Qt, cursor, terminal, and compositor integration failures
+remain independent records and do not suppress valid theme inventory. A
+snapshot returns status 3 after emitting its records when no valid theme can be
+resolved; partial snapshots and isolated integration failures return status 0.
+Inventory enforces the DWM parser's 512-entry ceiling and the exact section
+header grammar shared by the current QML and toolkit consumers. A trailing
+comment on a section header is therefore a typed compatibility error until all
+live consumers support it consistently.
+
+```text
+appearance-protocol<TAB>major<TAB>minor
+provider<TAB>id<TAB>status<TAB>class<TAB>detail
+source<TAB>user|managed|none<TAB>path|unavailable
+active<TAB>selected<TAB>resolved<TAB>selected|recovery|unresolved
+theme<TAB>name<TAB>selection<TAB>validity<TAB>dark-mode<TAB>gtk-theme<TAB>detail
+color<TAB>semantic-role<TAB>#RRGGBB<TAB>source-key
+integration<TAB>id<TAB>status<TAB>value<TAB>detail
+error<TAB>capability<TAB>code<TAB>detail
+```
 
 ### System Health and Administration
 

--- a/dwm.c
+++ b/dwm.c
@@ -453,6 +453,8 @@ static volatile sig_atomic_t sig_reload_pending = 0;
 static char   toml_arena_buf[TOML_ARENA_CAP];
 static size_t toml_arena_pos = 0;
 /* Default (fallback) config paths: ~/.local/share/dwm-titus/config/ */
+static char          dwm_config_home_dir[PATH_MAX];
+static char          dwm_data_home_dir[PATH_MAX];
 static char          dwm_data_dir[PATH_MAX];
 static char          toml_default_dir[PATH_MAX];
 static char          toml_hotkeys_default_path[PATH_MAX];
@@ -4002,6 +4004,13 @@ setup_inotify(void)
 			return;
 		}
 		data_home = data_home_fallback;
+	}
+	copystr(dwm_config_home_dir, sizeof(dwm_config_home_dir), config_home);
+	copystr(dwm_data_home_dir, sizeof(dwm_data_home_dir), data_home);
+	if (setenv("XDG_CONFIG_HOME", dwm_config_home_dir, 1) < 0 ||
+	    setenv("XDG_DATA_HOME", dwm_data_home_dir, 1) < 0) {
+		perror("dwm: cannot normalize XDG environment");
+		return;
 	}
 
 	/* User-editable config: ${XDG_CONFIG_HOME:-$HOME/.config}/dwm-titus/ */

--- a/dwm.c
+++ b/dwm.c
@@ -3979,11 +3979,37 @@ static void
 setup_inotify(void)
 {
 	const char *home = getenv("HOME");
-	if (!home) return;
+	const char *config_home = getenv("XDG_CONFIG_HOME");
+	const char *data_home = getenv("XDG_DATA_HOME");
+	char config_home_fallback[PATH_MAX];
+	char data_home_fallback[PATH_MAX];
+	if (((!config_home || config_home[0] != '/')
+	     || (!data_home || data_home[0] != '/'))
+	    && (!home || home[0] == '\0')) {
+		fprintf(stderr, "dwm: HOME is required for XDG fallback paths\n");
+		return;
+	}
 
-	/* User-editable config: ~/.config/dwm-titus/ */
+	if (!config_home || config_home[0] != '/') {
+		if (!pathjoin(config_home_fallback, sizeof(config_home_fallback),
+		              home, ".config")) {
+			fprintf(stderr, "dwm: config home path exceeds PATH_MAX\n");
+			return;
+		}
+		config_home = config_home_fallback;
+	}
+	if (!data_home || data_home[0] != '/') {
+		if (!pathjoin(data_home_fallback, sizeof(data_home_fallback),
+		              home, ".local/share")) {
+			fprintf(stderr, "dwm: data home path exceeds PATH_MAX\n");
+			return;
+		}
+		data_home = data_home_fallback;
+	}
+
+	/* User-editable config: ${XDG_CONFIG_HOME:-$HOME/.config}/dwm-titus/ */
 	if (!pathjoin(toml_config_dir, sizeof(toml_config_dir),
-	              home, ".config/dwm-titus")
+	              config_home, "dwm-titus")
 	    || !pathjoin(toml_hotkeys_path, sizeof(toml_hotkeys_path),
 	                 toml_config_dir, "hotkeys.toml")
 	    || !pathjoin(toml_themes_path, sizeof(toml_themes_path),
@@ -3994,9 +4020,9 @@ setup_inotify(void)
 		return;
 	}
 
-	/* Default (fallback) config: ~/.local/share/dwm-titus/config/ */
+	/* Default config: ${XDG_DATA_HOME:-$HOME/.local/share}/dwm-titus/config/ */
 	if (!pathjoin(toml_default_dir, sizeof(toml_default_dir),
-	              home, ".local/share/dwm-titus/config")
+	              data_home, "dwm-titus/config")
 	    || !pathjoin(toml_hotkeys_default_path,
 	                 sizeof(toml_hotkeys_default_path),
 	                 toml_default_dir, "hotkeys.toml")

--- a/dwm.c
+++ b/dwm.c
@@ -453,6 +453,7 @@ static volatile sig_atomic_t sig_reload_pending = 0;
 static char   toml_arena_buf[TOML_ARENA_CAP];
 static size_t toml_arena_pos = 0;
 /* Default (fallback) config paths: ~/.local/share/dwm-titus/config/ */
+static char          dwm_data_dir[PATH_MAX];
 static char          toml_default_dir[PATH_MAX];
 static char          toml_hotkeys_default_path[PATH_MAX];
 static char          toml_themes_default_path[PATH_MAX];
@@ -3897,16 +3898,12 @@ reload_config(void)
 	{
 		pid_t pid = fork();
 		if (pid == 0) {
-			/* child: find and run the theme-apply script */
-			const char *home = getenv("HOME");
-			char script_dir[PATH_MAX];
+			/* child: run the theme helper from the resolved data directory */
 			char script[PATH_MAX];
-			if (home &&
-			    pathjoin(script_dir, sizeof(script_dir),
-			            home, ".local/share/dwm-titus/scripts") &&
-			    pathjoin(script, sizeof(script),
-			            script_dir, "theme-apply.sh")) {
-				execl("/bin/sh", "sh", script, (char *)NULL);
+			if (dwm_data_dir[0] != '\0' &&
+			    pathjoin(script, sizeof(script), dwm_data_dir,
+			             "scripts/theme-apply.sh")) {
+				execl(script, script, (char *)NULL);
 			}
 			_exit(0);
 		}
@@ -4021,8 +4018,10 @@ setup_inotify(void)
 	}
 
 	/* Default config: ${XDG_DATA_HOME:-$HOME/.local/share}/dwm-titus/config/ */
-	if (!pathjoin(toml_default_dir, sizeof(toml_default_dir),
-	              data_home, "dwm-titus/config")
+	if (!pathjoin(dwm_data_dir, sizeof(dwm_data_dir),
+	              data_home, "dwm-titus")
+	    || !pathjoin(toml_default_dir, sizeof(toml_default_dir),
+	                 dwm_data_dir, "config")
 	    || !pathjoin(toml_hotkeys_default_path,
 	                 sizeof(toml_hotkeys_default_path),
 	                 toml_default_dir, "hotkeys.toml")

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export LC_ALL=C
 
 config_home=${XDG_CONFIG_HOME:-}
 data_home=${XDG_DATA_HOME:-}
@@ -113,7 +114,11 @@ select_source() {
 		source_report_file=$themes_file
 		return
 	fi
-	if [[ -e $themes_file || -L $themes_file ]]; then
+	if [[ -L $themes_file && ! -e $themes_file ]]; then
+		provider_state=partial
+		add_error source dangling-user \
+			"Ignoring dangling user theme symlink and trying the managed source: $themes_file"
+	elif [[ -e $themes_file || -L $themes_file ]]; then
 		source_kind=user
 		source_report_file=$themes_file
 		add_error source unreadable "User theme file is not a readable regular file: $themes_file"
@@ -235,7 +240,7 @@ parse_themes() {
 					section=theme
 					if [[ -z ${section_count[$theme]+x} ]] &&
 						((${#theme_order[@]} >= max_theme_count)) &&
-						[[ $theme != "$selected_theme_hint" ]]; then
+						[[ $theme != "$selected_theme_hint" && $theme != nord ]]; then
 						section=ignore
 						theme=
 						provider_state=partial
@@ -431,9 +436,10 @@ validate_themes() {
 }
 
 resolve_active_theme() {
-	local theme
+	local theme string_byte_length_result
 
 	selected_theme=${value[__active$key_separator'theme']:-}
+	string_byte_length "$selected_theme"
 	if [[ -z $selected_theme ]]; then
 		if [[ -n ${section_count[$legacy_theme_id]+x} && -z ${theme_invalid[$legacy_theme_id]+x} ]]; then
 			selected_theme=$legacy_theme_id
@@ -442,6 +448,13 @@ resolve_active_theme() {
 		fi
 		provider_state=partial
 		add_error active missing 'The active theme name is missing'
+	elif ((string_byte_length_result > max_theme_name_length)) &&
+		[[ -n ${section_count[$legacy_theme_id]+x} && -z ${theme_invalid[$legacy_theme_id]+x} ]]; then
+		provider_state=partial
+		resolved_theme=$legacy_theme_id
+		add_error active name-too-long \
+			"Active theme name exceeds the runtime section limit; using the legacy [colors] palette"
+		return
 	elif [[ -z ${section_count[$selected_theme]+x} ]]; then
 		provider_state=partial
 		add_error active unknown "Active theme '$selected_theme' is not defined"
@@ -647,7 +660,14 @@ alacritty_imports_active_theme() {
 	if [[ -z ${HOME:-} || $config_home != "$HOME/.config" ]]; then
 		default_import=
 	fi
-	awk -v active="$active" -v default_import="$default_import" '
+	DWM_ALACRITTY_ACTIVE_IMPORT=$active \
+		DWM_ALACRITTY_DEFAULT_IMPORT=$default_import \
+		awk '
+		BEGIN {
+			at_root = 1
+			active = ENVIRON["DWM_ALACRITTY_ACTIVE_IMPORT"]
+			default_import = ENVIRON["DWM_ALACRITTY_DEFAULT_IMPORT"]
+		}
 		{
 			line = $0
 			clean = ""
@@ -673,16 +693,56 @@ alacritty_imports_active_theme() {
 				}
 			}
 			line = clean
-			if (line ~ /^[[:space:]]*import[[:space:]]*=/) in_import = 1
-			if (in_import &&
-			    (index(line, "\"" active "\"") ||
-			     index(line, "\047" active "\047") ||
-			     (default_import != "" &&
-			      (index(line, "\"" default_import "\"") ||
-			       index(line, "\047" default_import "\047"))))) found = 1
-			if (in_import && index(line, "]")) exit
+			trimmed = line
+			gsub(/^[[:space:]]+|[[:space:]]+$/, "", trimmed)
+			if (!in_import && trimmed ~ /^\[/) {
+				at_root = 0
+				next
+			}
+			if (!in_import && at_root &&
+			    trimmed ~ /^import[[:space:]]*=[[:space:]]*\[/) in_import = 1
+			if (in_import) {
+				quote = ""
+				escaped = 0
+				item = ""
+				for (i = 1; i <= length(line); i++) {
+					char = substr(line, i, 1)
+					if (quote != "") {
+						if (escaped) {
+							if (char == "n") char = "\n"
+							else if (char == "t") char = "\t"
+							else if (char == "r") char = "\r"
+							item = item char
+							escaped = 0
+							continue
+						}
+						if (quote == "\"" && char == "\\") {
+							escaped = 1
+							continue
+						}
+						if (char == quote) {
+							if (item == active ||
+							    (default_import != "" && item == default_import)) found = 1
+							quote = ""
+							item = ""
+						} else {
+							item = item char
+						}
+					} else if (char == "\"" || char == "\047") {
+						quote = char
+						item = ""
+					} else if (char == "]") {
+						closed = 1
+						break
+					}
+				}
+				if (closed) {
+					valid = found
+					exit
+				}
+			}
 		}
-		END { exit(found ? 0 : 1) }
+		END { exit(valid ? 0 : 1) }
 	' "$primary"
 }
 

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-config_home=${XDG_CONFIG_HOME:-${HOME:?HOME is required}/.config}
-data_home=${XDG_DATA_HOME:-${HOME:?HOME is required}/.local/share}
+config_home=${XDG_CONFIG_HOME:-}
+data_home=${XDG_DATA_HOME:-}
+[[ $config_home == /* ]] || config_home=${HOME:?HOME is required for XDG_CONFIG_HOME fallback}/.config
+[[ $data_home == /* ]] || data_home=${HOME:?HOME is required for XDG_DATA_HOME fallback}/.local/share
 themes_file=${DWM_APPEARANCE_THEMES_FILE:-$config_home/dwm-titus/themes.toml}
 managed_themes_file=${DWM_APPEARANCE_MANAGED_THEMES_FILE:-$data_home/dwm-titus/config/themes.toml}
 readonly max_themes_size=1048576
@@ -95,7 +97,7 @@ select_source() {
 }
 
 prescan_active_theme() {
-	local file=$1 line trimmed section=''
+	local file=$1 line trimmed section='' candidate
 
 	while IFS= read -r line || [[ -n $line ]]; do
 		line=${line%$'\r'}
@@ -110,6 +112,12 @@ prescan_active_theme() {
 		elif [[ $section == active && -z $selected_theme_hint &&
 			$line =~ ^[[:space:]]*theme[[:space:]]*=[[:space:]]*\"([^\"]*)\"[[:space:]]*(#.*)?$ ]]; then
 			selected_theme_hint=${BASH_REMATCH[1]}
+		elif [[ $section == active && -z $selected_theme_hint &&
+			$line =~ ^[[:space:]]*theme[[:space:]]*=[[:space:]]*([^#[:space:]]+)[[:space:]]*(#.*)?$ ]]; then
+			candidate=${BASH_REMATCH[1]}
+			if ! runtime_bare_is_numeric "$candidate"; then
+				selected_theme_hint=$candidate
+			fi
 		fi
 	done <"$file"
 }
@@ -119,8 +127,14 @@ runtime_bare_is_numeric() {
 		[[ $1 =~ ^[+-]?([Nn][Aa][Nn]|[Ii][Nn][Ff]) ]]
 }
 
+string_byte_length() {
+	local LC_ALL=C
+	string_byte_length_result=${#1}
+}
+
 parse_themes() {
 	local file=$1 size line trimmed line_number=0 raw runtime_key runtime_value parsed_type
+	local string_byte_length_result
 	local section='' theme='' theme_candidate='' key='' parsed=''
 
 	size=$(stat -c %s -- "$file" 2>/dev/null) || {
@@ -206,7 +220,8 @@ parse_themes() {
 					"Arrays and inline tables are outside the appearance snapshot grammar at line $line_number"
 				return
 			fi
-			if [[ -n $runtime_key ]] && ((${#runtime_key} < 512)); then
+			string_byte_length "$runtime_key"
+			if [[ -n $runtime_key ]] && ((string_byte_length_result < 512)); then
 				((parsed_entry_count += 1))
 				if ((parsed_entry_count > max_entry_count)); then
 					provider_state=partial
@@ -366,6 +381,79 @@ asset_available() {
 	return 1
 }
 
+alacritty_field_matches() {
+	local file=$1 section=$2 field=$3 color=$4
+	awk -v target_section="$section" -v target_field="$field" -v target_color="$color" '
+		/^\[/ { in_section = ($0 == target_section); next }
+		in_section {
+			equals = index($0, "=")
+			if (!equals) next
+			name = substr($0, 1, equals - 1)
+			value = substr($0, equals + 1)
+			gsub(/^[[:space:]]+|[[:space:]]+$/, "", name)
+			gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+			gsub(/^['\''"]|['\''"]$/, "", value)
+			if (name == target_field) { found = (value == target_color); exit }
+		}
+		END { exit(found ? 0 : 1) }
+	' "$file"
+}
+
+kitty_field_matches() {
+	local file=$1 field=$2 color=$3
+	awk -v target_field="$field" -v target_color="$color" '
+		$1 == target_field { found = ($2 == target_color && NF == 2); exit }
+		END { exit(found ? 0 : 1) }
+	' "$file"
+}
+
+terminal_theme_matches() {
+	local terminal=$1 file=$2 key color field section index
+	local -a terminal_keys=(term_bg term_fg term_cursor term_color{0..15})
+	local -a color_fields=(black red green yellow blue magenta cyan white)
+
+	[[ -s $file && -n $resolved_theme ]] || return 1
+	for key in "${terminal_keys[@]}"; do
+		color=${value[$resolved_theme$key_separator$key]:-}
+		[[ -n $color ]] || return 1
+		if [[ $terminal == kitty ]]; then
+			case $key in
+			term_bg) field=background ;;
+			term_fg) field=foreground ;;
+			term_cursor) field=cursor ;;
+			term_color*) field=color${key#term_color} ;;
+			esac
+			kitty_field_matches "$file" "$field" "$color" || return 1
+		else
+			case $key in
+			term_bg)
+				section='[colors.primary]'
+				field=background
+				;;
+			term_fg)
+				section='[colors.primary]'
+				field=foreground
+				;;
+			term_cursor)
+				section='[colors.cursor]'
+				field=cursor
+				;;
+			term_color*)
+				index=${key#term_color}
+				if ((index < 8)); then
+					section='[colors.normal]'
+					field=${color_fields[$index]}
+				else
+					section='[colors.bright]'
+					field=${color_fields[$((index - 8))]}
+				fi
+				;;
+			esac
+			alacritty_field_matches "$file" "$section" "$field" "$color" || return 1
+		fi
+	done
+}
+
 emit_theme_records() {
 	local theme selection validity dark gtk detail
 	for theme in "${theme_order[@]}"; do
@@ -419,7 +507,7 @@ emit_color_records() {
 }
 
 emit_integrations() {
-	local dark requested_gtk fallback_gtk cursor qt_backend
+	local dark requested_gtk fallback_gtk cursor qt_backend terminal terminal_theme_file
 	[[ -n $resolved_theme ]] || return 0
 
 	dark=${value[$resolved_theme$key_separator'dark_mode']:-true}
@@ -458,8 +546,16 @@ emit_integrations() {
 	fi
 
 	for terminal in alacritty kitty; do
-		if [[ -f $config_home/$terminal/active-theme.$([[ $terminal == alacritty ]] && printf toml || printf conf) ]]; then
-			printf 'integration\t%s\tavailable\tactive-theme\tGenerated terminal theme is present\n' "$terminal"
+		if [[ $terminal == alacritty ]]; then
+			terminal_theme_file=$config_home/$terminal/active-theme.toml
+		else
+			terminal_theme_file=$config_home/$terminal/active-theme.conf
+		fi
+		if terminal_theme_matches "$terminal" "$terminal_theme_file"; then
+			printf 'integration\t%s\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette\n' "$terminal"
+		elif [[ -f $terminal_theme_file ]]; then
+			printf 'integration\t%s\tpartial\tactive-theme\tGenerated terminal theme is empty or stale\n' "$terminal"
+			add_error "$terminal" stale-theme 'Generated active theme does not match the resolved palette'
 		elif [[ -d $config_home/$terminal ]]; then
 			printf 'integration\t%s\tpartial\tconfiguration\tTerminal is configured but has no generated active theme\n' "$terminal"
 			add_error "$terminal" not-applied 'Generated active theme is missing'

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -9,6 +9,7 @@ readonly max_themes_size=1048576
 readonly max_theme_count=128
 readonly max_error_count=256
 readonly max_entry_count=512
+readonly max_theme_name_length=505
 readonly key_separator=$'\034'
 
 declare -a theme_order=()
@@ -20,6 +21,7 @@ declare -A theme_invalid=()
 
 source_kind=
 source_file=
+source_report_file=
 provider_state=available
 selected_theme=
 resolved_theme=
@@ -47,7 +49,7 @@ clean_field() {
 }
 
 add_error() {
-	local capability=$1 code=$2 detail=$3
+	local capability=$1 code=$2 detail=$3 clean_capability clean_code clean_detail
 	if ((${#errors[@]} >= max_error_count)); then
 		if [[ $errors_truncated == false ]]; then
 			errors+=("provider"$'\t'"error-limit"$'\t'"Additional errors were omitted")
@@ -55,22 +57,36 @@ add_error() {
 		fi
 		return
 	fi
-	errors+=("$(clean_field "$capability")"$'\t'"$(clean_field "$code")"$'\t'"$(clean_field "$detail")")
+	clean_capability=${capability//$'\t'/ }
+	clean_capability=${clean_capability//$'\r'/ }
+	clean_capability=${clean_capability//$'\n'/ }
+	clean_code=${code//$'\t'/ }
+	clean_code=${clean_code//$'\r'/ }
+	clean_code=${clean_code//$'\n'/ }
+	clean_detail=${detail//$'\t'/ }
+	clean_detail=${clean_detail//$'\r'/ }
+	clean_detail=${clean_detail//$'\n'/ }
+	errors+=("$clean_capability"$'\t'"$clean_code"$'\t'"$clean_detail")
 }
 
 select_source() {
 	if [[ -r $themes_file && -f $themes_file ]]; then
 		source_kind=user
 		source_file=$themes_file
+		source_report_file=$themes_file
 		return
 	fi
-	if [[ -e $themes_file ]]; then
+	if [[ -e $themes_file || -L $themes_file ]]; then
+		source_kind=user
+		source_report_file=$themes_file
 		add_error source unreadable "User theme file is not a readable regular file: $themes_file"
-		provider_state=partial
+		provider_state=unavailable
+		return
 	fi
 	if [[ -r $managed_themes_file && -f $managed_themes_file ]]; then
 		source_kind=managed
 		source_file=$managed_themes_file
+		source_report_file=$managed_themes_file
 		return
 	fi
 	provider_state=unavailable
@@ -78,7 +94,7 @@ select_source() {
 }
 
 parse_themes() {
-	local file=$1 size line trimmed line_number=0 raw
+	local file=$1 size line trimmed line_number=0 raw runtime_key
 	local section='' theme='' theme_candidate='' key='' parsed=''
 
 	size=$(stat -c %s -- "$file" 2>/dev/null) || {
@@ -103,7 +119,8 @@ parse_themes() {
 		if [[ $trimmed == \[* ]]; then
 			if [[ $trimmed =~ ^\[theme\.([^]]+)\]$ ]]; then
 				theme_candidate=${BASH_REMATCH[1]}
-				if [[ ! $theme_candidate =~ ^[A-Za-z0-9._-]+$ ]]; then
+				if [[ ! $theme_candidate =~ ^[A-Za-z0-9._-]+$ ]] ||
+					((${#theme_candidate} > max_theme_name_length)); then
 					section=ignore
 					theme=
 					provider_state=partial
@@ -147,6 +164,25 @@ parse_themes() {
 			continue
 		fi
 
+		# Mirror the C parser's document-wide entry budget. Its bare key grammar
+		# accepts any non-empty text before '=' up to TOML_MAX_STR - 1, including
+		# keys outside the narrower appearance schema.
+		if [[ $trimmed == *=* ]]; then
+			runtime_key=${trimmed%%=*}
+			runtime_key=${runtime_key%"${runtime_key##*[![:space:]]}"}
+			if [[ -n $runtime_key ]] && ((${#runtime_key} < 512)); then
+				((parsed_entry_count += 1))
+				if ((parsed_entry_count > max_entry_count)); then
+					provider_state=partial
+					if [[ $entry_limit_reported == false ]]; then
+						add_error parser entry-limit "Theme configuration exceeds the runtime parser limit of $max_entry_count entries"
+						entry_limit_reported=true
+					fi
+					continue
+				fi
+			fi
+		fi
+
 		if [[ $line =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*\"([^\"]*)\"[[:space:]]*(#.*)?$ ]]; then
 			key=${BASH_REMATCH[1]}
 			parsed=${BASH_REMATCH[2]}
@@ -162,17 +198,6 @@ parse_themes() {
 			continue
 		fi
 
-		# DWM's TOML_MAX_ENTRIES applies to the entire document, so otherwise
-		# ignored sections still consume the shared runtime parser budget.
-		((parsed_entry_count += 1))
-		if ((parsed_entry_count > max_entry_count)); then
-			provider_state=partial
-			if [[ $entry_limit_reported == false ]]; then
-				add_error parser entry-limit "Theme configuration exceeds the runtime parser limit of $max_entry_count entries"
-				entry_limit_reported=true
-			fi
-			continue
-		fi
 		[[ $section == theme || $section == active || $section == appearance ]] || continue
 
 		raw=$theme$key_separator$key
@@ -425,7 +450,7 @@ snapshot() {
 	fi
 	printf 'appearance-protocol\t1\t0\n'
 	printf 'provider\tappearance\t%s\tread-only\tShared theme inventory and integration state\n' "$provider_state"
-	printf 'source\t%s\t%s\n' "${source_kind:-none}" "$(clean_field "${source_file:-unavailable}")"
+	printf 'source\t%s\t%s\n' "${source_kind:-none}" "$(clean_field "${source_report_file:-unavailable}")"
 	printf 'active\t%s\t%s\t%s\n' \
 		"$(clean_field "${selected_theme:-none}")" \
 		"$(clean_field "${resolved_theme:-none}")" \

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -383,6 +383,15 @@ validate_themes() {
 				value[$theme$key_separator'selbgcolor']='#434C5E'
 			[[ -n ${value[$theme$key_separator'selfgcolor']:-} ]] ||
 				value[$theme$key_separator'selfgcolor']='#ECEFF4'
+			value[$theme$key_separator'term_bg']=${value[$theme$key_separator'normbgcolor']}
+			value[$theme$key_separator'term_fg']=${value[$theme$key_separator'normfgcolor']}
+			value[$theme$key_separator'term_cursor']=${value[$theme$key_separator'selfgcolor']}
+			value[$theme$key_separator'term_color0']=${value[$theme$key_separator'normbgcolor']}
+			value[$theme$key_separator'term_color1']=${value[$theme$key_separator'selbordercolor']}
+			value[$theme$key_separator'term_color2']=${value[$theme$key_separator'selbordercolor']}
+			value[$theme$key_separator'term_color3']=${value[$theme$key_separator'selbgcolor']}
+			value[$theme$key_separator'term_color4']=${value[$theme$key_separator'selbordercolor']}
+			value[$theme$key_separator'term_color8']=${value[$theme$key_separator'normbordercolor']}
 			keys_to_validate=(
 				normfgcolor normbgcolor normbordercolor selfgcolor selbgcolor selbordercolor
 			)
@@ -823,7 +832,10 @@ emit_integrations() {
 		else
 			terminal_theme_file=$config_home/$terminal/active-theme.conf
 		fi
-		if terminal_theme_matches "$terminal" "$terminal_theme_file" &&
+		if ! command -v "$terminal" >/dev/null 2>&1; then
+			printf 'integration\t%s\tunavailable\tmissing-application\tTerminal application is not installed\n' "$terminal"
+			add_error "$terminal" missing-application 'Terminal application is not installed'
+		elif terminal_theme_matches "$terminal" "$terminal_theme_file" &&
 			terminal_imports_active_theme "$terminal"; then
 			printf 'integration\t%s\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette\n' "$terminal"
 		elif terminal_theme_matches "$terminal" "$terminal_theme_file"; then
@@ -849,12 +861,19 @@ emit_integrations() {
 }
 
 snapshot() {
-	local active_state=unresolved selected_label=none resolved_label=none
+	local active_state=unresolved selected_label=none resolved_label=none source_fd source_snapshot
 	select_source
 	if [[ -n $source_file ]]; then
-		parse_themes "$source_file"
-		validate_themes
-		resolve_active_theme
+		if exec {source_fd}<"$source_file"; then
+			source_snapshot=/proc/self/fd/$source_fd
+			parse_themes "$source_snapshot"
+			exec {source_fd}<&-
+			validate_themes
+			resolve_active_theme
+		else
+			provider_state=unavailable
+			add_error source open-failed "Cannot open theme file: $source_file"
+		fi
 	fi
 
 	if [[ -n $resolved_theme ]]; then

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -1,0 +1,457 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+config_home=${XDG_CONFIG_HOME:-${HOME:?HOME is required}/.config}
+data_home=${XDG_DATA_HOME:-${HOME:?HOME is required}/.local/share}
+themes_file=${DWM_APPEARANCE_THEMES_FILE:-$config_home/dwm-titus/themes.toml}
+managed_themes_file=${DWM_APPEARANCE_MANAGED_THEMES_FILE:-$data_home/dwm-titus/config/themes.toml}
+readonly max_themes_size=1048576
+readonly max_theme_count=128
+readonly max_error_count=256
+readonly max_entry_count=512
+readonly key_separator=$'\034'
+
+declare -a theme_order=()
+declare -a errors=()
+declare -A section_count=()
+declare -A value=()
+declare -A key_seen=()
+declare -A theme_invalid=()
+
+source_kind=
+source_file=
+provider_state=available
+selected_theme=
+resolved_theme=
+errors_truncated=false
+entry_limit_reported=false
+parsed_entry_count=0
+
+readonly -a required_colors=(
+	normfgcolor normbgcolor normbordercolor selfgcolor selbgcolor selbordercolor
+	term_bg term_fg term_cursor term_color0 term_color1 term_color2 term_color3
+	term_color4 term_color5 term_color6 term_color7 term_color8 term_color9
+	term_color10 term_color11 term_color12 term_color13 term_color14 term_color15
+)
+
+usage() {
+	printf 'usage: %s snapshot\n' "$0" >&2
+}
+
+clean_field() {
+	local field=$1
+	field=${field//$'\t'/ }
+	field=${field//$'\r'/ }
+	field=${field//$'\n'/ }
+	printf '%s' "$field"
+}
+
+add_error() {
+	local capability=$1 code=$2 detail=$3
+	if ((${#errors[@]} >= max_error_count)); then
+		if [[ $errors_truncated == false ]]; then
+			errors+=("provider"$'\t'"error-limit"$'\t'"Additional errors were omitted")
+			errors_truncated=true
+		fi
+		return
+	fi
+	errors+=("$(clean_field "$capability")"$'\t'"$(clean_field "$code")"$'\t'"$(clean_field "$detail")")
+}
+
+select_source() {
+	if [[ -r $themes_file && -f $themes_file ]]; then
+		source_kind=user
+		source_file=$themes_file
+		return
+	fi
+	if [[ -e $themes_file ]]; then
+		add_error source unreadable "User theme file is not a readable regular file: $themes_file"
+		provider_state=partial
+	fi
+	if [[ -r $managed_themes_file && -f $managed_themes_file ]]; then
+		source_kind=managed
+		source_file=$managed_themes_file
+		return
+	fi
+	provider_state=unavailable
+	add_error source missing 'No readable user or managed themes.toml file is available'
+}
+
+parse_themes() {
+	local file=$1 size line trimmed line_number=0 raw
+	local section='' theme='' theme_candidate='' key='' parsed=''
+
+	size=$(stat -c %s -- "$file" 2>/dev/null) || {
+		provider_state=unavailable
+		add_error source stat-failed "Cannot inspect theme file: $file"
+		return
+	}
+	if ((size > max_themes_size)); then
+		provider_state=unavailable
+		add_error source too-large "Theme file exceeds $max_themes_size bytes"
+		return
+	fi
+
+	while IFS= read -r line || [[ -n $line ]]; do
+		((line_number += 1))
+		line=${line%$'\r'}
+		trimmed=$line
+		trimmed=${trimmed#"${trimmed%%[![:space:]]*}"}
+		trimmed=${trimmed%"${trimmed##*[![:space:]]}"}
+		[[ -z $trimmed || $trimmed == \#* ]] && continue
+
+		if [[ $trimmed == \[* ]]; then
+			if [[ $trimmed =~ ^\[theme\.([^]]+)\]$ ]]; then
+				theme_candidate=${BASH_REMATCH[1]}
+				if [[ ! $theme_candidate =~ ^[A-Za-z0-9._-]+$ ]]; then
+					section=ignore
+					theme=
+					provider_state=partial
+					add_error parser invalid-theme-name "Theme name is not a supported bare identifier at line $line_number"
+				else
+					theme=$theme_candidate
+					section=theme
+					if [[ -z ${section_count[$theme]+x} ]] &&
+						((${#theme_order[@]} >= max_theme_count)); then
+						section=ignore
+						theme=
+						provider_state=partial
+						add_error parser theme-limit "Theme inventory exceeds $max_theme_count records"
+						continue
+					fi
+					((section_count[$theme] = ${section_count[$theme]:-0} + 1))
+					if ((${section_count[$theme]} == 1)); then
+						theme_order+=("$theme")
+					else
+						theme_invalid[$theme]=1
+						provider_state=partial
+						add_error "theme:$theme" duplicate "Duplicate theme section at line $line_number"
+					fi
+				fi
+			elif [[ $trimmed == '[active]' ]]; then
+				section=active
+				theme=__active
+			elif [[ $trimmed == '[appearance]' ]]; then
+				section=appearance
+				theme=__appearance
+			else
+				section=ignore
+				theme=
+				case $trimmed in
+				'[theme.'* | '[active'* | '[appearance'*)
+					provider_state=partial
+					add_error parser malformed-section "Malformed theme section header at line $line_number"
+					;;
+				esac
+			fi
+			continue
+		fi
+
+		if [[ $line =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*\"([^\"]*)\"[[:space:]]*(#.*)?$ ]]; then
+			key=${BASH_REMATCH[1]}
+			parsed=${BASH_REMATCH[2]}
+		elif [[ $line =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*([^#[:space:]]+)[[:space:]]*(#.*)?$ ]]; then
+			key=${BASH_REMATCH[1]}
+			parsed=${BASH_REMATCH[2]}
+		else
+			if [[ $section == theme || $section == active || $section == appearance ]]; then
+				provider_state=partial
+				[[ $section != theme ]] || theme_invalid[$theme]=1
+				add_error "${section}:${theme}" invalid-record "Unsupported theme record at line $line_number"
+			fi
+			continue
+		fi
+
+		# DWM's TOML_MAX_ENTRIES applies to the entire document, so otherwise
+		# ignored sections still consume the shared runtime parser budget.
+		((parsed_entry_count += 1))
+		if ((parsed_entry_count > max_entry_count)); then
+			provider_state=partial
+			if [[ $entry_limit_reported == false ]]; then
+				add_error parser entry-limit "Theme configuration exceeds the runtime parser limit of $max_entry_count entries"
+				entry_limit_reported=true
+			fi
+			continue
+		fi
+		[[ $section == theme || $section == active || $section == appearance ]] || continue
+
+		raw=$theme$key_separator$key
+		if [[ -n ${key_seen[$raw]+x} ]]; then
+			provider_state=partial
+			[[ $section != theme ]] || theme_invalid[$theme]=1
+			add_error "${section}:${theme}" duplicate-key "Duplicate key '$key' at line $line_number"
+			continue
+		fi
+		key_seen[$raw]=1
+		value[$raw]=$parsed
+	done <"$file"
+}
+
+valid_color() {
+	[[ $1 =~ ^#[0-9A-Fa-f]{6}$ ]]
+}
+
+validate_themes() {
+	local theme key color dark first_missing missing_count invalid_count
+
+	for theme in "${theme_order[@]}"; do
+		first_missing=
+		missing_count=0
+		invalid_count=0
+		for key in "${required_colors[@]}"; do
+			color=${value[$theme$key_separator$key]:-}
+			if [[ -z $color ]]; then
+				theme_invalid[$theme]=1
+				provider_state=partial
+				[[ -n $first_missing ]] || first_missing=$key
+				((missing_count += 1))
+			elif ! valid_color "$color"; then
+				theme_invalid[$theme]=1
+				provider_state=partial
+				((invalid_count += 1))
+				if ((invalid_count == 1)); then
+					add_error "theme:$theme" invalid-color "Theme key '$key' is not a #RRGGBB color"
+				fi
+			fi
+		done
+		if ((missing_count > 0)); then
+			add_error "theme:$theme" missing-key \
+				"Theme is missing $missing_count required keys; first missing key is '$first_missing'"
+		fi
+		dark=${value[$theme$key_separator'dark_mode']:-true}
+		if [[ $dark != true && $dark != false ]]; then
+			theme_invalid[$theme]=1
+			provider_state=partial
+			add_error "theme:$theme" invalid-dark-mode "Theme dark_mode must be true or false"
+		fi
+	done
+}
+
+resolve_active_theme() {
+	local theme
+
+	selected_theme=${value[__active$key_separator'theme']:-}
+	if [[ -z $selected_theme ]]; then
+		provider_state=partial
+		add_error active missing 'The active theme name is missing'
+	elif [[ -z ${section_count[$selected_theme]+x} ]]; then
+		provider_state=partial
+		add_error active unknown "Active theme '$selected_theme' is not defined"
+	elif [[ -n ${theme_invalid[$selected_theme]+x} ]]; then
+		provider_state=partial
+		add_error active invalid "Active theme '$selected_theme' is invalid or incomplete"
+	else
+		resolved_theme=$selected_theme
+		return
+	fi
+
+	if [[ -n ${section_count[nord]+x} && -z ${theme_invalid[nord]+x} ]]; then
+		resolved_theme=nord
+		return
+	fi
+	for theme in "${theme_order[@]}"; do
+		if [[ -z ${theme_invalid[$theme]+x} ]]; then
+			resolved_theme=$theme
+			return
+		fi
+	done
+	provider_state=unavailable
+	add_error active no-valid-theme 'No complete theme is available for recovery'
+}
+
+data_roots() {
+	local roots root
+	local -a split_roots=()
+	if [[ -n ${DWM_APPEARANCE_DATA_DIRS:-} ]]; then
+		roots=$DWM_APPEARANCE_DATA_DIRS
+	else
+		roots=$data_home:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}
+	fi
+	IFS=: read -r -a split_roots <<<"$roots"
+	for root in "${split_roots[@]}"; do
+		[[ -n $root ]] && printf '%s\n' "$root"
+	done
+}
+
+gtk_theme_available() {
+	local name=$1 root
+	case $name in
+	Adwaita | Adwaita-dark) return 0 ;;
+	esac
+	while IFS= read -r root; do
+		if [[ -d $root/themes/$name/gtk-3.0 || -d $root/themes/$name/gtk-4.0 ]]; then
+			return 0
+		fi
+	done < <(data_roots)
+	[[ -d ${HOME:-}/.themes/$name/gtk-3.0 || -d ${HOME:-}/.themes/$name/gtk-4.0 ]]
+}
+
+asset_available() {
+	local kind=$1 name=$2 root
+	while IFS= read -r root; do
+		[[ -d $root/$kind/$name ]] && return 0
+	done < <(data_roots)
+	if [[ $kind == themes && -d ${HOME:-}/.themes/$name ]]; then
+		return 0
+	fi
+	return 1
+}
+
+emit_theme_records() {
+	local theme selection validity dark gtk detail
+	for theme in "${theme_order[@]}"; do
+		selection=available
+		[[ $theme != "$selected_theme" ]] || selection=selected
+		[[ $theme != "$resolved_theme" || $theme == "$selected_theme" ]] || selection=recovery
+		validity=valid
+		detail='Theme record is complete'
+		if [[ -n ${theme_invalid[$theme]+x} ]]; then
+			validity=invalid
+			detail='Theme record is duplicate, malformed, or incomplete'
+		fi
+		dark=${value[$theme$key_separator'dark_mode']:-true}
+		gtk=${value[$theme$key_separator'gtk_theme']:-automatic}
+		printf 'theme\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+			"$(clean_field "$theme")" "$selection" "$validity" "$dark" \
+			"$(clean_field "$gtk")" "$detail"
+	done
+}
+
+emit_color_records() {
+	local name key fallback color mapping
+	local -a mappings=(
+		'background|term_bg|'
+		'bar-background|normbgcolor|term_bg'
+		'surface|normbgcolor|term_bg'
+		'surface-hover|term_color8|selbgcolor'
+		'surface-active|selbgcolor|term_color8'
+		'border|normbordercolor|normbgcolor'
+		'border-strong|selbordercolor|normbordercolor'
+		'text|normfgcolor|'
+		'text-strong|selfgcolor|normfgcolor'
+		'text-muted|term_fg|normfgcolor'
+		'placeholder|term_color8|term_fg'
+		'accent|selbordercolor|'
+		'accent-secondary|term_color4|selbordercolor'
+		'accent-text|term_bg|'
+		'success|term_color2|'
+		'warning|term_color3|'
+		'danger|term_color1|'
+		'danger-surface|term_color0|normbgcolor'
+	)
+
+	[[ -n $resolved_theme ]] || return 0
+	for mapping in "${mappings[@]}"; do
+		IFS='|' read -r name key fallback <<<"$mapping"
+		color=${value[$resolved_theme$key_separator$key]:-}
+		[[ -n $color || -z $fallback ]] || color=${value[$resolved_theme$key_separator$fallback]:-}
+		printf 'color\t%s\t%s\t%s\n' "$name" "$(clean_field "$color")" "$key"
+	done
+}
+
+emit_integrations() {
+	local dark requested_gtk fallback_gtk cursor qt_backend
+	[[ -n $resolved_theme ]] || return 0
+
+	dark=${value[$resolved_theme$key_separator'dark_mode']:-true}
+	requested_gtk=${value[$resolved_theme$key_separator'gtk_theme']:-}
+	if [[ -z $requested_gtk ]]; then
+		if [[ $dark == true ]]; then
+			[[ $resolved_theme == nord ]] && requested_gtk=Nordic || requested_gtk=Adwaita-dark
+		else
+			requested_gtk=Adwaita
+		fi
+	fi
+	if gtk_theme_available "$requested_gtk"; then
+		printf 'integration\tgtk\tavailable\t%s\tRequested GTK theme is installed\n' "$(clean_field "$requested_gtk")"
+	else
+		[[ $dark == true ]] && fallback_gtk=Adwaita-dark || fallback_gtk=Adwaita
+		printf 'integration\tgtk\tpartial\t%s\tRequested GTK theme is missing; apply falls back to %s\n' \
+			"$(clean_field "$requested_gtk")" "$fallback_gtk"
+		add_error gtk missing-theme "GTK theme '$requested_gtk' is not installed"
+	fi
+
+	if command -v qt6ct >/dev/null 2>&1; then
+		qt_backend=qt6ct
+	elif command -v qt5ct >/dev/null 2>&1; then
+		qt_backend=qt5ct
+	else
+		qt_backend=gtk3
+	fi
+	printf 'integration\tqt\tavailable\t%s\tQt applications use the supported theme backend\n' "$qt_backend"
+
+	[[ $dark == true ]] && cursor=Capitaine-Cursors-White || cursor=Capitaine-Cursors
+	if asset_available icons "$cursor"; then
+		printf 'integration\tcursor\tavailable\t%s\tManaged cursor theme is installed\n' "$cursor"
+	else
+		printf 'integration\tcursor\tunavailable\t%s\tManaged cursor theme is missing\n' "$cursor"
+		add_error cursor missing-theme "Cursor theme '$cursor' is not installed"
+	fi
+
+	for terminal in alacritty kitty; do
+		if [[ -f $config_home/$terminal/active-theme.$([[ $terminal == alacritty ]] && printf toml || printf conf) ]]; then
+			printf 'integration\t%s\tavailable\tactive-theme\tGenerated terminal theme is present\n' "$terminal"
+		elif [[ -d $config_home/$terminal ]]; then
+			printf 'integration\t%s\tpartial\tconfiguration\tTerminal is configured but has no generated active theme\n' "$terminal"
+			add_error "$terminal" not-applied 'Generated active theme is missing'
+		else
+			printf 'integration\t%s\tunavailable\tnot-configured\tTerminal integration is not configured\n' "$terminal"
+		fi
+	done
+
+	if command -v picom >/dev/null 2>&1; then
+		printf 'integration\tcompositor\tpartial\tpicom\tPicom is available but has no shared theme mutation contract\n'
+		add_error compositor unsupported 'Picom theme mutation is not implemented'
+	else
+		printf 'integration\tcompositor\tunavailable\tmissing\tPicom is optional and not installed\n'
+	fi
+}
+
+snapshot() {
+	local active_state=unresolved
+	select_source
+	if [[ -n $source_file ]]; then
+		parse_themes "$source_file"
+		validate_themes
+		resolve_active_theme
+	fi
+
+	if [[ -n $resolved_theme ]]; then
+		if [[ $resolved_theme == "$selected_theme" ]]; then
+			active_state=selected
+		else
+			active_state=recovery
+		fi
+	fi
+	printf 'appearance-protocol\t1\t0\n'
+	printf 'provider\tappearance\t%s\tread-only\tShared theme inventory and integration state\n' "$provider_state"
+	printf 'source\t%s\t%s\n' "${source_kind:-none}" "$(clean_field "${source_file:-unavailable}")"
+	printf 'active\t%s\t%s\t%s\n' \
+		"$(clean_field "${selected_theme:-none}")" \
+		"$(clean_field "${resolved_theme:-none}")" \
+		"$active_state"
+	emit_theme_records
+	emit_color_records
+	emit_integrations
+	for error in "${errors[@]}"; do
+		printf 'error\t%s\n' "$error"
+	done
+	[[ $provider_state != unavailable ]] || return 3
+}
+
+case ${1:-} in
+snapshot)
+	[[ $# -eq 1 ]] || {
+		usage
+		exit 2
+	}
+	snapshot
+	;;
+-h | --help | help)
+	usage
+	;;
+*)
+	usage
+	exit 2
+	;;
+esac

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -532,10 +532,17 @@ emit_integrations() {
 		qt_backend=qt6ct
 	elif command -v qt5ct >/dev/null 2>&1; then
 		qt_backend=qt5ct
-	else
+	elif [[ ${QT_QPA_PLATFORMTHEME:-} == gtk3 ]]; then
 		qt_backend=gtk3
+	else
+		qt_backend=none
 	fi
-	printf 'integration\tqt\tavailable\t%s\tQt applications use the supported theme backend\n' "$qt_backend"
+	if [[ $qt_backend == none ]]; then
+		printf 'integration\tqt\tunavailable\tnone\tNo supported Qt theme backend is active\n'
+		add_error qt missing-backend 'Install qt6ct or qt5ct, or activate the Qt GTK3 platform theme'
+	else
+		printf 'integration\tqt\tavailable\t%s\tQt applications use the supported theme backend\n' "$qt_backend"
+	fi
 
 	[[ $dark == true ]] && cursor=Capitaine-Cursors-White || cursor=Capitaine-Cursors
 	if asset_available icons "$cursor"; then

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -187,6 +187,19 @@ parse_themes() {
 						add_error "theme:$theme" duplicate "Duplicate theme section at line $line_number"
 					fi
 				fi
+			elif [[ $trimmed == '[colors]' ]]; then
+				theme=legacy
+				section=theme
+				((section_count[$theme] = ${section_count[$theme]:-0} + 1))
+				if ((${section_count[$theme]} == 1)); then
+					theme_order+=("$theme")
+					provider_state=partial
+					add_error parser legacy-format \
+						'Legacy [colors] palette is active; named themes are recommended'
+				else
+					theme_invalid[$theme]=1
+					add_error theme:legacy duplicate "Duplicate legacy [colors] section at line $line_number"
+				fi
 			elif [[ $trimmed == '[active]' ]]; then
 				section=active
 				theme=__active
@@ -277,12 +290,32 @@ valid_color() {
 
 validate_themes() {
 	local theme key color dark first_missing missing_count invalid_count
+	local -a keys_to_validate=()
 
 	for theme in "${theme_order[@]}"; do
+		if [[ $theme == legacy ]]; then
+			[[ -n ${value[$theme$key_separator'normbordercolor']:-} ]] ||
+				value[$theme$key_separator'normbordercolor']='#3B4252'
+			[[ -n ${value[$theme$key_separator'normbgcolor']:-} ]] ||
+				value[$theme$key_separator'normbgcolor']='#434C5E'
+			[[ -n ${value[$theme$key_separator'normfgcolor']:-} ]] ||
+				value[$theme$key_separator'normfgcolor']='#D8DEE9'
+			[[ -n ${value[$theme$key_separator'selbordercolor']:-} ]] ||
+				value[$theme$key_separator'selbordercolor']='#81A1C1'
+			[[ -n ${value[$theme$key_separator'selbgcolor']:-} ]] ||
+				value[$theme$key_separator'selbgcolor']='#434C5E'
+			[[ -n ${value[$theme$key_separator'selfgcolor']:-} ]] ||
+				value[$theme$key_separator'selfgcolor']='#ECEFF4'
+			keys_to_validate=(
+				normfgcolor normbgcolor normbordercolor selfgcolor selbgcolor selbordercolor
+			)
+		else
+			keys_to_validate=("${required_colors[@]}")
+		fi
 		first_missing=
 		missing_count=0
 		invalid_count=0
-		for key in "${required_colors[@]}"; do
+		for key in "${keys_to_validate[@]}"; do
 			color=${value[$theme$key_separator$key]:-}
 			if [[ -z $color ]]; then
 				theme_invalid[$theme]=1
@@ -316,6 +349,11 @@ resolve_active_theme() {
 
 	selected_theme=${value[__active$key_separator'theme']:-}
 	if [[ -z $selected_theme ]]; then
+		if [[ -n ${section_count[legacy]+x} && -z ${theme_invalid[legacy]+x} ]]; then
+			selected_theme=legacy
+			resolved_theme=legacy
+			return
+		fi
 		provider_state=partial
 		add_error active missing 'The active theme name is missing'
 	elif [[ -z ${section_count[$selected_theme]+x} ]]; then
@@ -334,7 +372,7 @@ resolve_active_theme() {
 		return
 	fi
 	for theme in "${theme_order[@]}"; do
-		if [[ -z ${theme_invalid[$theme]+x} ]]; then
+		if [[ $theme != legacy && -z ${theme_invalid[$theme]+x} ]]; then
 			resolved_theme=$theme
 			return
 		fi
@@ -454,6 +492,43 @@ terminal_theme_matches() {
 	done
 }
 
+alacritty_imports_active_theme() {
+	local primary=$config_home/alacritty/alacritty.toml
+	local active=$config_home/alacritty/active-theme.toml
+	local default_import='~'/.config/alacritty/active-theme.toml
+	[[ -f $primary ]] || return 1
+	if [[ -z ${HOME:-} || $config_home != "$HOME/.config" ]]; then
+		default_import=
+	fi
+	awk -v active="$active" -v default_import="$default_import" '
+		/^[[:space:]]*#/ { next }
+		{
+			line = $0
+			comment = index(line, "#")
+			if (comment) line = substr(line, 1, comment - 1)
+			if (line ~ /^[[:space:]]*import[[:space:]]*=/) in_import = 1
+			if (in_import &&
+			    (index(line, "\"" active "\"") ||
+			     index(line, "\047" active "\047") ||
+			     (default_import != "" &&
+			      (index(line, "\"" default_import "\"") ||
+			       index(line, "\047" default_import "\047"))))) found = 1
+			if (in_import && index(line, "]")) exit
+		}
+		END { exit(found ? 0 : 1) }
+	' "$primary"
+}
+
+effective_qt_backend() {
+	local env_file=$config_home/dwm-titus/theme-env.sh
+	qt_backend=${QT_QPA_PLATFORMTHEME:-}
+	if [[ -z $qt_backend && -r $env_file ]]; then
+		qt_backend=$(awk -F= '
+			$1 == "export QT_QPA_PLATFORMTHEME" { print substr($0, index($0, "=") + 1); exit }
+		' "$env_file")
+	fi
+}
+
 emit_theme_records() {
 	local theme selection validity dark gtk detail
 	for theme in "${theme_order[@]}"; do
@@ -477,7 +552,7 @@ emit_theme_records() {
 emit_color_records() {
 	local name key fallback color mapping
 	local -a mappings=(
-		'background|term_bg|'
+		'background|term_bg|normbgcolor'
 		'bar-background|normbgcolor|term_bg'
 		'surface|normbgcolor|term_bg'
 		'surface-hover|term_color8|selbgcolor'
@@ -528,20 +603,20 @@ emit_integrations() {
 		add_error gtk missing-theme "GTK theme '$requested_gtk' is not installed"
 	fi
 
-	if command -v qt6ct >/dev/null 2>&1; then
-		qt_backend=qt6ct
-	elif command -v qt5ct >/dev/null 2>&1; then
-		qt_backend=qt5ct
-	elif [[ ${QT_QPA_PLATFORMTHEME:-} == gtk3 ]]; then
-		qt_backend=gtk3
-	else
+	effective_qt_backend
+	if [[ -z $qt_backend ]]; then
 		qt_backend=none
-	fi
-	if [[ $qt_backend == none ]]; then
 		printf 'integration\tqt\tunavailable\tnone\tNo supported Qt theme backend is active\n'
-		add_error qt missing-backend 'Install qt6ct or qt5ct, or activate the Qt GTK3 platform theme'
+		add_error qt missing-backend 'No applied Qt theme backend is recorded'
+	elif [[ $qt_backend == gtk3 ]] ||
+		[[ $qt_backend == qt6ct && $(command -v qt6ct 2>/dev/null) ]] ||
+		[[ $qt_backend == qt5ct && $(command -v qt5ct 2>/dev/null) ]]; then
+		printf 'integration\tqt\tavailable\t%s\tQt applications use the supported theme backend\n' \
+			"$(clean_field "$qt_backend")"
 	else
-		printf 'integration\tqt\tavailable\t%s\tQt applications use the supported theme backend\n' "$qt_backend"
+		printf 'integration\tqt\tpartial\t%s\tRecorded Qt theme backend is unsupported or unavailable\n' \
+			"$(clean_field "$qt_backend")"
+		add_error qt stale-backend "Recorded Qt theme backend '$qt_backend' is unsupported or unavailable"
 	fi
 
 	[[ $dark == true ]] && cursor=Capitaine-Cursors-White || cursor=Capitaine-Cursors
@@ -558,8 +633,12 @@ emit_integrations() {
 		else
 			terminal_theme_file=$config_home/$terminal/active-theme.conf
 		fi
-		if terminal_theme_matches "$terminal" "$terminal_theme_file"; then
+		if terminal_theme_matches "$terminal" "$terminal_theme_file" &&
+			{ [[ $terminal != alacritty ]] || alacritty_imports_active_theme; }; then
 			printf 'integration\t%s\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette\n' "$terminal"
+		elif [[ $terminal == alacritty ]] && terminal_theme_matches "$terminal" "$terminal_theme_file"; then
+			printf 'integration\t%s\tpartial\tconfiguration\tGenerated theme is not imported by the terminal configuration\n' "$terminal"
+			add_error "$terminal" not-imported 'Alacritty configuration does not import the generated active theme'
 		elif [[ -f $terminal_theme_file ]]; then
 			printf 'integration\t%s\tpartial\tactive-theme\tGenerated terminal theme is empty or stale\n' "$terminal"
 			add_error "$terminal" stale-theme 'Generated active theme does not match the resolved palette'

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -15,6 +15,8 @@ readonly max_theme_name_length=505
 readonly key_separator=$'\034'
 readonly legacy_theme_id=$'\035legacy-colors'
 readonly legacy_theme_label='@legacy-colors'
+readonly quoted_record_re='^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*"(([^"\\]|\\.)*)"[[:space:]]*(#.*)?$'
+readonly quoted_active_theme_re='^[[:space:]]*theme[[:space:]]*=[[:space:]]*"(([^"\\]|\\.)*)"[[:space:]]*(#.*)?$'
 
 declare -a theme_order=()
 declare -a errors=()
@@ -59,6 +61,28 @@ theme_label() {
 	else
 		printf '%s' "$1"
 	fi
+}
+
+unescape_runtime_string() {
+	local source=$1 char index=0
+	local LC_ALL=C
+	parsed_runtime_string=
+
+	while ((index < ${#source} && ${#parsed_runtime_string} < 511)); do
+		char=${source:index:1}
+		if [[ $char == \\ ]] && ((index + 1 < ${#source})); then
+			((index += 1))
+			char=${source:index:1}
+			case $char in
+			n) char=$'\n' ;;
+			t) char=$'\t' ;;
+			\\) char=\\ ;;
+			'"') char='"' ;;
+			esac
+		fi
+		parsed_runtime_string+=$char
+		((index += 1))
+	done
 }
 
 add_error() {
@@ -138,8 +162,9 @@ prescan_active_theme() {
 		elif [[ $trimmed == \[* ]]; then
 			section=other
 		elif [[ $section == active && -z $selected_theme_hint &&
-			$line =~ ^[[:space:]]*theme[[:space:]]*=[[:space:]]*\"([^\"]*)\"[[:space:]]*(#.*)?$ ]]; then
-			selected_theme_hint=${BASH_REMATCH[1]}
+			$line =~ $quoted_active_theme_re ]]; then
+			unescape_runtime_string "${BASH_REMATCH[1]}"
+			selected_theme_hint=$parsed_runtime_string
 		elif [[ $section == active && -z $selected_theme_hint &&
 			$line =~ ^[[:space:]]*theme[[:space:]]*=[[:space:]]*([^#[:space:]]+)[[:space:]]*(#.*)?$ ]]; then
 			candidate=${BASH_REMATCH[1]}
@@ -169,7 +194,7 @@ string_byte_length() {
 
 parse_themes() {
 	local file=$1 size line trimmed line_number raw runtime_key runtime_value parsed_type
-	local string_byte_length_result
+	local string_byte_length_result parsed_runtime_string
 	local section='' theme='' theme_candidate='' key='' parsed=''
 
 	size=$(stat -c %s -- "$file" 2>/dev/null) || {
@@ -286,9 +311,10 @@ parse_themes() {
 			fi
 		fi
 
-		if [[ $line =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*\"([^\"]*)\"[[:space:]]*(#.*)?$ ]]; then
+		if [[ $line =~ $quoted_record_re ]]; then
 			key=${BASH_REMATCH[1]}
-			parsed=${BASH_REMATCH[2]}
+			unescape_runtime_string "${BASH_REMATCH[2]}"
+			parsed=$parsed_runtime_string
 			parsed_type=string
 		elif [[ $line =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*([^#[:space:]]+)[[:space:]]*(#.*)?$ ]]; then
 			key=${BASH_REMATCH[1]}

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -105,7 +105,8 @@ numbered_theme_content_lines() {
 }
 
 prescan_active_theme() {
-	local file=$1 line trimmed section='' candidate
+	local file=$1 line trimmed section='' candidate runtime_key
+	local entry_count=0 string_byte_length_result
 
 	while IFS= read -r line || [[ -n $line ]]; do
 		line=${line%$'\r'}
@@ -113,6 +114,15 @@ prescan_active_theme() {
 		trimmed=${trimmed#"${trimmed%%[![:space:]]*}"}
 		trimmed=${trimmed%"${trimmed##*[![:space:]]}"}
 		[[ -z $trimmed || $trimmed == \#* ]] && continue
+		if [[ $trimmed == *=* ]]; then
+			runtime_key=${trimmed%%=*}
+			runtime_key=${runtime_key%"${runtime_key##*[![:space:]]}"}
+			string_byte_length "$runtime_key"
+			if [[ -n $runtime_key ]] && ((string_byte_length_result < 512)); then
+				((entry_count += 1))
+				((entry_count <= max_entry_count)) || break
+			fi
+		fi
 		if [[ $trimmed == '[active]' ]]; then
 			section=active
 		elif [[ $trimmed == \[* ]]; then
@@ -255,7 +265,7 @@ parse_themes() {
 						add_error parser entry-limit "Theme configuration exceeds the runtime parser limit of $max_entry_count entries"
 						entry_limit_reported=true
 					fi
-					continue
+					break
 				fi
 			fi
 		fi
@@ -434,10 +444,10 @@ gtk_theme_available() {
 }
 
 gtk_settings_file_matches() {
-	local file=$1 theme_name=$2
-	awk -F= -v expected="$theme_name" '
+	local file=$1 key=$2 expected=$3
+	awk -F= -v target_key="$key" -v expected="$expected" '
 		/^[[:space:]]*\[/ { in_settings = ($0 == "[Settings]"); next }
-		in_settings && $1 == "gtk-theme-name" {
+		in_settings && $1 == target_key {
 			value = substr($0, index($0, "=") + 1)
 			gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
 			found = (value == expected)
@@ -455,7 +465,37 @@ gtk_theme_applied() {
 	fi
 	for version in 3.0 4.0; do
 		file=$config_home/gtk-$version/settings.ini
-		[[ -f $file ]] && gtk_settings_file_matches "$file" "$theme_name" || return 1
+		[[ -f $file ]] && gtk_settings_file_matches "$file" gtk-theme-name "$theme_name" || return 1
+	done
+}
+
+theme_env_value() {
+	local key=$1 env_file=$config_home/dwm-titus/theme-env.sh
+	[[ -r $env_file ]] || return 1
+	awk -F= -v target="export $key" '
+		$1 == target { print substr($0, index($0, "=") + 1); found = 1; exit }
+		END { exit(found ? 0 : 1) }
+	' "$env_file"
+}
+
+cursor_theme_applied() {
+	local expected=$1 effective=${XCURSOR_THEME:-} version file
+	[[ -n $effective ]] || effective=$(theme_env_value XCURSOR_THEME) || return 1
+	[[ $effective == "$expected" ]] || return 1
+	[[ -f $config_home/dwm-titus/cursor.Xresources ]] || return 1
+	awk -F: -v expected="$expected" '
+		$1 == "Xcursor.theme" {
+			value = substr($0, index($0, ":") + 1)
+			gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+			found = (value == expected)
+			exit
+		}
+		END { exit(found ? 0 : 1) }
+	' "$config_home/dwm-titus/cursor.Xresources" || return 1
+	for version in 3.0 4.0; do
+		file=$config_home/gtk-$version/settings.ini
+		[[ -f $file ]] &&
+			gtk_settings_file_matches "$file" gtk-cursor-theme-name "$expected" || return 1
 	done
 }
 
@@ -588,13 +628,8 @@ terminal_imports_active_theme() {
 }
 
 effective_qt_backend() {
-	local env_file=$config_home/dwm-titus/theme-env.sh
 	qt_backend=${QT_QPA_PLATFORMTHEME:-}
-	if [[ -z $qt_backend && -r $env_file ]]; then
-		qt_backend=$(awk -F= '
-			$1 == "export QT_QPA_PLATFORMTHEME" { print substr($0, index($0, "=") + 1); exit }
-		' "$env_file")
-	fi
+	[[ -n $qt_backend ]] || qt_backend=$(theme_env_value QT_QPA_PLATFORMTHEME) || qt_backend=
 }
 
 emit_theme_records() {
@@ -693,8 +728,11 @@ emit_integrations() {
 	fi
 
 	[[ $dark == true ]] && cursor=Capitaine-Cursors-White || cursor=Capitaine-Cursors
-	if asset_available icons "$cursor"; then
-		printf 'integration\tcursor\tavailable\t%s\tManaged cursor theme is installed\n' "$cursor"
+	if asset_available icons "$cursor" && cursor_theme_applied "$cursor"; then
+		printf 'integration\tcursor\tavailable\t%s\tManaged cursor theme is installed and applied\n' "$cursor"
+	elif asset_available icons "$cursor"; then
+		printf 'integration\tcursor\tpartial\t%s\tManaged cursor theme is installed but not applied\n' "$cursor"
+		add_error cursor stale-theme "Applied cursor settings do not match '$cursor'"
 	else
 		printf 'integration\tcursor\tunavailable\t%s\tManaged cursor theme is missing\n' "$cursor"
 		add_error cursor missing-theme "Cursor theme '$cursor' is not installed"

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -127,6 +127,13 @@ runtime_bare_is_numeric() {
 		[[ $1 =~ ^[+-]?([Nn][Aa][Nn]|[Ii][Nn][Ff]) ]]
 }
 
+theme_key_supported() {
+	case $1 in
+	normfgcolor | normbgcolor | normbordercolor | selfgcolor | selbgcolor | selbordercolor | term_bg | term_fg | term_cursor | term_color[0-9] | term_color1[0-5] | dark_mode | gtk_theme) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
 string_byte_length() {
 	local LC_ALL=C
 	string_byte_length_result=${#1}
@@ -256,6 +263,15 @@ parse_themes() {
 			parsed=${BASH_REMATCH[2]}
 			parsed_type=bare
 		else
+			if [[ $section == theme && $trimmed == *=* ]]; then
+				if ((string_byte_length_result >= 512)) ||
+					[[ $runtime_value =~ ^\"[^\"]*\"[[:space:]]*(#.*)?$ ]] ||
+					[[ $runtime_value =~ ^[^#[:space:]]+[[:space:]]*(#.*)?$ ]]; then
+					# DWM skips overlong keys and ignores runtime-valid metadata
+					# outside the appearance schema, including punctuation.
+					continue
+				fi
+			fi
 			if [[ $section == theme || $section == active || $section == appearance ]]; then
 				provider_state=partial
 				[[ $section != theme ]] || theme_invalid[$theme]=1
@@ -265,13 +281,9 @@ parse_themes() {
 		fi
 
 		[[ $section == theme || $section == active || $section == appearance ]] || continue
-		if [[ $section == active && $key == theme && $parsed_type == bare ]] &&
-			runtime_bare_is_numeric "$parsed"; then
-			provider_state=partial
-			add_error active invalid-type "Active theme must resolve to a TOML string at line $line_number"
+		if [[ $section == theme ]] && ! theme_key_supported "$key"; then
 			continue
 		fi
-
 		raw=$theme$key_separator$key
 		if [[ -n ${key_seen[$raw]+x} ]]; then
 			provider_state=partial
@@ -280,6 +292,13 @@ parse_themes() {
 			continue
 		fi
 		key_seen[$raw]=1
+		if [[ $section == active && $key == theme && $parsed_type == bare ]] &&
+			runtime_bare_is_numeric "$parsed"; then
+			provider_state=partial
+			add_error active invalid-type "Active theme must resolve to a TOML string at line $line_number"
+			continue
+		fi
+
 		value[$raw]=$parsed
 	done <"$file"
 }
@@ -408,6 +427,32 @@ gtk_theme_available() {
 	[[ -d ${HOME:-}/.themes/$name/gtk-3.0 || -d ${HOME:-}/.themes/$name/gtk-4.0 ]]
 }
 
+gtk_settings_file_matches() {
+	local file=$1 theme_name=$2
+	awk -F= -v expected="$theme_name" '
+		/^[[:space:]]*\[/ { in_settings = ($0 == "[Settings]"); next }
+		in_settings && $1 == "gtk-theme-name" {
+			value = substr($0, index($0, "=") + 1)
+			gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+			found = (value == expected)
+			exit
+		}
+		END { exit(found ? 0 : 1) }
+	' "$file"
+}
+
+gtk_theme_applied() {
+	local theme_name=$1 effective=${GTK_THEME:-} version file
+	if [[ -n $effective ]]; then
+		[[ ${effective%%:*} == "$theme_name" ]]
+		return
+	fi
+	for version in 3.0 4.0; do
+		file=$config_home/gtk-$version/settings.ini
+		[[ -f $file ]] && gtk_settings_file_matches "$file" "$theme_name" || return 1
+	done
+}
+
 asset_available() {
 	local kind=$1 name=$2 root
 	while IFS= read -r root; do
@@ -519,6 +564,23 @@ alacritty_imports_active_theme() {
 	' "$primary"
 }
 
+kitty_imports_active_theme() {
+	local primary=$config_home/kitty/kitty.conf
+	[[ -f $primary ]] || return 1
+	awk '
+		/^[[:space:]]*#/ { next }
+		$1 == "include" && $2 == "active-theme.conf" && NF == 2 { found = 1; exit }
+		END { exit(found ? 0 : 1) }
+	' "$primary"
+}
+
+terminal_imports_active_theme() {
+	case $1 in
+	alacritty) alacritty_imports_active_theme ;;
+	kitty) kitty_imports_active_theme ;;
+	esac
+}
+
 effective_qt_backend() {
 	local env_file=$config_home/dwm-titus/theme-env.sh
 	qt_backend=${QT_QPA_PLATFORMTHEME:-}
@@ -594,8 +656,13 @@ emit_integrations() {
 			requested_gtk=Adwaita
 		fi
 	fi
-	if gtk_theme_available "$requested_gtk"; then
-		printf 'integration\tgtk\tavailable\t%s\tRequested GTK theme is installed\n' "$(clean_field "$requested_gtk")"
+	if gtk_theme_available "$requested_gtk" && gtk_theme_applied "$requested_gtk"; then
+		printf 'integration\tgtk\tavailable\t%s\tRequested GTK theme is installed and applied\n' \
+			"$(clean_field "$requested_gtk")"
+	elif gtk_theme_available "$requested_gtk"; then
+		printf 'integration\tgtk\tpartial\t%s\tRequested GTK theme is installed but not applied\n' \
+			"$(clean_field "$requested_gtk")"
+		add_error gtk stale-theme "Applied GTK settings do not match '$requested_gtk'"
 	else
 		[[ $dark == true ]] && fallback_gtk=Adwaita-dark || fallback_gtk=Adwaita
 		printf 'integration\tgtk\tpartial\t%s\tRequested GTK theme is missing; apply falls back to %s\n' \
@@ -634,11 +701,11 @@ emit_integrations() {
 			terminal_theme_file=$config_home/$terminal/active-theme.conf
 		fi
 		if terminal_theme_matches "$terminal" "$terminal_theme_file" &&
-			{ [[ $terminal != alacritty ]] || alacritty_imports_active_theme; }; then
+			terminal_imports_active_theme "$terminal"; then
 			printf 'integration\t%s\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette\n' "$terminal"
-		elif [[ $terminal == alacritty ]] && terminal_theme_matches "$terminal" "$terminal_theme_file"; then
+		elif terminal_theme_matches "$terminal" "$terminal_theme_file"; then
 			printf 'integration\t%s\tpartial\tconfiguration\tGenerated theme is not imported by the terminal configuration\n' "$terminal"
-			add_error "$terminal" not-imported 'Alacritty configuration does not import the generated active theme'
+			add_error "$terminal" not-imported 'Terminal configuration does not import the generated active theme'
 		elif [[ -f $terminal_theme_file ]]; then
 			printf 'integration\t%s\tpartial\tactive-theme\tGenerated terminal theme is empty or stale\n' "$terminal"
 			add_error "$terminal" stale-theme 'Generated active theme does not match the resolved palette'

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -28,6 +28,7 @@ resolved_theme=
 errors_truncated=false
 entry_limit_reported=false
 parsed_entry_count=0
+selected_theme_hint=
 
 readonly -a required_colors=(
 	normfgcolor normbgcolor normbordercolor selfgcolor selbgcolor selbordercolor
@@ -93,8 +94,33 @@ select_source() {
 	add_error source missing 'No readable user or managed themes.toml file is available'
 }
 
+prescan_active_theme() {
+	local file=$1 line trimmed section=''
+
+	while IFS= read -r line || [[ -n $line ]]; do
+		line=${line%$'\r'}
+		trimmed=$line
+		trimmed=${trimmed#"${trimmed%%[![:space:]]*}"}
+		trimmed=${trimmed%"${trimmed##*[![:space:]]}"}
+		[[ -z $trimmed || $trimmed == \#* ]] && continue
+		if [[ $trimmed == '[active]' ]]; then
+			section=active
+		elif [[ $trimmed == \[* ]]; then
+			section=other
+		elif [[ $section == active && -z $selected_theme_hint &&
+			$line =~ ^[[:space:]]*theme[[:space:]]*=[[:space:]]*\"([^\"]*)\"[[:space:]]*(#.*)?$ ]]; then
+			selected_theme_hint=${BASH_REMATCH[1]}
+		fi
+	done <"$file"
+}
+
+runtime_bare_is_numeric() {
+	[[ $1 =~ ^[+-]?([0-9]|\.[0-9]) ]] ||
+		[[ $1 =~ ^[+-]?([Nn][Aa][Nn]|[Ii][Nn][Ff]) ]]
+}
+
 parse_themes() {
-	local file=$1 size line trimmed line_number=0 raw runtime_key
+	local file=$1 size line trimmed line_number=0 raw runtime_key runtime_value parsed_type
 	local section='' theme='' theme_candidate='' key='' parsed=''
 
 	size=$(stat -c %s -- "$file" 2>/dev/null) || {
@@ -107,6 +133,7 @@ parse_themes() {
 		add_error source too-large "Theme file exceeds $max_themes_size bytes"
 		return
 	fi
+	prescan_active_theme "$file"
 
 	while IFS= read -r line || [[ -n $line ]]; do
 		((line_number += 1))
@@ -129,7 +156,8 @@ parse_themes() {
 					theme=$theme_candidate
 					section=theme
 					if [[ -z ${section_count[$theme]+x} ]] &&
-						((${#theme_order[@]} >= max_theme_count)); then
+						((${#theme_order[@]} >= max_theme_count)) &&
+						[[ $theme != "$selected_theme_hint" ]]; then
 						section=ignore
 						theme=
 						provider_state=partial
@@ -170,6 +198,14 @@ parse_themes() {
 		if [[ $trimmed == *=* ]]; then
 			runtime_key=${trimmed%%=*}
 			runtime_key=${runtime_key%"${runtime_key##*[![:space:]]}"}
+			runtime_value=${trimmed#*=}
+			runtime_value=${runtime_value#"${runtime_value%%[![:space:]]*}"}
+			if [[ $runtime_value == \[* || $runtime_value == \{* ]]; then
+				provider_state=unavailable
+				add_error parser unsupported-complex-value \
+					"Arrays and inline tables are outside the appearance snapshot grammar at line $line_number"
+				return
+			fi
 			if [[ -n $runtime_key ]] && ((${#runtime_key} < 512)); then
 				((parsed_entry_count += 1))
 				if ((parsed_entry_count > max_entry_count)); then
@@ -186,9 +222,11 @@ parse_themes() {
 		if [[ $line =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*\"([^\"]*)\"[[:space:]]*(#.*)?$ ]]; then
 			key=${BASH_REMATCH[1]}
 			parsed=${BASH_REMATCH[2]}
+			parsed_type=string
 		elif [[ $line =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*([^#[:space:]]+)[[:space:]]*(#.*)?$ ]]; then
 			key=${BASH_REMATCH[1]}
 			parsed=${BASH_REMATCH[2]}
+			parsed_type=bare
 		else
 			if [[ $section == theme || $section == active || $section == appearance ]]; then
 				provider_state=partial
@@ -199,6 +237,12 @@ parse_themes() {
 		fi
 
 		[[ $section == theme || $section == active || $section == appearance ]] || continue
+		if [[ $section == active && $key == theme && $parsed_type == bare ]] &&
+			runtime_bare_is_numeric "$parsed"; then
+			provider_state=partial
+			add_error active invalid-type "Active theme must resolve to a TOML string at line $line_number"
+			continue
+		fi
 
 		raw=$theme$key_separator$key
 		if [[ -n ${key_seen[$raw]+x} ]]; then
@@ -337,7 +381,7 @@ emit_theme_records() {
 		dark=${value[$theme$key_separator'dark_mode']:-true}
 		gtk=${value[$theme$key_separator'gtk_theme']:-automatic}
 		printf 'theme\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-			"$(clean_field "$theme")" "$selection" "$validity" "$dark" \
+			"$(clean_field "$theme")" "$selection" "$validity" "$(clean_field "$dark")" \
 			"$(clean_field "$gtk")" "$detail"
 	done
 }

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -250,12 +250,6 @@ parse_themes() {
 			runtime_key=${runtime_key%"${runtime_key##*[![:space:]]}"}
 			runtime_value=${trimmed#*=}
 			runtime_value=${runtime_value#"${runtime_value%%[![:space:]]*}"}
-			if [[ $runtime_value == \[* || $runtime_value == \{* ]]; then
-				provider_state=unavailable
-				add_error parser unsupported-complex-value \
-					"Arrays and inline tables are outside the appearance snapshot grammar at line $line_number"
-				return
-			fi
 			string_byte_length "$runtime_key"
 			if [[ -n $runtime_key ]] && ((string_byte_length_result < 512)); then
 				((parsed_entry_count += 1))
@@ -267,6 +261,12 @@ parse_themes() {
 					fi
 					break
 				fi
+			fi
+			if [[ $runtime_value == \[* || $runtime_value == \{* ]]; then
+				provider_state=unavailable
+				add_error parser unsupported-complex-value \
+					"Arrays and inline tables are outside the appearance snapshot grammar at line $line_number"
+				return
 			fi
 		fi
 
@@ -430,17 +430,19 @@ data_roots() {
 	done
 }
 
-gtk_theme_available() {
-	local name=$1 root
+gtk_theme_version_available() {
+	local name=$1 version=$2 root
 	case $name in
 	Adwaita | Adwaita-dark) return 0 ;;
 	esac
 	while IFS= read -r root; do
-		if [[ -d $root/themes/$name/gtk-3.0 || -d $root/themes/$name/gtk-4.0 ]]; then
-			return 0
-		fi
+		[[ -d $root/themes/$name/gtk-$version ]] && return 0
 	done < <(data_roots)
-	[[ -d ${HOME:-}/.themes/$name/gtk-3.0 || -d ${HOME:-}/.themes/$name/gtk-4.0 ]]
+	[[ -d ${HOME:-}/.themes/$name/gtk-$version ]]
+}
+
+gtk_theme_available() {
+	gtk_theme_version_available "$1" 3.0 || gtk_theme_version_available "$1" 4.0
 }
 
 gtk_settings_file_matches() {
@@ -579,6 +581,9 @@ terminal_theme_matches() {
 				;;
 			esac
 			alacritty_field_matches "$file" "$section" "$field" "$color" || return 1
+			if [[ $key == term_bg ]]; then
+				alacritty_field_matches "$file" '[colors.cursor]' text "$color" || return 1
+			fi
 		fi
 	done
 }
@@ -697,9 +702,20 @@ emit_integrations() {
 			requested_gtk=Adwaita
 		fi
 	fi
-	if gtk_theme_available "$requested_gtk" && gtk_theme_applied "$requested_gtk"; then
+	if gtk_theme_version_available "$requested_gtk" 3.0 &&
+		gtk_theme_version_available "$requested_gtk" 4.0 &&
+		gtk_theme_applied "$requested_gtk"; then
 		printf 'integration\tgtk\tavailable\t%s\tRequested GTK theme is installed and applied\n' \
 			"$(clean_field "$requested_gtk")"
+	elif gtk_theme_available "$requested_gtk" &&
+		{ ! gtk_theme_version_available "$requested_gtk" 3.0 ||
+			! gtk_theme_version_available "$requested_gtk" 4.0; }; then
+		printf 'integration\tgtk\tpartial\t%s\tRequested GTK theme is missing GTK 3 or GTK 4 assets\n' \
+			"$(clean_field "$requested_gtk")"
+		add_error gtk missing-version "GTK theme '$requested_gtk' does not support both GTK 3 and GTK 4"
+		if ! gtk_theme_applied "$requested_gtk"; then
+			add_error gtk stale-theme "Applied GTK settings do not match '$requested_gtk'"
+		fi
 	elif gtk_theme_available "$requested_gtk"; then
 		printf 'integration\tgtk\tpartial\t%s\tRequested GTK theme is installed but not applied\n' \
 			"$(clean_field "$requested_gtk")"

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -13,6 +13,8 @@ readonly max_error_count=256
 readonly max_entry_count=512
 readonly max_theme_name_length=505
 readonly key_separator=$'\034'
+readonly legacy_theme_id=$'\035legacy-colors'
+readonly legacy_theme_label='@legacy-colors'
 
 declare -a theme_order=()
 declare -a errors=()
@@ -49,6 +51,14 @@ clean_field() {
 	field=${field//$'\r'/ }
 	field=${field//$'\n'/ }
 	printf '%s' "$field"
+}
+
+theme_label() {
+	if [[ $1 == "$legacy_theme_id" ]]; then
+		printf '%s' "$legacy_theme_label"
+	else
+		printf '%s' "$1"
+	fi
 }
 
 add_error() {
@@ -172,6 +182,12 @@ parse_themes() {
 		add_error source too-large "Theme file exceeds $max_themes_size bytes"
 		return
 	fi
+	if ! LC_ALL=C awk 'length($0) >= 4095 { exit 1 }' "$file"; then
+		provider_state=unavailable
+		add_error parser line-too-long \
+			'Theme configuration contains a physical line that exceeds the runtime reader limit'
+		return
+	fi
 	prescan_active_theme "$file"
 
 	while IFS= read -r line_number && IFS= read -r line; do
@@ -211,7 +227,7 @@ parse_themes() {
 					fi
 				fi
 			elif [[ $trimmed == '[colors]' ]]; then
-				theme=legacy
+				theme=$legacy_theme_id
 				section=theme
 				((section_count[$theme] = ${section_count[$theme]:-0} + 1))
 				if ((${section_count[$theme]} == 1)); then
@@ -221,7 +237,7 @@ parse_themes() {
 						'Legacy [colors] palette is active; named themes are recommended'
 				else
 					theme_invalid[$theme]=1
-					add_error theme:legacy duplicate "Duplicate legacy [colors] section at line $line_number"
+					add_error "theme:$legacy_theme_label" duplicate "Duplicate legacy [colors] section at line $line_number"
 				fi
 			elif [[ $trimmed == '[active]' ]]; then
 				section=active
@@ -328,7 +344,7 @@ validate_themes() {
 	local -a keys_to_validate=()
 
 	for theme in "${theme_order[@]}"; do
-		if [[ $theme == legacy ]]; then
+		if [[ $theme == "$legacy_theme_id" ]]; then
 			[[ -n ${value[$theme$key_separator'normbordercolor']:-} ]] ||
 				value[$theme$key_separator'normbordercolor']='#3B4252'
 			[[ -n ${value[$theme$key_separator'normbgcolor']:-} ]] ||
@@ -362,19 +378,19 @@ validate_themes() {
 				provider_state=partial
 				((invalid_count += 1))
 				if ((invalid_count == 1)); then
-					add_error "theme:$theme" invalid-color "Theme key '$key' is not a #RRGGBB color"
+					add_error "theme:$(theme_label "$theme")" invalid-color "Theme key '$key' is not a #RRGGBB color"
 				fi
 			fi
 		done
 		if ((missing_count > 0)); then
-			add_error "theme:$theme" missing-key \
+			add_error "theme:$(theme_label "$theme")" missing-key \
 				"Theme is missing $missing_count required keys; first missing key is '$first_missing'"
 		fi
 		dark=${value[$theme$key_separator'dark_mode']:-true}
 		if [[ $dark != true && $dark != false ]]; then
 			theme_invalid[$theme]=1
 			provider_state=partial
-			add_error "theme:$theme" invalid-dark-mode "Theme dark_mode must be true or false"
+			add_error "theme:$(theme_label "$theme")" invalid-dark-mode "Theme dark_mode must be true or false"
 		fi
 	done
 }
@@ -384,9 +400,9 @@ resolve_active_theme() {
 
 	selected_theme=${value[__active$key_separator'theme']:-}
 	if [[ -z $selected_theme ]]; then
-		if [[ -n ${section_count[legacy]+x} && -z ${theme_invalid[legacy]+x} ]]; then
-			selected_theme=legacy
-			resolved_theme=legacy
+		if [[ -n ${section_count[$legacy_theme_id]+x} && -z ${theme_invalid[$legacy_theme_id]+x} ]]; then
+			selected_theme=$legacy_theme_id
+			resolved_theme=$legacy_theme_id
 			return
 		fi
 		provider_state=partial
@@ -407,7 +423,7 @@ resolve_active_theme() {
 		return
 	fi
 	for theme in "${theme_order[@]}"; do
-		if [[ $theme != legacy && -z ${theme_invalid[$theme]+x} ]]; then
+		if [[ $theme != "$legacy_theme_id" && -z ${theme_invalid[$theme]+x} ]]; then
 			resolved_theme=$theme
 			return
 		fi
@@ -597,11 +613,31 @@ alacritty_imports_active_theme() {
 		default_import=
 	fi
 	awk -v active="$active" -v default_import="$default_import" '
-		/^[[:space:]]*#/ { next }
 		{
 			line = $0
-			comment = index(line, "#")
-			if (comment) line = substr(line, 1, comment - 1)
+			clean = ""
+			quote = ""
+			escaped = 0
+			for (i = 1; i <= length(line); i++) {
+				char = substr(line, i, 1)
+				if (quote != "") {
+					clean = clean char
+					if (quote == "\"" && escaped) {
+						escaped = 0
+						continue
+					}
+					if (quote == "\"" && char == "\\") {
+						escaped = 1
+						continue
+					}
+					if (char == quote) quote = ""
+				} else {
+					if (char == "#") break
+					clean = clean char
+					if (char == "\"" || char == "\047") quote = char
+				}
+			}
+			line = clean
 			if (line ~ /^[[:space:]]*import[[:space:]]*=/) in_import = 1
 			if (in_import &&
 			    (index(line, "\"" active "\"") ||
@@ -638,8 +674,9 @@ effective_qt_backend() {
 }
 
 emit_theme_records() {
-	local theme selection validity dark gtk detail
+	local theme label selection validity dark gtk detail
 	for theme in "${theme_order[@]}"; do
+		label=$(theme_label "$theme")
 		selection=available
 		[[ $theme != "$selected_theme" ]] || selection=selected
 		[[ $theme != "$resolved_theme" || $theme == "$selected_theme" ]] || selection=recovery
@@ -652,7 +689,7 @@ emit_theme_records() {
 		dark=${value[$theme$key_separator'dark_mode']:-true}
 		gtk=${value[$theme$key_separator'gtk_theme']:-automatic}
 		printf 'theme\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-			"$(clean_field "$theme")" "$selection" "$validity" "$(clean_field "$dark")" \
+			"$(clean_field "$label")" "$selection" "$validity" "$(clean_field "$dark")" \
 			"$(clean_field "$gtk")" "$detail"
 	done
 }
@@ -786,7 +823,7 @@ emit_integrations() {
 }
 
 snapshot() {
-	local active_state=unresolved
+	local active_state=unresolved selected_label=none resolved_label=none
 	select_source
 	if [[ -n $source_file ]]; then
 		parse_themes "$source_file"
@@ -801,12 +838,14 @@ snapshot() {
 			active_state=recovery
 		fi
 	fi
+	[[ -z $selected_theme ]] || selected_label=$(theme_label "$selected_theme")
+	[[ -z $resolved_theme ]] || resolved_label=$(theme_label "$resolved_theme")
 	printf 'appearance-protocol\t1\t0\n'
 	printf 'provider\tappearance\t%s\tread-only\tShared theme inventory and integration state\n' "$provider_state"
 	printf 'source\t%s\t%s\n' "${source_kind:-none}" "$(clean_field "${source_report_file:-unavailable}")"
 	printf 'active\t%s\t%s\t%s\n' \
-		"$(clean_field "${selected_theme:-none}")" \
-		"$(clean_field "${resolved_theme:-none}")" \
+		"$(clean_field "$selected_label")" \
+		"$(clean_field "$resolved_label")" \
 		"$active_state"
 	emit_theme_records
 	emit_color_records

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -96,6 +96,14 @@ select_source() {
 	add_error source missing 'No readable user or managed themes.toml file is available'
 }
 
+theme_content_lines() {
+	awk '!/^[[:space:]]*(#.*)?$/ { sub(/\r$/, ""); print }' "$1"
+}
+
+numbered_theme_content_lines() {
+	awk '!/^[[:space:]]*(#.*)?$/ { sub(/\r$/, ""); print NR; print }' "$1"
+}
+
 prescan_active_theme() {
 	local file=$1 line trimmed section='' candidate
 
@@ -119,7 +127,7 @@ prescan_active_theme() {
 				selected_theme_hint=$candidate
 			fi
 		fi
-	done <"$file"
+	done < <(theme_content_lines "$file")
 }
 
 runtime_bare_is_numeric() {
@@ -140,7 +148,7 @@ string_byte_length() {
 }
 
 parse_themes() {
-	local file=$1 size line trimmed line_number=0 raw runtime_key runtime_value parsed_type
+	local file=$1 size line trimmed line_number raw runtime_key runtime_value parsed_type
 	local string_byte_length_result
 	local section='' theme='' theme_candidate='' key='' parsed=''
 
@@ -156,9 +164,7 @@ parse_themes() {
 	fi
 	prescan_active_theme "$file"
 
-	while IFS= read -r line || [[ -n $line ]]; do
-		((line_number += 1))
-		line=${line%$'\r'}
+	while IFS= read -r line_number && IFS= read -r line; do
 		trimmed=$line
 		trimmed=${trimmed#"${trimmed%%[![:space:]]*}"}
 		trimmed=${trimmed%"${trimmed##*[![:space:]]}"}
@@ -300,7 +306,7 @@ parse_themes() {
 		fi
 
 		value[$raw]=$parsed
-	done <"$file"
+	done < <(numbered_theme_content_lines "$file")
 }
 
 valid_color() {

--- a/scripts/dwm-settings-provider
+++ b/scripts/dwm-settings-provider
@@ -59,6 +59,14 @@ run_bounded_probe() {
 	"$timeout_path" 2 "$command_path" "$@" >/dev/null 2>&1
 }
 
+appearance_snapshot_valid() {
+	command_path=$(provider_path dwm-settings-appearance) || return 1
+	timeout_path=$(command -v timeout 2>/dev/null) || return 1
+	appearance_snapshot=$("$timeout_path" 2 "$command_path" snapshot 2>/dev/null) || return 1
+	printf '%s\n' "$appearance_snapshot" |
+		grep -Fqx 'appearance-protocol	1	0'
+}
+
 emit_capability() {
 	section=$1
 	id=$2
@@ -259,7 +267,7 @@ discover() {
 	if ! provider_available dwm-settings-appearance; then
 		emit_capability appearance themes Themes unavailable read-only dwm-settings-appearance \
 			'Install the managed appearance provider'
-	elif run_bounded_probe dwm-settings-appearance snapshot; then
+	elif appearance_snapshot_valid; then
 		emit_capability appearance themes Themes available read-only dwm-settings-appearance \
 			'Versioned theme inventory and integration state are available'
 	else

--- a/scripts/dwm-settings-provider
+++ b/scripts/dwm-settings-provider
@@ -5,11 +5,6 @@ script_dir=$(
 	unset CDPATH
 	cd -- "$(dirname -- "$0")" && pwd
 )
-repo_dir=$(
-	unset CDPATH
-	cd -- "$script_dir/.." && pwd
-)
-
 usage() {
 	printf 'usage: %s discover\n' "$0" >&2
 }
@@ -261,13 +256,15 @@ discover() {
 			'Autostart entries are readable; install inotify-tools for live updates'
 	fi
 
-	themes_file=${XDG_CONFIG_HOME:-${HOME:-}/.config}/dwm-titus/themes.toml
-	if [ -r "$themes_file" ] || [ -r "$repo_dir/config/themes.toml" ]; then
-		emit_capability appearance themes Themes available user-session themes.toml \
-			'Theme state is available through the managed configuration'
+	if ! provider_available dwm-settings-appearance; then
+		emit_capability appearance themes Themes unavailable read-only dwm-settings-appearance \
+			'Install the managed appearance provider'
+	elif run_bounded_probe dwm-settings-appearance snapshot; then
+		emit_capability appearance themes Themes available read-only dwm-settings-appearance \
+			'Versioned theme inventory and integration state are available'
 	else
-		emit_capability appearance themes Themes unavailable user-session themes.toml \
-			'Install or restore the managed theme configuration'
+		emit_capability appearance themes Themes unavailable read-only dwm-settings-appearance \
+			'Restore a valid themes.toml configuration or inspect the appearance snapshot errors'
 	fi
 	emit_capability appearance accessibility Accessibility unsupported user-session x11 \
 		'Accessibility settings begin in Phase 5'

--- a/scripts/dwm-settings-provider
+++ b/scripts/dwm-settings-provider
@@ -62,7 +62,7 @@ run_bounded_probe() {
 appearance_snapshot_valid() {
 	command_path=$(provider_path dwm-settings-appearance) || return 1
 	timeout_path=$(command -v timeout 2>/dev/null) || return 1
-	appearance_snapshot=$("$timeout_path" 2 "$command_path" snapshot 2>/dev/null) || return 1
+	appearance_snapshot=$("$timeout_path" 5 "$command_path" snapshot 2>/dev/null) || return 1
 	printf '%s\n' "$appearance_snapshot" |
 		awk 'NR == 1 { valid = ($0 == "appearance-protocol	1	0"); exit }
 			END { exit(valid ? 0 : 1) }'

--- a/scripts/dwm-settings-provider
+++ b/scripts/dwm-settings-provider
@@ -64,7 +64,8 @@ appearance_snapshot_valid() {
 	timeout_path=$(command -v timeout 2>/dev/null) || return 1
 	appearance_snapshot=$("$timeout_path" 2 "$command_path" snapshot 2>/dev/null) || return 1
 	printf '%s\n' "$appearance_snapshot" |
-		grep -Fqx 'appearance-protocol	1	0'
+		awk 'NR == 1 { valid = ($0 == "appearance-protocol	1	0"); exit }
+			END { exit(valid ? 0 : 1) }'
 }
 
 emit_capability() {

--- a/scripts/dwm-settings-provider
+++ b/scripts/dwm-settings-provider
@@ -69,8 +69,7 @@ appearance_snapshot_valid() {
 			$1 == "provider" && $2 == "appearance" &&
 				($3 == "available" || $3 == "partial") && $4 == "read-only" { provider = 1 }
 			$1 == "source" && ($2 == "user" || $2 == "managed") && $3 != "" { source = 1 }
-			$1 == "active" && $2 != "" && $2 != "none" &&
-				$3 != "" && $3 != "none" &&
+			$1 == "active" && $2 != "" && $3 != "" &&
 				($4 == "selected" || $4 == "recovery") { active = 1 }
 			$1 == "theme" && NF >= 7 { theme = 1 }
 			END { exit(header && provider && source && active && theme ? 0 : 1) }

--- a/scripts/dwm-settings-provider
+++ b/scripts/dwm-settings-provider
@@ -64,8 +64,17 @@ appearance_snapshot_valid() {
 	timeout_path=$(command -v timeout 2>/dev/null) || return 1
 	appearance_snapshot=$("$timeout_path" 5 "$command_path" snapshot 2>/dev/null) || return 1
 	printf '%s\n' "$appearance_snapshot" |
-		awk 'NR == 1 { valid = ($0 == "appearance-protocol	1	0"); exit }
-			END { exit(valid ? 0 : 1) }'
+		awk -F '\t' '
+			NR == 1 { header = ($0 == "appearance-protocol\t1\t0"); next }
+			$1 == "provider" && $2 == "appearance" &&
+				($3 == "available" || $3 == "partial") && $4 == "read-only" { provider = 1 }
+			$1 == "source" && ($2 == "user" || $2 == "managed") && $3 != "" { source = 1 }
+			$1 == "active" && $2 != "" && $2 != "none" &&
+				$3 != "" && $3 != "none" &&
+				($4 == "selected" || $4 == "recovery") { active = 1 }
+			$1 == "theme" && NF >= 7 { theme = 1 }
+			END { exit(header && provider && source && active && theme ? 0 : 1) }
+		'
 }
 
 emit_capability() {

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -117,6 +117,33 @@ installed_managed=$(PATH=$bin_dir XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$da
 	DWM_APPEARANCE_DATA_DIRS=$data_root "$helper" snapshot)
 grep -Fqx $'source\tmanaged\t'"$data_root/dwm-titus/config/themes.toml" <<<"$installed_managed"
 
+mkdir "$config_home/dwm-titus/themes.toml"
+set +e
+blocked_user=$(snapshot)
+blocked_user_status=$?
+set -e
+[[ $blocked_user_status -eq 3 ]]
+grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory and integration state' \
+	<<<"$blocked_user"
+grep -Fqx $'source\tuser\t'"$config_home/dwm-titus/themes.toml" <<<"$blocked_user"
+grep -Fqx $'active\tnone\tnone\tunresolved' <<<"$blocked_user"
+grep -Fq $'error\tsource\tunreadable\tUser theme file is not a readable regular file: ' \
+	<<<"$blocked_user"
+rmdir "$config_home/dwm-titus/themes.toml"
+
+ln -s "$work/missing-user-theme.toml" "$config_home/dwm-titus/themes.toml"
+set +e
+dangling_user=$(snapshot)
+dangling_user_status=$?
+set -e
+[[ $dangling_user_status -eq 3 ]]
+grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory and integration state' \
+	<<<"$dangling_user"
+grep -Fqx $'source\tuser\t'"$config_home/dwm-titus/themes.toml" <<<"$dangling_user"
+grep -Fq $'error\tsource\tunreadable\tUser theme file is not a readable regular file: ' \
+	<<<"$dangling_user"
+rm -f "$config_home/dwm-titus/themes.toml"
+
 custom_theme=-custom_theme_with_a_name_that_is_longer_than_sixty_four_characters_1234567890
 cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
 sed -i "0,/theme = \"nord\"/s//theme = \"$custom_theme\"/" "$config_home/dwm-titus/themes.toml"
@@ -124,6 +151,16 @@ sed -i "0,/^\[theme\.nord\]$/s//[theme.$custom_theme]/" "$config_home/dwm-titus/
 custom=$(snapshot)
 grep -Fqx $'active\t'"$custom_theme"$'\t'"$custom_theme"$'\tselected' <<<"$custom"
 grep -Fq $'theme\t'"$custom_theme"$'\tselected\tvalid\ttrue\tNordic' <<<"$custom"
+
+printf -v overlong_theme '%*s' 506 ''
+overlong_theme=${overlong_theme// /a}
+cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
+sed -i "0,/theme = \"nord\"/s//theme = \"$overlong_theme\"/" "$config_home/dwm-titus/themes.toml"
+sed -i "0,/^\[theme\.nord\]$/s//[theme.$overlong_theme]/" "$config_home/dwm-titus/themes.toml"
+overlong=$(snapshot)
+grep -Fqx $'active\t'"$overlong_theme"$'\tdracula\trecovery' <<<"$overlong"
+grep -Fq $'error\tparser\tinvalid-theme-name\tTheme name is not a supported bare identifier at line ' \
+	<<<"$overlong"
 
 cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
 sed -i '0,/theme = "nord"/s//theme = "dracula"/' "$config_home/dwm-titus/themes.toml"
@@ -162,6 +199,23 @@ sed -i '0,/normfgcolor     = "#D8DEE9"/s//normfgcolor     = "not-a-color"/' \
 invalid_color=$(snapshot)
 grep -Fqx $'active\tnord\tdracula\trecovery' <<<"$invalid_color"
 grep -Fqx $'error\ttheme:nord\tinvalid-color\tTheme key '\''normfgcolor'\'' is not a #RRGGBB color' <<<"$invalid_color"
+
+{
+	printf '[ignored]\n'
+	for ((entry_index = 0; entry_index < 512; entry_index++)); do
+		printf 'extra-%s = 1\n' "$entry_index"
+	done
+	cat "$work/managed-themes.toml"
+} >"$config_home/dwm-titus/themes.toml"
+set +e
+alternate_key_limit=$(snapshot)
+alternate_key_status=$?
+set -e
+[[ $alternate_key_status -eq 3 ]]
+grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory and integration state' \
+	<<<"$alternate_key_limit"
+grep -Fqx $'error\tparser\tentry-limit\tTheme configuration exceeds the runtime parser limit of 512 entries' \
+	<<<"$alternate_key_limit"
 
 nord_block=$(awk '
 	/^\[theme\.nord\]$/ { capture = 1; next }

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -71,9 +71,14 @@ cp "$config_home/alacritty/active-theme.toml" "$work/alacritty-valid.toml"
 cp "$config_home/kitty/active-theme.conf" "$work/kitty-valid.conf"
 printf 'import = ["%s"]\n' "$config_home/alacritty/active-theme.toml" \
 	>"$config_home/alacritty/alacritty.toml"
-printf 'export QT_QPA_PLATFORMTHEME=qt6ct\n' >"$config_home/dwm-titus/theme-env.sh"
-printf '[Settings]\ngtk-theme-name=Nordic\n' >"$config_home/gtk-3.0/settings.ini"
-printf '[Settings]\ngtk-theme-name=Nordic\n' >"$config_home/gtk-4.0/settings.ini"
+printf 'export QT_QPA_PLATFORMTHEME=qt6ct\nexport XCURSOR_THEME=Capitaine-Cursors-White\n' \
+	>"$config_home/dwm-titus/theme-env.sh"
+printf 'Xcursor.theme: Capitaine-Cursors-White\n' \
+	>"$config_home/dwm-titus/cursor.Xresources"
+printf '[Settings]\ngtk-theme-name=Nordic\ngtk-cursor-theme-name=Capitaine-Cursors-White\n' \
+	>"$config_home/gtk-3.0/settings.ini"
+printf '[Settings]\ngtk-theme-name=Nordic\ngtk-cursor-theme-name=Capitaine-Cursors-White\n' \
+	>"$config_home/gtk-4.0/settings.ini"
 printf 'include active-theme.conf\n' >"$config_home/kitty/kitty.conf"
 
 for command_name in awk bash dirname grep stat tr; do
@@ -84,7 +89,7 @@ printf '#!/bin/sh\nexit 0\n' >"$bin_dir/picom"
 chmod +x "$bin_dir/qt6ct" "$bin_dir/picom"
 
 snapshot() {
-	PATH=$bin_dir GTK_THEME='' XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
+	PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
 		DWM_APPEARANCE_DATA_DIRS=$data_root \
 		"$helper" snapshot
 }
@@ -107,7 +112,7 @@ grep -Fqx $'color\taccent\t#81A1C1\tselbordercolor' <<<"$output"
 grep -Fqx $'color\tdanger\t#BF616A\tterm_color1' <<<"$output"
 grep -Fqx $'integration\tgtk\tavailable\tNordic\tRequested GTK theme is installed and applied' <<<"$output"
 grep -Fqx $'integration\tqt\tavailable\tqt6ct\tQt applications use the supported theme backend' <<<"$output"
-grep -Fqx $'integration\tcursor\tavailable\tCapitaine-Cursors-White\tManaged cursor theme is installed' <<<"$output"
+grep -Fqx $'integration\tcursor\tavailable\tCapitaine-Cursors-White\tManaged cursor theme is installed and applied' <<<"$output"
 grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' <<<"$output"
 grep -Fqx $'integration\tkitty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' <<<"$output"
 grep -Fqx $'integration\tcompositor\tpartial\tpicom\tPicom is available but has no shared theme mutation contract' <<<"$output"
@@ -128,6 +133,16 @@ mv "$work/theme-env.sh" "$config_home/dwm-titus/theme-env.sh"
 gtk3_qt=$(QT_QPA_PLATFORMTHEME=gtk3 snapshot)
 grep -Fqx $'integration\tqt\tavailable\tgtk3\tQt applications use the supported theme backend' \
 	<<<"$gtk3_qt"
+
+sed -i 's/XCURSOR_THEME=Capitaine-Cursors-White/XCURSOR_THEME=Capitaine-Cursors/' \
+	"$config_home/dwm-titus/theme-env.sh"
+stale_cursor=$(snapshot)
+grep -Fqx $'integration\tcursor\tpartial\tCapitaine-Cursors-White\tManaged cursor theme is installed but not applied' \
+	<<<"$stale_cursor"
+grep -Fqx $'error\tcursor\tstale-theme\tApplied cursor settings do not match '\''Capitaine-Cursors-White'\''' \
+	<<<"$stale_cursor"
+sed -i 's/XCURSOR_THEME=Capitaine-Cursors/XCURSOR_THEME=Capitaine-Cursors-White/' \
+	"$config_home/dwm-titus/theme-env.sh"
 
 printf 'import = ["/wrong/active-theme.toml"]\n' >"$config_home/alacritty/alacritty.toml"
 unimported_alacritty=$(snapshot)
@@ -466,7 +481,10 @@ grep -Fqx $'provider\tappearance\tpartial\tread-only\tShared theme inventory and
 grep -Fqx $'active\tt19\tt0\trecovery' <<<"$entry_limited"
 grep -Fqx $'error\tparser\tentry-limit\tTheme configuration exceeds the runtime parser limit of 512 entries' \
 	<<<"$entry_limited"
-grep -Fq $'theme\tt19\tselected\tinvalid\t' <<<"$entry_limited"
+if grep -Fq $'theme\tt19\t' <<<"$entry_limited"; then
+	printf 'Theme defined after the runtime entry limit was inventoried\n' >&2
+	exit 1
+fi
 
 {
 	printf '[active]\ntheme = "t0"\n'
@@ -494,6 +512,20 @@ timeout 5 env PATH="$bin_dir" GTK_THEME='' XDG_CONFIG_HOME="$config_home" \
 	XDG_DATA_HOME="$data_root" DWM_APPEARANCE_DATA_DIRS="$data_root" \
 	"$helper" snapshot >"$work/comment-heavy.out"
 grep -Fqx $'active\tnord\tnord\tselected' "$work/comment-heavy.out"
+
+{
+	cat "$work/managed-themes.toml"
+	for ((scalar_index = 0; scalar_index < 68000; scalar_index++)); do
+		printf 'extra%s = 1\n' "$scalar_index"
+	done
+} >"$config_home/dwm-titus/themes.toml"
+timeout 5 env PATH="$bin_dir" GTK_THEME='' XCURSOR_THEME='' \
+	XDG_CONFIG_HOME="$config_home" XDG_DATA_HOME="$data_root" \
+	DWM_APPEARANCE_DATA_DIRS="$data_root" "$helper" snapshot \
+	>"$work/scalar-heavy.out"
+grep -Fqx $'active\tnord\tnord\tselected' "$work/scalar-heavy.out"
+grep -Fqx $'error\tparser\tentry-limit\tTheme configuration exceeds the runtime parser limit of 512 entries' \
+	"$work/scalar-heavy.out"
 
 cat >"$config_home/dwm-titus/themes.toml" <<'EOF'
 [colors]

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -484,6 +484,17 @@ grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory
 	"$work/many-incomplete.out"
 [[ $(grep -c $'^error\ttheme:' "$work/many-incomplete.out") -eq 100 ]]
 
+{
+	for ((comment_index = 0; comment_index < 30000; comment_index++)); do
+		printf '# comment\n'
+	done
+	cat "$work/managed-themes.toml"
+} >"$config_home/dwm-titus/themes.toml"
+timeout 5 env PATH="$bin_dir" GTK_THEME='' XDG_CONFIG_HOME="$config_home" \
+	XDG_DATA_HOME="$data_root" DWM_APPEARANCE_DATA_DIRS="$data_root" \
+	"$helper" snapshot >"$work/comment-heavy.out"
+grep -Fqx $'active\tnord\tnord\tselected' "$work/comment-heavy.out"
+
 cat >"$config_home/dwm-titus/themes.toml" <<'EOF'
 [colors]
 normfgcolor = "#D8DEE9"

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -68,6 +68,9 @@ color15 ${fixture_color[term_color15]}
 EOF
 cp "$config_home/alacritty/active-theme.toml" "$work/alacritty-valid.toml"
 cp "$config_home/kitty/active-theme.conf" "$work/kitty-valid.conf"
+printf 'import = ["%s"]\n' "$config_home/alacritty/active-theme.toml" \
+	>"$config_home/alacritty/alacritty.toml"
+printf 'export QT_QPA_PLATFORMTHEME=qt6ct\n' >"$config_home/dwm-titus/theme-env.sh"
 
 for command_name in awk bash dirname grep stat tr; do
 	ln -s "$(command -v "$command_name")" "$bin_dir/$command_name"
@@ -109,12 +112,27 @@ grep -Fqx $'error\tcompositor\tunsupported\tPicom theme mutation is not implemen
 no_qt_bin=$work/no-qt-bin
 cp -a "$bin_dir" "$no_qt_bin"
 rm -f "$no_qt_bin/qt6ct"
+mv "$config_home/dwm-titus/theme-env.sh" "$work/theme-env.sh"
 no_qt=$(PATH=$no_qt_bin QT_QPA_PLATFORMTHEME='' XDG_CONFIG_HOME=$config_home \
 	XDG_DATA_HOME=$data_root DWM_APPEARANCE_DATA_DIRS=$data_root \
 	"$helper" snapshot)
 grep -Fqx $'integration\tqt\tunavailable\tnone\tNo supported Qt theme backend is active' <<<"$no_qt"
-grep -Fqx $'error\tqt\tmissing-backend\tInstall qt6ct or qt5ct, or activate the Qt GTK3 platform theme' \
+grep -Fqx $'error\tqt\tmissing-backend\tNo applied Qt theme backend is recorded' \
 	<<<"$no_qt"
+mv "$work/theme-env.sh" "$config_home/dwm-titus/theme-env.sh"
+
+gtk3_qt=$(QT_QPA_PLATFORMTHEME=gtk3 snapshot)
+grep -Fqx $'integration\tqt\tavailable\tgtk3\tQt applications use the supported theme backend' \
+	<<<"$gtk3_qt"
+
+printf 'import = ["/wrong/active-theme.toml"]\n' >"$config_home/alacritty/alacritty.toml"
+unimported_alacritty=$(snapshot)
+grep -Fqx $'integration\talacritty\tpartial\tconfiguration\tGenerated theme is not imported by the terminal configuration' \
+	<<<"$unimported_alacritty"
+grep -Fqx $'error\talacritty\tnot-imported\tAlacritty configuration does not import the generated active theme' \
+	<<<"$unimported_alacritty"
+printf 'import = ["%s"]\n' "$config_home/alacritty/active-theme.toml" \
+	>"$config_home/alacritty/alacritty.toml"
 
 sed -i "s|${fixture_color[term_bg]}|__DWM_COLOR_SWAP__|; \
 	s|${fixture_color[term_fg]}|${fixture_color[term_bg]}|; \
@@ -414,7 +432,7 @@ grep -Fq $'theme\tt19\tselected\tinvalid\t' <<<"$entry_limited"
 	done
 } >"$config_home/dwm-titus/themes.toml"
 set +e
-timeout 2 env PATH="$bin_dir" XDG_CONFIG_HOME="$config_home" XDG_DATA_HOME="$data_root" \
+timeout 5 env PATH="$bin_dir" XDG_CONFIG_HOME="$config_home" XDG_DATA_HOME="$data_root" \
 	DWM_APPEARANCE_DATA_DIRS="$data_root" "$helper" snapshot >"$work/many-incomplete.out"
 many_status=$?
 set -e
@@ -422,6 +440,40 @@ set -e
 grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory and integration state' \
 	"$work/many-incomplete.out"
 [[ $(grep -c $'^error\ttheme:' "$work/many-incomplete.out") -eq 100 ]]
+
+cat >"$config_home/dwm-titus/themes.toml" <<'EOF'
+[colors]
+normfgcolor = "#D8DEE9"
+normbgcolor = "#2E3440"
+normbordercolor = "#4C566A"
+selfgcolor = "#ECEFF4"
+selbgcolor = "#5E81AC"
+selbordercolor = "#81A1C1"
+EOF
+legacy=$(snapshot)
+grep -Fqx $'provider\tappearance\tpartial\tread-only\tShared theme inventory and integration state' \
+	<<<"$legacy"
+grep -Fqx $'active\tlegacy\tlegacy\tselected' <<<"$legacy"
+grep -Fqx $'theme\tlegacy\tselected\tvalid\ttrue\tautomatic\tTheme record is complete' \
+	<<<"$legacy"
+grep -Fqx $'color\tbackground\t#2E3440\tterm_bg' <<<"$legacy"
+grep -Fqx $'error\tparser\tlegacy-format\tLegacy [colors] palette is active; named themes are recommended' \
+	<<<"$legacy"
+
+cat >"$config_home/dwm-titus/themes.toml" <<'EOF'
+[active]
+theme = "missing"
+[colors]
+normbgcolor = "#2E3440"
+EOF
+set +e
+legacy_not_recovery=$(snapshot)
+legacy_not_recovery_status=$?
+set -e
+[[ $legacy_not_recovery_status -eq 3 ]]
+grep -Fqx $'active\tmissing\tnone\tunresolved' <<<"$legacy_not_recovery"
+grep -Fqx $'error\tactive\tno-valid-theme\tNo complete theme is available for recovery' \
+	<<<"$legacy_not_recovery"
 
 mkdir -p "$work/fallback-home/.config/dwm-titus"
 cp "$work/managed-themes.toml" "$work/fallback-home/.config/dwm-titus/themes.toml"

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -85,6 +85,49 @@ grep -Fq $'error\tparser\tmalformed-section\tMalformed theme section header at l
 	<<<"$truncated_header"
 cp "$repo/config/themes.toml" "$config_home/dwm-titus/themes.toml"
 
+{
+	printf '[ignored]\nextra = [{x=1}, {x=2}]\n'
+	cat "$repo/config/themes.toml"
+} >"$config_home/dwm-titus/themes.toml"
+set +e
+inline_table=$(snapshot)
+inline_table_status=$?
+set -e
+[[ $inline_table_status -eq 3 ]]
+grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory and integration state' \
+	<<<"$inline_table"
+grep -Fq $'error\tparser\tunsupported-complex-value\tArrays and inline tables are outside the appearance snapshot grammar at line ' \
+	<<<"$inline_table"
+
+{
+	printf '[ignored]\nextra = {x=1}\n'
+	cat "$repo/config/themes.toml"
+} >"$config_home/dwm-titus/themes.toml"
+set +e
+direct_inline_table=$(snapshot)
+direct_inline_table_status=$?
+set -e
+[[ $direct_inline_table_status -eq 3 ]]
+grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory and integration state' \
+	<<<"$direct_inline_table"
+grep -Fq $'error\tparser\tunsupported-complex-value\tArrays and inline tables are outside the appearance snapshot grammar at line ' \
+	<<<"$direct_inline_table"
+
+{
+	printf '[ignored]\nextra = [\n'
+	cat "$repo/config/themes.toml"
+} >"$config_home/dwm-titus/themes.toml"
+set +e
+unterminated_array=$(snapshot)
+unterminated_array_status=$?
+set -e
+[[ $unterminated_array_status -eq 3 ]]
+grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory and integration state' \
+	<<<"$unterminated_array"
+grep -Fq $'error\tparser\tunsupported-complex-value\tArrays and inline tables are outside the appearance snapshot grammar at line ' \
+	<<<"$unterminated_array"
+cp "$repo/config/themes.toml" "$config_home/dwm-titus/themes.toml"
+
 printf '\n[theme.@unsafe]\nterm_bg = "#000000"\n' >>"$config_home/dwm-titus/themes.toml"
 unsafe_name=$(snapshot)
 grep -Fqx $'provider\tappearance\tpartial\tread-only\tShared theme inventory and integration state' \
@@ -152,6 +195,13 @@ custom=$(snapshot)
 grep -Fqx $'active\t'"$custom_theme"$'\t'"$custom_theme"$'\tselected' <<<"$custom"
 grep -Fq $'theme\t'"$custom_theme"$'\tselected\tvalid\ttrue\tNordic' <<<"$custom"
 
+cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
+sed -i '0,/theme = "nord"/s//theme = 123/' "$config_home/dwm-titus/themes.toml"
+numeric_active=$(snapshot)
+grep -Fqx $'active\tnone\tnord\trecovery' <<<"$numeric_active"
+grep -Fq $'error\tactive\tinvalid-type\tActive theme must resolve to a TOML string at line ' \
+	<<<"$numeric_active"
+
 printf -v overlong_theme '%*s' 506 ''
 overlong_theme=${overlong_theme// /a}
 cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
@@ -200,6 +250,15 @@ invalid_color=$(snapshot)
 grep -Fqx $'active\tnord\tdracula\trecovery' <<<"$invalid_color"
 grep -Fqx $'error\ttheme:nord\tinvalid-color\tTheme key '\''normfgcolor'\'' is not a #RRGGBB color' <<<"$invalid_color"
 
+cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
+sed -i $'0,/dark_mode       = true/s//dark_mode       = "bogus\tvalue"/' \
+	"$config_home/dwm-titus/themes.toml"
+invalid_dark=$(snapshot)
+grep -Fqx $'theme\tnord\tselected\tinvalid\tbogus value\tNordic\tTheme record is duplicate, malformed, or incomplete' \
+	<<<"$invalid_dark"
+grep -Fqx $'error\ttheme:nord\tinvalid-dark-mode\tTheme dark_mode must be true or false' \
+	<<<"$invalid_dark"
+
 {
 	printf '[ignored]\n'
 	for ((entry_index = 0; entry_index < 512; entry_index++)); do
@@ -222,6 +281,18 @@ nord_block=$(awk '
 	/^\[theme\.dracula\]$/ { exit }
 	capture && /^[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=/ { print }
 ' "$repo/config/themes.toml")
+{
+	printf '[active]\ntheme = "chosen"\n'
+	for ((theme_index = 0; theme_index < 128; theme_index++)); do
+		printf '[theme.sparse%s]\n' "$theme_index"
+	done
+	printf '[theme.chosen]\n%s\n' "$nord_block"
+} >"$config_home/dwm-titus/themes.toml"
+selected_after_cap=$(snapshot)
+grep -Fqx $'active\tchosen\tchosen\tselected' <<<"$selected_after_cap"
+grep -Fqx $'theme\tchosen\tselected\tvalid\ttrue\tNordic\tTheme record is complete' \
+	<<<"$selected_after_cap"
+
 {
 	printf '[active]\ntheme = "t19"\n'
 	for ((theme_index = 0; theme_index < 20; theme_index++)); do

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+helper=$repo/scripts/dwm-settings-appearance
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+config_home=$work/config
+data_root=$work/data
+bin_dir=$work/bin
+mkdir -p "$config_home/dwm-titus" "$config_home/alacritty" "$config_home/kitty" \
+	"$data_root/themes/Nordic/gtk-3.0" "$data_root/icons/Capitaine-Cursors-White" "$bin_dir"
+cp "$repo/config/themes.toml" "$config_home/dwm-titus/themes.toml"
+: >"$config_home/alacritty/active-theme.toml"
+: >"$config_home/kitty/active-theme.conf"
+
+for command_name in bash dirname stat tr; do
+	ln -s "$(command -v "$command_name")" "$bin_dir/$command_name"
+done
+printf '#!/bin/sh\nexit 0\n' >"$bin_dir/qt6ct"
+printf '#!/bin/sh\nexit 0\n' >"$bin_dir/picom"
+chmod +x "$bin_dir/qt6ct" "$bin_dir/picom"
+
+snapshot() {
+	PATH=$bin_dir XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
+		DWM_APPEARANCE_DATA_DIRS=$data_root \
+		"$helper" snapshot
+}
+
+before_hash=$(sha256sum "$config_home/dwm-titus/themes.toml")
+before_mode=$(stat -c %a "$config_home/dwm-titus/themes.toml")
+output=$(snapshot)
+after_hash=$(sha256sum "$config_home/dwm-titus/themes.toml")
+after_mode=$(stat -c %a "$config_home/dwm-titus/themes.toml")
+[[ $before_hash == "$after_hash" && $before_mode == "$after_mode" ]]
+
+grep -Fqx $'appearance-protocol\t1\t0' <<<"$output"
+grep -Fqx $'provider\tappearance\tavailable\tread-only\tShared theme inventory and integration state' <<<"$output"
+grep -Fqx $'source\tuser\t'"$config_home/dwm-titus/themes.toml" <<<"$output"
+grep -Fqx $'active\tnord\tnord\tselected' <<<"$output"
+grep -Fqx $'theme\tnord\tselected\tvalid\ttrue\tNordic\tTheme record is complete' <<<"$output"
+[[ $(grep -c $'^theme\t' <<<"$output") -eq 15 ]]
+grep -Fqx $'color\tbackground\t#2E3440\tterm_bg' <<<"$output"
+grep -Fqx $'color\taccent\t#81A1C1\tselbordercolor' <<<"$output"
+grep -Fqx $'color\tdanger\t#BF616A\tterm_color1' <<<"$output"
+grep -Fqx $'integration\tgtk\tavailable\tNordic\tRequested GTK theme is installed' <<<"$output"
+grep -Fqx $'integration\tqt\tavailable\tqt6ct\tQt applications use the supported theme backend' <<<"$output"
+grep -Fqx $'integration\tcursor\tavailable\tCapitaine-Cursors-White\tManaged cursor theme is installed' <<<"$output"
+grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme is present' <<<"$output"
+grep -Fqx $'integration\tcompositor\tpartial\tpicom\tPicom is available but has no shared theme mutation contract' <<<"$output"
+grep -Fqx $'error\tcompositor\tunsupported\tPicom theme mutation is not implemented' <<<"$output"
+
+sed -i 's/^\[active\]$/[active] # selected theme/' "$config_home/dwm-titus/themes.toml"
+sed -i 's/^\[theme\.nord\]$/[theme.nord] # default theme/' "$config_home/dwm-titus/themes.toml"
+commented_headers=$(snapshot)
+grep -Fqx $'provider\tappearance\tpartial\tread-only\tShared theme inventory and integration state' \
+	<<<"$commented_headers"
+grep -Fqx $'active\tnone\tdracula\trecovery' <<<"$commented_headers"
+[[ $(grep -c $'^error\tparser\tmalformed-section\t' <<<"$commented_headers") -eq 2 ]]
+if grep -Fq $'theme\tnord\t' <<<"$commented_headers"; then
+	printf 'Commented section header was reported as live-compatible\n' >&2
+	exit 1
+fi
+cp "$repo/config/themes.toml" "$config_home/dwm-titus/themes.toml"
+
+sed -i 's/^\[theme\.dracula\]$/[theme.dracula] trailing/' "$config_home/dwm-titus/themes.toml"
+malformed_header=$(snapshot)
+grep -Fqx $'provider\tappearance\tpartial\tread-only\tShared theme inventory and integration state' \
+	<<<"$malformed_header"
+grep -Fq $'error\tparser\tmalformed-section\tMalformed theme section header at line ' \
+	<<<"$malformed_header"
+if grep -Fq $'theme\tdracula\t' <<<"$malformed_header"; then
+	printf 'Malformed theme section was inventoried\n' >&2
+	exit 1
+fi
+
+cp "$repo/config/themes.toml" "$config_home/dwm-titus/themes.toml"
+sed -i 's/^\[active\]$/[active/' "$config_home/dwm-titus/themes.toml"
+truncated_header=$(snapshot)
+grep -Fqx $'provider\tappearance\tpartial\tread-only\tShared theme inventory and integration state' \
+	<<<"$truncated_header"
+grep -Fqx $'active\tnone\tnord\trecovery' <<<"$truncated_header"
+grep -Fq $'error\tparser\tmalformed-section\tMalformed theme section header at line ' \
+	<<<"$truncated_header"
+cp "$repo/config/themes.toml" "$config_home/dwm-titus/themes.toml"
+
+printf '\n[theme.@unsafe]\nterm_bg = "#000000"\n' >>"$config_home/dwm-titus/themes.toml"
+unsafe_name=$(snapshot)
+grep -Fqx $'provider\tappearance\tpartial\tread-only\tShared theme inventory and integration state' \
+	<<<"$unsafe_name"
+grep -Fq $'error\tparser\tinvalid-theme-name\tTheme name is not a supported bare identifier at line ' \
+	<<<"$unsafe_name"
+if grep -Fq $'theme\t@unsafe\t' <<<"$unsafe_name"; then
+	printf 'Unsafe theme identifier was inventoried\n' >&2
+	exit 1
+fi
+cp "$repo/config/themes.toml" "$config_home/dwm-titus/themes.toml"
+
+rmdir "$data_root/themes/Nordic/gtk-3.0"
+stale_gtk=$(snapshot)
+grep -Fqx $'integration\tgtk\tpartial\tNordic\tRequested GTK theme is missing; apply falls back to Adwaita-dark' <<<"$stale_gtk"
+grep -Fqx $'error\tgtk\tmissing-theme\tGTK theme '\''Nordic'\'' is not installed' <<<"$stale_gtk"
+mkdir "$data_root/themes/Nordic/gtk-3.0"
+
+mv "$config_home/dwm-titus/themes.toml" "$work/managed-themes.toml"
+managed=$(PATH=$bin_dir XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
+	DWM_APPEARANCE_DATA_DIRS=$data_root \
+	DWM_APPEARANCE_MANAGED_THEMES_FILE="$work/managed-themes.toml" \
+	"$helper" snapshot)
+grep -Fqx $'source\tmanaged\t'"$work/managed-themes.toml" <<<"$managed"
+grep -Fqx $'active\tnord\tnord\tselected' <<<"$managed"
+
+mkdir -p "$data_root/dwm-titus/config"
+cp "$work/managed-themes.toml" "$data_root/dwm-titus/config/themes.toml"
+installed_managed=$(PATH=$bin_dir XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
+	DWM_APPEARANCE_DATA_DIRS=$data_root "$helper" snapshot)
+grep -Fqx $'source\tmanaged\t'"$data_root/dwm-titus/config/themes.toml" <<<"$installed_managed"
+
+custom_theme=-custom_theme_with_a_name_that_is_longer_than_sixty_four_characters_1234567890
+cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
+sed -i "0,/theme = \"nord\"/s//theme = \"$custom_theme\"/" "$config_home/dwm-titus/themes.toml"
+sed -i "0,/^\[theme\.nord\]$/s//[theme.$custom_theme]/" "$config_home/dwm-titus/themes.toml"
+custom=$(snapshot)
+grep -Fqx $'active\t'"$custom_theme"$'\t'"$custom_theme"$'\tselected' <<<"$custom"
+grep -Fq $'theme\t'"$custom_theme"$'\tselected\tvalid\ttrue\tNordic' <<<"$custom"
+
+cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
+sed -i '0,/theme = "nord"/s//theme = "dracula"/' "$config_home/dwm-titus/themes.toml"
+adwaita=$(snapshot)
+grep -Fqx $'integration\tgtk\tavailable\tAdwaita-dark\tRequested GTK theme is installed' <<<"$adwaita"
+if grep -Fq $'error\tgtk\tmissing-theme' <<<"$adwaita"; then
+	printf 'Built-in Adwaita fallback was reported missing\n' >&2
+	exit 1
+fi
+
+cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
+sed -i '0,/theme = "nord"/s//theme = "missing"/' "$config_home/dwm-titus/themes.toml"
+unknown=$(snapshot)
+grep -Fqx $'provider\tappearance\tpartial\tread-only\tShared theme inventory and integration state' <<<"$unknown"
+grep -Fqx $'active\tmissing\tnord\trecovery' <<<"$unknown"
+grep -Fqx $'error\tactive\tunknown\tActive theme '\''missing'\'' is not defined' <<<"$unknown"
+
+cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
+printf '\n[theme.nord]\nterm_bg = "#000000"\n' >>"$config_home/dwm-titus/themes.toml"
+duplicate=$(snapshot)
+grep -Fqx $'active\tnord\tdracula\trecovery' <<<"$duplicate"
+grep -Fq $'error\ttheme:nord\tduplicate\tDuplicate theme section at line ' <<<"$duplicate"
+grep -Fqx $'theme\tnord\tselected\tinvalid\ttrue\tNordic\tTheme record is duplicate, malformed, or incomplete' <<<"$duplicate"
+
+cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
+sed -i '0,/theme = "nord"/s//theme = "broken"/' "$config_home/dwm-titus/themes.toml"
+printf '\n[theme.broken]\ndark_mode = true\n' >>"$config_home/dwm-titus/themes.toml"
+incomplete=$(snapshot)
+grep -Fqx $'active\tbroken\tnord\trecovery' <<<"$incomplete"
+grep -Fqx $'error\ttheme:broken\tmissing-key\tTheme is missing 25 required keys; first missing key is '\''normfgcolor'\''' <<<"$incomplete"
+grep -Fqx $'error\tactive\tinvalid\tActive theme '\''broken'\'' is invalid or incomplete' <<<"$incomplete"
+
+cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
+sed -i '0,/normfgcolor     = "#D8DEE9"/s//normfgcolor     = "not-a-color"/' \
+	"$config_home/dwm-titus/themes.toml"
+invalid_color=$(snapshot)
+grep -Fqx $'active\tnord\tdracula\trecovery' <<<"$invalid_color"
+grep -Fqx $'error\ttheme:nord\tinvalid-color\tTheme key '\''normfgcolor'\'' is not a #RRGGBB color' <<<"$invalid_color"
+
+nord_block=$(awk '
+	/^\[theme\.nord\]$/ { capture = 1; next }
+	/^\[theme\.dracula\]$/ { exit }
+	capture && /^[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=/ { print }
+' "$repo/config/themes.toml")
+{
+	printf '[active]\ntheme = "t19"\n'
+	for ((theme_index = 0; theme_index < 20; theme_index++)); do
+		printf '[theme.t%s]\n%s\n' "$theme_index" "$nord_block"
+	done
+} >"$config_home/dwm-titus/themes.toml"
+entry_limited=$(snapshot)
+grep -Fqx $'provider\tappearance\tpartial\tread-only\tShared theme inventory and integration state' \
+	<<<"$entry_limited"
+grep -Fqx $'active\tt19\tt0\trecovery' <<<"$entry_limited"
+grep -Fqx $'error\tparser\tentry-limit\tTheme configuration exceeds the runtime parser limit of 512 entries' \
+	<<<"$entry_limited"
+grep -Fq $'theme\tt19\tselected\tinvalid\t' <<<"$entry_limited"
+
+{
+	printf '[active]\ntheme = "t0"\n'
+	for ((theme_index = 0; theme_index < 100; theme_index++)); do
+		printf '[theme.t%s]\ndark_mode = true\n' "$theme_index"
+	done
+} >"$config_home/dwm-titus/themes.toml"
+set +e
+timeout 2 env PATH="$bin_dir" XDG_CONFIG_HOME="$config_home" XDG_DATA_HOME="$data_root" \
+	DWM_APPEARANCE_DATA_DIRS="$data_root" "$helper" snapshot >"$work/many-incomplete.out"
+many_status=$?
+set -e
+[[ $many_status -eq 3 ]]
+grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory and integration state' \
+	"$work/many-incomplete.out"
+[[ $(grep -c $'^error\ttheme:' "$work/many-incomplete.out") -eq 100 ]]
+
+rm -f "$config_home/dwm-titus/themes.toml" "$work/missing-managed.toml"
+set +e
+missing=$(PATH=$bin_dir XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
+	DWM_APPEARANCE_DATA_DIRS=$data_root \
+	DWM_APPEARANCE_MANAGED_THEMES_FILE="$work/missing-managed.toml" \
+	"$helper" snapshot)
+missing_status=$?
+set -e
+[[ $missing_status -eq 3 ]]
+grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory and integration state' <<<"$missing"
+grep -Fqx $'source\tnone\tunavailable' <<<"$missing"
+grep -Fqx $'active\tnone\tnone\tunresolved' <<<"$missing"
+grep -Fqx $'error\tsource\tmissing\tNo readable user or managed themes.toml file is available' <<<"$missing"
+
+if "$helper" invalid 2>"$work/usage.err"; then
+	printf 'Unknown appearance action unexpectedly succeeded\n' >&2
+	exit 1
+fi
+grep -Fq 'usage:' "$work/usage.err"
+
+printf 'Appearance provider contract: PASS\n'

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -88,7 +88,9 @@ for command_name in awk bash dirname grep stat tr; do
 done
 printf '#!/bin/sh\nexit 0\n' >"$bin_dir/qt6ct"
 printf '#!/bin/sh\nexit 0\n' >"$bin_dir/picom"
-chmod +x "$bin_dir/qt6ct" "$bin_dir/picom"
+printf '#!/bin/sh\nexit 0\n' >"$bin_dir/alacritty"
+printf '#!/bin/sh\nexit 0\n' >"$bin_dir/kitty"
+chmod +x "$bin_dir/qt6ct" "$bin_dir/picom" "$bin_dir/alacritty" "$bin_dir/kitty"
 
 hash_config_home=$work/config#hash
 cp -a "$config_home" "$hash_config_home"
@@ -130,6 +132,42 @@ grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal 
 grep -Fqx $'integration\tkitty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' <<<"$output"
 grep -Fqx $'integration\tcompositor\tpartial\tpicom\tPicom is available but has no shared theme mutation contract' <<<"$output"
 grep -Fqx $'error\tcompositor\tunsupported\tPicom theme mutation is not implemented' <<<"$output"
+
+no_kitty_bin=$work/no-kitty-bin
+cp -a "$bin_dir" "$no_kitty_bin"
+rm -f "$no_kitty_bin/kitty"
+no_kitty=$(PATH=$no_kitty_bin GTK_THEME='' XCURSOR_THEME='' \
+	XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
+	DWM_APPEARANCE_DATA_DIRS=$data_root "$helper" snapshot)
+grep -Fqx $'integration\tkitty\tunavailable\tmissing-application\tTerminal application is not installed' \
+	<<<"$no_kitty"
+grep -Fqx $'error\tkitty\tmissing-application\tTerminal application is not installed' \
+	<<<"$no_kitty"
+
+cp "$config_home/dwm-titus/themes.toml" "$work/replacement-themes.toml"
+sed -i '0,/theme = "nord"/s//theme = "dracula"/' "$work/replacement-themes.toml"
+rm -f "$bin_dir/awk"
+cat >"$bin_dir/awk" <<'EOF'
+#!/bin/sh
+if [ ! -e "$DWM_TEST_REPLACED_MARKER" ]; then
+	"$DWM_TEST_REAL_MV" "$DWM_TEST_REPLACEMENT" "$DWM_TEST_REPLACEMENT_TARGET"
+	: >"$DWM_TEST_REPLACED_MARKER"
+fi
+exec "$DWM_TEST_REAL_AWK" "$@"
+EOF
+chmod +x "$bin_dir/awk"
+immutable_snapshot=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
+	XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
+	DWM_APPEARANCE_DATA_DIRS=$data_root DWM_TEST_REAL_AWK="$(command -v awk)" \
+	DWM_TEST_REAL_MV="$(command -v mv)" \
+	DWM_TEST_REPLACEMENT="$work/replacement-themes.toml" \
+	DWM_TEST_REPLACEMENT_TARGET="$config_home/dwm-titus/themes.toml" \
+	DWM_TEST_REPLACED_MARKER="$work/replaced.marker" "$helper" snapshot)
+grep -Fqx $'active\tnord\tnord\tselected' <<<"$immutable_snapshot"
+grep -Fq 'theme = "dracula"' "$config_home/dwm-titus/themes.toml"
+rm -f "$bin_dir/awk"
+ln -s "$(command -v awk)" "$bin_dir/awk"
+cp "$repo/config/themes.toml" "$config_home/dwm-titus/themes.toml"
 
 no_qt_bin=$work/no-qt-bin
 cp -a "$bin_dir" "$no_qt_bin"
@@ -619,6 +657,12 @@ grep -Fqx $'active\t@legacy-colors\t@legacy-colors\tselected' <<<"$legacy"
 grep -Fqx $'theme\t@legacy-colors\tselected\tvalid\ttrue\tautomatic\tTheme record is complete' \
 	<<<"$legacy"
 grep -Fqx $'color\tbackground\t#2E3440\tterm_bg' <<<"$legacy"
+if awk -F '\t' '$1 == "color" && $3 !~ /^#[0-9A-Fa-f]{6}$/ { exit 1 }' <<<"$legacy"; then
+	:
+else
+	printf 'Legacy palette emitted an empty or invalid semantic color\n' >&2
+	exit 1
+fi
 grep -Fqx $'error\tparser\tlegacy-format\tLegacy [colors] palette is active; named themes are recommended' \
 	<<<"$legacy"
 

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -73,6 +73,7 @@ cp "$config_home/alacritty/active-theme.toml" "$work/alacritty-valid.toml"
 cp "$config_home/kitty/active-theme.conf" "$work/kitty-valid.conf"
 printf 'import = ["%s"]\n' "$config_home/alacritty/active-theme.toml" \
 	>"$config_home/alacritty/alacritty.toml"
+
 printf 'export QT_QPA_PLATFORMTHEME=qt6ct\nexport XCURSOR_THEME=Capitaine-Cursors-White\n' \
 	>"$config_home/dwm-titus/theme-env.sh"
 printf 'Xcursor.theme: Capitaine-Cursors-White\n' \
@@ -103,6 +104,18 @@ hash_path=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
 grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' \
 	<<<"$hash_path"
 
+escaped_config_home=$work/config\\escaped
+cp -a "$config_home" "$escaped_config_home"
+escaped_active_path=$escaped_config_home/alacritty/active-theme.toml
+encoded_active_path=${escaped_active_path//\\/\\\\}
+printf 'import = ["%s"]\n' "$encoded_active_path" \
+	>"$escaped_config_home/alacritty/alacritty.toml"
+escaped_path=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
+	XDG_CONFIG_HOME="$escaped_config_home" XDG_DATA_HOME="$data_root" \
+	DWM_APPEARANCE_DATA_DIRS="$data_root" "$helper" snapshot)
+grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' \
+	<<<"$escaped_path"
+
 snapshot() {
 	PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
 		DWM_APPEARANCE_DATA_DIRS=$data_root \
@@ -132,6 +145,20 @@ grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal 
 grep -Fqx $'integration\tkitty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' <<<"$output"
 grep -Fqx $'integration\tcompositor\tpartial\tpicom\tPicom is available but has no shared theme mutation contract' <<<"$output"
 grep -Fqx $'error\tcompositor\tunsupported\tPicom theme mutation is not implemented' <<<"$output"
+
+printf '[window]\nimport = ["%s"]\n' "$config_home/alacritty/active-theme.toml" \
+	>"$config_home/alacritty/alacritty.toml"
+table_import_alacritty=$(snapshot)
+grep -Fqx $'integration\talacritty\tpartial\tconfiguration\tGenerated theme is not imported by the terminal configuration' \
+	<<<"$table_import_alacritty"
+
+printf 'import = "%s"\n' "$config_home/alacritty/active-theme.toml" \
+	>"$config_home/alacritty/alacritty.toml"
+scalar_import_alacritty=$(snapshot)
+grep -Fqx $'integration\talacritty\tpartial\tconfiguration\tGenerated theme is not imported by the terminal configuration' \
+	<<<"$scalar_import_alacritty"
+printf 'import = ["%s"]\n' "$config_home/alacritty/active-theme.toml" \
+	>"$config_home/alacritty/alacritty.toml"
 
 no_kitty_bin=$work/no-kitty-bin
 cp -a "$bin_dir" "$no_kitty_bin"
@@ -377,15 +404,12 @@ grep -Fq $'error\tsource\tunreadable\tUser theme file is not a readable regular 
 rmdir "$config_home/dwm-titus/themes.toml"
 
 ln -s "$work/missing-user-theme.toml" "$config_home/dwm-titus/themes.toml"
-set +e
 dangling_user=$(snapshot)
-dangling_user_status=$?
-set -e
-[[ $dangling_user_status -eq 3 ]]
-grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory and integration state' \
+grep -Fqx $'provider\tappearance\tpartial\tread-only\tShared theme inventory and integration state' \
 	<<<"$dangling_user"
-grep -Fqx $'source\tuser\t'"$config_home/dwm-titus/themes.toml" <<<"$dangling_user"
-grep -Fq $'error\tsource\tunreadable\tUser theme file is not a readable regular file: ' \
+grep -Fqx $'source\tmanaged\t'"$data_root/dwm-titus/config/themes.toml" <<<"$dangling_user"
+grep -Fqx $'active\tnord\tnord\tselected' <<<"$dangling_user"
+grep -Fq $'error\tsource\tdangling-user\tIgnoring dangling user theme symlink and trying the managed source: ' \
 	<<<"$dangling_user"
 rm -f "$config_home/dwm-titus/themes.toml"
 
@@ -402,6 +426,14 @@ sed -i '0,/theme = "nord"/s//theme = "no\\rd"/' \
 	"$config_home/dwm-titus/themes.toml"
 escaped_active=$(snapshot)
 grep -Fqx $'active\tnord\tnord\tselected' <<<"$escaped_active"
+
+cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
+em_space=$'\u2003'
+sed -i "0,/^\[active\]$/s//${em_space}[active]/; 0,/^theme =/s//${em_space}theme =/" \
+	"$config_home/dwm-titus/themes.toml"
+unicode_space=$(snapshot)
+grep -Fqx $'active\tnone\tnord\trecovery' <<<"$unicode_space"
+grep -Fqx $'error\tactive\tmissing\tThe active theme name is missing' <<<"$unicode_space"
 
 cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
 sed -i '0,/theme = "nord"/s//theme = 123/' "$config_home/dwm-titus/themes.toml"
@@ -436,6 +468,22 @@ overlong=$(snapshot)
 grep -Fqx $'active\t'"$overlong_theme"$'\tdracula\trecovery' <<<"$overlong"
 grep -Fq $'error\tparser\tinvalid-theme-name\tTheme name is not a supported bare identifier at line ' \
 	<<<"$overlong"
+
+cat >"$config_home/dwm-titus/themes.toml" <<EOF
+[active]
+theme = "$overlong_theme"
+[colors]
+normfgcolor = "#D8DEE9"
+normbgcolor = "#2E3440"
+normbordercolor = "#4C566A"
+selfgcolor = "#ECEFF4"
+selbgcolor = "#5E81AC"
+selbordercolor = "#81A1C1"
+EOF
+overlong_legacy=$(snapshot)
+grep -Fqx $'active\t'"$overlong_theme"$'\t@legacy-colors\trecovery' <<<"$overlong_legacy"
+grep -Fqx $'error\tactive\tname-too-long\tActive theme name exceeds the runtime section limit; using the legacy [colors] palette' \
+	<<<"$overlong_legacy"
 
 {
 	printf '[ignored]\nmetadata = "'
@@ -553,6 +601,18 @@ grep -Fqx $'theme\tlegacy\tselected\tvalid\ttrue\tNordic\tTheme record is comple
 	<<<"$legacy_collision"
 grep -Fqx $'theme\t@legacy-colors\tavailable\tvalid\ttrue\tautomatic\tTheme record is complete' \
 	<<<"$legacy_collision"
+
+{
+	printf '[active]\ntheme = "missing"\n'
+	for ((theme_index = 0; theme_index < 128; theme_index++)); do
+		printf '[theme.sparse%s]\n' "$theme_index"
+	done
+	printf '[theme.nord]\n%s\n' "$nord_block"
+} >"$config_home/dwm-titus/themes.toml"
+nord_after_cap=$(snapshot)
+grep -Fqx $'active\tmissing\tnord\trecovery' <<<"$nord_after_cap"
+grep -Fqx $'theme\tnord\trecovery\tvalid\ttrue\tNordic\tTheme record is complete' \
+	<<<"$nord_after_cap"
 
 {
 	printf '[active]\ntheme = "chosen"\n'

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -11,7 +11,8 @@ data_root=$work/data
 bin_dir=$work/bin
 mkdir -p "$config_home/dwm-titus" "$config_home/alacritty" "$config_home/kitty" \
 	"$config_home/gtk-3.0" "$config_home/gtk-4.0" \
-	"$data_root/themes/Nordic/gtk-3.0" "$data_root/icons/Capitaine-Cursors-White" "$bin_dir"
+	"$data_root/themes/Nordic/gtk-3.0" "$data_root/themes/Nordic/gtk-4.0" \
+	"$data_root/icons/Capitaine-Cursors-White" "$bin_dir"
 cp "$repo/config/themes.toml" "$config_home/dwm-titus/themes.toml"
 declare -A fixture_color=()
 while read -r key _ color; do
@@ -26,6 +27,7 @@ cat >"$config_home/alacritty/active-theme.toml" <<EOF
 background = '${fixture_color[term_bg]}'
 foreground = '${fixture_color[term_fg]}'
 [colors.cursor]
+text = '${fixture_color[term_bg]}'
 cursor = '${fixture_color[term_cursor]}'
 [colors.normal]
 black = '${fixture_color[term_color0]}'
@@ -161,6 +163,12 @@ grep -Fqx $'error\tkitty\tnot-imported\tTerminal configuration does not import t
 	<<<"$unimported_kitty"
 printf 'include active-theme.conf\n' >"$config_home/kitty/kitty.conf"
 
+sed -i '/^text =/d' "$config_home/alacritty/active-theme.toml"
+missing_cursor_text=$(snapshot)
+grep -Fqx $'integration\talacritty\tpartial\tactive-theme\tGenerated terminal theme is empty or stale' \
+	<<<"$missing_cursor_text"
+cp "$work/alacritty-valid.toml" "$config_home/alacritty/active-theme.toml"
+
 sed -i "s|${fixture_color[term_bg]}|__DWM_COLOR_SWAP__|; \
 	s|${fixture_color[term_fg]}|${fixture_color[term_bg]}|; \
 	s|__DWM_COLOR_SWAP__|${fixture_color[term_fg]}|" \
@@ -267,11 +275,17 @@ if grep -Fq $'theme\t@unsafe\t' <<<"$unsafe_name"; then
 fi
 cp "$repo/config/themes.toml" "$config_home/dwm-titus/themes.toml"
 
+rmdir "$data_root/themes/Nordic/gtk-4.0"
+partial_gtk_assets=$(snapshot)
+grep -Fqx $'integration\tgtk\tpartial\tNordic\tRequested GTK theme is missing GTK 3 or GTK 4 assets' \
+	<<<"$partial_gtk_assets"
+grep -Fqx $'error\tgtk\tmissing-version\tGTK theme '\''Nordic'\'' does not support both GTK 3 and GTK 4' \
+	<<<"$partial_gtk_assets"
 rmdir "$data_root/themes/Nordic/gtk-3.0"
-stale_gtk=$(snapshot)
-grep -Fqx $'integration\tgtk\tpartial\tNordic\tRequested GTK theme is missing; apply falls back to Adwaita-dark' <<<"$stale_gtk"
-grep -Fqx $'error\tgtk\tmissing-theme\tGTK theme '\''Nordic'\'' is not installed' <<<"$stale_gtk"
-mkdir "$data_root/themes/Nordic/gtk-3.0"
+missing_gtk=$(snapshot)
+grep -Fqx $'integration\tgtk\tpartial\tNordic\tRequested GTK theme is missing; apply falls back to Adwaita-dark' <<<"$missing_gtk"
+grep -Fqx $'error\tgtk\tmissing-theme\tGTK theme '\''Nordic'\'' is not installed' <<<"$missing_gtk"
+mkdir -p "$data_root/themes/Nordic/gtk-3.0" "$data_root/themes/Nordic/gtk-4.0"
 
 sed -i 's/gtk-theme-name=Nordic/gtk-theme-name=Adwaita/' \
 	"$config_home/gtk-4.0/settings.ini"
@@ -526,6 +540,20 @@ timeout 5 env PATH="$bin_dir" GTK_THEME='' XCURSOR_THEME='' \
 grep -Fqx $'active\tnord\tnord\tselected' "$work/scalar-heavy.out"
 grep -Fqx $'error\tparser\tentry-limit\tTheme configuration exceeds the runtime parser limit of 512 entries' \
 	"$work/scalar-heavy.out"
+
+{
+	cat "$work/managed-themes.toml"
+	for ((post_budget_index = 0; post_budget_index < 512; post_budget_index++)); do
+		printf 'post-budget%s = 1\n' "$post_budget_index"
+	done
+	printf 'ignored-complex = [{x=1}]\n'
+} >"$config_home/dwm-titus/themes.toml"
+post_budget_complex=$(snapshot)
+grep -Fqx $'active\tnord\tnord\tselected' <<<"$post_budget_complex"
+if grep -Fq $'error\tparser\tunsupported-complex-value\t' <<<"$post_budget_complex"; then
+	printf 'Post-budget complex value invalidated the runtime snapshot\n' >&2
+	exit 1
+fi
 
 cat >"$config_home/dwm-titus/themes.toml" <<'EOF'
 [colors]

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -106,6 +106,16 @@ grep -Fqx $'integration\tkitty\tavailable\tactive-theme\tGenerated terminal them
 grep -Fqx $'integration\tcompositor\tpartial\tpicom\tPicom is available but has no shared theme mutation contract' <<<"$output"
 grep -Fqx $'error\tcompositor\tunsupported\tPicom theme mutation is not implemented' <<<"$output"
 
+no_qt_bin=$work/no-qt-bin
+cp -a "$bin_dir" "$no_qt_bin"
+rm -f "$no_qt_bin/qt6ct"
+no_qt=$(PATH=$no_qt_bin QT_QPA_PLATFORMTHEME='' XDG_CONFIG_HOME=$config_home \
+	XDG_DATA_HOME=$data_root DWM_APPEARANCE_DATA_DIRS=$data_root \
+	"$helper" snapshot)
+grep -Fqx $'integration\tqt\tunavailable\tnone\tNo supported Qt theme backend is active' <<<"$no_qt"
+grep -Fqx $'error\tqt\tmissing-backend\tInstall qt6ct or qt5ct, or activate the Qt GTK3 platform theme' \
+	<<<"$no_qt"
+
 sed -i "s|${fixture_color[term_bg]}|__DWM_COLOR_SWAP__|; \
 	s|${fixture_color[term_fg]}|${fixture_color[term_bg]}|; \
 	s|__DWM_COLOR_SWAP__|${fixture_color[term_fg]}|" \

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -12,10 +12,64 @@ bin_dir=$work/bin
 mkdir -p "$config_home/dwm-titus" "$config_home/alacritty" "$config_home/kitty" \
 	"$data_root/themes/Nordic/gtk-3.0" "$data_root/icons/Capitaine-Cursors-White" "$bin_dir"
 cp "$repo/config/themes.toml" "$config_home/dwm-titus/themes.toml"
-: >"$config_home/alacritty/active-theme.toml"
-: >"$config_home/kitty/active-theme.conf"
+declare -A fixture_color=()
+while read -r key _ color; do
+	fixture_color[$key]=${color//\"/}
+done < <(awk '
+	/^\[theme\.nord\]$/ { capture = 1; next }
+	/^\[theme\./ && capture { exit }
+	capture && /^[[:space:]]*term_/ { print }
+' "$repo/config/themes.toml")
+cat >"$config_home/alacritty/active-theme.toml" <<EOF
+[colors.primary]
+background = '${fixture_color[term_bg]}'
+foreground = '${fixture_color[term_fg]}'
+[colors.cursor]
+cursor = '${fixture_color[term_cursor]}'
+[colors.normal]
+black = '${fixture_color[term_color0]}'
+red = '${fixture_color[term_color1]}'
+green = '${fixture_color[term_color2]}'
+yellow = '${fixture_color[term_color3]}'
+blue = '${fixture_color[term_color4]}'
+magenta = '${fixture_color[term_color5]}'
+cyan = '${fixture_color[term_color6]}'
+white = '${fixture_color[term_color7]}'
+[colors.bright]
+black = '${fixture_color[term_color8]}'
+red = '${fixture_color[term_color9]}'
+green = '${fixture_color[term_color10]}'
+yellow = '${fixture_color[term_color11]}'
+blue = '${fixture_color[term_color12]}'
+magenta = '${fixture_color[term_color13]}'
+cyan = '${fixture_color[term_color14]}'
+white = '${fixture_color[term_color15]}'
+EOF
+cat >"$config_home/kitty/active-theme.conf" <<EOF
+background ${fixture_color[term_bg]}
+foreground ${fixture_color[term_fg]}
+cursor ${fixture_color[term_cursor]}
+color0 ${fixture_color[term_color0]}
+color1 ${fixture_color[term_color1]}
+color2 ${fixture_color[term_color2]}
+color3 ${fixture_color[term_color3]}
+color4 ${fixture_color[term_color4]}
+color5 ${fixture_color[term_color5]}
+color6 ${fixture_color[term_color6]}
+color7 ${fixture_color[term_color7]}
+color8 ${fixture_color[term_color8]}
+color9 ${fixture_color[term_color9]}
+color10 ${fixture_color[term_color10]}
+color11 ${fixture_color[term_color11]}
+color12 ${fixture_color[term_color12]}
+color13 ${fixture_color[term_color13]}
+color14 ${fixture_color[term_color14]}
+color15 ${fixture_color[term_color15]}
+EOF
+cp "$config_home/alacritty/active-theme.toml" "$work/alacritty-valid.toml"
+cp "$config_home/kitty/active-theme.conf" "$work/kitty-valid.conf"
 
-for command_name in bash dirname stat tr; do
+for command_name in awk bash dirname grep stat tr; do
 	ln -s "$(command -v "$command_name")" "$bin_dir/$command_name"
 done
 printf '#!/bin/sh\nexit 0\n' >"$bin_dir/qt6ct"
@@ -47,9 +101,27 @@ grep -Fqx $'color\tdanger\t#BF616A\tterm_color1' <<<"$output"
 grep -Fqx $'integration\tgtk\tavailable\tNordic\tRequested GTK theme is installed' <<<"$output"
 grep -Fqx $'integration\tqt\tavailable\tqt6ct\tQt applications use the supported theme backend' <<<"$output"
 grep -Fqx $'integration\tcursor\tavailable\tCapitaine-Cursors-White\tManaged cursor theme is installed' <<<"$output"
-grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme is present' <<<"$output"
+grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' <<<"$output"
+grep -Fqx $'integration\tkitty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' <<<"$output"
 grep -Fqx $'integration\tcompositor\tpartial\tpicom\tPicom is available but has no shared theme mutation contract' <<<"$output"
 grep -Fqx $'error\tcompositor\tunsupported\tPicom theme mutation is not implemented' <<<"$output"
+
+sed -i "s|${fixture_color[term_bg]}|__DWM_COLOR_SWAP__|; \
+	s|${fixture_color[term_fg]}|${fixture_color[term_bg]}|; \
+	s|__DWM_COLOR_SWAP__|${fixture_color[term_fg]}|" \
+	"$config_home/alacritty/active-theme.toml"
+swapped_terminal=$(snapshot)
+grep -Fqx $'integration\talacritty\tpartial\tactive-theme\tGenerated terminal theme is empty or stale' \
+	<<<"$swapped_terminal"
+cp "$work/alacritty-valid.toml" "$config_home/alacritty/active-theme.toml"
+
+: >"$config_home/alacritty/active-theme.toml"
+stale_terminal=$(snapshot)
+grep -Fqx $'integration\talacritty\tpartial\tactive-theme\tGenerated terminal theme is empty or stale' \
+	<<<"$stale_terminal"
+grep -Fqx $'error\talacritty\tstale-theme\tGenerated active theme does not match the resolved palette' \
+	<<<"$stale_terminal"
+cp "$work/alacritty-valid.toml" "$config_home/alacritty/active-theme.toml"
 
 sed -i 's/^\[active\]$/[active] # selected theme/' "$config_home/dwm-titus/themes.toml"
 sed -i 's/^\[theme\.nord\]$/[theme.nord] # default theme/' "$config_home/dwm-titus/themes.toml"
@@ -276,6 +348,19 @@ grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory
 grep -Fqx $'error\tparser\tentry-limit\tTheme configuration exceeds the runtime parser limit of 512 entries' \
 	<<<"$alternate_key_limit"
 
+printf -v multibyte_key 'é%.0s' {1..300}
+{
+	printf '[ignored]\n'
+	for ((entry_index = 0; entry_index < 512; entry_index++)); do
+		printf '%s-%s = 1\n' "$multibyte_key" "$entry_index"
+	done
+	cat "$work/managed-themes.toml"
+} >"$config_home/dwm-titus/themes.toml"
+multibyte_keys=$(snapshot)
+grep -Fqx $'provider\tappearance\tavailable\tread-only\tShared theme inventory and integration state' \
+	<<<"$multibyte_keys"
+grep -Fqx $'active\tnord\tnord\tselected' <<<"$multibyte_keys"
+
 nord_block=$(awk '
 	/^\[theme\.nord\]$/ { capture = 1; next }
 	/^\[theme\.dracula\]$/ { exit }
@@ -292,6 +377,11 @@ selected_after_cap=$(snapshot)
 grep -Fqx $'active\tchosen\tchosen\tselected' <<<"$selected_after_cap"
 grep -Fqx $'theme\tchosen\tselected\tvalid\ttrue\tNordic\tTheme record is complete' \
 	<<<"$selected_after_cap"
+sed -i '0,/theme = "chosen"/s//theme = chosen/' "$config_home/dwm-titus/themes.toml"
+bare_selected_after_cap=$(snapshot)
+grep -Fqx $'active\tchosen\tchosen\tselected' <<<"$bare_selected_after_cap"
+grep -Fqx $'theme\tchosen\tselected\tvalid\ttrue\tNordic\tTheme record is complete' \
+	<<<"$bare_selected_after_cap"
 
 {
 	printf '[active]\ntheme = "t19"\n'
@@ -322,6 +412,15 @@ set -e
 grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory and integration state' \
 	"$work/many-incomplete.out"
 [[ $(grep -c $'^error\ttheme:' "$work/many-incomplete.out") -eq 100 ]]
+
+mkdir -p "$work/fallback-home/.config/dwm-titus"
+cp "$work/managed-themes.toml" "$work/fallback-home/.config/dwm-titus/themes.toml"
+relative_xdg=$(HOME="$work/fallback-home" XDG_CONFIG_HOME=relative-config \
+	XDG_DATA_HOME=relative-data DWM_APPEARANCE_DATA_DIRS=$data_root \
+	"$helper" snapshot)
+grep -Fqx $'source\tuser\t'"$work/fallback-home/.config/dwm-titus/themes.toml" \
+	<<<"$relative_xdg"
+grep -Fqx $'active\tnord\tnord\tselected' <<<"$relative_xdg"
 
 rm -f "$config_home/dwm-titus/themes.toml" "$work/missing-managed.toml"
 set +e

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -10,6 +10,7 @@ config_home=$work/config
 data_root=$work/data
 bin_dir=$work/bin
 mkdir -p "$config_home/dwm-titus" "$config_home/alacritty" "$config_home/kitty" \
+	"$config_home/gtk-3.0" "$config_home/gtk-4.0" \
 	"$data_root/themes/Nordic/gtk-3.0" "$data_root/icons/Capitaine-Cursors-White" "$bin_dir"
 cp "$repo/config/themes.toml" "$config_home/dwm-titus/themes.toml"
 declare -A fixture_color=()
@@ -71,6 +72,9 @@ cp "$config_home/kitty/active-theme.conf" "$work/kitty-valid.conf"
 printf 'import = ["%s"]\n' "$config_home/alacritty/active-theme.toml" \
 	>"$config_home/alacritty/alacritty.toml"
 printf 'export QT_QPA_PLATFORMTHEME=qt6ct\n' >"$config_home/dwm-titus/theme-env.sh"
+printf '[Settings]\ngtk-theme-name=Nordic\n' >"$config_home/gtk-3.0/settings.ini"
+printf '[Settings]\ngtk-theme-name=Nordic\n' >"$config_home/gtk-4.0/settings.ini"
+printf 'include active-theme.conf\n' >"$config_home/kitty/kitty.conf"
 
 for command_name in awk bash dirname grep stat tr; do
 	ln -s "$(command -v "$command_name")" "$bin_dir/$command_name"
@@ -80,7 +84,7 @@ printf '#!/bin/sh\nexit 0\n' >"$bin_dir/picom"
 chmod +x "$bin_dir/qt6ct" "$bin_dir/picom"
 
 snapshot() {
-	PATH=$bin_dir XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
+	PATH=$bin_dir GTK_THEME='' XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
 		DWM_APPEARANCE_DATA_DIRS=$data_root \
 		"$helper" snapshot
 }
@@ -101,7 +105,7 @@ grep -Fqx $'theme\tnord\tselected\tvalid\ttrue\tNordic\tTheme record is complete
 grep -Fqx $'color\tbackground\t#2E3440\tterm_bg' <<<"$output"
 grep -Fqx $'color\taccent\t#81A1C1\tselbordercolor' <<<"$output"
 grep -Fqx $'color\tdanger\t#BF616A\tterm_color1' <<<"$output"
-grep -Fqx $'integration\tgtk\tavailable\tNordic\tRequested GTK theme is installed' <<<"$output"
+grep -Fqx $'integration\tgtk\tavailable\tNordic\tRequested GTK theme is installed and applied' <<<"$output"
 grep -Fqx $'integration\tqt\tavailable\tqt6ct\tQt applications use the supported theme backend' <<<"$output"
 grep -Fqx $'integration\tcursor\tavailable\tCapitaine-Cursors-White\tManaged cursor theme is installed' <<<"$output"
 grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' <<<"$output"
@@ -129,10 +133,18 @@ printf 'import = ["/wrong/active-theme.toml"]\n' >"$config_home/alacritty/alacri
 unimported_alacritty=$(snapshot)
 grep -Fqx $'integration\talacritty\tpartial\tconfiguration\tGenerated theme is not imported by the terminal configuration' \
 	<<<"$unimported_alacritty"
-grep -Fqx $'error\talacritty\tnot-imported\tAlacritty configuration does not import the generated active theme' \
+grep -Fqx $'error\talacritty\tnot-imported\tTerminal configuration does not import the generated active theme' \
 	<<<"$unimported_alacritty"
 printf 'import = ["%s"]\n' "$config_home/alacritty/active-theme.toml" \
 	>"$config_home/alacritty/alacritty.toml"
+
+printf '# include active-theme.conf\n' >"$config_home/kitty/kitty.conf"
+unimported_kitty=$(snapshot)
+grep -Fqx $'integration\tkitty\tpartial\tconfiguration\tGenerated theme is not imported by the terminal configuration' \
+	<<<"$unimported_kitty"
+grep -Fqx $'error\tkitty\tnot-imported\tTerminal configuration does not import the generated active theme' \
+	<<<"$unimported_kitty"
+printf 'include active-theme.conf\n' >"$config_home/kitty/kitty.conf"
 
 sed -i "s|${fixture_color[term_bg]}|__DWM_COLOR_SWAP__|; \
 	s|${fixture_color[term_fg]}|${fixture_color[term_bg]}|; \
@@ -246,6 +258,16 @@ grep -Fqx $'integration\tgtk\tpartial\tNordic\tRequested GTK theme is missing; a
 grep -Fqx $'error\tgtk\tmissing-theme\tGTK theme '\''Nordic'\'' is not installed' <<<"$stale_gtk"
 mkdir "$data_root/themes/Nordic/gtk-3.0"
 
+sed -i 's/gtk-theme-name=Nordic/gtk-theme-name=Adwaita/' \
+	"$config_home/gtk-4.0/settings.ini"
+stale_gtk_application=$(snapshot)
+grep -Fqx $'integration\tgtk\tpartial\tNordic\tRequested GTK theme is installed but not applied' \
+	<<<"$stale_gtk_application"
+grep -Fqx $'error\tgtk\tstale-theme\tApplied GTK settings do not match '\''Nordic'\''' \
+	<<<"$stale_gtk_application"
+sed -i 's/gtk-theme-name=Adwaita/gtk-theme-name=Nordic/' \
+	"$config_home/gtk-4.0/settings.ini"
+
 mv "$config_home/dwm-titus/themes.toml" "$work/managed-themes.toml"
 managed=$(PATH=$bin_dir XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
 	DWM_APPEARANCE_DATA_DIRS=$data_root \
@@ -302,6 +324,23 @@ grep -Fqx $'active\tnone\tnord\trecovery' <<<"$numeric_active"
 grep -Fq $'error\tactive\tinvalid-type\tActive theme must resolve to a TOML string at line ' \
 	<<<"$numeric_active"
 
+sed -i '0,/theme = 123/s//theme = 123\n theme = "nord"/' \
+	"$config_home/dwm-titus/themes.toml"
+duplicate_after_numeric=$(snapshot)
+grep -Fqx $'active\tnone\tnord\trecovery' <<<"$duplicate_after_numeric"
+grep -Fq $'error\tactive:__active\tduplicate-key\tDuplicate key '\''theme'\'' at line ' \
+	<<<"$duplicate_after_numeric"
+
+cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
+sed -i '/^gtk_theme[[:space:]]*=/a author-name = "demo"' \
+	"$config_home/dwm-titus/themes.toml"
+metadata_key=$(snapshot)
+grep -Fqx $'active\tnord\tnord\tselected' <<<"$metadata_key"
+if grep -Fq $'error\ttheme:nord\tinvalid-record\t' <<<"$metadata_key"; then
+	printf 'Runtime-valid metadata invalidated the active theme\n' >&2
+	exit 1
+fi
+
 printf -v overlong_theme '%*s' 506 ''
 overlong_theme=${overlong_theme// /a}
 cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
@@ -314,12 +353,16 @@ grep -Fq $'error\tparser\tinvalid-theme-name\tTheme name is not a supported bare
 
 cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
 sed -i '0,/theme = "nord"/s//theme = "dracula"/' "$config_home/dwm-titus/themes.toml"
+sed -i 's/gtk-theme-name=Nordic/gtk-theme-name=Adwaita-dark/' \
+	"$config_home/gtk-3.0/settings.ini" "$config_home/gtk-4.0/settings.ini"
 adwaita=$(snapshot)
-grep -Fqx $'integration\tgtk\tavailable\tAdwaita-dark\tRequested GTK theme is installed' <<<"$adwaita"
+grep -Fqx $'integration\tgtk\tavailable\tAdwaita-dark\tRequested GTK theme is installed and applied' <<<"$adwaita"
 if grep -Fq $'error\tgtk\tmissing-theme' <<<"$adwaita"; then
 	printf 'Built-in Adwaita fallback was reported missing\n' >&2
 	exit 1
 fi
+sed -i 's/gtk-theme-name=Adwaita-dark/gtk-theme-name=Nordic/' \
+	"$config_home/gtk-3.0/settings.ini" "$config_home/gtk-4.0/settings.ini"
 
 cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
 sed -i '0,/theme = "nord"/s//theme = "missing"/' "$config_home/dwm-titus/themes.toml"

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -90,6 +90,17 @@ printf '#!/bin/sh\nexit 0\n' >"$bin_dir/qt6ct"
 printf '#!/bin/sh\nexit 0\n' >"$bin_dir/picom"
 chmod +x "$bin_dir/qt6ct" "$bin_dir/picom"
 
+hash_config_home=$work/config#hash
+cp -a "$config_home" "$hash_config_home"
+printf 'import = ["%s"] # active palette\n' \
+	"$hash_config_home/alacritty/active-theme.toml" \
+	>"$hash_config_home/alacritty/alacritty.toml"
+hash_path=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
+	XDG_CONFIG_HOME="$hash_config_home" XDG_DATA_HOME="$data_root" \
+	DWM_APPEARANCE_DATA_DIRS="$data_root" "$helper" snapshot)
+grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' \
+	<<<"$hash_path"
+
 snapshot() {
 	PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
 		DWM_APPEARANCE_DATA_DIRS=$data_root \
@@ -380,6 +391,20 @@ grep -Fqx $'active\t'"$overlong_theme"$'\tdracula\trecovery' <<<"$overlong"
 grep -Fq $'error\tparser\tinvalid-theme-name\tTheme name is not a supported bare identifier at line ' \
 	<<<"$overlong"
 
+{
+	printf '[ignored]\nmetadata = "'
+	printf '%4095s' '' | tr ' ' x
+	printf '"\n'
+	cat "$work/managed-themes.toml"
+} >"$config_home/dwm-titus/themes.toml"
+set +e
+long_line=$(snapshot)
+long_line_status=$?
+set -e
+[[ $long_line_status -eq 3 ]]
+grep -Fqx $'error\tparser\tline-too-long\tTheme configuration contains a physical line that exceeds the runtime reader limit' \
+	<<<"$long_line"
+
 cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
 sed -i '0,/theme = "nord"/s//theme = "dracula"/' "$config_home/dwm-titus/themes.toml"
 sed -i 's/gtk-theme-name=Nordic/gtk-theme-name=Adwaita-dark/' \
@@ -466,6 +491,23 @@ nord_block=$(awk '
 	/^\[theme\.dracula\]$/ { exit }
 	capture && /^[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=/ { print }
 ' "$repo/config/themes.toml")
+{
+	printf '[active]\ntheme = "legacy"\n[theme.legacy]\n%s\n' "$nord_block"
+	printf '%s\n' '[colors]' \
+		'normfgcolor = "#D8DEE9"' \
+		'normbgcolor = "#2E3440"' \
+		'normbordercolor = "#4C566A"' \
+		'selfgcolor = "#ECEFF4"' \
+		'selbgcolor = "#5E81AC"' \
+		'selbordercolor = "#81A1C1"'
+} >"$config_home/dwm-titus/themes.toml"
+legacy_collision=$(snapshot)
+grep -Fqx $'active\tlegacy\tlegacy\tselected' <<<"$legacy_collision"
+grep -Fqx $'theme\tlegacy\tselected\tvalid\ttrue\tNordic\tTheme record is complete' \
+	<<<"$legacy_collision"
+grep -Fqx $'theme\t@legacy-colors\tavailable\tvalid\ttrue\tautomatic\tTheme record is complete' \
+	<<<"$legacy_collision"
+
 {
 	printf '[active]\ntheme = "chosen"\n'
 	for ((theme_index = 0; theme_index < 128; theme_index++)); do
@@ -567,8 +609,8 @@ EOF
 legacy=$(snapshot)
 grep -Fqx $'provider\tappearance\tpartial\tread-only\tShared theme inventory and integration state' \
 	<<<"$legacy"
-grep -Fqx $'active\tlegacy\tlegacy\tselected' <<<"$legacy"
-grep -Fqx $'theme\tlegacy\tselected\tvalid\ttrue\tautomatic\tTheme record is complete' \
+grep -Fqx $'active\t@legacy-colors\t@legacy-colors\tselected' <<<"$legacy"
+grep -Fqx $'theme\t@legacy-colors\tselected\tvalid\ttrue\tautomatic\tTheme record is complete' \
 	<<<"$legacy"
 grep -Fqx $'color\tbackground\t#2E3440\tterm_bg' <<<"$legacy"
 grep -Fqx $'error\tparser\tlegacy-format\tLegacy [colors] palette is active; named themes are recommended' \

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -146,6 +146,8 @@ grep -Fqx $'error\tkitty\tmissing-application\tTerminal application is not insta
 
 cp "$config_home/dwm-titus/themes.toml" "$work/replacement-themes.toml"
 sed -i '0,/theme = "nord"/s//theme = "dracula"/' "$work/replacement-themes.toml"
+real_awk=$(command -v awk)
+real_mv=$(command -v mv)
 rm -f "$bin_dir/awk"
 cat >"$bin_dir/awk" <<'EOF'
 #!/bin/sh
@@ -158,15 +160,15 @@ EOF
 chmod +x "$bin_dir/awk"
 immutable_snapshot=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
 	XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
-	DWM_APPEARANCE_DATA_DIRS=$data_root DWM_TEST_REAL_AWK="$(command -v awk)" \
-	DWM_TEST_REAL_MV="$(command -v mv)" \
+	DWM_APPEARANCE_DATA_DIRS=$data_root DWM_TEST_REAL_AWK="$real_awk" \
+	DWM_TEST_REAL_MV="$real_mv" \
 	DWM_TEST_REPLACEMENT="$work/replacement-themes.toml" \
 	DWM_TEST_REPLACEMENT_TARGET="$config_home/dwm-titus/themes.toml" \
 	DWM_TEST_REPLACED_MARKER="$work/replaced.marker" "$helper" snapshot)
 grep -Fqx $'active\tnord\tnord\tselected' <<<"$immutable_snapshot"
 grep -Fq 'theme = "dracula"' "$config_home/dwm-titus/themes.toml"
 rm -f "$bin_dir/awk"
-ln -s "$(command -v awk)" "$bin_dir/awk"
+ln -s "$real_awk" "$bin_dir/awk"
 cp "$repo/config/themes.toml" "$config_home/dwm-titus/themes.toml"
 
 no_qt_bin=$work/no-qt-bin

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -358,6 +358,12 @@ grep -Fqx $'active\t'"$custom_theme"$'\t'"$custom_theme"$'\tselected' <<<"$custo
 grep -Fq $'theme\t'"$custom_theme"$'\tselected\tvalid\ttrue\tNordic' <<<"$custom"
 
 cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
+sed -i '0,/theme = "nord"/s//theme = "no\\rd"/' \
+	"$config_home/dwm-titus/themes.toml"
+escaped_active=$(snapshot)
+grep -Fqx $'active\tnord\tnord\tselected' <<<"$escaped_active"
+
+cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
 sed -i '0,/theme = "nord"/s//theme = 123/' "$config_home/dwm-titus/themes.toml"
 numeric_active=$(snapshot)
 grep -Fqx $'active\tnone\tnord\trecovery' <<<"$numeric_active"

--- a/tests/test-quickshell-session-actions.sh
+++ b/tests/test-quickshell-session-actions.sh
@@ -333,6 +333,10 @@ SH
 #!/bin/sh
 : >"${DWM_SESSION_TEST_AUTOSTOP_MARKER:?}"
 SH
+	cat >"$work/runtime-data/dwm-titus/scripts/theme-apply.sh" <<'SH'
+#!/bin/sh
+printf x >>"${DWM_SESSION_TEST_THEME_APPLY_MARKER:?}"
+SH
 	chmod +x "$work/runtime-data/dwm-titus/scripts/"*.sh
 
 	Xvfb "$runtime_display" -screen 0 800x600x24 -nolisten tcp \
@@ -350,6 +354,7 @@ SH
 	done
 
 	DWM_SESSION_TEST_AUTOSTOP_MARKER="$work/autostop.marker" \
+		DWM_SESSION_TEST_THEME_APPLY_MARKER="$work/theme-apply.marker" \
 		DISPLAY=$runtime_display HOME="$work/home" \
 		XDG_CONFIG_HOME="$work/runtime-config" \
 		XDG_DATA_HOME="$work/runtime-data" "$repo/dwm" \
@@ -371,6 +376,16 @@ SH
 		printf '%s\n' 'Nested DWM did not load its XDG_DATA_HOME theme fallback.' >&2
 		exit 1
 	}
+	i=0
+	while [ ! -f "$work/theme-apply.marker" ]; do
+		i=$((i + 1))
+		[ "$i" -lt 100 ] || {
+			printf '%s\n' 'Nested DWM did not run theme-apply from XDG_DATA_HOME.' >&2
+			exit 1
+		}
+		sleep 0.02
+	done
+	initial_theme_applies=$(wc -c <"$work/theme-apply.marker")
 	cp "$repo/config/themes.toml" "$work/runtime-config/dwm-titus/themes.toml"
 	i=0
 	while [ "$(grep -Fc 'dwm: loaded theme from config' "$work/dwm.log" || true)" \
@@ -378,6 +393,15 @@ SH
 		i=$((i + 1))
 		[ "$i" -lt 100 ] || {
 			printf '%s\n' 'Nested DWM did not hot-reload its XDG_CONFIG_HOME theme.' >&2
+			exit 1
+		}
+		sleep 0.02
+	done
+	i=0
+	while [ "$(wc -c <"$work/theme-apply.marker")" -le "$initial_theme_applies" ]; do
+		i=$((i + 1))
+		[ "$i" -lt 100 ] || {
+			printf '%s\n' 'Nested DWM did not run theme-apply from XDG_DATA_HOME.' >&2
 			exit 1
 		}
 		sleep 0.02

--- a/tests/test-quickshell-session-actions.sh
+++ b/tests/test-quickshell-session-actions.sh
@@ -366,6 +366,22 @@ SH
 		}
 		sleep 0.02
 	done
+	initial_theme_loads=$(grep -Fc 'dwm: loaded theme from config' "$work/dwm.log" || true)
+	[ "$initial_theme_loads" -ge 1 ] || {
+		printf '%s\n' 'Nested DWM did not load its XDG_DATA_HOME theme fallback.' >&2
+		exit 1
+	}
+	cp "$repo/config/themes.toml" "$work/runtime-config/dwm-titus/themes.toml"
+	i=0
+	while [ "$(grep -Fc 'dwm: loaded theme from config' "$work/dwm.log" || true)" \
+		-le "$initial_theme_loads" ]; do
+		i=$((i + 1))
+		[ "$i" -lt 100 ] || {
+			printf '%s\n' 'Nested DWM did not hot-reload its XDG_CONFIG_HOME theme.' >&2
+			exit 1
+		}
+		sleep 0.02
+	done
 	support_window=$(DISPLAY=$runtime_display /usr/bin/xprop -root \
 		_NET_SUPPORTING_WM_CHECK | awk '{ print $NF }')
 	DISPLAY=$runtime_display /usr/bin/xprop -id "$support_window" _NET_WM_PID |

--- a/tests/test-quickshell-session-actions.sh
+++ b/tests/test-quickshell-session-actions.sh
@@ -321,23 +321,28 @@ if command -v Xvfb >/dev/null 2>&1 && [ -x "$repo/dwm" ]; then
 		runtime_display_number=$((runtime_display_number + 1))
 	done
 	runtime_display=:$runtime_display_number
-	mkdir -p "$work/runtime-data/dwm-titus/scripts" \
-		"$work/runtime-data/dwm-titus/config" "$work/runtime-config/dwm-titus"
+	runtime_home=$work/runtime-home
+	runtime_data_home=$runtime_home/.local/share
+	runtime_config_home=$runtime_home/.config
+	mkdir -p "$runtime_data_home/dwm-titus/scripts" \
+		"$runtime_data_home/dwm-titus/config" "$runtime_config_home/dwm-titus"
 	cp "$repo/config/hotkeys.toml" "$repo/config/themes.toml" \
-		"$repo/config/window-rules.toml" "$work/runtime-data/dwm-titus/config/"
-	cat >"$work/runtime-data/dwm-titus/scripts/autostart.sh" <<'SH'
+		"$repo/config/window-rules.toml" "$runtime_data_home/dwm-titus/config/"
+	cat >"$runtime_data_home/dwm-titus/scripts/autostart.sh" <<'SH'
 #!/bin/sh
 exit 0
 SH
-	cat >"$work/runtime-data/dwm-titus/scripts/autostop.sh" <<'SH'
+	cat >"$runtime_data_home/dwm-titus/scripts/autostop.sh" <<'SH'
 #!/bin/sh
 : >"${DWM_SESSION_TEST_AUTOSTOP_MARKER:?}"
 SH
-	cat >"$work/runtime-data/dwm-titus/scripts/theme-apply.sh" <<'SH'
+	cat >"$runtime_data_home/dwm-titus/scripts/theme-apply.sh" <<'SH'
 #!/bin/sh
 printf x >>"${DWM_SESSION_TEST_THEME_APPLY_MARKER:?}"
+printf '%s\n%s\n' "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" \
+	>"${DWM_SESSION_TEST_THEME_ENV_MARKER:?}"
 SH
-	chmod +x "$work/runtime-data/dwm-titus/scripts/"*.sh
+	chmod +x "$runtime_data_home/dwm-titus/scripts/"*.sh
 
 	Xvfb "$runtime_display" -screen 0 800x600x24 -nolisten tcp \
 		>"$work/xvfb.log" 2>&1 &
@@ -355,9 +360,9 @@ SH
 
 	DWM_SESSION_TEST_AUTOSTOP_MARKER="$work/autostop.marker" \
 		DWM_SESSION_TEST_THEME_APPLY_MARKER="$work/theme-apply.marker" \
-		DISPLAY=$runtime_display HOME="$work/home" \
-		XDG_CONFIG_HOME="$work/runtime-config" \
-		XDG_DATA_HOME="$work/runtime-data" "$repo/dwm" \
+		DWM_SESSION_TEST_THEME_ENV_MARKER="$work/theme-env.marker" \
+		DISPLAY=$runtime_display HOME="$runtime_home" \
+		XDG_CONFIG_HOME=relative-config XDG_DATA_HOME=relative-data "$repo/dwm" \
 		>"$work/dwm.log" 2>&1 &
 	real_dwm_pid=$!
 	test_pids="$test_pids $real_dwm_pid"
@@ -377,7 +382,7 @@ SH
 		exit 1
 	}
 	i=0
-	while [ ! -f "$work/theme-apply.marker" ]; do
+	while [ ! -f "$work/theme-apply.marker" ] || [ ! -f "$work/theme-env.marker" ]; do
 		i=$((i + 1))
 		[ "$i" -lt 100 ] || {
 			printf '%s\n' 'Nested DWM did not run theme-apply from XDG_DATA_HOME.' >&2
@@ -385,8 +390,10 @@ SH
 		}
 		sleep 0.02
 	done
+	grep -Fqx "$runtime_config_home" "$work/theme-env.marker"
+	grep -Fqx "$runtime_data_home" "$work/theme-env.marker"
 	initial_theme_applies=$(wc -c <"$work/theme-apply.marker")
-	cp "$repo/config/themes.toml" "$work/runtime-config/dwm-titus/themes.toml"
+	cp "$repo/config/themes.toml" "$runtime_config_home/dwm-titus/themes.toml"
 	i=0
 	while [ "$(grep -Fc 'dwm: loaded theme from config' "$work/dwm.log" || true)" \
 		-le "$initial_theme_loads" ]; do
@@ -411,9 +418,8 @@ SH
 	DISPLAY=$runtime_display /usr/bin/xprop -id "$support_window" _NET_WM_PID |
 		grep -Fqx "_NET_WM_PID(CARDINAL) = $real_dwm_pid"
 	real_logout=$(DWM_SESSION_TEST_AUTOSTOP_MARKER="$work/autostop.marker" \
-		DISPLAY=$runtime_display HOME="$work/home" \
-		XDG_CONFIG_HOME="$work/runtime-config" \
-		XDG_DATA_HOME="$work/runtime-data" PATH=/usr/bin:/bin \
+		DISPLAY=$runtime_display HOME="$runtime_home" \
+		XDG_CONFIG_HOME=relative-config XDG_DATA_HOME=relative-data PATH=/usr/bin:/bin \
 		"$helper" session-action logout)
 	[ "$real_logout" = 'session-action	logout	accepted' ]
 	i=0

--- a/tests/test-settings.sh
+++ b/tests/test-settings.sh
@@ -31,6 +31,20 @@ make_failing_stub() {
 	chmod +x "$path"
 }
 
+make_appearance_stub() {
+	path=$1
+	mkdir -p "${path%/*}"
+	printf '%s\n' '#!/bin/sh' 'printf "appearance-protocol\t1\t0\n"' >"$path"
+	chmod +x "$path"
+}
+
+make_malformed_appearance_stub() {
+	path=$1
+	mkdir -p "${path%/*}"
+	printf '%s\n' '#!/bin/sh' 'printf "not-an-appearance-snapshot\n"' >"$path"
+	chmod +x "$path"
+}
+
 base_bin=$work/base-bin
 fedora_bin=$work/fedora-bin
 make_tools "$base_bin" dirname awk tr stat find grep timeout readlink
@@ -41,7 +55,7 @@ for command_name in xrandr nmcli bluetoothctl pactl xset gsettings light-locker 
 	make_stub "$fedora_bin/$command_name"
 done
 make_stub "$fedora_bin/dwm-xdg-autostart"
-make_stub "$fedora_bin/dwm-settings-appearance"
+make_appearance_stub "$fedora_bin/dwm-settings-appearance"
 make_stub "$fedora_bin/inotifywait"
 make_failing_stub "$fedora_bin/pkexec"
 make_failing_stub "$fedora_bin/sudo"
@@ -97,6 +111,14 @@ printf '%s\n' "$runtime_down_output" | grep -Fqx \
 printf '%s\n' "$runtime_down_output" | grep -Fqx \
 	'capability	audio	pipewire-audio	Audio	unavailable	user-session	pipewire	Audio tools are installed, but no PipeWire or Pulse session is responding'
 printf '%s\n' "$runtime_down_output" | grep -Fqx \
+	'capability	appearance	themes	Themes	unavailable	read-only	dwm-settings-appearance	Restore a valid themes.toml configuration or inspect the appearance snapshot errors'
+
+malformed_appearance_bin=$work/malformed-appearance-bin
+cp -a "$fedora_bin" "$malformed_appearance_bin"
+make_malformed_appearance_stub "$malformed_appearance_bin/dwm-settings-appearance"
+malformed_appearance_output=$(PATH="$malformed_appearance_bin" XDG_CONFIG_HOME="$work/fedora-config" \
+	DWM_SETTINGS_OS_RELEASE="$work/fedora-os-release" "$provider" discover)
+printf '%s\n' "$malformed_appearance_output" | grep -Fqx \
 	'capability	appearance	themes	Themes	unavailable	read-only	dwm-settings-appearance	Restore a valid themes.toml configuration or inspect the appearance snapshot errors'
 
 missing_appearance_bin=$work/missing-appearance-bin

--- a/tests/test-settings.sh
+++ b/tests/test-settings.sh
@@ -45,6 +45,13 @@ make_malformed_appearance_stub() {
 	chmod +x "$path"
 }
 
+make_preamble_appearance_stub() {
+	path=$1
+	mkdir -p "${path%/*}"
+	printf '%s\n' '#!/bin/sh' 'printf "preamble\nappearance-protocol\t1\t0\n"' >"$path"
+	chmod +x "$path"
+}
+
 base_bin=$work/base-bin
 fedora_bin=$work/fedora-bin
 make_tools "$base_bin" dirname awk tr stat find grep timeout readlink
@@ -119,6 +126,14 @@ make_malformed_appearance_stub "$malformed_appearance_bin/dwm-settings-appearanc
 malformed_appearance_output=$(PATH="$malformed_appearance_bin" XDG_CONFIG_HOME="$work/fedora-config" \
 	DWM_SETTINGS_OS_RELEASE="$work/fedora-os-release" "$provider" discover)
 printf '%s\n' "$malformed_appearance_output" | grep -Fqx \
+	'capability	appearance	themes	Themes	unavailable	read-only	dwm-settings-appearance	Restore a valid themes.toml configuration or inspect the appearance snapshot errors'
+
+preamble_appearance_bin=$work/preamble-appearance-bin
+cp -a "$fedora_bin" "$preamble_appearance_bin"
+make_preamble_appearance_stub "$preamble_appearance_bin/dwm-settings-appearance"
+preamble_appearance_output=$(PATH="$preamble_appearance_bin" XDG_CONFIG_HOME="$work/fedora-config" \
+	DWM_SETTINGS_OS_RELEASE="$work/fedora-os-release" "$provider" discover)
+printf '%s\n' "$preamble_appearance_output" | grep -Fqx \
 	'capability	appearance	themes	Themes	unavailable	read-only	dwm-settings-appearance	Restore a valid themes.toml configuration or inspect the appearance snapshot errors'
 
 missing_appearance_bin=$work/missing-appearance-bin

--- a/tests/test-settings.sh
+++ b/tests/test-settings.sh
@@ -35,7 +35,7 @@ make_appearance_stub() {
 	path=$1
 	mkdir -p "${path%/*}"
 	printf '%s\n' '#!/bin/sh' \
-		'printf "appearance-protocol\t1\t0\nprovider\tappearance\tavailable\tread-only\tfixture\nsource\tuser\t/fixture/themes.toml\nactive\tnord\tnord\tselected\ntheme\tnord\tselected\tvalid\ttrue\tautomatic\tfixture\n"' >"$path"
+		'printf "appearance-protocol\t1\t0\nprovider\tappearance\tavailable\tread-only\tfixture\nsource\tuser\t/fixture/themes.toml\nactive\tnone\tnone\tselected\ntheme\tnone\tselected\tvalid\ttrue\tautomatic\tfixture\n"' >"$path"
 	chmod +x "$path"
 }
 

--- a/tests/test-settings.sh
+++ b/tests/test-settings.sh
@@ -41,6 +41,7 @@ for command_name in xrandr nmcli bluetoothctl pactl xset gsettings light-locker 
 	make_stub "$fedora_bin/$command_name"
 done
 make_stub "$fedora_bin/dwm-xdg-autostart"
+make_stub "$fedora_bin/dwm-settings-appearance"
 make_stub "$fedora_bin/inotifywait"
 make_failing_stub "$fedora_bin/pkexec"
 make_failing_stub "$fedora_bin/sudo"
@@ -74,6 +75,8 @@ printf '%s\n' "$fedora_output" | grep -Fqx \
 	'capability	audio	pipewire-audio	Audio	available	user-session	pactl	PipeWire Pulse-compatible session controls are available'
 printf '%s\n' "$fedora_output" | grep -Fqx \
 	'capability	defaults	xdg-autostart	Startup applications	available	user-session	xdg-autostart	Per-user XDG autostart overrides and live updates are available'
+printf '%s\n' "$fedora_output" | grep -Fqx \
+	'capability	appearance	themes	Themes	available	read-only	dwm-settings-appearance	Versioned theme inventory and integration state are available'
 printf '%s\n' "$fedora_output" | grep -Eq \
 	'^capability	system	authorization	Administrative authorization	(available|restricted)	privileged	polkit	'
 
@@ -82,6 +85,7 @@ cp -a "$fedora_bin" "$runtime_down_bin"
 for command_name in xrandr nmcli bluetoothctl pactl xset; do
 	make_failing_stub "$runtime_down_bin/$command_name"
 done
+make_failing_stub "$runtime_down_bin/dwm-settings-appearance"
 runtime_down_output=$(PATH="$runtime_down_bin" XDG_CONFIG_HOME="$work/fedora-config" \
 	DWM_SETTINGS_OS_RELEASE="$work/fedora-os-release" "$provider" discover)
 printf '%s\n' "$runtime_down_output" | grep -Fqx \
@@ -92,6 +96,20 @@ printf '%s\n' "$runtime_down_output" | grep -Fqx \
 	'capability	bluetooth	bluez	Bluetooth	unavailable	delegated	bluetoothctl	BlueZ tools are installed, but no daemon or adapter is responding'
 printf '%s\n' "$runtime_down_output" | grep -Fqx \
 	'capability	audio	pipewire-audio	Audio	unavailable	user-session	pipewire	Audio tools are installed, but no PipeWire or Pulse session is responding'
+printf '%s\n' "$runtime_down_output" | grep -Fqx \
+	'capability	appearance	themes	Themes	unavailable	read-only	dwm-settings-appearance	Restore a valid themes.toml configuration or inspect the appearance snapshot errors'
+
+missing_appearance_bin=$work/missing-appearance-bin
+cp -a "$fedora_bin" "$missing_appearance_bin"
+rm -f "$missing_appearance_bin/dwm-settings-appearance"
+isolated_provider_dir=$work/isolated-provider
+mkdir "$isolated_provider_dir"
+cp "$provider" "$isolated_provider_dir/dwm-settings-provider"
+missing_appearance_output=$(PATH="$missing_appearance_bin" XDG_CONFIG_HOME="$work/fedora-config" \
+	DWM_SETTINGS_OS_RELEASE="$work/fedora-os-release" \
+	"$isolated_provider_dir/dwm-settings-provider" discover)
+printf '%s\n' "$missing_appearance_output" | grep -Fqx \
+	'capability	appearance	themes	Themes	unavailable	read-only	dwm-settings-appearance	Install the managed appearance provider'
 
 if "$provider" unknown 2>"$work/provider.err"; then
 	exit 1

--- a/tests/test-settings.sh
+++ b/tests/test-settings.sh
@@ -34,7 +34,23 @@ make_failing_stub() {
 make_appearance_stub() {
 	path=$1
 	mkdir -p "${path%/*}"
+	printf '%s\n' '#!/bin/sh' \
+		'printf "appearance-protocol\t1\t0\nprovider\tappearance\tavailable\tread-only\tfixture\nsource\tuser\t/fixture/themes.toml\nactive\tnord\tnord\tselected\ntheme\tnord\tselected\tvalid\ttrue\tautomatic\tfixture\n"' >"$path"
+	chmod +x "$path"
+}
+
+make_header_only_appearance_stub() {
+	path=$1
+	mkdir -p "${path%/*}"
 	printf '%s\n' '#!/bin/sh' 'printf "appearance-protocol\t1\t0\n"' >"$path"
+	chmod +x "$path"
+}
+
+make_empty_active_appearance_stub() {
+	path=$1
+	mkdir -p "${path%/*}"
+	printf '%s\n' '#!/bin/sh' \
+		'printf "appearance-protocol\t1\t0\nprovider\tappearance\tavailable\tread-only\tfixture\nsource\tuser\t/fixture/themes.toml\nactive\t\t\tselected\ntheme\tnord\tselected\tvalid\ttrue\tautomatic\tfixture\n"' >"$path"
 	chmod +x "$path"
 }
 
@@ -134,6 +150,24 @@ make_preamble_appearance_stub "$preamble_appearance_bin/dwm-settings-appearance"
 preamble_appearance_output=$(PATH="$preamble_appearance_bin" XDG_CONFIG_HOME="$work/fedora-config" \
 	DWM_SETTINGS_OS_RELEASE="$work/fedora-os-release" "$provider" discover)
 printf '%s\n' "$preamble_appearance_output" | grep -Fqx \
+	'capability	appearance	themes	Themes	unavailable	read-only	dwm-settings-appearance	Restore a valid themes.toml configuration or inspect the appearance snapshot errors'
+
+header_only_appearance_bin=$work/header-only-appearance-bin
+cp -a "$fedora_bin" "$header_only_appearance_bin"
+make_header_only_appearance_stub "$header_only_appearance_bin/dwm-settings-appearance"
+header_only_appearance_output=$(PATH="$header_only_appearance_bin" \
+	XDG_CONFIG_HOME="$work/fedora-config" \
+	DWM_SETTINGS_OS_RELEASE="$work/fedora-os-release" "$provider" discover)
+printf '%s\n' "$header_only_appearance_output" | grep -Fqx \
+	'capability	appearance	themes	Themes	unavailable	read-only	dwm-settings-appearance	Restore a valid themes.toml configuration or inspect the appearance snapshot errors'
+
+empty_active_appearance_bin=$work/empty-active-appearance-bin
+cp -a "$fedora_bin" "$empty_active_appearance_bin"
+make_empty_active_appearance_stub "$empty_active_appearance_bin/dwm-settings-appearance"
+empty_active_appearance_output=$(PATH="$empty_active_appearance_bin" \
+	XDG_CONFIG_HOME="$work/fedora-config" \
+	DWM_SETTINGS_OS_RELEASE="$work/fedora-os-release" "$provider" discover)
+printf '%s\n' "$empty_active_appearance_output" | grep -Fqx \
 	'capability	appearance	themes	Themes	unavailable	read-only	dwm-settings-appearance	Restore a valid themes.toml configuration or inspect the appearance snapshot errors'
 
 missing_appearance_bin=$work/missing-appearance-bin


### PR DESCRIPTION
## Summary

- begin Phase 5 with a read-only appearance inventory provider
- expose selected/resolved themes, semantic colors, integration state, and typed errors
- install and test the provider while documenting deliberately deferred Phase 5 slices

## Bounded scope

This PR contains only the provider contract and its tests/docs. It does not add the Appearance QML page, apply/reset/preview operations, or privileged behavior. Those remain separate follow-up PRs so this change can be reviewed and merged independently.

## Validation

- `scripts/run-tests make clean all`
- `scripts/run-tests`
- focused ShellCheck and shfmt gates
- focused appearance/settings provider contract tests
- CodeRabbit local review: 0 findings
- independent Codex review: 0 findings
- live read-only snapshot against the current user theme configuration; file hash and mode unchanged

## Manual scope

There is no visible UI change in this provider-only slice. Real/nested X11 visual acceptance applies to the later QML PR.