### PR TITLE
test(autostart): make watcher teardown deterministic

### DIFF
--- a/tests/test-dwm-xdg-autostart.sh
+++ b/tests/test-dwm-xdg-autostart.sh
@@ -598,7 +598,7 @@ if command -v inotifywait >/dev/null 2>&1; then
 	kill -0 "$watch_helper"
 	kill -0 "$watch_child"
 	kill -CONT "$watch_owner"
-	kill -TERM "$watch_owner"
+	kill -KILL "$watch_owner"
 	wait "$watch_owner" 2>/dev/null || true
 	watch_owner=
 	wait_for pid_gone "$watch_helper"
@@ -628,7 +628,7 @@ if command -v inotifywait >/dev/null 2>&1; then
 	wait_for watch_child_replaced
 	cp "$work/vendor-a/autostart/example.desktop" "$work/watch-config/autostart/watched.desktop"
 	wait_for line_count_at_least "$work/watch-absent.out" $'changed\tautostart' 2
-	kill -TERM "$watch_owner"
+	kill -KILL "$watch_owner"
 	wait "$watch_owner" 2>/dev/null || true
 	watch_owner=
 	wait_for pid_gone "$watch_helper"
@@ -661,7 +661,7 @@ if command -v inotifywait >/dev/null 2>&1; then
 	done
 	cp "$work/vendor-a/autostart/example.desktop" "$work/watch-deep/one/two/config/autostart/watched.desktop"
 	wait_for line_count_at_least "$work/watch-deep.out" $'changed\tautostart' 5
-	kill -TERM "$watch_owner"
+	kill -KILL "$watch_owner"
 	wait "$watch_owner" 2>/dev/null || true
 	watch_owner=
 	wait_for pid_gone "$watch_helper"


### PR DESCRIPTION
## Summary

- terminate the synthetic watcher-owner shells immediately so Bash cannot defer TERM while blocked in wait
- preserve the product watchdog assertion that helper and inotify child exit after parent loss

## Validation

- `timeout 30 make check-xdg-autostart` (4 consecutive passes)
- `shellcheck tests/test-dwm-xdg-autostart.sh`
- `shfmt -d tests/test-dwm-xdg-autostart.sh`
- CodeRabbit local review: no findings

This is intentionally isolated from Phase 5 PR #170 so that appearance work does not absorb an unrelated CI test-harness fix.