### PR TITLE
fix(settings): detect shipped Alacritty theme import

### DIFF
--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -769,7 +769,7 @@ alacritty_imports_active_theme() {
 		DWM_ALACRITTY_DEFAULT_IMPORT=$default_import \
 		awk '
 		BEGIN {
-			at_root = 1
+			import_scope = 1
 			active = ENVIRON["DWM_ALACRITTY_ACTIVE_IMPORT"]
 			default_import = ENVIRON["DWM_ALACRITTY_DEFAULT_IMPORT"]
 		}
@@ -801,10 +801,10 @@ alacritty_imports_active_theme() {
 			trimmed = line
 			gsub(/^[[:space:]]+|[[:space:]]+$/, "", trimmed)
 			if (!in_import && trimmed ~ /^\[/) {
-				at_root = 0
+				import_scope = (trimmed ~ /^\[[[:space:]]*general[[:space:]]*\]$/)
 				next
 			}
-			if (!in_import && at_root &&
+			if (!in_import && import_scope &&
 			    trimmed ~ /^import[[:space:]]*=[[:space:]]*\[/) in_import = 1
 			if (in_import) {
 				quote = ""

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -769,7 +769,7 @@ alacritty_imports_active_theme() {
 		DWM_ALACRITTY_DEFAULT_IMPORT=$default_import \
 		awk '
 		BEGIN {
-			import_scope = 1
+			import_scope = "root"
 			active = ENVIRON["DWM_ALACRITTY_ACTIVE_IMPORT"]
 			default_import = ENVIRON["DWM_ALACRITTY_DEFAULT_IMPORT"]
 		}
@@ -801,11 +801,14 @@ alacritty_imports_active_theme() {
 			trimmed = line
 			gsub(/^[[:space:]]+|[[:space:]]+$/, "", trimmed)
 			if (!in_import && trimmed ~ /^\[/) {
-				import_scope = (trimmed ~ /^\[[[:space:]]*general[[:space:]]*\]$/)
+				import_scope = (trimmed ~ /^\[[[:space:]]*general[[:space:]]*\]$/ ? "general" : "other")
 				next
 			}
-			if (!in_import && import_scope &&
-			    trimmed ~ /^import[[:space:]]*=[[:space:]]*\[/) in_import = 1
+			if (!in_import &&
+			    ((import_scope == "root" &&
+			      trimmed ~ /^general[[:space:]]*\.[[:space:]]*import[[:space:]]*=[[:space:]]*\[/) ||
+			     (import_scope != "other" &&
+			      trimmed ~ /^import[[:space:]]*=[[:space:]]*\[/))) in_import = 1
 			if (in_import) {
 				quote = ""
 				escaped = 0

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -770,6 +770,8 @@ alacritty_imports_active_theme() {
 		awk '
 		BEGIN {
 			import_scope = "root"
+			general_key = "(general|\"general\"|\047general\047)"
+			import_key = "(import|\"import\"|\047import\047)"
 			active = ENVIRON["DWM_ALACRITTY_ACTIVE_IMPORT"]
 			default_import = ENVIRON["DWM_ALACRITTY_DEFAULT_IMPORT"]
 		}
@@ -801,14 +803,14 @@ alacritty_imports_active_theme() {
 			trimmed = line
 			gsub(/^[[:space:]]+|[[:space:]]+$/, "", trimmed)
 			if (!in_import && trimmed ~ /^\[/) {
-				import_scope = (trimmed ~ /^\[[[:space:]]*(general|"general"|\047general\047)[[:space:]]*\]$/ ? "general" : "other")
+				import_scope = (trimmed ~ ("^\\[[[:space:]]*" general_key "[[:space:]]*\\]$") ? "general" : "other")
 				next
 			}
 			if (!in_import &&
 			    ((import_scope == "root" &&
-			      trimmed ~ /^general[[:space:]]*\.[[:space:]]*import[[:space:]]*=[[:space:]]*\[/) ||
+			      trimmed ~ ("^" general_key "[[:space:]]*\\.[[:space:]]*" import_key "[[:space:]]*=[[:space:]]*\\[")) ||
 			     (import_scope != "other" &&
-			      trimmed ~ /^import[[:space:]]*=[[:space:]]*\[/))) in_import = 1
+			      trimmed ~ ("^" import_key "[[:space:]]*=[[:space:]]*\\[")))) in_import = 1
 			if (in_import) {
 				quote = ""
 				escaped = 0

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -801,7 +801,7 @@ alacritty_imports_active_theme() {
 			trimmed = line
 			gsub(/^[[:space:]]+|[[:space:]]+$/, "", trimmed)
 			if (!in_import && trimmed ~ /^\[/) {
-				import_scope = (trimmed ~ /^\[[[:space:]]*general[[:space:]]*\]$/ ? "general" : "other")
+				import_scope = (trimmed ~ /^\[[[:space:]]*(general|"general"|\047general\047)[[:space:]]*\]$/ ? "general" : "other")
 				next
 			}
 			if (!in_import &&

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -183,9 +183,14 @@ table_import_alacritty=$(snapshot)
 grep -Fqx $'integration\talacritty\tpartial\tconfiguration\tGenerated theme is not imported by the terminal configuration' \
 	<<<"$table_import_alacritty"
 
-printf '[general]\ngeneral.import = ["%s"]\n' "$config_home/alacritty/active-theme.toml" \
-	>"$config_home/alacritty/alacritty.toml"
-nested_dotted_import=$(snapshot)
+nested_dotted_config_home=$work/config-nested-dotted
+cp -a "$config_home" "$nested_dotted_config_home"
+printf '[general]\ngeneral.import = ["%s"]\n' \
+	"$nested_dotted_config_home/alacritty/active-theme.toml" \
+	>"$nested_dotted_config_home/alacritty/alacritty.toml"
+nested_dotted_import=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
+	XDG_CONFIG_HOME="$nested_dotted_config_home" XDG_DATA_HOME="$data_root" \
+	DWM_APPEARANCE_DATA_DIRS="$data_root" "$helper" snapshot)
 grep -Fqx $'integration\talacritty\tpartial\tconfiguration\tGenerated theme is not imported by the terminal configuration' \
 	<<<"$nested_dotted_import"
 

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -116,6 +116,27 @@ escaped_path=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
 grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' \
 	<<<"$escaped_path"
 
+fresh_home=$work/fresh-home
+fresh_config_home=$fresh_home/.config
+mkdir -p "$fresh_home"
+cp -a "$config_home" "$fresh_config_home"
+cp "$repo/config/alacritty/alacritty.toml" "$fresh_config_home/alacritty/alacritty.toml"
+fresh_install=$(HOME=$fresh_home PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
+	XDG_CONFIG_HOME="$fresh_config_home" XDG_DATA_HOME="$data_root" \
+	DWM_APPEARANCE_DATA_DIRS="$data_root" "$helper" snapshot)
+grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' \
+	<<<"$fresh_install"
+
+spaced_config_home=$work/config-spaced
+cp -a "$config_home" "$spaced_config_home"
+printf '[ general ]\nimport = ["%s"]\n' "$spaced_config_home/alacritty/active-theme.toml" \
+	>"$spaced_config_home/alacritty/alacritty.toml"
+spaced_header=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
+	XDG_CONFIG_HOME="$spaced_config_home" XDG_DATA_HOME="$data_root" \
+	DWM_APPEARANCE_DATA_DIRS="$data_root" "$helper" snapshot)
+grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' \
+	<<<"$spaced_header"
+
 snapshot() {
 	PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
 		DWM_APPEARANCE_DATA_DIRS=$data_root \

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -159,6 +159,28 @@ single_quoted_header=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
 grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' \
 	<<<"$single_quoted_header"
 
+quoted_import_config_home=$work/config-quoted-import
+cp -a "$config_home" "$quoted_import_config_home"
+printf '[general]\n"import" = ["%s"]\n' \
+	"$quoted_import_config_home/alacritty/active-theme.toml" \
+	>"$quoted_import_config_home/alacritty/alacritty.toml"
+quoted_import=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
+	XDG_CONFIG_HOME="$quoted_import_config_home" XDG_DATA_HOME="$data_root" \
+	DWM_APPEARANCE_DATA_DIRS="$data_root" "$helper" snapshot)
+grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' \
+	<<<"$quoted_import"
+
+quoted_dotted_config_home=$work/config-quoted-dotted
+cp -a "$config_home" "$quoted_dotted_config_home"
+printf "'general' . 'import' = [\"%s\"]\n" \
+	"$quoted_dotted_config_home/alacritty/active-theme.toml" \
+	>"$quoted_dotted_config_home/alacritty/alacritty.toml"
+quoted_dotted=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
+	XDG_CONFIG_HOME="$quoted_dotted_config_home" XDG_DATA_HOME="$data_root" \
+	DWM_APPEARANCE_DATA_DIRS="$data_root" "$helper" snapshot)
+grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' \
+	<<<"$quoted_dotted"
+
 dotted_config_home=$work/config-dotted
 cp -a "$config_home" "$dotted_config_home"
 printf 'general . import = ["%s"]\n' "$dotted_config_home/alacritty/active-theme.toml" \

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -137,6 +137,16 @@ spaced_header=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
 grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' \
 	<<<"$spaced_header"
 
+dotted_config_home=$work/config-dotted
+cp -a "$config_home" "$dotted_config_home"
+printf 'general . import = ["%s"]\n' "$dotted_config_home/alacritty/active-theme.toml" \
+	>"$dotted_config_home/alacritty/alacritty.toml"
+dotted_key=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
+	XDG_CONFIG_HOME="$dotted_config_home" XDG_DATA_HOME="$data_root" \
+	DWM_APPEARANCE_DATA_DIRS="$data_root" "$helper" snapshot)
+grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' \
+	<<<"$dotted_key"
+
 snapshot() {
 	PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
 		DWM_APPEARANCE_DATA_DIRS=$data_root \
@@ -172,6 +182,12 @@ printf '[window]\nimport = ["%s"]\n' "$config_home/alacritty/active-theme.toml" 
 table_import_alacritty=$(snapshot)
 grep -Fqx $'integration\talacritty\tpartial\tconfiguration\tGenerated theme is not imported by the terminal configuration' \
 	<<<"$table_import_alacritty"
+
+printf '[general]\ngeneral.import = ["%s"]\n' "$config_home/alacritty/active-theme.toml" \
+	>"$config_home/alacritty/alacritty.toml"
+nested_dotted_import=$(snapshot)
+grep -Fqx $'integration\talacritty\tpartial\tconfiguration\tGenerated theme is not imported by the terminal configuration' \
+	<<<"$nested_dotted_import"
 
 printf 'import = "%s"\n' "$config_home/alacritty/active-theme.toml" \
 	>"$config_home/alacritty/alacritty.toml"

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -137,6 +137,28 @@ spaced_header=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
 grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' \
 	<<<"$spaced_header"
 
+double_quoted_config_home=$work/config-double-quoted
+cp -a "$config_home" "$double_quoted_config_home"
+printf '["general"]\nimport = ["%s"]\n' \
+	"$double_quoted_config_home/alacritty/active-theme.toml" \
+	>"$double_quoted_config_home/alacritty/alacritty.toml"
+double_quoted_header=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
+	XDG_CONFIG_HOME="$double_quoted_config_home" XDG_DATA_HOME="$data_root" \
+	DWM_APPEARANCE_DATA_DIRS="$data_root" "$helper" snapshot)
+grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' \
+	<<<"$double_quoted_header"
+
+single_quoted_config_home=$work/config-single-quoted
+cp -a "$config_home" "$single_quoted_config_home"
+printf "['general']\nimport = [\"%s\"]\n" \
+	"$single_quoted_config_home/alacritty/active-theme.toml" \
+	>"$single_quoted_config_home/alacritty/alacritty.toml"
+single_quoted_header=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
+	XDG_CONFIG_HOME="$single_quoted_config_home" XDG_DATA_HOME="$data_root" \
+	DWM_APPEARANCE_DATA_DIRS="$data_root" "$helper" snapshot)
+grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' \
+	<<<"$single_quoted_header"
+
 dotted_config_home=$work/config-dotted
 cp -a "$config_home" "$dotted_config_home"
 printf 'general . import = ["%s"]\n' "$dotted_config_home/alacritty/active-theme.toml" \
@@ -193,6 +215,18 @@ nested_dotted_import=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
 	DWM_APPEARANCE_DATA_DIRS="$data_root" "$helper" snapshot)
 grep -Fqx $'integration\talacritty\tpartial\tconfiguration\tGenerated theme is not imported by the terminal configuration' \
 	<<<"$nested_dotted_import"
+
+legacy_precedence_config_home=$work/config-legacy-precedence
+cp -a "$config_home" "$legacy_precedence_config_home"
+printf 'import = ["%s"]\n[general]\nimport = ["%s"]\n' \
+	"$legacy_precedence_config_home/alacritty/legacy-theme.toml" \
+	"$legacy_precedence_config_home/alacritty/active-theme.toml" \
+	>"$legacy_precedence_config_home/alacritty/alacritty.toml"
+legacy_precedence=$(PATH=$bin_dir GTK_THEME='' XCURSOR_THEME='' \
+	XDG_CONFIG_HOME="$legacy_precedence_config_home" XDG_DATA_HOME="$data_root" \
+	DWM_APPEARANCE_DATA_DIRS="$data_root" "$helper" snapshot)
+grep -Fqx $'integration\talacritty\tpartial\tconfiguration\tGenerated theme is not imported by the terminal configuration' \
+	<<<"$legacy_precedence"
 
 printf 'import = "%s"\n' "$config_home/alacritty/active-theme.toml" \
 	>"$config_home/alacritty/alacritty.toml"


### PR DESCRIPTION
## Summary

- recognize Alacritty theme imports from the current `[general]` table while preserving the deprecated root-level form and Alacritty's root-first precedence
- accept equivalent TOML spellings: spaced or quoted `general` table names, root dotted keys, and quoted `general` / `import` key segments
- add isolated regression fixtures for the shipped fresh-install configuration, supported variants, precedence, and invalid nested scope

## Problem

A fresh install correctly placed `import` under `[general]`, and Alacritty loaded `active-theme.toml`, but the Appearance provider only inspected root-level imports. Settings therefore reported Alacritty as partially integrated even though the terminal configuration was working.

## Validation

- `bash -n scripts/dwm-settings-appearance tests/test-dwm-settings-appearance.sh`
- `shellcheck scripts/dwm-settings-appearance tests/test-dwm-settings-appearance.sh`
- `shfmt -d scripts/dwm-settings-appearance tests/test-dwm-settings-appearance.sh`
- `scripts/run-tests make check-appearance`
- `scripts/run-tests make clean all`
- `codex review --uncommitted` (clean after the review-fix loop)
- Alacritty 0.17.0 accepted the shipped, spaced, quoted-table, quoted-key, and dotted-key forms
- exact-head hosted checks on `cb06c44`: validate, analyze, quickshell-qml, CodeQL, and automated review passed; clang-build skipped by workflow design

The local full `scripts/run-tests` gate reaches `check-quickshell-settings-xvfb` and fails because the Xvfb input provider remains unavailable. The same failure reproduces on untouched `origin/main`, so it is a current-host/baseline issue rather than a regression in this two-file change.

## Manual evidence

Validated on Fedora X11 after removing checkout-facing development symlinks and recreating regular fresh-install configuration files. The installed Alacritty runtime loaded `~/.config/alacritty/active-theme.toml`, and the patched provider reported the integration available.

## Scope

Two files only: provider parser plus regression coverage. No QML, installer, packaging, or theme mutation behavior changes.