### PR TITLE
feat(settings): add shared appearance pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ versions from `config.mk`.
   staged and compare-and-swap published, manual applies honor active previews,
   and DWM re-arms hot reload after the user theme directory is first created.
 
+- Add one root-scoped Appearance model as the owner of theme inventory,
+  validation, and semantic shell colors, plus a Settings Appearance pane for
+  bounded preview, keep, revert, apply, reset, and interrupted-operation
+  recovery. Partial toolkit, terminal, cursor, and compositor application is
+  reported explicitly, while unsafe ownership or symlink paths keep the pane
+  readable and disable mutation.
+
 - Add one shared session-action model for Lock, Log Out, Suspend, Reboot, and
   Shutdown across the panel and Settings. Fixed helper actions require exact
   accepted records, preserve destructive confirmations, attribute failures to

--- a/Makefile
+++ b/Makefile
@@ -408,6 +408,9 @@ check-quickshell-session-actions:
 check-quickshell-defaults-model:
 	tests/test-quickshell-defaults-model.sh
 
+check-quickshell-appearance-model:
+	tests/test-quickshell-appearance-model.sh
+
 check-quickshell-design-system:
 	tests/test-quickshell-design-system.sh
 
@@ -581,6 +584,7 @@ check:
 	$(MAKE) check-quickshell-power-model
 	$(MAKE) check-quickshell-session-actions
 	$(MAKE) check-quickshell-defaults-model
+	$(MAKE) check-quickshell-appearance-model
 	$(MAKE) check-quickshell-settings-xvfb
 	$(MAKE) check-quickshell-design-system
 	$(MAKE) check-quickshell-large-surfaces
@@ -616,5 +620,5 @@ check:
 	check-display-profile check-display-setup check-fedora-iso-builder check-fedora-packages check-fedora-platform check-format check-install \
 	check-gearlever-install check-herdr-install check-install-manifest check-install-preservation check-kickstart check-lock \
 	check-session-guards check-session-migration check-screenshot check-release-helper check-shell check-diagnostics check-status check-system-health check-settings \
-	check-quickshell-launcher check-quickshell-controls check-quickshell-audio check-quickshell-controlcenter check-quickshell-power check-quickshell-power-backend check-quickshell-power-model check-quickshell-session-actions check-quickshell-defaults-model check-quickshell-design-system check-quickshell-large-surfaces check-quickshell-large-surfaces-xvfb check-quickshell-panel-menus check-quickshell-command-menu check-quickshell-notifications check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-connectivity check-quickshell-qml check-lightdm-config check-terminal check-xvfb-runtime install install-system install-user \
+	check-quickshell-launcher check-quickshell-controls check-quickshell-audio check-quickshell-controlcenter check-quickshell-power check-quickshell-power-backend check-quickshell-power-model check-quickshell-session-actions check-quickshell-defaults-model check-quickshell-appearance-model check-quickshell-design-system check-quickshell-large-surfaces check-quickshell-large-surfaces-xvfb check-quickshell-panel-menus check-quickshell-command-menu check-quickshell-notifications check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-connectivity check-quickshell-qml check-lightdm-config check-terminal check-xvfb-runtime install install-system install-user \
 	install-cursors native release release-check uninstall

--- a/TASKS.md
+++ b/TASKS.md
@@ -30,12 +30,12 @@ validate, and merge each boundary before starting the next one:
 - [x] Add a user-session transaction helper for bounded preview, confirm,
   automatic or explicit rollback, apply, reset, and interrupted-operation
   recovery without replacing unrelated theme configuration.
-- [ ] Add one root-scoped appearance model shared by Settings and existing shell
+- [x] Add one root-scoped appearance model shared by Settings and existing shell
   surfaces without duplicating the `Theme.qml` or `themes.toml` ownership path.
-- [ ] Add a Settings Appearance pane with theme preview, apply, reset, and
+- [x] Add a Settings Appearance pane with theme preview, apply, reset, and
   recovery behavior. Preserve comments, custom themes, file mode, and unrelated
   user configuration.
-- [ ] Make partial GTK, Qt, terminal, cursor, or compositor application failures
+- [x] Make partial GTK, Qt, terminal, cursor, or compositor application failures
   visible without reporting the selected theme as fully applied.
 
 Acceptance:

--- a/config/quickshell/appearance/AppearanceModel.qml
+++ b/config/quickshell/appearance/AppearanceModel.qml
@@ -1,0 +1,662 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.core
+
+pragma ComponentBehavior: Bound
+
+Scope {
+    id: root
+
+    property bool settingsVisible: false
+    property bool busy: false
+    property bool mutationReady: false
+    property string providerState: "idle"
+    property string providerDetail: "Appearance has not been loaded"
+    property string sourceKind: "none"
+    property string sourcePath: ""
+    property string activeTheme: "none"
+    property string resolvedTheme: "nord"
+    property string activeState: "recovery"
+    property var themes: []
+    property var colors: ({})
+    property var integrations: []
+    property var errors: []
+    property string message: ""
+    property string messageSeverity: "idle"
+    property string previewState: "none"
+    property string previewToken: ""
+    property string previewTheme: ""
+    property int previewRemaining: 0
+    property string previewDetail: ""
+    property int previewZeroRetryAttempts: 0
+    property bool previewStatusParsed: false
+    property string recoveryState: "none"
+    property string recoveryAction: ""
+    property string recoveryTheme: ""
+    property int snapshotGeneration: 0
+    property int snapshotRunGeneration: 0
+    property bool snapshotPending: false
+    property bool snapshotParsed: false
+    property string actionKind: ""
+    property string actionTheme: ""
+    property string actionToken: ""
+    property string actionError: ""
+    property bool actionSucceeded: false
+
+    readonly property string homeDir: Quickshell.env("HOME") || ""
+    readonly property string configuredConfigHome: Quickshell.env("XDG_CONFIG_HOME")
+    readonly property string configuredDataHome: Quickshell.env("XDG_DATA_HOME")
+    readonly property string configuredStateHome: Quickshell.env("XDG_STATE_HOME")
+    readonly property string configHome: root.configuredConfigHome.startsWith("/")
+        ? root.configuredConfigHome : root.homeDir + "/.config"
+    readonly property string dataHome: root.configuredDataHome.startsWith("/")
+        ? root.configuredDataHome : root.homeDir + "/.local/share"
+    readonly property string stateHome: root.configuredStateHome.startsWith("/")
+        ? root.configuredStateHome : root.homeDir + "/.local/state"
+    readonly property string themesPath: root.configHome + "/dwm-titus/themes.toml"
+    readonly property string managedThemesPath: root.dataHome + "/dwm-titus/config/themes.toml"
+    readonly property var integrationWatchPaths: [
+        root.configHome + "/alacritty/active-theme.toml",
+        root.configHome + "/alacritty/alacritty.toml",
+        root.configHome + "/kitty/active-theme.conf",
+        root.configHome + "/kitty/kitty.conf",
+        root.configHome + "/gtk-3.0/settings.ini",
+        root.configHome + "/gtk-4.0/settings.ini",
+        (Quickshell.env("HOME") || "") + "/.gtkrc-2.0",
+        root.configHome + "/dwm-titus/cursor.Xresources",
+        root.configHome + "/dwm-titus/theme-env.sh",
+        root.configHome + "/qt5ct/qt5ct.conf",
+        root.configHome + "/qt6ct/qt6ct.conf"
+    ]
+    readonly property var statusWatchPaths: [
+        root.stateHome + "/dwm-titus/appearance/preview.current",
+        root.stateHome + "/dwm-titus/appearance/transaction.meta",
+        root.stateHome + "/dwm-titus/appearance/transaction.failed",
+        root.stateHome + "/dwm-titus/appearance/integration-transaction"
+    ]
+    readonly property var requiredIntegrationIds: [
+        "gtk", "qt", "cursor", "alacritty", "kitty", "compositor"
+    ]
+    readonly property var requiredColors: [
+        "background", "bar-background", "surface", "surface-hover", "surface-active",
+        "border", "border-strong", "text", "text-strong", "text-muted", "placeholder",
+        "accent", "accent-secondary", "accent-text", "success", "warning", "danger",
+        "danger-surface"
+    ]
+    readonly property string applicationState: {
+        if (root.providerState === "idle") return "idle";
+        let appliedTheme = null;
+        for (const theme of root.themes) {
+            if (theme.id === root.resolvedTheme) {
+                appliedTheme = theme;
+                break;
+            }
+        }
+        if (root.providerState === "unavailable" || root.activeState === "unresolved"
+                || appliedTheme === null || !appliedTheme.valid) return "unavailable";
+        if (root.activeState === "recovery") return "partial";
+        for (const integration of root.integrations) {
+            if (integration.state !== "available") return "partial";
+        }
+        return "available";
+    }
+
+    function validState(value) {
+        return value === "available" || value === "partial" || value === "restricted"
+            || value === "unavailable";
+    }
+
+    function validThemeName(value) {
+        // Match dwm-settings-theme's public identifier contract exactly.
+        return typeof value === "string" && /^[A-Za-z0-9._-]{1,505}$/.test(value);
+    }
+
+    function validProviderThemeId(value) {
+        // The read-only provider also owns a synthetic legacy palette record.
+        return value === "@legacy-colors" || root.validThemeName(value);
+    }
+
+    function validProviderActiveLabel(value) {
+        // Recovery snapshots preserve an invalid selected value for diagnosis.
+        // The provider rejects physical lines of 4095 bytes or more.
+        return typeof value === "string" && value.length > 0 && value.length < 4095;
+    }
+
+    function validActiveState(value) {
+        return value === "selected" || value === "recovery" || value === "unresolved";
+    }
+
+    function validColor(value) {
+        return typeof value === "string" && /^#[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$/.test(value);
+    }
+
+    function colorsComplete(values) {
+        for (const name of root.requiredColors) {
+            if (!root.validColor(values[name])) return false;
+        }
+        return true;
+    }
+
+    function integrationsComplete(values) {
+        const seen = {};
+        for (const integration of values) {
+            if (root.requiredIntegrationIds.indexOf(integration.id) < 0 || seen[integration.id])
+                return false;
+            seen[integration.id] = true;
+        }
+        for (const id of root.requiredIntegrationIds) {
+            if (!seen[id]) return false;
+        }
+        return true;
+    }
+
+    function themeById(themeId) {
+        for (const theme of root.themes) {
+            if (theme.id === themeId) return theme;
+        }
+        return null;
+    }
+
+    function clearSnapshot(detail) {
+        root.providerState = "unavailable";
+        root.providerDetail = detail;
+        root.sourceKind = "none";
+        root.sourcePath = "";
+        root.activeTheme = "none";
+        root.activeState = "recovery";
+        root.themes = [];
+        root.integrations = [];
+        root.errors = [];
+    }
+
+    function parseSnapshot(text) {
+        if (root.snapshotRunGeneration !== root.snapshotGeneration) return;
+        let protocolValid = false;
+        let provider = null;
+        let source = null;
+        let active = null;
+        const themes = [];
+        const colors = {};
+        const integrations = [];
+        const errors = [];
+
+        for (const line of text.trim().split("\n")) {
+            if (line.length === 0) continue;
+            const fields = line.split("\t");
+            if (fields[0] === "appearance-protocol") {
+                protocolValid = fields.length === 3 && fields[1] === "1" && fields[2] === "0";
+            } else if (fields[0] === "provider" && fields.length === 5
+                    && fields[1] === "appearance" && root.validState(fields[2])
+                    && fields[3] === "read-only") {
+                provider = { "state": fields[2], "detail": fields[4] };
+            } else if (fields[0] === "source" && fields.length === 3
+                    && ((fields[1] === "user" || fields[1] === "managed")
+                        || (fields[1] === "none" && fields[2] === "unavailable"))) {
+                source = { "kind": fields[1], "path": fields[2] };
+            } else if (fields[0] === "active" && fields.length === 4
+                    && root.validProviderActiveLabel(fields[1])
+                    && root.validProviderThemeId(fields[2])
+                    && root.validActiveState(fields[3])) {
+                active = { "theme": fields[1], "resolved": fields[2], "state": fields[3] };
+            } else if (fields[0] === "theme" && fields.length === 7
+                    && root.validProviderThemeId(fields[1])
+                    && (fields[3] === "valid" || fields[3] === "invalid")
+                    && (fields[3] === "invalid"
+                        || fields[4] === "true" || fields[4] === "false")) {
+                themes.push({
+                    "id": fields[1], "state": fields[2], "valid": fields[3] === "valid",
+                    "mutable": root.validThemeName(fields[1]), "dark": fields[4] !== "false",
+                    "gtkTheme": fields[5], "detail": fields[6]
+                });
+            } else if (fields[0] === "color" && fields.length === 4
+                    && root.validColor(fields[2])) {
+                colors[fields[1]] = fields[2];
+            } else if (fields[0] === "integration" && fields.length === 5
+                    && root.validState(fields[2])) {
+                integrations.push({
+                    "id": fields[1], "state": fields[2], "value": fields[3], "detail": fields[4]
+                });
+            } else if (fields[0] === "error" && fields.length === 4) {
+                errors.push({ "scope": fields[1], "code": fields[2], "detail": fields[3] });
+            }
+        }
+
+        const snapshotComplete = provider !== null && (provider.state === "unavailable"
+            || (themes.length > 0 && root.colorsComplete(colors)
+                && root.integrationsComplete(integrations)));
+        if (!protocolValid || provider === null || source === null || active === null
+                || !snapshotComplete) {
+            root.clearSnapshot("Appearance provider returned an unsupported response");
+            return;
+        }
+
+        root.snapshotParsed = true;
+        root.providerState = provider.state;
+        root.providerDetail = provider.detail;
+        root.sourceKind = source.kind;
+        root.sourcePath = source.path;
+        root.activeTheme = active.theme;
+        root.resolvedTheme = active.resolved;
+        root.activeState = active.state;
+        root.themes = themes;
+        root.colors = colors;
+        root.integrations = integrations;
+        root.errors = errors;
+
+        if (root.colorsComplete(colors)) {
+            let darkMode = Theme.dark;
+            for (const theme of themes) {
+                if (theme.id === active.resolved) {
+                    darkMode = theme.dark;
+                    break;
+                }
+            }
+            Theme.applyAppearanceColors(colors, darkMode);
+        }
+    }
+
+    function refreshSnapshot() {
+        root.snapshotGeneration++;
+        if (snapshotProcess.running) {
+            root.snapshotPending = true;
+            return;
+        }
+        root.snapshotPending = false;
+        root.snapshotRunGeneration = root.snapshotGeneration;
+        root.snapshotParsed = false;
+        snapshotProcess.running = true;
+    }
+
+    function refreshPreviewStatus() {
+        if (!previewStatusProcess.running && !actionProcess.running) {
+            root.previewStatusParsed = false;
+            previewStatusProcess.running = true;
+        }
+    }
+
+    function refreshRecoveryStatus() {
+        if (!recoveryStatusProcess.running && !actionProcess.running)
+            recoveryStatusProcess.running = true;
+    }
+
+    function refreshMutationReadiness() {
+        if (!readinessProcess.running && !actionProcess.running)
+            readinessProcess.running = true;
+    }
+
+    function refreshAll() {
+        root.refreshSnapshot();
+        root.refreshPreviewStatus();
+        root.refreshRecoveryStatus();
+        root.refreshMutationReadiness();
+    }
+
+    function openSettings() {
+        root.settingsVisible = true;
+        root.refreshAll();
+    }
+
+    function closeSettings() {
+        root.settingsVisible = false;
+    }
+
+    function nextPreviewToken() {
+        return "qs-" + Quickshell.processId.toString() + "-" + Date.now().toString();
+    }
+
+    function runAction(action, args, theme, token) {
+        if (root.busy || actionProcess.running) {
+            root.message = "Another appearance change is already in progress";
+            root.messageSeverity = "warning";
+            return;
+        }
+        root.busy = true;
+        root.actionKind = action;
+        root.actionTheme = theme || "";
+        root.actionToken = token || "";
+        root.actionError = "";
+        root.actionSucceeded = false;
+        root.message = "Applying appearance change...";
+        root.messageSeverity = "idle";
+        actionProcess.command = Commands.checkedCommand(Commands.settingsThemeCommand(action, args));
+        actionProcess.running = true;
+    }
+
+    function startPreview(theme) {
+        if (!root.mutationReady || !root.validThemeName(theme) || root.previewState !== "none"
+                || root.recoveryState !== "none") return;
+        const token = root.nextPreviewToken();
+        root.runAction("preview", [token, "30", theme], theme, token);
+    }
+
+    function applyTheme(theme) {
+        if (!root.mutationReady || !root.validThemeName(theme) || root.previewState !== "none"
+                || root.recoveryState !== "none") return;
+        root.runAction("apply", [theme], theme, "");
+    }
+
+    function resetTheme() {
+        if (!root.mutationReady || root.previewState !== "none" || root.recoveryState !== "none") return;
+        root.runAction("reset", [], "", "");
+    }
+
+    function keepPreview() {
+        if (root.previewState !== "active" || !root.validThemeName(root.previewTheme)
+                || root.previewToken.length === 0) return;
+        root.runAction("keep", [root.previewToken], root.previewTheme, root.previewToken);
+    }
+
+    function revertPreview() {
+        if ((root.previewState !== "active" && root.previewState !== "failed")
+                || root.previewToken.length === 0) return;
+        root.runAction("revert", [root.previewToken], root.previewTheme, root.previewToken);
+    }
+
+    function abandonPreview() {
+        if (root.previewState !== "failed" || root.previewToken.length === 0) return;
+        root.runAction("abandon", [root.previewToken], root.previewTheme, root.previewToken);
+    }
+
+    function recover() {
+        if (root.recoveryState !== "available") return;
+        root.runAction("recover", [], root.recoveryTheme, "");
+    }
+
+    function parseActionResult(text) {
+        const lines = text.trim().split("\n");
+        if (lines.length !== 2 || lines[0] !== "appearance-action-protocol\t1\t0") return;
+        const fields = lines[1].split("\t");
+        if (root.actionKind === "preview") {
+            root.actionSucceeded = fields.length === 5 && fields[0] === "preview"
+                && fields[1] === root.actionToken && fields[2] === "30"
+                && fields[3] === root.actionTheme;
+        } else if (root.actionKind === "apply" || root.actionKind === "reset") {
+            root.actionSucceeded = fields.length === 4 && fields[0] === "result"
+                && fields[1] === root.actionKind
+                && (root.actionKind === "reset" || fields[2] === root.actionTheme);
+        } else if (root.actionKind === "keep" || root.actionKind === "revert"
+                || root.actionKind === "abandon") {
+            root.actionSucceeded = fields.length === 4 && fields[0] === "result"
+                && fields[1] === root.actionKind && fields[2] === root.actionToken;
+        } else if (root.actionKind === "recover") {
+            root.actionSucceeded = fields.length === 2 && fields[0] === "result"
+                && fields[1] === "recovered";
+        }
+    }
+
+    function finishAction() {
+        root.busy = false;
+        if (root.actionSucceeded) {
+            if (root.actionKind === "preview") {
+                root.previewState = "active";
+                root.previewToken = root.actionToken;
+                root.previewTheme = root.actionTheme;
+                root.previewRemaining = 30;
+                root.previewZeroRetryAttempts = 0;
+                root.message = "Preview active; keep it within 30 seconds or it will revert";
+                root.messageSeverity = "warning";
+            } else {
+                if (root.actionKind === "keep" || root.actionKind === "revert"
+                        || root.actionKind === "abandon") {
+                    root.previewState = "none";
+                    root.previewToken = "";
+                    root.previewTheme = "";
+                    root.previewRemaining = 0;
+                    root.previewDetail = "";
+                    root.previewZeroRetryAttempts = 0;
+                } else if (root.actionKind === "recover") {
+                    root.recoveryState = "none";
+                    root.recoveryAction = "";
+                    root.recoveryTheme = "";
+                }
+                root.message = root.actionKind === "keep" ? "Theme preview kept"
+                    : root.actionKind === "revert" ? "Theme preview reverted"
+                    : root.actionKind === "abandon" ? "External theme state accepted"
+                    : root.actionKind === "recover" ? "Interrupted theme change recovered"
+                    : root.actionKind === "reset" ? "Theme reset to the managed default"
+                    : "Theme applied";
+                root.messageSeverity = "success";
+            }
+        } else {
+            root.message = root.actionError.length > 0 ? root.actionError
+                : "Appearance helper did not confirm the requested change";
+            root.messageSeverity = "danger";
+        }
+        Qt.callLater(root.refreshAll);
+    }
+
+    Component.onCompleted: root.refreshAll()
+
+    FileView {
+        id: userThemesWatch
+        path: root.themesPath
+        watchChanges: true
+        printErrors: false
+        onLoaded: sourceChangeSettleTimer.restart()
+        onLoadFailed: sourceChangeSettleTimer.restart()
+        onFileChanged: reload()
+    }
+
+    FileView {
+        id: managedThemesWatch
+        path: root.managedThemesPath
+        watchChanges: true
+        printErrors: false
+        onLoaded: sourceChangeSettleTimer.restart()
+        onLoadFailed: sourceChangeSettleTimer.restart()
+        onFileChanged: reload()
+    }
+
+    Variants {
+        model: root.integrationWatchPaths
+
+        FileView {
+            required property string modelData
+            path: modelData
+            watchChanges: root.settingsVisible
+            printErrors: false
+            onLoaded: if (root.settingsVisible) integrationChangeSettleTimer.restart()
+            onLoadFailed: if (root.settingsVisible) integrationChangeSettleTimer.restart()
+            onFileChanged: reload()
+        }
+    }
+
+    Variants {
+        model: root.settingsVisible ? root.statusWatchPaths : []
+
+        FileView {
+            required property string modelData
+            path: modelData
+            watchChanges: true
+            printErrors: false
+            onLoaded: statusChangeSettleTimer.restart()
+            onLoadFailed: statusChangeSettleTimer.restart()
+            onFileChanged: reload()
+        }
+    }
+
+    Process {
+        id: snapshotProcess
+        command: Commands.settingsAppearanceCommand("snapshot", [])
+        running: false
+        stdout: StdioCollector {
+            onStreamFinished: root.parseSnapshot(this.text)
+        }
+        stderr: StdioCollector {
+            id: snapshotError
+        }
+        onRunningChanged: {
+            if (!running && root.snapshotRunGeneration === root.snapshotGeneration
+                    && !root.snapshotParsed) {
+                const error = snapshotError.text.trim();
+                root.clearSnapshot(error.length > 0 ? error
+                    : "Appearance provider failed before returning a valid snapshot");
+            }
+            if (!running && root.snapshotPending) {
+                root.snapshotPending = false;
+                Qt.callLater(root.refreshSnapshot);
+            }
+        }
+    }
+
+    Process {
+        id: readinessProcess
+        command: Commands.booleanStatusCommand(Commands.settingsThemeCommand("mutation-ready", []))
+        running: false
+        stdout: StdioCollector {
+            onStreamFinished: root.mutationReady = this.text.trim() === "available"
+        }
+    }
+
+    Process {
+        id: previewStatusProcess
+        command: Commands.checkedCommand(Commands.settingsThemeCommand("preview-status", []))
+        running: false
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const lines = this.text.trim().split("\n");
+                if (lines.length < 2 || lines[0] !== "appearance-action-protocol\t1\t0") return;
+                const record = lines[1].split("\t");
+                if (record[0] === "result" && record[1] === "none") {
+                    root.previewStatusParsed = true;
+                    const wasActive = root.previewState === "active";
+                    root.previewState = "none";
+                    root.previewToken = "";
+                    root.previewTheme = "";
+                    root.previewRemaining = 0;
+                    root.previewDetail = "";
+                    root.previewZeroRetryAttempts = 0;
+                    if (wasActive) {
+                        root.message = "Theme preview completed outside Settings";
+                        root.messageSeverity = "idle";
+                    }
+                } else if (record[0] === "result" && record[1] === "expired") {
+                    root.previewStatusParsed = true;
+                    root.previewState = "none";
+                    root.previewToken = "";
+                    root.previewTheme = "";
+                    root.previewRemaining = 0;
+                    root.previewDetail = "";
+                    root.previewZeroRetryAttempts = 0;
+                    root.message = "Theme preview reverted automatically";
+                    root.messageSeverity = "warning";
+                } else if (record.length === 3 && record[0] === "preview-active") {
+                    root.previewStatusParsed = true;
+                    root.previewState = "active";
+                    root.previewToken = record[1];
+                    root.previewTheme = record[2];
+                    root.previewDetail = "Automatic rollback is armed";
+                    if (lines.length === 3) {
+                        const remaining = lines[2].split("\t");
+                        root.previewRemaining = remaining.length === 2
+                            && remaining[0] === "preview-remaining" && /^[0-9]+$/.test(remaining[1])
+                            ? Number(remaining[1]) : 0;
+                    } else root.previewRemaining = 0;
+                    if (root.previewRemaining > 0) root.previewZeroRetryAttempts = 0;
+                    else {
+                        root.previewZeroRetryAttempts++;
+                        if (root.previewZeroRetryAttempts > 3) {
+                            root.message = "Automatic rollback status needs a manual refresh";
+                            root.messageSeverity = "warning";
+                        }
+                    }
+                } else if (record.length === 3 && record[0] === "preview-failed") {
+                    root.previewStatusParsed = true;
+                    root.previewState = "failed";
+                    root.previewToken = record[1];
+                    root.previewDetail = record[2];
+                    root.previewRemaining = 0;
+                    root.previewZeroRetryAttempts = 0;
+                }
+            }
+        }
+        onRunningChanged: {
+            if (running) return;
+            // preview-status shares the helper's mutation lock, so this second
+            // snapshot observes integrations only after an external transaction
+            // has finished publishing them.
+            Qt.callLater(root.refreshSnapshot);
+            if (root.previewState !== "active" || root.previewRemaining !== 0) return;
+            if (!root.previewStatusParsed) root.previewZeroRetryAttempts++;
+            if (root.previewZeroRetryAttempts <= 3) previewZeroRetryTimer.restart();
+            else {
+                root.message = "Automatic rollback status needs a manual refresh";
+                root.messageSeverity = "warning";
+            }
+        }
+    }
+
+    Process {
+        id: recoveryStatusProcess
+        command: Commands.checkedCommand(Commands.settingsThemeCommand("recovery-status", []))
+        running: false
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const lines = this.text.trim().split("\n");
+                if (lines.length !== 2 || lines[0] !== "appearance-action-protocol\t1\t0") return;
+                const record = lines[1].split("\t");
+                if (record.length === 2 && record[0] === "recovery" && record[1] === "none") {
+                    root.recoveryState = "none";
+                    root.recoveryAction = "";
+                    root.recoveryTheme = "";
+                } else if (record.length === 4 && record[0] === "recovery"
+                        && record[1] === "available") {
+                    root.recoveryState = "available";
+                    root.recoveryAction = record[2];
+                    root.recoveryTheme = record[3];
+                }
+            }
+        }
+    }
+
+    Process {
+        id: actionProcess
+        command: ["sh", "-c", "exit 1"]
+        running: false
+        stdout: StdioCollector { onStreamFinished: root.parseActionResult(this.text) }
+        stderr: StdioCollector { onStreamFinished: root.actionError = this.text.trim() }
+        onRunningChanged: if (!running && root.busy) root.finishAction()
+    }
+
+    Timer {
+        id: previewZeroRetryTimer
+        interval: 250
+        repeat: false
+        onTriggered: root.refreshPreviewStatus()
+    }
+
+    Timer {
+        id: sourceChangeSettleTimer
+        interval: 100
+        repeat: false
+        onTriggered: root.refreshAll()
+    }
+
+    Timer {
+        id: integrationChangeSettleTimer
+        interval: 100
+        repeat: false
+        onTriggered: if (root.settingsVisible) root.refreshAll()
+    }
+
+    Timer {
+        id: statusChangeSettleTimer
+        interval: 100
+        repeat: false
+        onTriggered: if (root.settingsVisible) root.refreshAll()
+    }
+
+    Timer {
+        interval: 1000
+        repeat: true
+        running: root.previewState === "active" && root.previewRemaining > 0
+        onTriggered: {
+            root.previewRemaining--;
+            if (root.previewRemaining === 0) {
+                Qt.callLater(root.refreshPreviewStatus);
+                Qt.callLater(root.refreshSnapshot);
+            }
+        }
+    }
+}

--- a/config/quickshell/core/Commands.qml
+++ b/config/quickshell/core/Commands.qml
@@ -30,6 +30,11 @@ Singleton {
         return ["sh", "-c", script, "dwm-checked-command"].concat(command);
     }
 
+    function booleanStatusCommand(command) {
+        const script = 'if "$@" >/dev/null 2>&1; then printf "available\\n"; else printf "restricted\\n"; fi';
+        return ["sh", "-c", script, "dwm-boolean-status"].concat(command);
+    }
+
     function launcherHelperCommand(action, args) {
         return helperCommand("dwm-quickshell-launcher", action, args, true);
     }
@@ -88,5 +93,13 @@ Singleton {
 
     function settingsInputCommand(action, args) {
         return helperCommand("dwm-settings-input", action, args, true);
+    }
+
+    function settingsAppearanceCommand(action, args) {
+        return helperCommand("dwm-settings-appearance", action, args, true);
+    }
+
+    function settingsThemeCommand(action, args) {
+        return helperCommand("dwm-settings-theme", action, args, true);
     }
 }

--- a/config/quickshell/core/Theme.qml
+++ b/config/quickshell/core/Theme.qml
@@ -1,7 +1,6 @@
 pragma Singleton
 
 import Quickshell
-import Quickshell.Io
 
 Singleton {
     id: root
@@ -58,84 +57,28 @@ Singleton {
     readonly property string controlDisabledBorder: border
     readonly property string controlDisabledText: textMuted
 
-    readonly property string configHome: Quickshell.env("XDG_CONFIG_HOME")
-        || ((Quickshell.env("HOME") || "") + "/.config")
-    readonly property string dataHome: Quickshell.env("XDG_DATA_HOME")
-        || ((Quickshell.env("HOME") || "") + "/.local/share")
-    readonly property string themesPath: configHome + "/dwm-titus/themes.toml"
-    readonly property string managedThemesPath: dataHome + "/dwm-titus/config/themes.toml"
-
-    function sectionValue(text, section, key, fallback) {
-        const lines = text.split("\n");
-        let active = false;
-        const sectionHeader = "[" + section + "]";
-        const expression = new RegExp("^\\s*" + key + "\\s*=\\s*(?:\\\"([^\\\"]*)\\\"|([^#\\s]+))");
-
-        for (const line of lines) {
-            const trimmed = line.trim();
-            const commentIndex = trimmed.indexOf("#");
-            const header = (commentIndex >= 0 ? trimmed.substring(0, commentIndex) : trimmed).trim();
-            if (header.startsWith("[")) {
-                active = header === sectionHeader;
-                continue;
-            }
-            if (!active) continue;
-            const match = line.match(expression);
-            if (match) return match[1] !== undefined ? match[1] : match[2];
-        }
-        return fallback;
-    }
-
-    function applyThemes(themeText) {
-        const activeTheme = sectionValue(themeText, "active", "theme", "nord");
-        const section = "theme." + activeTheme;
-        const value = function(key, fallback) { return sectionValue(themeText, section, key, fallback); };
-
-        root.dark = value("dark_mode", "true") !== "false";
-        root.bg = value("term_bg", root.bg);
-        root.barBackground = value("normbgcolor", root.bg);
-        root.surface = value("normbgcolor", root.bg);
-        root.surfaceHover = value("term_color8", value("selbgcolor", root.surface));
-        root.surfaceActive = value("selbgcolor", root.surfaceHover);
-        root.border = value("normbordercolor", root.surface);
-        root.borderStrong = value("selbordercolor", root.border);
-        root.text = value("normfgcolor", root.text);
-        root.textStrong = value("selfgcolor", root.text);
-        root.textMuted = value("term_fg", root.text);
-        root.placeholder = value("term_color8", root.textMuted);
-        root.accent = value("selbordercolor", root.accent);
-        root.accentSecondary = value("term_color4", root.accent);
-        root.accentText = root.bg;
-        root.success = value("term_color2", root.success);
-        root.warning = value("term_color3", root.warning);
-        root.danger = value("term_color1", root.danger);
-        root.dangerSurface = value("term_color0", root.surface);
-    }
-
-    function applyManagedTheme() {
-        const managedText = managedThemesFile.text();
-        if (managedText.length > 0) root.applyThemes(managedText);
-    }
-
-    FileView {
-        id: managedThemesFile
-        path: root.managedThemesPath
-        watchChanges: true
-        printErrors: false
-        onLoaded: {
-            if (!themesFile.loaded) root.applyThemes(text());
-        }
-        onFileChanged: reload()
-    }
-
-    FileView {
-        id: themesFile
-        path: root.themesPath
-        watchChanges: true
-        printErrors: false
-        onLoaded: root.applyThemes(text())
-        onLoadFailed: root.applyManagedTheme()
-        onFileChanged: reload()
+    // AppearanceModel is the single owner of theme inventory and validation.
+    // Existing shell surfaces continue to consume these semantic properties.
+    function applyAppearanceColors(colors, darkMode) {
+        root.dark = darkMode;
+        root.bg = colors.background;
+        root.barBackground = colors["bar-background"];
+        root.surface = colors.surface;
+        root.surfaceHover = colors["surface-hover"];
+        root.surfaceActive = colors["surface-active"];
+        root.border = colors.border;
+        root.borderStrong = colors["border-strong"];
+        root.text = colors.text;
+        root.textStrong = colors["text-strong"];
+        root.textMuted = colors["text-muted"];
+        root.placeholder = colors.placeholder;
+        root.accent = colors.accent;
+        root.accentSecondary = colors["accent-secondary"];
+        root.accentText = colors["accent-text"];
+        root.success = colors.success;
+        root.warning = colors.warning;
+        root.danger = colors.danger;
+        root.dangerSurface = colors["danger-surface"];
     }
 
     readonly property string fontFamily: "MesloLGS Nerd Font Mono"

--- a/config/quickshell/settings/AppearanceSettingsPane.qml
+++ b/config/quickshell/settings/AppearanceSettingsPane.qml
@@ -1,0 +1,318 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.core
+
+pragma ComponentBehavior: Bound
+
+Flickable {
+    id: root
+
+    required property var appearanceModel
+    required property var capabilities
+    property string selectedThemeId: ""
+    readonly property var selectedTheme: root.appearanceModel.themeById(root.selectedThemeId)
+    contentWidth: width
+    contentHeight: content.implicitHeight
+    clip: true
+
+    function statusColor(state) {
+        if (state === "available") return Theme.success;
+        if (state === "partial" || state === "restricted") return Theme.warning;
+        if (state === "unavailable" || state === "failed") return Theme.danger;
+        return Theme.menuMutedText;
+    }
+
+    function displayName(value) {
+        if (!value || value.length === 0) return "Unknown";
+        return value.charAt(0).toUpperCase() + value.substring(1).replace(/-/g, " ");
+    }
+
+    function ensureSelection() {
+        if (root.appearanceModel.themeById(root.selectedThemeId)) return;
+        let preferred = root.appearanceModel.activeTheme;
+        if (!root.appearanceModel.themeById(preferred))
+            preferred = root.appearanceModel.resolvedTheme;
+        if (root.appearanceModel.themeById(preferred)) root.selectedThemeId = preferred;
+        else if (root.appearanceModel.themes.length > 0)
+            root.selectedThemeId = root.appearanceModel.themes[0].id;
+    }
+
+    onVisibleChanged: if (visible) root.ensureSelection()
+    Component.onCompleted: root.ensureSelection()
+
+    Connections {
+        target: root.appearanceModel
+        function onThemesChanged() { root.ensureSelection(); }
+    }
+
+    component StatusCard: Rectangle {
+        id: statusCard
+        required property string label
+        required property string statusState
+        required property string detail
+        property string value: ""
+
+        Layout.fillWidth: true
+        Layout.preferredHeight: Math.max(70, statusColumn.implicitHeight + Theme.spacingLg * 2)
+        color: Theme.controlNormalFill
+        border.color: root.statusColor(statusState)
+        border.width: Theme.controlBorderWidth
+        radius: Theme.controlRadius
+
+        ColumnLayout {
+            id: statusColumn
+            anchors.fill: parent
+            anchors.margins: Theme.spacingLg
+            spacing: Theme.spacingXs
+
+            RowLayout {
+                Layout.fillWidth: true
+                UiText {
+                    Layout.fillWidth: true
+                    text: statusCard.label
+                    color: Theme.controlNormalText
+                    font.bold: true
+                    elide: Text.ElideRight
+                }
+                UiText {
+                    visible: statusCard.value.length > 0
+                    text: statusCard.value
+                    color: root.statusColor(statusCard.statusState)
+                    font.bold: true
+                }
+            }
+            UiText {
+                Layout.fillWidth: true
+                text: statusCard.detail
+                color: Theme.menuMutedText
+                wrapMode: Text.WordWrap
+            }
+        }
+    }
+
+    ColumnLayout {
+        id: content
+        width: root.width
+        spacing: Theme.spacingLg
+
+        RowLayout {
+            Layout.fillWidth: true
+            UiText {
+                Layout.fillWidth: true
+                text: root.appearanceModel.applicationState === "available"
+                    ? "Selected appearance is fully applied"
+                    : root.appearanceModel.applicationState === "partial"
+                        ? "Selected appearance is only partially applied"
+                        : root.appearanceModel.providerDetail
+                color: root.statusColor(root.appearanceModel.applicationState)
+                font.bold: true
+                elide: Text.ElideRight
+            }
+            ShellButton {
+                label: root.appearanceModel.busy ? "Working..." : "Refresh"
+                enabled: !root.appearanceModel.busy
+                onActivated: root.appearanceModel.refreshAll()
+            }
+        }
+
+        UiText {
+            Layout.fillWidth: true
+            visible: root.appearanceModel.message.length > 0
+            text: root.appearanceModel.message
+            color: root.appearanceModel.messageSeverity === "success" ? Theme.success
+                : root.appearanceModel.messageSeverity === "warning" ? Theme.warning
+                    : root.appearanceModel.messageSeverity === "danger" ? Theme.danger
+                        : Theme.menuMutedText
+            wrapMode: Text.WordWrap
+        }
+
+        StatusCard {
+            visible: !root.appearanceModel.mutationReady
+            label: "Theme changes are read-only"
+            statusState: "restricted"
+            value: "Protected"
+            detail: "Inventory and active colors remain available, but a theme source or integration path failed ownership, link, or atomic-update safety checks."
+        }
+
+        StatusCard {
+            visible: root.appearanceModel.recoveryState === "available"
+            label: "Interrupted theme transaction"
+            statusState: "failed"
+            value: root.appearanceModel.recoveryAction
+            detail: "Recovery is available for " + root.appearanceModel.recoveryTheme
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            visible: root.appearanceModel.recoveryState === "available"
+            ShellButton {
+                label: root.appearanceModel.busy ? "Recovering..." : "Restore previous state"
+                enabled: !root.appearanceModel.busy
+                onActivated: root.appearanceModel.recover()
+            }
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            visible: root.appearanceModel.previewState !== "none"
+            Layout.preferredHeight: previewColumn.implicitHeight + Theme.spacingLg * 2
+            color: Theme.controlNormalFill
+            border.color: root.appearanceModel.previewState === "failed" ? Theme.danger : Theme.warning
+            border.width: Theme.controlFocusBorderWidth
+            radius: Theme.controlRadius
+
+            ColumnLayout {
+                id: previewColumn
+                anchors.fill: parent
+                anchors.margins: Theme.spacingLg
+                spacing: Theme.spacingSm
+
+                UiText {
+                    Layout.fillWidth: true
+                    text: root.appearanceModel.previewState === "failed"
+                        ? "Preview rollback needs attention"
+                        : "Previewing " + root.appearanceModel.previewTheme
+                            + " / " + root.appearanceModel.previewRemaining + "s remaining"
+                    color: root.appearanceModel.previewState === "failed" ? Theme.danger : Theme.warning
+                    font.bold: true
+                    wrapMode: Text.WordWrap
+                }
+                UiText {
+                    Layout.fillWidth: true
+                    text: root.appearanceModel.previewDetail
+                    color: Theme.menuText
+                    wrapMode: Text.WordWrap
+                }
+                RowLayout {
+                    ShellButton {
+                        visible: root.appearanceModel.previewState === "active"
+                        label: "Keep theme"
+                        enabled: !root.appearanceModel.busy
+                        onActivated: root.appearanceModel.keepPreview()
+                    }
+                    ShellButton {
+                        label: "Restore previous"
+                        enabled: !root.appearanceModel.busy
+                        onActivated: root.appearanceModel.revertPreview()
+                    }
+                    ShellButton {
+                        visible: root.appearanceModel.previewState === "failed"
+                        label: "Accept external state"
+                        danger: true
+                        enabled: !root.appearanceModel.busy
+                        onActivated: root.appearanceModel.abandonPreview()
+                    }
+                }
+            }
+        }
+
+        SectionLabel { label: "Themes" }
+
+        Flow {
+            Layout.fillWidth: true
+            spacing: Theme.spacingSm
+
+            Repeater {
+                model: root.appearanceModel.themes
+                delegate: ShellButton {
+                    id: themeButton
+                    required property var modelData
+                    label: root.displayName(themeButton.modelData.id)
+                        + (themeButton.modelData.id === root.selectedThemeId ? " / Selected" : "")
+                        + (themeButton.modelData.id === root.appearanceModel.activeTheme ? " / Active" : "")
+                    enabled: themeButton.modelData.valid && !root.appearanceModel.busy
+                    onActivated: root.selectedThemeId = themeButton.modelData.id
+                }
+            }
+        }
+
+        StatusCard {
+            visible: root.selectedTheme !== null
+            label: root.selectedTheme ? root.displayName(root.selectedTheme.id) : "Theme"
+            statusState: root.selectedTheme && root.selectedTheme.valid ? "available" : "unavailable"
+            value: root.selectedTheme && root.selectedTheme.dark ? "Dark" : "Light"
+            detail: root.selectedTheme ? root.selectedTheme.detail
+                + " / GTK: " + root.selectedTheme.gtkTheme : "Select a theme"
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacingSm
+            ShellButton {
+                label: "Preview for 30 seconds"
+                enabled: root.appearanceModel.mutationReady && root.selectedTheme !== null
+                    && root.selectedTheme.valid && root.selectedTheme.mutable
+                    && !root.appearanceModel.busy
+                    && root.appearanceModel.previewState === "none"
+                    && root.appearanceModel.recoveryState === "none"
+                onActivated: root.appearanceModel.startPreview(root.selectedThemeId)
+            }
+            ShellButton {
+                label: "Apply"
+                enabled: root.appearanceModel.mutationReady && root.selectedTheme !== null
+                    && root.selectedTheme.valid && root.selectedTheme.mutable
+                    && !root.appearanceModel.busy
+                    && root.appearanceModel.previewState === "none"
+                    && root.appearanceModel.recoveryState === "none"
+                onActivated: root.appearanceModel.applyTheme(root.selectedThemeId)
+            }
+            ShellButton {
+                label: "Reset to managed default"
+                enabled: root.appearanceModel.mutationReady && !root.appearanceModel.busy
+                    && root.appearanceModel.previewState === "none"
+                    && root.appearanceModel.recoveryState === "none"
+                onActivated: root.appearanceModel.resetTheme()
+            }
+        }
+
+        SectionLabel { label: "Application status" }
+
+        Repeater {
+            model: root.appearanceModel.integrations
+            delegate: StatusCard {
+                id: integrationCard
+                required property var modelData
+                label: root.displayName(integrationCard.modelData.id)
+                statusState: integrationCard.modelData.state
+                value: integrationCard.modelData.state
+                detail: integrationCard.modelData.detail
+                    + (integrationCard.modelData.value.length > 0
+                        ? " / " + integrationCard.modelData.value : "")
+            }
+        }
+
+        SectionLabel {
+            visible: root.capabilities.length > 0
+            label: "Additional capabilities"
+        }
+
+        Repeater {
+            model: root.capabilities
+            delegate: StatusCard {
+                id: capabilityCard
+                required property var modelData
+                label: capabilityCard.modelData.label
+                statusState: capabilityCard.modelData.status
+                value: capabilityCard.modelData.status
+                detail: capabilityCard.modelData.detail
+            }
+        }
+
+        SectionLabel {
+            visible: root.appearanceModel.errors.length > 0
+            label: "Unresolved details"
+        }
+
+        Repeater {
+            model: root.appearanceModel.errors
+            delegate: StatusCard {
+                id: errorCard
+                required property var modelData
+                label: root.displayName(errorCard.modelData.scope)
+                statusState: "failed"
+                value: errorCard.modelData.code
+                detail: errorCard.modelData.detail
+            }
+        }
+    }
+}

--- a/config/quickshell/settings/SettingsModel.qml
+++ b/config/quickshell/settings/SettingsModel.qml
@@ -23,6 +23,7 @@ Scope {
     property var powerMenuModel: null
     property var defaultsModel: null
     property var autostartModel: null
+    property var appearanceModel: null
     property var capabilities: []
     property int selectedIndex: 0
     property var displayOutputs: []
@@ -138,6 +139,11 @@ Scope {
             const wantAutostart = id === "defaults" && root.visible;
             if (wantAutostart && !root.autostartModel.settingsVisible) root.autostartModel.openSettings();
             else if (!wantAutostart && root.autostartModel.settingsVisible) root.autostartModel.closeSettings();
+        }
+        if (root.appearanceModel) {
+            const wantAppearance = id === "appearance" && root.visible;
+            if (wantAppearance && !root.appearanceModel.settingsVisible) root.appearanceModel.openSettings();
+            else if (!wantAppearance && root.appearanceModel.settingsVisible) root.appearanceModel.closeSettings();
         }
         if (id === "displays") root.refreshDisplays();
         if (id === "input") root.refreshInput();
@@ -526,6 +532,7 @@ Scope {
 		if (root.powerMenuModel) root.powerMenuModel.cancelConfirmation("settings");
 		if (root.defaultsModel) root.defaultsModel.closeSettings();
 		if (root.autostartModel) root.autostartModel.closeSettings();
+		if (root.appearanceModel) root.appearanceModel.closeSettings();
 			inputSettleTimer.stop();
         root.visible = false;
         root.busy = false;

--- a/config/quickshell/settings/SettingsWindow.qml
+++ b/config/quickshell/settings/SettingsWindow.qml
@@ -16,6 +16,7 @@ FloatingWindow {
     required property var powerMenuModel
     required property var defaultsModel
     required property var autostartModel
+    required property var appearanceModel
 
     title: "dwm settings"
     visible: settingsModel.visible
@@ -374,6 +375,15 @@ FloatingWindow {
                                 autostartModel: root.autostartModel
                             }
 
+                            AppearanceSettingsPane {
+                                Layout.fillWidth: true
+                                Layout.fillHeight: true
+                                visible: root.settingsModel.selectedSectionId === "appearance"
+                                appearanceModel: root.appearanceModel
+                                capabilities: root.settingsModel.capabilitiesForSection("appearance")
+                                    .filter(function(capability) { return capability.id !== "themes"; })
+                            }
+
                             ListView {
                                 id: capabilityList
 
@@ -386,6 +396,7 @@ FloatingWindow {
                                     && root.settingsModel.selectedSectionId !== "audio"
                                     && root.settingsModel.selectedSectionId !== "power"
                                     && root.settingsModel.selectedSectionId !== "defaults"
+                                    && root.settingsModel.selectedSectionId !== "appearance"
                                 clip: true
                                 spacing: Theme.spacingLg
                                 model: root.settingsModel.capabilitiesForSection(root.settingsModel.selectedSectionId)

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -4,6 +4,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import Quickshell.Services.SystemTray
+import qs.appearance
 import qs.controlcenter
 import qs.controls
 import qs.defaults
@@ -169,6 +170,10 @@ ShellRoot {
         id: autostartModel
     }
 
+    AppearanceModel {
+        id: appearanceModel
+    }
+
     NetworkModel {
         id: networkModel
     }
@@ -199,6 +204,7 @@ ShellRoot {
         powerMenuModel: powerMenuModel
         defaultsModel: defaultsModel
         autostartModel: autostartModel
+        appearanceModel: appearanceModel
     }
 
     LazyLoader {
@@ -636,6 +642,51 @@ ShellRoot {
             return entry ? entry.origin : "";
         }
 
+        function appearanceProviderStatus(): string {
+            return appearanceModel.providerState;
+        }
+
+        function appearanceProviderDetail(): string {
+            return appearanceModel.providerDetail;
+        }
+
+        function appearanceApplicationState(): string {
+            return appearanceModel.applicationState;
+        }
+
+        function appearanceIntegrationState(integrationId: string): string {
+            const match = appearanceModel.integrations.find(function(item) { return item.id === integrationId; });
+            return match ? match.state : "";
+        }
+
+        function appearanceActiveTheme(): string {
+            return appearanceModel.activeTheme;
+        }
+
+        function appearanceThemeCount(): int {
+            return appearanceModel.themes.length;
+        }
+
+        function appearanceMutationReady(): bool {
+            return appearanceModel.mutationReady;
+        }
+
+        function appearancePreviewState(): string {
+            return appearanceModel.previewState;
+        }
+
+        function appearancePreviewRemaining(): int {
+            return appearanceModel.previewRemaining;
+        }
+
+        function appearanceMessage(): string {
+            return appearanceModel.message;
+        }
+
+        function appearanceRecoveryState(): string {
+            return appearanceModel.recoveryState;
+        }
+
         function autostartConfirming(): bool {
             return autostartModel.confirming;
         }
@@ -806,5 +857,6 @@ ShellRoot {
         powerMenuModel: powerMenuModel
         defaultsModel: defaultsModel
         autostartModel: autostartModel
+        appearanceModel: appearanceModel
     }
 }

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -16,6 +16,7 @@ readonly max_theme_name_length=505
 readonly key_separator=$'\034'
 readonly legacy_theme_id=$'\035legacy-colors'
 readonly legacy_theme_label='@legacy-colors'
+readonly builtin_palette_id=$'\036builtin-palette'
 readonly quoted_record_re='^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*"(([^"\\]|\\.)*)"[[:space:]]*(#.*)?$'
 readonly quoted_active_theme_re='^[[:space:]]*theme[[:space:]]*=[[:space:]]*"(([^"\\]|\\.)*)"[[:space:]]*(#.*)?$'
 
@@ -32,6 +33,7 @@ source_report_file=
 provider_state=available
 selected_theme=
 resolved_theme=
+palette_theme=
 errors_truncated=false
 entry_limit_reported=false
 parsed_entry_count=0
@@ -199,10 +201,38 @@ string_byte_length() {
 	string_byte_length_result=${#1}
 }
 
+count_inline_table_entries() {
+	local source=$1 char index=0 depth=0 quote='' escaped=false
+	local LC_ALL=C
+	inline_entry_count=0
+	while ((index < ${#source})); do
+		char=${source:index:1}
+		if [[ -n $quote ]]; then
+			if [[ $escaped == true ]]; then
+				escaped=false
+			elif [[ $quote == '"' && $char == \\ ]]; then
+				escaped=true
+			elif [[ $char == "$quote" ]]; then
+				quote=
+			fi
+		else
+			case $char in
+			'"' | "'") quote=$char ;;
+			'#') break ;;
+			'{') depth=$((depth + 1)) ;;
+			'}') ((depth == 0)) || depth=$((depth - 1)) ;;
+			'=') ((depth != 1)) || inline_entry_count=$((inline_entry_count + 1)) ;;
+			esac
+		fi
+		index=$((index + 1))
+	done
+}
+
 parse_themes() {
 	local file=$1 size line trimmed header line_number raw runtime_key runtime_value parsed_type
-	local string_byte_length_result parsed_runtime_string
+	local string_byte_length_result parsed_runtime_string complex_after runtime_entries inline_entry_count
 	local section='' theme='' theme_candidate='' key='' parsed=''
+	local complex_array_active=false
 
 	size=$(stat -c %s -- "$file" 2>/dev/null) || {
 		provider_state=unavailable
@@ -229,6 +259,23 @@ parse_themes() {
 		[[ -z $trimmed || $trimmed == \#* ]] && continue
 		header=${trimmed%%#*}
 		header=${header%"${header##*[![:space:]]}"}
+		if [[ $complex_array_active == true ]]; then
+			# tomlparser.c only leaves multi-line array mode when the trimmed
+			# physical line begins with ']'; keep later sections hidden likewise.
+			if [[ $trimmed == \]* ]]; then
+				complex_array_active=false
+				continue
+			fi
+			count_inline_table_entries "$trimmed"
+			parsed_entry_count=$((parsed_entry_count + inline_entry_count))
+			if ((parsed_entry_count > max_entry_count)); then
+				provider_state=partial
+				add_error parser entry-limit "Theme configuration exceeds the runtime parser limit of $max_entry_count entries"
+				entry_limit_reported=true
+				break
+			fi
+			continue
+		fi
 
 		if [[ $header == \[* ]]; then
 			if [[ $header =~ ^\[theme\.([^]]+)\]$ ]]; then
@@ -302,7 +349,19 @@ parse_themes() {
 			runtime_value=${runtime_value#"${runtime_value%%[![:space:]]*}"}
 			string_byte_length "$runtime_key"
 			if [[ -n $runtime_key ]] && ((string_byte_length_result < 512)); then
-				((parsed_entry_count += 1))
+				runtime_entries=1
+				if [[ $runtime_value == \[* ]]; then
+					complex_after=${runtime_value#\[}
+					complex_after=${complex_after#"${complex_after%%[![:space:]]*}"}
+					if [[ -z $complex_after || $complex_after == \#* ]]; then
+						runtime_entries=0
+						complex_array_active=true
+					elif [[ $complex_after == \{* ]]; then
+						count_inline_table_entries "$runtime_value"
+						runtime_entries=$inline_entry_count
+					fi
+				fi
+				parsed_entry_count=$((parsed_entry_count + runtime_entries))
 				if ((parsed_entry_count > max_entry_count)); then
 					provider_state=partial
 					if [[ $entry_limit_reported == false ]]; then
@@ -313,6 +372,7 @@ parse_themes() {
 				fi
 			fi
 			if [[ $runtime_value == \[* || $runtime_value == \{* ]]; then
+				[[ $section != ignore ]] || continue
 				provider_state=unavailable
 				add_error parser unsupported-complex-value \
 					"Arrays and inline tables are outside the appearance snapshot grammar at line $line_number"
@@ -368,6 +428,11 @@ parse_themes() {
 
 		value[$raw]=$parsed
 	done < <(numbered_theme_content_lines "$file")
+	if [[ $complex_array_active == true && $entry_limit_reported == false ]]; then
+		provider_state=unavailable
+		add_error parser unterminated-complex-value \
+			'An unrelated multi-line array was not terminated before the end of the theme configuration'
+	fi
 }
 
 valid_color() {
@@ -444,6 +509,14 @@ resolve_active_theme() {
 
 	selected_theme=${value[__active$key_separator'theme']:-}
 	string_byte_length "$selected_theme"
+	palette_theme=$selected_theme
+	if [[ -z $selected_theme ]]; then
+		[[ -z ${section_count[$legacy_theme_id]+x} ]] && palette_theme=$builtin_palette_id || palette_theme=$legacy_theme_id
+	elif ((string_byte_length_result > max_theme_name_length)); then
+		[[ -z ${section_count[$legacy_theme_id]+x} ]] && palette_theme=$builtin_palette_id || palette_theme=$legacy_theme_id
+	elif [[ -z ${section_count[$selected_theme]+x} ]]; then
+		palette_theme=$builtin_palette_id
+	fi
 	if [[ -z $selected_theme ]]; then
 		if [[ -n ${section_count[$legacy_theme_id]+x} && -z ${theme_invalid[$legacy_theme_id]+x} ]]; then
 			selected_theme=$legacy_theme_id
@@ -465,6 +538,14 @@ resolve_active_theme() {
 	elif [[ -n ${theme_invalid[$selected_theme]+x} ]]; then
 		provider_state=partial
 		add_error active invalid "Active theme '$selected_theme' is invalid or incomplete"
+		if dwm_palette_complete "$selected_theme"; then
+			# DWM's toml_get consumes the first value for each key across
+			# same-named sections, even when duplicate or non-core metadata makes
+			# the provider record invalid.
+			# Preserve that visible palette while still exposing recovery state.
+			resolved_theme=$selected_theme
+			return
+		fi
 	else
 		resolved_theme=$selected_theme
 		return
@@ -482,6 +563,26 @@ resolve_active_theme() {
 	done
 	provider_state=unavailable
 	add_error active no-valid-theme 'No complete theme is available for recovery'
+}
+
+dwm_builtin_color() {
+	case $1 in
+	normbordercolor) printf '#3B4252' ;;
+	normbgcolor) printf '#434C5E' ;;
+	normfgcolor) printf '#D8DEE9' ;;
+	selbordercolor) printf '#81A1C1' ;;
+	selbgcolor) printf '#434C5E' ;;
+	selfgcolor) printf '#ECEFF4' ;;
+	*) return 1 ;;
+	esac
+}
+
+dwm_palette_complete() {
+	local theme=$1 key color
+	for key in normfgcolor normbgcolor normbordercolor selfgcolor selbgcolor selbordercolor; do
+		color=${value[$theme$key_separator$key]:-}
+		[[ -n $color ]] && valid_color "$color" || return 1
+	done
 }
 
 data_roots() {
@@ -794,7 +895,7 @@ emit_theme_records() {
 }
 
 emit_color_records() {
-	local name key fallback color mapping
+	local name key fallback second_fallback color mapping candidate
 	local -a mappings=(
 		'background|term_bg|normbgcolor'
 		'bar-background|normbgcolor|term_bg'
@@ -806,21 +907,34 @@ emit_color_records() {
 		'text|normfgcolor|'
 		'text-strong|selfgcolor|normfgcolor'
 		'text-muted|term_fg|normfgcolor'
-		'placeholder|term_color8|term_fg'
+		'placeholder|term_color8|term_fg|normfgcolor'
 		'accent|selbordercolor|'
 		'accent-secondary|term_color4|selbordercolor'
-		'accent-text|term_bg|'
-		'success|term_color2|'
-		'warning|term_color3|'
-		'danger|term_color1|'
+		'accent-text|term_bg|normbgcolor'
+		'success|term_color2|selbordercolor'
+		'warning|term_color3|selbgcolor'
+		'danger|term_color1|selbordercolor'
 		'danger-surface|term_color0|normbgcolor'
 	)
 
-	[[ -n $resolved_theme ]] || return 0
+	[[ -n $palette_theme ]] || return 0
 	for mapping in "${mappings[@]}"; do
-		IFS='|' read -r name key fallback <<<"$mapping"
-		color=${value[$resolved_theme$key_separator$key]:-}
-		[[ -n $color || -z $fallback ]] || color=${value[$resolved_theme$key_separator$fallback]:-}
+		IFS='|' read -r name key fallback second_fallback <<<"$mapping"
+		color=
+		for candidate in "$key" "$fallback" "$second_fallback"; do
+			[[ -n $candidate ]] || continue
+			color=${value[$palette_theme$key_separator$candidate]:-}
+			valid_color "$color" && break
+			color=
+		done
+		if [[ -z $color ]]; then
+			for candidate in "$key" "$fallback" "$second_fallback"; do
+				[[ -n $candidate ]] || continue
+				if color=$(dwm_builtin_color "$candidate"); then
+					break
+				fi
+			done
+		fi
 		printf 'color\t%s\t%s\t%s\n' "$name" "$(clean_field "$color")" "$key"
 	done
 }
@@ -830,6 +944,7 @@ emit_integrations() {
 	[[ -n $resolved_theme ]] || return 0
 
 	dark=${value[$resolved_theme$key_separator'dark_mode']:-true}
+	[[ $dark == true || $dark == false ]] || dark=true
 	requested_gtk=${value[$resolved_theme$key_separator'gtk_theme']:-}
 	if [[ -z $requested_gtk ]]; then
 		if [[ $dark == true ]]; then
@@ -941,7 +1056,7 @@ snapshot() {
 	fi
 
 	if [[ -n $resolved_theme ]]; then
-		if [[ $resolved_theme == "$selected_theme" ]]; then
+		if [[ $resolved_theme == "$selected_theme" && -z ${theme_invalid[$selected_theme]+x} ]]; then
 			active_state=selected
 		else
 			active_state=recovery

--- a/scripts/dwm-settings-theme
+++ b/scripts/dwm-settings-theme
@@ -1638,7 +1638,7 @@ resume_preview() {
 }
 
 preview_status() {
-	local token=${1:-} prefix target
+	local token=${1:-} prefix target deadline now remaining
 	acquire_lock
 	ensure_recovery_dir
 	reconcile_preview_locked false
@@ -1657,6 +1657,14 @@ preview_status() {
 	elif [[ -f $prefix.meta ]]; then
 		target=$(meta_value "$prefix" target) || target=unknown
 		printf 'preview-active\t%s\t%s\n' "$token" "$target"
+		deadline=$(meta_value "$prefix" deadline) || deadline=0
+		now=$(date +%s)
+		if [[ $deadline =~ ^[0-9]+$ ]] && ((deadline > now)); then
+			remaining=$((deadline - now))
+		else
+			remaining=0
+		fi
+		printf 'preview-remaining\t%s\n' "$remaining"
 	else
 		printf 'result\texpired\t%s\n' "$token"
 	fi

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -300,18 +300,17 @@ grep -Fq $'error\tparser\tmalformed-section\tMalformed theme section header at l
 cp "$repo/config/themes.toml" "$config_home/dwm-titus/themes.toml"
 
 {
-	printf '[ignored]\nextra = [{x=1}, {x=2}]\n'
+	printf '%s\n' '[ignored]' 'extra = [{x="a=b"}, {x='"'"'c=d'"'"'}] # ignored = comment'
 	cat "$repo/config/themes.toml"
 } >"$config_home/dwm-titus/themes.toml"
 set +e
 inline_table=$(snapshot)
 inline_table_status=$?
 set -e
-[[ $inline_table_status -eq 3 ]]
-grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory and integration state' \
+[[ $inline_table_status -eq 0 ]]
+grep -Fqx $'provider\tappearance\tavailable\tread-only\tShared theme inventory and integration state' \
 	<<<"$inline_table"
-grep -Fq $'error\tparser\tunsupported-complex-value\tArrays and inline tables are outside the appearance snapshot grammar at line ' \
-	<<<"$inline_table"
+grep -Fqx $'active\tnord\tnord\tselected' <<<"$inline_table"
 
 {
 	printf '[ignored]\nextra = {x=1}\n'
@@ -321,11 +320,26 @@ set +e
 direct_inline_table=$(snapshot)
 direct_inline_table_status=$?
 set -e
-[[ $direct_inline_table_status -eq 3 ]]
-grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory and integration state' \
+[[ $direct_inline_table_status -eq 0 ]]
+grep -Fqx $'provider\tappearance\tavailable\tread-only\tShared theme inventory and integration state' \
 	<<<"$direct_inline_table"
-grep -Fq $'error\tparser\tunsupported-complex-value\tArrays and inline tables are outside the appearance snapshot grammar at line ' \
-	<<<"$direct_inline_table"
+grep -Fqx $'active\tnord\tnord\tselected' <<<"$direct_inline_table"
+
+{
+	printf '[ignored]\nextra = ["one", "two"]\n'
+	cat "$repo/config/themes.toml"
+} >"$config_home/dwm-titus/themes.toml"
+scalar_array=$(snapshot)
+grep -Fqx $'provider\tappearance\tavailable\tread-only\tShared theme inventory and integration state' \
+	<<<"$scalar_array"
+grep -Fqx $'active\tnord\tnord\tselected' <<<"$scalar_array"
+
+{
+	printf '[ignored]\nextra = [\n  {x=1},\n  {x=2}\n]\n'
+	cat "$repo/config/themes.toml"
+} >"$config_home/dwm-titus/themes.toml"
+multiline_array=$(snapshot)
+grep -Fqx $'active\tnord\tnord\tselected' <<<"$multiline_array"
 
 {
 	printf '[ignored]\nextra = [\n'
@@ -338,8 +352,46 @@ set -e
 [[ $unterminated_array_status -eq 3 ]]
 grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory and integration state' \
 	<<<"$unterminated_array"
-grep -Fq $'error\tparser\tunsupported-complex-value\tArrays and inline tables are outside the appearance snapshot grammar at line ' \
+grep -Fqx $'error\tparser\tunterminated-complex-value\tAn unrelated multi-line array was not terminated before the end of the theme configuration' \
 	<<<"$unterminated_array"
+
+{
+	printf '[ignored]\nextra = [\n  {x=1}, {x=2}]\n'
+	cat "$repo/config/themes.toml"
+} >"$config_home/dwm-titus/themes.toml"
+set +e
+runtime_stuck_array=$(snapshot)
+runtime_stuck_array_status=$?
+set -e
+[[ $runtime_stuck_array_status -eq 3 ]]
+grep -Fqx $'provider\tappearance\tunavailable\tread-only\tShared theme inventory and integration state' \
+	<<<"$runtime_stuck_array"
+grep -Fqx $'error\tparser\tunterminated-complex-value\tAn unrelated multi-line array was not terminated before the end of the theme configuration' \
+	<<<"$runtime_stuck_array"
+if grep -Fq $'theme\tnord\t' <<<"$runtime_stuck_array"; then
+	printf 'Provider parsed a theme section hidden by the runtime multi-line array state\n' >&2
+	exit 1
+fi
+for runtime_array_snapshot in "$inline_table" "$direct_inline_table" "$scalar_array" \
+	"$multiline_array" "$unterminated_array" "$runtime_stuck_array"; do
+	if grep -Fq $'error\tparser\tunsupported-complex-value\t' <<<"$runtime_array_snapshot"; then
+		printf 'Runtime-compatible unrelated array retained a superseded parser diagnostic\n' >&2
+		exit 1
+	fi
+done
+
+{
+	printf '[ignored]\nextra = [\n'
+	for ((nested_index = 0; nested_index < 257; nested_index++)); do
+		printf '  {outer={inner="x"}},\n'
+	done
+	printf ']\n'
+	cat "$repo/config/themes.toml"
+} >"$config_home/dwm-titus/themes.toml"
+nested_inline_tables=$(snapshot)
+grep -Fqx $'active\tnord\tnord\tselected' <<<"$nested_inline_tables"
+grep -Fqx $'error\tparser\tentry-limit\tTheme configuration exceeds the runtime parser limit of 512 entries' \
+	<<<"$nested_inline_tables"
 cp "$repo/config/themes.toml" "$config_home/dwm-titus/themes.toml"
 
 printf '\n[theme.@unsafe]\nterm_bg = "#000000"\n' >>"$config_home/dwm-titus/themes.toml"
@@ -519,19 +571,46 @@ unknown=$(snapshot)
 grep -Fqx $'provider\tappearance\tpartial\tread-only\tShared theme inventory and integration state' <<<"$unknown"
 grep -Fqx $'active\tmissing\tnord\trecovery' <<<"$unknown"
 grep -Fqx $'error\tactive\tunknown\tActive theme '\''missing'\'' is not defined' <<<"$unknown"
+grep -Fqx $'color\tbackground\t#434C5E\tterm_bg' <<<"$unknown"
+grep -Fqx $'color\tbar-background\t#434C5E\tnormbgcolor' <<<"$unknown"
+grep -Fqx $'color\taccent\t#81A1C1\tselbordercolor' <<<"$unknown"
 
 cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
 printf '\n[theme.nord]\nterm_bg = "#000000"\n' >>"$config_home/dwm-titus/themes.toml"
 duplicate=$(snapshot)
-grep -Fqx $'active\tnord\tdracula\trecovery' <<<"$duplicate"
+grep -Fqx $'active\tnord\tnord\trecovery' <<<"$duplicate"
 grep -Fq $'error\ttheme:nord\tduplicate\tDuplicate theme section at line ' <<<"$duplicate"
 grep -Fqx $'theme\tnord\tselected\tinvalid\ttrue\tNordic\tTheme record is duplicate, malformed, or incomplete' <<<"$duplicate"
+grep -Fqx $'color\tbackground\t#2E3440\tterm_bg' <<<"$duplicate"
+
+cat >"$config_home/dwm-titus/themes.toml" <<'EOF'
+[active]
+theme = "nord"
+
+[theme.nord]
+normfgcolor = "#D8DEE9"
+normbgcolor = "#434C5E"
+normbordercolor = "#3B4252"
+
+[theme.nord]
+selfgcolor = "#ECEFF4"
+selbgcolor = "#434C5E"
+selbordercolor = "#81A1C1"
+normbgcolor = "#FFFFFF"
+EOF
+split_duplicate=$(snapshot)
+grep -Fqx $'active\tnord\tnord\trecovery' <<<"$split_duplicate"
+grep -Fqx $'color\tbar-background\t#434C5E\tnormbgcolor' <<<"$split_duplicate"
+grep -Fqx $'color\tplaceholder\t#D8DEE9\tterm_color8' <<<"$split_duplicate"
+grep -Fqx $'color\tsuccess\t#81A1C1\tterm_color2' <<<"$split_duplicate"
+[[ $(grep -Ec $'^color\t[^\t]+\t#[0-9A-Fa-f]{6}\t' <<<"$split_duplicate") -eq 18 ]]
 
 cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"
 sed -i '0,/theme = "nord"/s//theme = "broken"/' "$config_home/dwm-titus/themes.toml"
 printf '\n[theme.broken]\ndark_mode = true\n' >>"$config_home/dwm-titus/themes.toml"
 incomplete=$(snapshot)
 grep -Fqx $'active\tbroken\tnord\trecovery' <<<"$incomplete"
+grep -Fqx $'color\tbackground\t#434C5E\tterm_bg' <<<"$incomplete"
 grep -Fqx $'error\ttheme:broken\tmissing-key\tTheme is missing 25 required keys; first missing key is '\''normfgcolor'\''' <<<"$incomplete"
 grep -Fqx $'error\tactive\tinvalid\tActive theme '\''broken'\'' is invalid or incomplete' <<<"$incomplete"
 
@@ -540,6 +619,7 @@ sed -i '0,/normfgcolor     = "#D8DEE9"/s//normfgcolor     = "not-a-color"/' \
 	"$config_home/dwm-titus/themes.toml"
 invalid_color=$(snapshot)
 grep -Fqx $'active\tnord\tdracula\trecovery' <<<"$invalid_color"
+grep -Fqx $'color\tbackground\t#2E3440\tterm_bg' <<<"$invalid_color"
 grep -Fqx $'error\ttheme:nord\tinvalid-color\tTheme key '\''normfgcolor'\'' is not a #RRGGBB color' <<<"$invalid_color"
 
 cp "$work/managed-themes.toml" "$config_home/dwm-titus/themes.toml"

--- a/tests/test-dwm-settings-theme.sh
+++ b/tests/test-dwm-settings-theme.sh
@@ -452,6 +452,7 @@ grep -Fqx $'preview\tpreview-keep\t10\tnord\tdracula' <<<"$preview_output"
 [[ $(active_theme) == nord ]]
 status_output=$(run_theme preview-status preview-keep)
 grep -Fqx $'preview-active\tpreview-keep\tnord' <<<"$status_output"
+grep -Eq $'^preview-remaining\t([1-9]|10)$' <<<"$status_output"
 keep_output=$(run_theme keep preview-keep)
 grep -Fqx $'result\tkeep\tpreview-keep\tnord' <<<"$keep_output"
 [[ $(active_theme) == nord ]]

--- a/tests/test-quickshell-appearance-model.sh
+++ b/tests/test-quickshell-appearance-model.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+set -eu
+
+repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+shell_qml=$repo/config/quickshell/shell.qml
+theme=$repo/config/quickshell/core/Theme.qml
+commands=$repo/config/quickshell/core/Commands.qml
+model=$repo/config/quickshell/appearance/AppearanceModel.qml
+settings_model=$repo/config/quickshell/settings/SettingsModel.qml
+settings_window=$repo/config/quickshell/settings/SettingsWindow.qml
+pane=$repo/config/quickshell/settings/AppearanceSettingsPane.qml
+
+# Syntax is validated here; executable state and lifecycle are exercised by
+# test-quickshell-settings-xvfb.sh. The assertions below protect module wiring
+# and security boundaries that are intentionally source-level contracts.
+"$repo/scripts/quickshell-qmllint" --root "$repo/config/quickshell"
+
+test "$(grep -c 'AppearanceModel {' "$shell_qml")" -eq 1
+grep -Fq 'appearanceModel: appearanceModel' "$shell_qml"
+grep -Fq 'root.appearanceModel.openSettings()' "$settings_model"
+grep -Fq 'root.appearanceModel.closeSettings()' "$settings_model"
+test "$(grep -Fc 'root.appearanceModel.closeSettings()' "$settings_model")" -eq 2
+grep -Fq 'AppearanceSettingsPane {' "$settings_window"
+grep -Fq 'root.settingsModel.selectedSectionId === "appearance"' "$settings_window"
+grep -Fq 'capability.id !== "themes"' "$settings_window"
+
+grep -Fq 'function settingsAppearanceCommand(action, args)' "$commands"
+grep -Fq 'function settingsThemeCommand(action, args)' "$commands"
+grep -Fq 'function booleanStatusCommand(command)' "$commands"
+grep -Fq 'appearance-protocol' "$model"
+grep -Fq 'appearance-action-protocol' "$model"
+grep -Fq 'value === "@legacy-colors" || root.validThemeName(value)' "$model"
+grep -Fq 'root.validProviderActiveLabel(fields[1])' "$model"
+grep -Fq 'fields[3] === "invalid"' "$model"
+grep -Fq '"dark": fields[4] !== "false"' "$model"
+grep -Fq 'value === "selected" || value === "recovery" || value === "unresolved"' "$model"
+grep -Fq 'fields[1] === "none" && fields[2] === "unavailable"' "$model"
+grep -Fq '"mutable": root.validThemeName(fields[1])' "$model"
+grep -Fq 'Commands.checkedCommand(Commands.settingsThemeCommand(action, args))' "$model"
+grep -Fq 'Commands.settingsThemeCommand("mutation-ready", [])' "$model"
+grep -Fq 'Theme.applyAppearanceColors(colors, darkMode)' "$model"
+grep -Fq 'watchChanges: true' "$model"
+test "$(grep -Fc 'watchChanges: true' "$model")" -eq 3
+grep -Fq 'model: root.integrationWatchPaths' "$model"
+grep -Fq 'model: root.settingsVisible ? root.statusWatchPaths : []' "$model"
+grep -Fq 'watchChanges: root.settingsVisible' "$model"
+grep -Fq 'onTriggered: if (root.settingsVisible) root.refreshAll()' "$model"
+test "$(grep -Fc 'onTriggered: if (root.settingsVisible) root.refreshAll()' "$model")" -eq 2
+grep -Fq 'running: root.previewState === "active" && root.previewRemaining > 0' "$model"
+grep -Fq 'previewZeroRetryTimer.restart()' "$model"
+grep -Fq 'if (!root.previewStatusParsed) root.previewZeroRetryAttempts++' "$model"
+grep -Fq 'root.snapshotParsed = false' "$model"
+grep -Fq 'root.snapshotRunGeneration === root.snapshotGeneration' "$model"
+grep -Fq '&& !root.snapshotParsed' "$model"
+grep -Fq 'const error = snapshotError.text.trim()' "$model"
+grep -Fq 'Appearance provider failed before returning a valid snapshot' "$model"
+grep -Fq 'root.configuredConfigHome.startsWith("/")' "$model"
+grep -Fq 'root.configuredDataHome.startsWith("/")' "$model"
+grep -Fq 'root.configuredStateHome.startsWith("/")' "$model"
+grep -Fq 'appliedTheme === null || !appliedTheme.valid' "$model"
+grep -Fq 'if (root.activeState === "recovery") return "partial"' "$model"
+grep -Fq 'root.colorsComplete(colors)' "$model"
+grep -Fq 'root.integrationsComplete(integrations)' "$model"
+grep -Fq 'Qt.callLater(root.refreshSnapshot)' "$model"
+grep -Fq 'onTriggered: root.refreshAll()' "$model"
+grep -Fq 'const wasActive = root.previewState === "active"' "$model"
+grep -Fq 'Theme preview completed outside Settings' "$model"
+
+grep -Fq 'function applyAppearanceColors(colors, darkMode)' "$theme"
+if grep -Eq 'FileView|themes\.toml|function applyThemes' "$theme"; then
+	printf 'Theme.qml still owns theme file parsing instead of the shared AppearanceModel\n' >&2
+	exit 1
+fi
+
+grep -Fq 'Preview for 30 seconds' "$pane"
+grep -Fq 'Component.onCompleted: root.ensureSelection()' "$pane"
+grep -Fq 'preferred = root.appearanceModel.resolvedTheme' "$pane"
+grep -Fq 'label: "Additional capabilities"' "$pane"
+grep -Fq 'model: root.capabilities' "$pane"
+grep -Fq 'onActivated: root.appearanceModel.keepPreview()' "$pane"
+grep -Fq 'onActivated: root.appearanceModel.revertPreview()' "$pane"
+grep -Fq 'onActivated: root.appearanceModel.abandonPreview()' "$pane"
+grep -Fq 'onActivated: root.appearanceModel.recover()' "$pane"
+grep -Fq 'Selected appearance is only partially applied' "$pane"
+grep -Fq 'root.appearanceModel.integrations' "$pane"
+grep -Fq 'root.appearanceModel.errors' "$pane"
+grep -Fq 'function appearanceIntegrationState(integrationId: string): string' "$shell_qml"
+test "$(grep -Fc 'root.selectedTheme.valid && root.selectedTheme.mutable' "$pane")" -eq 2
+
+if grep -ERq 'Quickshell\.(Wayland|Hyprland)|WlrLayershell|hyprctl|uwsm-app|wl-copy|wl-paste' \
+	"$model" "$pane"; then
+	printf 'Appearance model introduced a forbidden Wayland or Omarchy dependency\n' >&2
+	exit 1
+fi
+
+printf 'Quickshell shared appearance model contract: PASS\n'

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -428,15 +428,15 @@ if run_helper action not-real 2>"$work/action.err"; then
 fi
 grep -Fqx 'unknown action: not-real' "$work/action.err"
 
-grep -Fq 'watchChanges: true' "$repo/config/quickshell/core/Theme.qml"
-[ "$(grep -Fc 'watchChanges: true' "$repo/config/quickshell/core/Theme.qml")" -ge 2 ]
-[ "$(grep -Fc 'onFileChanged: reload()' "$repo/config/quickshell/core/Theme.qml")" -ge 2 ]
-grep -Fq 'themes.toml' "$repo/config/quickshell/core/Theme.qml"
+grep -Fq 'watchChanges: true' "$repo/config/quickshell/appearance/AppearanceModel.qml"
+[ "$(grep -Fc 'watchChanges: true' "$repo/config/quickshell/appearance/AppearanceModel.qml")" -eq 3 ]
+[ "$(grep -Fc 'onFileChanged: reload()' "$repo/config/quickshell/appearance/AppearanceModel.qml")" -eq 4 ]
+grep -Fq 'themes.toml' "$repo/config/quickshell/appearance/AppearanceModel.qml"
 grep -Fq 'ClickAwayPopup {' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
 grep -Fq 'onDismissed: controlCenterModel.close()' "$repo/config/quickshell/controlcenter/ControlCenterWindow.qml"
 grep -Fq 'grabFocus: true' "$repo/config/quickshell/core/ClickAwayPopup.qml"
-grep -Fq 'function applyThemes(themeText)' "$repo/config/quickshell/core/Theme.qml"
-grep -Fq 'root.text = value("normfgcolor", root.text)' "$repo/config/quickshell/core/Theme.qml"
+grep -Fq 'function applyAppearanceColors(colors, darkMode)' "$repo/config/quickshell/core/Theme.qml"
+grep -Fq 'root.text = colors.text' "$repo/config/quickshell/core/Theme.qml"
 grep -Fq 'label: root.delegated ? "Advanced" : root.busy ? "Connecting..." : "Connect"' "$repo/config/quickshell/network/NetworkWifiRow.qml"
 grep -Fq 'property bool wifiPasswordPromptVisible: false' "$repo/config/quickshell/network/NetworkModel.qml"
 grep -Fq 'root.wifiPasswordPromptVisible = true;' "$repo/config/quickshell/network/NetworkModel.qml"

--- a/tests/test-quickshell-settings-xvfb.sh
+++ b/tests/test-quickshell-settings-xvfb.sh
@@ -128,6 +128,11 @@ cleanup() {
 	if [ "$cleanup_status" -ne 0 ]; then
 		printf 'Settings Xvfb failed while %s (status %s)\n' \
 			"${test_stage:-stage unknown}" "$cleanup_status" >&2
+		if [ -n "${quickshell_pid:-}" ] && [ -n "${quickshell_identity:-}" ] &&
+			! process_identity_alive "$quickshell_identity"; then
+			wait "$quickshell_pid" 2>/dev/null
+			printf 'Quickshell exited before teardown with status %s\n' "$?" >&2
+		fi
 		if [ -f "${work:-}/quickshell.log" ]; then
 			tail -80 "$work/quickshell.log" >&2
 		fi
@@ -157,9 +162,12 @@ runtime=$runtime_storage
 schema_dir=$work/schemas
 config_home=$home/.config
 data_home=$home/.local/share
+state_home=$home/.local/state
 mkdir -p "$config_home/quickshell" "$config_home/dwm-titus" \
 	"$config_home/autostart" "$data_home/applications" \
-	"$data_home/dwm-titus/scripts" "$runtime_storage" "$schema_dir" "$helper_tmp"
+	"$data_home/dwm-titus/config" "$data_home/dwm-titus/scripts" \
+	"$state_home/dwm-titus/appearance" \
+	"$runtime_storage" "$schema_dir" "$helper_tmp"
 chmod 700 "$runtime_storage"
 if [ "${#runtime}" -gt 64 ]; then
 	runtime_alias_dir=$(mktemp -d /tmp/dwm-settings-runtime.XXXXXX)
@@ -187,6 +195,8 @@ cp -a "$repo/config/quickshell/." "$config_home/quickshell/"
 sed -i 's/readonly property var nativeBattery: UPower.displayDevice/readonly property var nativeBattery: null/' \
 	"$config_home/quickshell/power/PowerModel.qml"
 cp "$repo/config/"*.toml "$config_home/dwm-titus/"
+cp "$repo/config/themes.toml" "$data_home/dwm-titus/config/themes.toml"
+printf '# inactive integration watch fixture\n' >"$config_home/dwm-titus/theme-env.sh"
 cat >"$data_home/applications/kitty.desktop" <<'EOF'
 [Desktop Entry]
 Type=Application
@@ -225,7 +235,97 @@ cp "$repo/scripts/dwm-settings-provider" "$repo/scripts/dwm-system-health" \
 	"$repo/scripts/dwm-quickshell-controlcenter" "$repo/scripts/dwm-quickshell-controls" \
 	"$repo/scripts/dwm-quickshell-network" "$repo/scripts/dwm-diagnostics" \
 	"$repo/scripts/dwm-default-apps" "$repo/scripts/dwm-xdg-autostart" \
+	"$repo/scripts/dwm-settings-appearance" "$repo/scripts/dwm-settings-theme" \
+	"$repo/scripts/theme-apply.sh" \
 	"$repo/scripts/dwm-terminal" "$repo/scripts/dwm-lock" "$data_home/dwm-titus/scripts/"
+
+appearance_failure_fixture=$work/appearance-snapshot-failure
+mv "$data_home/dwm-titus/scripts/dwm-settings-appearance" \
+	"$data_home/dwm-titus/scripts/dwm-settings-appearance.real"
+cat >"$data_home/dwm-titus/scripts/dwm-settings-appearance" <<'SH'
+#!/bin/sh
+set -eu
+fixture=${DWM_SETTINGS_TEST_APPEARANCE_FAILURE:?}
+if [ "${1:-}" = snapshot ] && [ -f "$fixture" ]; then
+	case $(cat "$fixture") in
+	silent) exit 1 ;;
+	truncated)
+		"$(dirname -- "$0")/dwm-settings-appearance.real" "$@" | awk 'NR <= 5'
+		exit 1
+		;;
+	inventory-only)
+		"$(dirname -- "$0")/dwm-settings-appearance.real" "$@" | awk -F '\t' 'BEGIN { OFS = "\t" }
+			$1 == "provider" { $3 = "partial" }
+			$1 == "integration" {
+				$3 = "available"; $5 = "Integration is applied";
+			}
+			$1 == "error" && ($2 == "gtk" || $2 == "qt" || $2 == "cursor" ||
+				$2 == "alacritty" || $2 == "kitty" || $2 == "compositor") { next }
+			{ print }
+			END {
+				print "theme", "unused-broken", "available", "invalid", "true", "automatic", "Unused theme is incomplete";
+				print "error", "theme:unused-broken", "missing-key", "Unused theme is missing required keys";
+			}'
+		exit 0
+		;;
+	esac
+fi
+exec "$(dirname -- "$0")/dwm-settings-appearance.real" "$@"
+SH
+chmod +x "$data_home/dwm-titus/scripts/dwm-settings-appearance"
+
+theme_status_fixture=$work/theme-preview-status
+mv "$data_home/dwm-titus/scripts/dwm-settings-theme" \
+	"$data_home/dwm-titus/scripts/dwm-settings-theme.real"
+cat >"$data_home/dwm-titus/scripts/dwm-settings-theme" <<'SH'
+#!/bin/sh
+set -eu
+fixture=${DWM_SETTINGS_TEST_THEME_STATUS:?}
+if [ "${1:-}" = preview-status ] && [ -f "$fixture" ]; then
+	case $(cat "$fixture") in
+	active-zero)
+		printf '%s\n' none >"$fixture"
+		printf 'appearance-action-protocol\t1\t0\n'
+		printf 'preview-active\tboundary-preview\tnord\n'
+		printf 'preview-remaining\t0\n'
+		;;
+	none)
+		printf 'appearance-action-protocol\t1\t0\nresult\tnone\n'
+		;;
+	active-zero-fail)
+		printf x >>"$fixture.calls"
+		if [ ! -f "$fixture.started" ]; then
+			: >"$fixture.started"
+			printf 'appearance-action-protocol\t1\t0\n'
+			printf 'preview-active\tboundary-preview\tnord\n'
+			printf 'preview-remaining\t0\n'
+		else
+			exit 1
+		fi
+		;;
+	external-active)
+		printf 'appearance-action-protocol\t1\t0\n'
+		if [ -f "$fixture.external" ]; then
+			printf 'preview-active\texternal-preview\tnord\n'
+			printf 'preview-remaining\t30\n'
+		else
+			printf 'result\tnone\n'
+		fi
+		;;
+	external-failed)
+		printf 'appearance-action-protocol\t1\t0\n'
+		if [ -f "$fixture.external" ]; then
+			printf 'preview-failed\texternal-preview\tExternal preview failed\n'
+		else
+			printf 'result\tnone\n'
+		fi
+		;;
+	esac
+	exit 0
+fi
+exec "$(dirname -- "$0")/dwm-settings-theme.real" "$@"
+SH
+chmod +x "$data_home/dwm-titus/scripts/dwm-settings-theme"
 
 malformed_power_snapshot=$work/malformed-power-snapshot
 mv "$data_home/dwm-titus/scripts/dwm-quickshell-controlcenter" \
@@ -417,9 +517,12 @@ HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
 
 env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
 	XDG_DATA_HOME="$data_home" XDG_RUNTIME_DIR="$runtime" \
+	QT_QPA_PLATFORMTHEME= \
 	TMPDIR="$helper_tmp" \
 	DWM_SETTINGS_TEST_POWER_STATE="$power_state" DWM_SETTINGS_TEST_DELAY_POWER=1 \
 	DWM_SETTINGS_TEST_MALFORMED_POWER_SNAPSHOT="$malformed_power_snapshot" \
+	DWM_SETTINGS_TEST_APPEARANCE_FAILURE="$appearance_failure_fixture" \
+	DWM_SETTINGS_TEST_THEME_STATUS="$theme_status_fixture" \
 	PATH="$data_home/dwm-titus/scripts:$PATH" \
 	quickshell --no-duplicate >"$work/quickshell.log" 2>&1 &
 quickshell_pid=$!
@@ -1109,6 +1212,395 @@ while [ "$i" -lt 100 ]; do
 	sleep 0.05
 done
 [ "$bluetooth_status" = available ]
+
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select appearance >/dev/null
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_status=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceProviderStatus 2>/dev/null || true)
+	case $appearance_status in
+	available | partial) break ;;
+	esac
+	i=$((i + 1))
+	sleep 0.05
+done
+case $appearance_status in
+available | partial) ;;
+*)
+	appearance_detail=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceProviderDetail 2>/dev/null || true)
+	printf 'Appearance provider did not become readable: %s (%s)\n' \
+		"$appearance_status" "$appearance_detail" >&2
+	HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		DWM_SETTINGS_TEST_APPEARANCE_FAILURE="$appearance_failure_fixture" \
+		"$data_home/dwm-titus/scripts/dwm-settings-appearance" snapshot >&2 || true
+	exit 1
+	;;
+esac
+appearance_theme=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceActiveTheme)
+appearance_count=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceThemeCount)
+appearance_application=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceApplicationState)
+appearance_preview=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearancePreviewState)
+appearance_recovery=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceRecoveryState)
+[ "$appearance_theme" = nord ]
+[ "$appearance_count" -eq 15 ]
+[ "$appearance_application" = partial ]
+[ "$appearance_preview" = none ]
+[ "$appearance_recovery" = none ]
+
+# Preview and recovery metadata are watched while Appearance is open. An
+# external keep or abandon must clear active and failed controls without
+# waiting for a theme-file change or a countdown boundary.
+transaction_state_file=$state_home/dwm-titus/appearance/integration-transaction
+printf '%s\n' external-active >"$theme_status_fixture"
+: >"$theme_status_fixture.external"
+printf 'active\n' >"$transaction_state_file"
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select audio >/dev/null
+test_stage='validating appearance provider and inventory state'
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select appearance >/dev/null
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_preview=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearancePreviewState 2>/dev/null || true)
+	[ "$appearance_preview" = active ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$appearance_preview" = active ]
+rm -f "$theme_status_fixture.external"
+rm -f "$transaction_state_file"
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_preview=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearancePreviewState 2>/dev/null || true)
+	[ "$appearance_preview" = none ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$appearance_preview" = none ]
+[ "$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceMessage)" = \
+	'Theme preview completed outside Settings' ]
+
+printf '%s\n' external-failed >"$theme_status_fixture"
+: >"$theme_status_fixture.external"
+printf 'failed\n' >"$transaction_state_file"
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select audio >/dev/null
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select appearance >/dev/null
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_preview=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearancePreviewState 2>/dev/null || true)
+	[ "$appearance_preview" = failed ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$appearance_preview" = failed ]
+rm -f "$theme_status_fixture.external"
+rm -f "$transaction_state_file"
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_preview=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearancePreviewState 2>/dev/null || true)
+	[ "$appearance_preview" = none ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$appearance_preview" = none ]
+printf '%s\n' none >"$theme_status_fixture"
+
+# A helper that exits silently must clear the last good snapshot instead of
+# leaving stale available state visible.
+printf '%s\n' silent >"$appearance_failure_fixture"
+printf '# trigger silent provider failure\n' >>"$config_home/dwm-titus/themes.toml"
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_status=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceProviderStatus 2>/dev/null || true)
+	appearance_detail=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceProviderDetail 2>/dev/null || true)
+	[ "$appearance_status" = unavailable ] &&
+		[ "$appearance_detail" = 'Appearance provider failed before returning a valid snapshot' ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$appearance_status" = unavailable ]
+[ "$appearance_detail" = 'Appearance provider failed before returning a valid snapshot' ]
+rm -f "$appearance_failure_fixture"
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select audio >/dev/null
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select appearance >/dev/null
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_status=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceProviderStatus 2>/dev/null || true)
+	case $appearance_status in available | partial) break ;; esac
+	i=$((i + 1))
+	sleep 0.05
+done
+case $appearance_status in available | partial) ;; *) exit 1 ;; esac
+
+# Early provider records from a failed helper are not a complete snapshot.
+printf '%s\n' truncated >"$appearance_failure_fixture"
+printf '# trigger truncated provider failure\n' >>"$config_home/dwm-titus/themes.toml"
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_status=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceProviderStatus 2>/dev/null || true)
+	appearance_count=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceThemeCount 2>/dev/null || true)
+	[ "$appearance_status" = unavailable ] && [ "$appearance_count" -eq 0 ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$appearance_status" = unavailable ]
+[ "$appearance_count" -eq 0 ]
+rm -f "$appearance_failure_fixture"
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select audio >/dev/null
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select appearance >/dev/null
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_status=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceProviderStatus 2>/dev/null || true)
+	case $appearance_status in available | partial) break ;; esac
+	i=$((i + 1))
+	sleep 0.05
+done
+case $appearance_status in available | partial) ;; *) exit 1 ;; esac
+
+# Integration inputs are watched only while Appearance is open. Updating the
+# generated environment file must refresh the provider without manual action.
+test_stage='validating active appearance integration watches'
+printf 'export QT_QPA_PLATFORMTHEME=gtk3\n' >"$config_home/dwm-titus/theme-env.sh"
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_qt=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceIntegrationState qt 2>/dev/null || true)
+	[ "$appearance_qt" = available ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$appearance_qt" = available ]
+
+# Inventory diagnostics for an unused theme remain visible without degrading
+# the application state of a valid resolved theme and healthy integrations.
+test_stage='validating unused appearance inventory diagnostics'
+printf '%s\n' inventory-only >"$appearance_failure_fixture"
+printf '# trigger inventory-only provider fixture\n' >>"$config_home/dwm-titus/themes.toml"
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_status=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceProviderStatus 2>/dev/null || true)
+	appearance_application=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceApplicationState 2>/dev/null || true)
+	[ "$appearance_status" = partial ] && [ "$appearance_application" = available ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+if [ "$appearance_status" != partial ] || [ "$appearance_application" != available ]; then
+	printf 'Inventory-only diagnostics reported provider=%s application=%s\n' \
+		"$appearance_status" "$appearance_application" >&2
+	for integration_id in gtk qt cursor alacritty kitty compositor; do
+		integration_state=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+			XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings \
+			appearanceIntegrationState "$integration_id" 2>/dev/null || true)
+		printf '  %s: %s\n' "$integration_id" "$integration_state" >&2
+	done
+	exit 1
+fi
+rm -f "$appearance_failure_fixture"
+printf '# restore real provider snapshot\n' >>"$config_home/dwm-titus/themes.toml"
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_count=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceThemeCount 2>/dev/null || true)
+	[ "$appearance_count" -eq 15 ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$appearance_count" -eq 15 ]
+
+test_stage='validating restored appearance integration state'
+printf '# inactive integration watch fixture\n' >"$config_home/dwm-titus/theme-env.sh"
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_qt=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceIntegrationState qt 2>/dev/null || true)
+	[ "$appearance_qt" = unavailable ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+if [ "$appearance_qt" != unavailable ]; then
+	printf 'Restored Qt integration state remained %s\n' "$appearance_qt" >&2
+	exit 1
+fi
+
+# Invalid selected labels are diagnostic provider output. Keep the valid
+# fallback inventory available so Settings can offer recovery.
+test_stage='validating appearance recovery inventory'
+cp "$config_home/dwm-titus/themes.toml" "$work/valid-themes.toml"
+sed -i '0,/theme = "nord"/s//theme = "missing theme"/' \
+	"$config_home/dwm-titus/themes.toml"
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_theme=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceActiveTheme 2>/dev/null || true)
+	appearance_count=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceThemeCount 2>/dev/null || true)
+	[ "$appearance_theme" = 'missing theme' ] && [ "$appearance_count" -eq 15 ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$appearance_theme" = 'missing theme' ]
+[ "$appearance_count" -eq 15 ]
+[ "$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceProviderStatus)" = partial ]
+[ "$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceApplicationState)" = partial ]
+cp "$work/valid-themes.toml" "$config_home/dwm-titus/themes.toml"
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_theme=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceActiveTheme 2>/dev/null || true)
+	[ "$appearance_theme" = nord ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$appearance_theme" = nord ]
+
+# Invalid dark-mode metadata remains visible in the inventory and uses the
+# provider's safe dark default instead of dropping the active row.
+test_stage='validating appearance metadata recovery'
+sed -i '0,/dark_mode       = true/s//dark_mode       = "bogus"/' \
+	"$config_home/dwm-titus/themes.toml"
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_status=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceProviderStatus 2>/dev/null || true)
+	appearance_count=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceThemeCount 2>/dev/null || true)
+	[ "$appearance_status" = partial ] && [ "$appearance_count" -eq 15 ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$appearance_status" = partial ]
+[ "$appearance_count" -eq 15 ]
+[ "$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceActiveTheme)" = nord ]
+cp "$work/valid-themes.toml" "$config_home/dwm-titus/themes.toml"
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_status=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceProviderStatus 2>/dev/null || true)
+	case $appearance_status in available | partial) break ;; esac
+	i=$((i + 1))
+	sleep 0.05
+done
+
+printf '%s\n' active-zero >"$theme_status_fixture"
+test_stage='validating appearance preview completion'
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select audio >/dev/null
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select appearance >/dev/null
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_preview=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearancePreviewState 2>/dev/null || true)
+	appearance_message=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceMessage 2>/dev/null || true)
+	[ "$appearance_preview" = none ] &&
+		[ "$appearance_message" = 'Theme preview completed outside Settings' ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$appearance_preview" = none ]
+[ "$appearance_message" = 'Theme preview completed outside Settings' ]
+[ "$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearancePreviewRemaining)" -eq 0 ]
+
+# A broken status helper after the rollback boundary is retried only a bounded
+# number of times instead of creating a permanent subprocess loop.
+test_stage='validating bounded appearance preview retries'
+rm -f "$theme_status_fixture.started" "$theme_status_fixture.calls"
+printf '%s\n' active-zero-fail >"$theme_status_fixture"
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select audio >/dev/null
+DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings select appearance >/dev/null
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_message=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceMessage 2>/dev/null || true)
+	[ "$appearance_message" = 'Automatic rollback status needs a manual refresh' ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$appearance_message" = 'Automatic rollback status needs a manual refresh' ]
+preview_status_calls=$(wc -c <"$theme_status_fixture.calls")
+sleep 0.75
+[ "$(wc -c <"$theme_status_fixture.calls")" -eq "$preview_status_calls" ]
+[ "$preview_status_calls" -le 5 ]
+rm -f "$theme_status_fixture.started" "$theme_status_fixture.calls"
+printf '%s\n' none >"$theme_status_fixture"
+
+# The provider's missing-source and legacy identifiers are intentional
+# read-only protocol sentinels, not mutation-safe theme names.
+mv "$config_home/dwm-titus/themes.toml" "$work/named-themes.toml"
+mv "$data_home/dwm-titus/config/themes.toml" "$work/managed-themes.toml"
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_status=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceProviderStatus 2>/dev/null || true)
+	appearance_detail=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceProviderDetail 2>/dev/null || true)
+	[ "$appearance_status" = unavailable ] &&
+		[ "$appearance_detail" = 'Shared theme inventory and integration state' ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$appearance_status" = unavailable ]
+[ "$appearance_detail" = 'Shared theme inventory and integration state' ]
+[ "$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceMutationReady)" = false ]
+[ "$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceActiveTheme)" = none ]
+
+cat >"$config_home/dwm-titus/themes.toml" <<'EOF'
+[colors]
+normfgcolor = "#D8DEE9"
+normbgcolor = "#2E3440"
+normbordercolor = "#4C566A"
+selfgcolor = "#ECEFF4"
+selbgcolor = "#5E81AC"
+selbordercolor = "#81A1C1"
+EOF
+i=0
+while [ "$i" -lt 100 ]; do
+	appearance_theme=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceActiveTheme 2>/dev/null || true)
+	[ "$appearance_theme" = @legacy-colors ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$appearance_theme" = @legacy-colors ]
+[ "$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceProviderStatus)" = partial ]
+[ "$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+	XDG_RUNTIME_DIR=$runtime quickshell ipc --path "$config" call settings appearanceThemeCount)" -eq 1 ]
 
 # IPC selection clears a search that hides the requested section.
 DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \


### PR DESCRIPTION
## Summary
- add one root-scoped AppearanceModel as the owner of validated theme inventory and semantic shell colors
- add a Settings Appearance pane for bounded preview, keep, revert, apply, reset, and interrupted-operation recovery
- surface partial GTK, Qt, terminal, cursor, and compositor state without reporting a partially applied theme as complete
- preserve the existing Control Center theme path and move direct themes.toml parsing out of Theme.qml

## Scope guard
- 15 files, +1005/-91
- no wallpaper, font, icon, panel-widget, accessibility, notification-policy, or Phase 6 work

## Validation
- scripts/run-tests make clean all
- scripts/run-tests
- configured Quickshell qmllint
- nested-X11 Settings lifecycle and closed-idle test
- CodeRabbit CLI review: zero findings
- real Fedora 44 LightDM X11 visual and IPC validation at 980x620
- real 30-second closed baseline: 0.067% Quickshell CPU
- real 30-second sample after opening and closing Appearance: 0.067% (0.000-point delta)
- tray remained healthy with five items; preview and recovery remained none

## Known live limitation
- this workstation keeps ~/.config/alacritty as a symlink, so mutation safety correctly leaves Appearance read-only; no theme or integration file was changed
- the live installer replaced the byte-identical DWM inode during validation, so one logout/login remains required after merge for the installed-runtime parity gate
