### PR TITLE
fix(settings): keep wallpaper status observable

### DIFF
--- a/config/quickshell/appearance/AppearanceModel.qml
+++ b/config/quickshell/appearance/AppearanceModel.qml
@@ -456,8 +456,7 @@ Scope {
     function refreshWallpaperStatus() {
         if (!root.settingsVisible) return;
         if (wallpaperReadinessProcess.running || wallpaperStatusProcess.running
-                || wallpaperActionProcess.running || inventoryProcess.running
-                || (inventoryWatchProcess.running && !root.inventoryWatchReady)) {
+                || wallpaperActionProcess.running || inventoryProcess.running) {
             root.wallpaperStatusPending = true;
             return;
         }
@@ -516,6 +515,7 @@ Scope {
     }
 
     function startInventoryWatcher(restartIfRunning) {
+        if (!root.settingsVisible) return;
         if (inventoryWatchProcess.running) {
             if (restartIfRunning === true) root.inventoryWatchRestartPending = true;
             return;

--- a/tests/test-quickshell-appearance-model.sh
+++ b/tests/test-quickshell-appearance-model.sh
@@ -53,6 +53,8 @@ fi
 grep -Fq 'Commands.settingsAppearanceCommand("watch-inventory", [])' "$model"
 grep -Fq 'Commands.settingsAppearanceCommand("watch-compositor", [])' "$model"
 grep -Fq 'function startInventoryWatcher(restartIfRunning)' "$model"
+sed -n '/function startInventoryWatcher(restartIfRunning)/,/^    }/p' "$model" |
+	grep -Fq 'if (!root.settingsVisible) return;'
 grep -Fq 'root.startInventoryWatcher(true);' "$model"
 grep -Fq 'if (restartIfRunning === true) root.inventoryWatchRestartPending = true;' "$model"
 grep -Fq 'root.inventoryWatchSawEvent = false' "$model"
@@ -100,6 +102,10 @@ grep -Fq 'if (!running && root.wallpaperStatusPending && root.settingsVisible) {
 grep -Fq 'readonly property bool wallpaperStatusBusy: wallpaperReadinessProcess.running' "$model"
 grep -Fq 'Commands.settingsWallpaperCommand("reset-ready", [])' "$model"
 grep -Fq 'if (wallpaperReadinessProcess.running || wallpaperStatusProcess.running' "$model"
+if grep -Fq '|| (inventoryWatchProcess.running && !root.inventoryWatchReady)) {' "$model"; then
+	printf 'Wallpaper status discovery is still gated on inventory watcher startup\n' >&2
+	exit 1
+fi
 grep -Fq '|| wallpaperReadinessProcess.running || wallpaperStatusProcess.running' "$model"
 grep -Fq 'root.wallpaperPreviewState = "active";' "$model"
 test "$(grep -Fc 'root.wallpaperPreviewState = "active";' "$model")" -eq 1


### PR DESCRIPTION
## Summary
- discover active wallpaper previews without waiting for inventory watcher startup
- prevent deferred inventory watcher restarts after the Appearance pane closes
- scope the regression contract to the watcher-start function

## Validation
- scripts/run-tests make check-quickshell-appearance-model
- scripts/run-tests make check-quickshell-settings-xvfb
- Fedora 44 container: scripts/run-tests make check-quickshell-settings-xvfb
- git diff --check HEAD^ HEAD
- built-in Codex review on 1163e35: no actionable defects