### PR TITLE
fix(settings): bound preview status retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,11 @@ versions from `config.mk`.
 
 ### Fixed
 
+- Stop automatic theme-preview status retries after their bounded failure
+  budget is exhausted. Reopening Appearance or using its refresh action still
+  performs one explicit retry, and successful preview lifecycle actions re-arm
+  automatic status observation.
+
 - Keep the managed Quickshell recovery scoped to the exact configuration and
   display, validate fixed PID/start-time cohorts before signals, and bound
   graceful and forced recovery so a stale shell cannot suppress the panel or

--- a/config/quickshell/appearance/AppearanceModel.qml
+++ b/config/quickshell/appearance/AppearanceModel.qml
@@ -124,6 +124,7 @@ Scope {
     property string previewDetail: ""
     property int previewZeroRetryAttempts: 0
     property bool previewStatusParsed: false
+    property bool previewStatusManualOnly: false
     property string recoveryState: "none"
     property string recoveryAction: ""
     property string recoveryTheme: ""
@@ -639,7 +640,8 @@ Scope {
         snapshotProcess.running = true;
     }
 
-    function refreshPreviewStatus() {
+    function refreshPreviewStatus(force) {
+        if (root.previewStatusManualOnly && force !== true) return;
         if (!previewStatusProcess.running && !actionProcess.running) {
             root.previewStatusParsed = false;
             previewStatusProcess.running = true;
@@ -842,10 +844,10 @@ Scope {
         inventoryProcess.running = true;
     }
 
-    function refreshAll() {
+    function refreshAll(forcePreviewStatus) {
         root.refreshSnapshot();
         root.refreshInventory();
-        root.refreshPreviewStatus();
+        root.refreshPreviewStatus(forcePreviewStatus === true);
         root.refreshRecoveryStatus();
         root.refreshMutationReadiness();
         root.refreshWallpaperStatus();
@@ -864,7 +866,7 @@ Scope {
         if (!wallpaperReadinessProcess.running)
             wallpaperReadinessProcess.running = true;
         root.startInventoryWatcher(true);
-        root.refreshAll();
+        root.refreshAll(true);
     }
 
     function startInventoryWatcher(restartIfRunning) {
@@ -1584,6 +1586,7 @@ Scope {
         if (root.actionSucceeded) {
             if (root.actionKind === "preview") {
                 root.previewState = "active";
+                root.previewStatusManualOnly = false;
                 root.previewToken = root.actionToken;
                 root.previewTheme = root.actionTheme;
                 root.previewRemaining = 30;
@@ -1594,6 +1597,7 @@ Scope {
                 if (root.actionKind === "keep" || root.actionKind === "revert"
                         || root.actionKind === "abandon") {
                     root.previewState = "none";
+                    root.previewStatusManualOnly = false;
                     root.previewToken = "";
                     root.previewTheme = "";
                     root.previewRemaining = 0;
@@ -1943,6 +1947,7 @@ Scope {
                 const record = lines[1].split("\t");
                 if (record[0] === "result" && record[1] === "none") {
                     root.previewStatusParsed = true;
+                    root.previewStatusManualOnly = false;
                     const wasActive = root.previewState === "active";
                     root.previewState = "none";
                     root.previewToken = "";
@@ -1956,6 +1961,7 @@ Scope {
                     }
                 } else if (record[0] === "result" && record[1] === "expired") {
                     root.previewStatusParsed = true;
+                    root.previewStatusManualOnly = false;
                     root.previewState = "none";
                     root.previewToken = "";
                     root.previewTheme = "";
@@ -1976,16 +1982,21 @@ Scope {
                             && remaining[0] === "preview-remaining" && /^[0-9]+$/.test(remaining[1])
                             ? Number(remaining[1]) : 0;
                     } else root.previewRemaining = 0;
-                    if (root.previewRemaining > 0) root.previewZeroRetryAttempts = 0;
+                    if (root.previewRemaining > 0) {
+                        root.previewZeroRetryAttempts = 0;
+                        root.previewStatusManualOnly = false;
+                    }
                     else {
                         root.previewZeroRetryAttempts++;
                         if (root.previewZeroRetryAttempts > 3) {
+                            root.previewStatusManualOnly = true;
                             root.message = "Automatic rollback status needs a manual refresh";
                             root.messageSeverity = "warning";
                         }
                     }
                 } else if (record.length === 3 && record[0] === "preview-failed") {
                     root.previewStatusParsed = true;
+                    root.previewStatusManualOnly = false;
                     root.previewState = "failed";
                     root.previewToken = record[1];
                     root.previewDetail = record[2];
@@ -2004,6 +2015,7 @@ Scope {
             if (!root.previewStatusParsed) root.previewZeroRetryAttempts++;
             if (root.previewZeroRetryAttempts <= 3) previewZeroRetryTimer.restart();
             else {
+                root.previewStatusManualOnly = true;
                 root.message = "Automatic rollback status needs a manual refresh";
                 root.messageSeverity = "warning";
             }

--- a/config/quickshell/settings/AppearanceSettingsPane.qml
+++ b/config/quickshell/settings/AppearanceSettingsPane.qml
@@ -396,7 +396,7 @@ Flickable {
             ShellButton {
                 label: root.appearanceBusy ? "Working..." : "Refresh"
                 enabled: !root.appearanceBusy
-                onActivated: root.appearanceModel.refreshAll()
+                onActivated: root.appearanceModel.refreshAll(true)
             }
         }
 

--- a/tests/test-quickshell-appearance-model.sh
+++ b/tests/test-quickshell-appearance-model.sh
@@ -296,6 +296,12 @@ test "$(grep -Fc 'onTriggered: if (root.settingsVisible) root.refreshAll()' "$mo
 grep -Fq 'running: root.previewState === "active" && root.previewRemaining > 0' "$model"
 grep -Fq 'previewZeroRetryTimer.restart()' "$model"
 grep -Fq 'if (!root.previewStatusParsed) root.previewZeroRetryAttempts++' "$model"
+grep -Fq 'if (root.previewStatusManualOnly && force !== true) return;' "$model"
+grep -Fq 'root.previewStatusManualOnly = true;' "$model"
+grep -Fq 'root.previewStatusManualOnly = false;' "$model"
+grep -Fq 'root.appearanceModel.refreshAll(true)' "$pane"
+finish_action=$(sed -n '/function finishAction()/,/^    }/p' "$model")
+test "$(printf '%s\n' "$finish_action" | grep -Fc 'root.previewStatusManualOnly = false;')" -eq 2
 grep -Fq 'root.snapshotParsed = false' "$model"
 grep -Fq 'root.snapshotRunGeneration === root.snapshotGeneration' "$model"
 grep -Fq '&& !root.snapshotParsed' "$model"


### PR DESCRIPTION
## Summary
- stop automatic theme preview-status retries after the bounded failure budget
- allow reopening Appearance or using Refresh to perform one explicit retry
- re-arm automatic observation after successful preview, keep, revert, abandon, expiry, or failure status

This rewrites the former toolkit-controls branch because desktop appearance controls already merged in #184; the PR now contains only the independently reviewable lifecycle hardening that remained.

## Validation
- `scripts/run-tests make clean all`
- `scripts/run-tests`
- `shellcheck install.sh scripts/*.sh tests/*.sh`
- `shfmt -d install.sh scripts/*.sh tests/*.sh`
- `tests/test-quickshell-appearance-model.sh`
- `tests/test-quickshell-settings-xvfb.sh` (PASS, 0.067% focused / 0.033% full-suite closed-idle CPU)
- local Codex review: no actionable findings
- CodeRabbit CLI review: 0 findings
