### PR TITLE
Phase 5: group accessibility settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ versions from `config.mk`.
 
 ### Added
 
+- Group the existing bounded application text-scale choices under a dedicated
+  Settings Accessibility section with keyboard-focusable apply and reset
+  controls, wrapping actions for compact display sizes, and capability-scoped
+  explanations for contrast, reduced motion, notification policy, and input
+  features that are not yet managed. Event-driven personalization changes
+  coalesce a fresh strict capability snapshot so recovery cannot leave the
+  text-scale controls incorrectly disabled.
+
 - Replace the generic Phase 5 accessibility placeholder with distinct Settings
   capability records for text scaling, high contrast, reduced motion,
   notification policy, and keyboard or pointer access. Text scaling consumes

--- a/TASKS.md
+++ b/TASKS.md
@@ -7,19 +7,19 @@ completion evidence is recorded in `ROADMAP.md`, `CHANGELOG.md`,
 
 ## Verified Checkpoint
 
-Status reconciled 2026-08-30 against `origin/main` at `edb5478`. Twelve of the
-25 Phase 5 implementation checkboxes are merged. Cross-capability
-optional-component qualification merged in PR #188, completing
-`APPEARANCE-001`; the automatic small-PR workflow merged in PR #189. Only the
-primary worktree remains registered.
+Status reconciled 2026-08-31 against `origin/main` at `63e49ab`. Thirteen of
+the 25 Phase 5 implementation checkboxes are merged. PR #190 completed the
+accessibility capability contract after PR #188 completed `APPEARANCE-001` and
+PR #189 established the automatic small-PR workflow. Only the primary worktree
+remains registered.
 
-The current accessibility capability boundary validates one additional
-checkbox, leaving 12 open in this branch. It replaces the generic Phase 5
-placeholder with separate records for text scaling, contrast, reduced motion,
-notification policy, and practical keyboard or pointer access. Text-scale
-state comes from the existing versioned personalization protocol; missing or
-incomplete providers degrade only that capability. Settings controls and state
-mutation remain separate review boundaries.
+The current accessibility Settings boundary exposes the already-supported
+application text scale in a dedicated group with apply, reset, keyboard focus,
+and compact-width action wrapping. Contrast, reduced motion, notification
+policy, and practical keyboard or pointer access remain explanatory
+capability-scoped cards until their mutation contracts land separately. The
+overall Settings-controls checkbox remains open until those controls and the
+required interaction evidence are complete.
 
 ## Active Phase: Personalization and Accessibility
 

--- a/config/quickshell/settings/AppearanceSettingsPane.qml
+++ b/config/quickshell/settings/AppearanceSettingsPane.qml
@@ -10,6 +10,7 @@ Flickable {
     required property var appearanceModel
     required property var panelSettingsModel
     required property var capabilities
+    required property var textScaleCapability
     property string selectedThemeId: ""
     property string selectedWallpaperPath: ""
     property string selectedWallpaperFit: "fill"
@@ -34,6 +35,13 @@ Flickable {
         !root.appearanceModel.personalizationStatusBusy
         && root.appearanceModel.previewState === "none"
         && root.appearanceModel.recoveryState === "none"
+    readonly property var accessibilityCapabilities: root.capabilities.filter(function(capability) {
+        return capability.id.indexOf("accessibility-") === 0
+            && capability.id !== "accessibility-text-scale";
+    })
+    readonly property var additionalCapabilities: root.capabilities.filter(function(capability) {
+        return capability.id.indexOf("accessibility-") !== 0;
+    })
     contentWidth: width
     contentHeight: content.implicitHeight
     clip: true
@@ -208,6 +216,7 @@ Flickable {
         required property string title
         required property string resetLabel
         required property var candidates
+        property var capabilityGate: null
         property bool advancedEditor: false
         property string selectedValue: ""
         property bool selectionDirty: false
@@ -218,10 +227,15 @@ Flickable {
             personalizationControl.capability)
         readonly property var inventorySelection: root.appearanceModel.inventorySelection(
             personalizationControl.capability)
-        readonly property string effectiveState: root.appearanceModel.personalizationEffectiveState(
-            personalizationControl.capability)
-        readonly property string effectiveDetail: root.appearanceModel.personalizationEffectiveDetail(
-            personalizationControl.capability)
+        readonly property bool gateAllowsActions: personalizationControl.capabilityGate === null
+            || personalizationControl.capabilityGate.status === "available"
+            || personalizationControl.capabilityGate.status === "partial"
+        readonly property string effectiveState: personalizationControl.gateAllowsActions
+            ? root.appearanceModel.personalizationEffectiveState(personalizationControl.capability)
+            : personalizationControl.capabilityGate.status
+        readonly property string effectiveDetail: personalizationControl.gateAllowsActions
+            ? root.appearanceModel.personalizationEffectiveDetail(personalizationControl.capability)
+            : personalizationControl.capabilityGate.detail
         readonly property var delegateRecord: root.appearanceModel.personalizationDelegates[
             personalizationControl.capability] || ({ "state": "unavailable", "tool": "",
                 "detail": "No trusted advanced editor is installed" })
@@ -288,7 +302,7 @@ Flickable {
                             === personalizationControl.selectedValue ? " / Selected" : "")
                         + (personalizationButton.modelData.token
                             === personalizationControl.selection.option ? " / Saved" : "")
-                    enabled: !root.appearanceBusy
+                    enabled: personalizationControl.gateAllowsActions && !root.appearanceBusy
                         && personalizationButton.modelData.state === "available"
                     onActivated: {
                         personalizationControl.selectedValue = personalizationButton.modelData.token;
@@ -317,12 +331,13 @@ Flickable {
             wrapMode: Text.WordWrap
         }
 
-        RowLayout {
+        Flow {
             Layout.fillWidth: true
             spacing: Theme.spacingSm
             ShellButton {
                 label: "Apply " + personalizationControl.title.toLowerCase()
                 enabled: root.personalizationActionsReady
+                    && personalizationControl.gateAllowsActions
                     && root.appearanceModel.personalizationApplyReady(
                         personalizationControl.capability)
                     && personalizationControl.candidateAvailable(
@@ -333,6 +348,7 @@ Flickable {
             ShellButton {
                 label: personalizationControl.resetLabel
                 enabled: root.personalizationActionsReady
+                    && personalizationControl.gateAllowsActions
                     && root.appearanceModel.personalizationResetReady(
                         personalizationControl.capability)
                     && !root.appearanceBusy
@@ -949,13 +965,6 @@ Flickable {
         }
 
         PersonalizationControl {
-            capability: "text-size"
-            title: "Application text scale"
-            resetLabel: "Follow system scale"
-            candidates: root.appearanceModel.desktopTextScaleCandidates
-        }
-
-        PersonalizationControl {
             capability: "cursor"
             title: "Cursor theme"
             resetLabel: "Follow DWM theme"
@@ -983,6 +992,35 @@ Flickable {
             resetLabel: "Follow DWM theme"
             candidates: root.appearanceModel.personalizationCandidates("qt", 24)
             advancedEditor: true
+        }
+
+        SectionLabel { label: "Accessibility" }
+
+        UiText {
+            Layout.fillWidth: true
+            text: "Use the text-scale controls below when their provider is available. The remaining cards explain which keyboard, pointer, contrast, motion, and notification controls are not yet managed by this desktop."
+            color: Theme.menuMutedText
+            wrapMode: Text.WordWrap
+        }
+
+        PersonalizationControl {
+            capability: "text-size"
+            title: "Application text scale"
+            resetLabel: "Follow system scale"
+            candidates: root.appearanceModel.desktopTextScaleCandidates
+            capabilityGate: root.textScaleCapability
+        }
+
+        Repeater {
+            model: root.accessibilityCapabilities
+            delegate: StatusCard {
+                id: accessibilityCard
+                required property var modelData
+                label: accessibilityCard.modelData.label
+                statusState: accessibilityCard.modelData.status
+                value: accessibilityCard.modelData.status
+                detail: accessibilityCard.modelData.detail
+            }
         }
 
         SectionLabel { label: "Panel widgets" }
@@ -1080,12 +1118,12 @@ Flickable {
         }
 
         SectionLabel {
-            visible: root.capabilities.length > 0
+            visible: root.additionalCapabilities.length > 0
             label: "Additional capabilities"
         }
 
         Repeater {
-            model: root.capabilities
+            model: root.additionalCapabilities
             delegate: StatusCard {
                 id: capabilityCard
                 required property var modelData

--- a/config/quickshell/settings/SettingsModel.qml
+++ b/config/quickshell/settings/SettingsModel.qml
@@ -12,6 +12,7 @@ Scope {
     property string selectedSectionId: "displays"
     property string discoveryState: "idle"
     property string message: ""
+    property bool capabilityRefreshPending: false
     property string platformId: "unknown"
     property string platformFamily: "unknown"
     property string platformName: "Unknown Linux"
@@ -94,6 +95,13 @@ Scope {
         return root.capabilities.filter(function(capability) {
             return capability.section === id;
         });
+    }
+
+    function capabilityById(id) {
+        for (const capability of root.capabilities) {
+            if (capability.id === id) return capability;
+        }
+        return { "status": "unavailable", "detail": "Capability has not been discovered" };
     }
 
     function watchOwnerArguments() {
@@ -482,7 +490,16 @@ Scope {
     function refresh() {
         if (root.visible && root.selectedSectionId === "appearance" && root.panelSettingsModel)
             root.panelSettingsModel.refresh();
-        if (!root.visible || providerProcess.running) return;
+        root.refreshCapabilities();
+    }
+
+    function refreshCapabilities() {
+        if (!root.visible) return;
+        if (providerProcess.running) {
+            root.capabilityRefreshPending = true;
+            return;
+        }
+        root.capabilityRefreshPending = false;
         root.busy = true;
         root.discoveryState = "loading";
         root.message = "Discovering capabilities...";
@@ -525,6 +542,7 @@ Scope {
 			}
 		}
         providerProcess.running = false;
+        root.capabilityRefreshPending = false;
         displayDiscoverProcess.running = false;
         inputDiscoverProcess.running = false;
         displayWatchProcess.running = false;
@@ -563,6 +581,21 @@ Scope {
                 const error = this.text.trim();
                 if (error.length > 0) root.message = error;
             }
+        }
+
+        onRunningChanged: {
+            if (!running && root.capabilityRefreshPending && root.visible)
+                Qt.callLater(root.refreshCapabilities);
+        }
+    }
+
+    Connections {
+        target: root.appearanceModel
+        enabled: root.appearanceModel !== null
+
+        function onPersonalizationSelectionsChanged() {
+            if (root.visible && root.selectedSectionId === "appearance")
+                root.refreshCapabilities();
         }
     }
 

--- a/config/quickshell/settings/SettingsModel.qml
+++ b/config/quickshell/settings/SettingsModel.qml
@@ -98,6 +98,8 @@ Scope {
     }
 
     function capabilityById(id) {
+        if (root.discoveryState !== "ready" || root.capabilityRefreshPending)
+            return { "status": "unavailable", "detail": "Capability discovery is still refreshing" };
         for (const capability of root.capabilities) {
             if (capability.id === id) return capability;
         }
@@ -584,8 +586,12 @@ Scope {
         }
 
         onRunningChanged: {
-            if (!running && root.capabilityRefreshPending && root.visible)
-                Qt.callLater(root.refreshCapabilities);
+            if (!running && root.capabilityRefreshPending && root.visible) {
+                root.capabilityRefreshPending = false;
+                Qt.callLater(function() {
+                    if (!providerProcess.running) root.refreshCapabilities();
+                });
+            }
         }
     }
 

--- a/config/quickshell/settings/SettingsWindow.qml
+++ b/config/quickshell/settings/SettingsWindow.qml
@@ -381,6 +381,8 @@ FloatingWindow {
                                 visible: root.settingsModel.selectedSectionId === "appearance"
                                 appearanceModel: root.appearanceModel
                                 panelSettingsModel: root.panelSettingsModel
+                                textScaleCapability: root.settingsModel.capabilityById(
+                                    "accessibility-text-scale")
                                 capabilities: root.settingsModel.capabilitiesForSection("appearance")
                                     .filter(function(capability) {
                                         return capability.id !== "themes" && capability.id !== "wallpaper";

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -806,6 +806,14 @@ ShellRoot {
             return appearanceModel.personalizationStatusBusy;
         }
 
+        function appearanceRefresh(): void {
+            appearanceModel.refreshAll(true);
+        }
+
+        function capabilityStatus(capabilityId: string): string {
+            return settingsModel.capabilityById(capabilityId).status;
+        }
+
         function appearancePersonalizationMutationState(): string {
             return appearanceModel.personalizationMutationState;
         }

--- a/docs/P5-STATUS.md
+++ b/docs/P5-STATUS.md
@@ -1,19 +1,18 @@
 # Phase 5 Project Status
 
-Date: 2026-08-30
+Date: 2026-08-31
 
 ## Verification Baseline
 
 This checkpoint was reconciled against `origin/main` at
-`edb54788acbf93b467568138e4df8f6ce7b0ec66`. The primary checkout matched that
-remote revision before the continuation branch was created, and no open pull
-request targeted `main`. PR #188 merged the optional-component qualification,
-and PR #189 merged the automatic small-PR workflow. Only the primary checkout
-remains registered.
+`63e49ab5dc7f1e95d1da0667560a5fe9a4c35822`. PR #190 merged the accessibility
+capability contract after PR #188 merged optional-component qualification and
+PR #189 merged the automatic small-PR workflow. The primary checkout matched
+the remote revision before this continuation branch was created, no pull
+request remained open, and only the primary checkout was registered.
 
-The active `TASKS.md` contains 25 implementation checkboxes. Twelve are
-complete on `main`. The current accessibility capability boundary validates
-one additional checkbox and leaves 12 open in the branch.
+The active `TASKS.md` contains 25 implementation checkboxes. Thirteen are
+complete on `main`, leaving 12 open.
 
 The merged APPEARANCE-001 boundaries and their documentation passed:
 
@@ -46,6 +45,7 @@ boundaries passed before merge.
 | APPEARANCE-001 desktop controls | Complete | PRs #183 and #184 | All executed hosted checks passed; conditional checks skipped according to their paths. |
 | APPEARANCE-001 panel-widget persistence | Complete | PR #186 | Hosted CI, CodeQL, docs, focused panel, nested-X11, and live-session checks passed. |
 | APPEARANCE-001 optional-component isolation | Complete | PR #188 | Focused and full managed suites, nested X11, install, docs, lint, CodeQL, and hosted checks passed. |
+| ACCESSIBILITY-001 capability contract | Complete | PR #190 | Five hosted checks and exact-head Codex and CodeRabbit review passed; one conditional check skipped. |
 
 The detailed contracts and focused validation commands remain in
 `P5-THEME-TRANSACTIONS.md`, `P5-APPEARANCE-INVENTORY.md`,
@@ -69,36 +69,34 @@ nested-X11 validation covers the shared-state path.
 
 ## Current Review Boundary
 
-The current `codex/phase5-accessibility-capabilities` boundary defines five
-separate Settings capability records for text scaling, high contrast, reduced
-motion, notification policy, and keyboard or pointer access. It replaces the
-generic Phase 5 placeholder without introducing a new provider, polling loop,
-or mutation path.
+The current `codex/phase5-accessibility-settings` boundary groups the existing
+bounded application text-scale choices under Accessibility. Its apply and
+reset actions retain the shared personalization transaction, keyboard focus,
+and visible focus border, while action rows wrap at compact widths. The four
+remaining accessibility records render in the same group with explicit
+capability-scoped explanations and no implied mutation path.
 
-Text-scale status and detail are accepted only from a complete version 1
-personalization status response. Missing, unresponsive, incomplete, duplicate,
-or otherwise unsupported responses degrade only text scaling. The other
-records disclose the exact partial or unsupported state of existing managed
-shell and X11 facilities so later control work has an explicit contract.
-`docs/P5-ACCESSIBILITY-CAPABILITIES.md` records the detailed contract and
-validation evidence.
-
-Next action: obtain exact-head review and hosted validation, merge this
-boundary, then implement accessible Settings controls as a separate PR.
+Personalization selection changes coalesce a strict capability refresh, so a
+provider or XSETTINGS recovery updates the text-scale gate without polling or a
+second provider. This slice introduces no new persistent state, helper,
+watcher, polling loop, or privilege boundary. The overall Settings-controls
+checkbox stays open for dedicated contrast, reduced-motion,
+notification-policy, and practical input controls plus the required
+real-session interaction evidence.
 
 ## Open Task Boundaries
 
 | Boundary | Open checkboxes | Verified current state | Next evidence needed |
 | --- | ---: | --- | --- |
 | APPEARANCE-001 | 0 | Complete on `main` through PR #188. | Preserve the merged contracts while completing Phase 5. |
-| ACCESSIBILITY-001 | 3 in this branch; 4 on `main` | The current boundary defines five distinct read-only records and validates capability-scoped degradation. | Merge this boundary, then implement Settings controls, apply contrast and reduced motion, and add notification policy. |
+| ACCESSIBILITY-001 | 3 | The merged boundary defines five distinct capability records; the current UI slice groups text scale and truthful unavailable states without adding mutation. | Finish dedicated controls and interaction evidence, then apply contrast and reduced motion and add notification policy. |
 | P5-UI5 | 4 | No candidate decision record is complete. | Inventory candidates, record adopt/defer/reject decisions, and qualify each adopted X11-native experience independently. |
 | P5-VALIDATE | 5 | Individual merged slices have focused and full-suite evidence, but the combined Phase 5 product is incomplete. | Run the final Fedora 44, clean build, full suite, QML, shell, install/parity, fresh-login, `startx`, multi-monitor, optional-loss, recovery, and 30-second CPU qualification after all selected Phase 5 work merges. |
 
 ## Phase Position
 
 Phase 5 remains active. THEME-001 and APPEARANCE-001 are complete on `main`.
-The first ACCESSIBILITY-001 checkbox is complete in the current review boundary;
+The first ACCESSIBILITY-001 checkbox is complete on `main` through PR #190;
 no P5-UI5 or final Phase 5 qualification checkbox is complete. Phase 6 must not
 begin until the Phase 5 exit criteria pass or an explicit roadmap decision
 defers named work and records the resulting limitation.

--- a/tests/test-quickshell-appearance-model.sh
+++ b/tests/test-quickshell-appearance-model.sh
@@ -25,9 +25,17 @@ grep -Fq 'appearanceModel: appearanceModel' "$shell_qml"
 grep -Fq 'root.appearanceModel.openSettings()' "$settings_model"
 grep -Fq 'root.appearanceModel.closeSettings()' "$settings_model"
 test "$(grep -Fc 'root.appearanceModel.closeSettings()' "$settings_model")" -eq 2
+grep -Fq 'property bool capabilityRefreshPending: false' "$settings_model"
+grep -Fq 'function refreshCapabilities()' "$settings_model"
+grep -Fq 'root.capabilityRefreshPending = true;' "$settings_model"
+grep -Fq 'Qt.callLater(root.refreshCapabilities);' "$settings_model"
+grep -Fq 'function onPersonalizationSelectionsChanged()' "$settings_model"
+grep -Fq 'root.refreshCapabilities();' "$settings_model"
 grep -Fq 'AppearanceSettingsPane {' "$settings_window"
 grep -Fq 'root.settingsModel.selectedSectionId === "appearance"' "$settings_window"
 grep -Fq 'capability.id !== "themes"' "$settings_window"
+grep -Fq 'textScaleCapability: root.settingsModel.capabilityById(' "$settings_window"
+grep -Fq 'function capabilityById(id)' "$settings_model"
 
 grep -Fq 'function settingsAppearanceCommand(action, args)' "$commands"
 grep -Fq 'function settingsFontCommand(action, args)' "$commands"
@@ -398,7 +406,30 @@ grep -Fq 'Component.onCompleted: {' "$pane"
 grep -Fq 'root.ensureWallpaperSelection();' "$pane"
 grep -Fq 'preferred = root.appearanceModel.resolvedTheme' "$pane"
 grep -Fq 'label: "Additional capabilities"' "$pane"
-grep -Fq 'model: root.capabilities' "$pane"
+grep -Fq 'SectionLabel { label: "Accessibility" }' "$pane"
+grep -Fq 'readonly property var accessibilityCapabilities:' "$pane"
+grep -Fq 'capability.id !== "accessibility-text-scale"' "$pane"
+grep -Fq 'required property var textScaleCapability' "$pane"
+grep -Fq 'property var capabilityGate: null' "$pane"
+grep -Fq 'readonly property bool gateAllowsActions:' "$pane"
+grep -Fq 'personalizationControl.capabilityGate.status === "partial"' "$pane"
+grep -Fq 'capabilityGate: root.textScaleCapability' "$pane"
+test "$(grep -Fc '&& personalizationControl.gateAllowsActions' "$pane")" -eq 2
+grep -Fq 'enabled: personalizationControl.gateAllowsActions && !root.appearanceBusy' "$pane"
+grep -Fq 'model: root.accessibilityCapabilities' "$pane"
+grep -Fq 'model: root.additionalCapabilities' "$pane"
+grep -Fq 'text: "Use the text-scale controls below when their provider is available.' "$pane"
+if grep -Fq 'Text scaling is available now' "$pane"; then
+	printf 'Accessibility summary makes an unconditional text-scale availability claim\n' >&2
+	exit 1
+fi
+test "$(grep -Fc 'component PersonalizationControl: ColumnLayout' "$pane")" -eq 1
+personalization_actions=$(sed -n '/component PersonalizationControl: ColumnLayout/,/^    }/p' "$pane")
+printf '%s\n' "$personalization_actions" | grep -Fq 'Flow {'
+if printf '%s\n' "$personalization_actions" | grep -Fq 'RowLayout {'; then
+	printf 'Personalization actions do not wrap at compact display sizes\n' >&2
+	exit 1
+fi
 grep -Fq 'onActivated: root.appearanceModel.keepPreview()' "$pane"
 grep -Fq 'onActivated: root.appearanceModel.revertPreview()' "$pane"
 grep -Fq 'onActivated: root.appearanceModel.abandonPreview()' "$pane"
@@ -414,6 +445,8 @@ grep -Fq 'function appearanceFontScale(): string' "$shell_qml"
 grep -Fq 'function appearanceFontPreviewState(): string' "$shell_qml"
 grep -Fq 'function appearancePersonalizationStatus(): string' "$shell_qml"
 grep -Fq 'function appearancePersonalizationOption(capability: string): string' "$shell_qml"
+grep -Fq 'function appearanceRefresh(): void' "$shell_qml"
+grep -Fq 'function capabilityStatus(capabilityId: string): string' "$shell_qml"
 test "$(grep -Fc 'root.selectedTheme.valid && root.selectedTheme.mutable' "$pane")" -eq 2
 
 if grep -ERq 'Quickshell\.(Wayland|Hyprland)|WlrLayershell|hyprctl|uwsm-app|wl-copy|wl-paste' \

--- a/tests/test-quickshell-appearance-model.sh
+++ b/tests/test-quickshell-appearance-model.sh
@@ -28,7 +28,31 @@ test "$(grep -Fc 'root.appearanceModel.closeSettings()' "$settings_model")" -eq 
 grep -Fq 'property bool capabilityRefreshPending: false' "$settings_model"
 grep -Fq 'function refreshCapabilities()' "$settings_model"
 grep -Fq 'root.capabilityRefreshPending = true;' "$settings_model"
-grep -Fq 'Qt.callLater(root.refreshCapabilities);' "$settings_model"
+grep -Fq 'if (root.discoveryState !== "ready" || root.capabilityRefreshPending)' "$settings_model"
+grep -Fq '"detail": "Capability discovery is still refreshing"' "$settings_model"
+awk '
+	/id: providerProcess/ { in_provider = 1 }
+	in_provider && /onRunningChanged: \{/ {
+		in_handler = 1
+		depth = 0
+	}
+	in_handler {
+		line = $0
+		opens = gsub(/\{/, "", line)
+		closes = gsub(/\}/, "", line)
+		depth += opens - closes
+		if (/root.capabilityRefreshPending = false;/ && !cleared) cleared = NR
+		if (/Qt.callLater\(function\(\) \{/ && !deferred) deferred = NR
+		if (/if \(!providerProcess.running\) root.refreshCapabilities\(\);/ && !guarded) guarded = NR
+		if (depth == 0) {
+			in_handler = 0
+			verified = cleared && deferred && guarded && cleared < deferred && deferred < guarded
+		}
+	}
+	END {
+		exit !verified
+	}
+' "$settings_model"
 grep -Fq 'function onPersonalizationSelectionsChanged()' "$settings_model"
 grep -Fq 'root.refreshCapabilities();' "$settings_model"
 grep -Fq 'AppearanceSettingsPane {' "$settings_window"

--- a/tests/test-quickshell-settings-xvfb.sh
+++ b/tests/test-quickshell-settings-xvfb.sh
@@ -391,9 +391,10 @@ cat >"$data_home/dwm-titus/scripts/dwm-settings-personalization" <<'SH'
 #!/bin/sh
 set -eu
 fixture=${DWM_SETTINGS_TEST_APPEARANCE_FAILURE:?}
-if [ "${1:-}" = status ] && [ -f "$fixture" ] &&
-	[ "$(cat "$fixture")" = optional-loss ]; then
-	"$(dirname -- "$0")/dwm-settings-personalization.real" "$@" | awk -F '\t' 'BEGIN { OFS = "\t" }
+if [ "${1:-}" = status ] && [ -f "$fixture" ]; then
+	case $(cat "$fixture") in
+	optional-loss)
+		"$(dirname -- "$0")/dwm-settings-personalization.real" "$@" | awk -F '\t' 'BEGIN { OFS = "\t" }
 		$1 == "action-readiness" && ($2 == "gtk" || $2 == "qt") {
 			$3 = "available"; $4 = "available";
 			$5 = "Built-in personalization actions remain available";
@@ -403,7 +404,17 @@ if [ "${1:-}" = status ] && [ -f "$fixture" ] &&
 			$5 = "No trusted advanced editor is installed";
 		}
 		{ print }'
-	exit 0
+		exit 0
+		;;
+	invalid-text-scale)
+		"$(dirname -- "$0")/dwm-settings-personalization.real" "$@" | awk -F '\t' 'BEGIN { OFS = "\t" }
+			$1 == "selection" && $2 == "text-size" {
+				$3 = "available"; $4 = "";
+			}
+			{ print }'
+		exit 0
+		;;
+	esac
 fi
 exec "$(dirname -- "$0")/dwm-settings-personalization.real" "$@"
 SH
@@ -1439,6 +1450,36 @@ appearance_recovery=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home X
 [ "$appearance_application" = partial ]
 [ "$appearance_preview" = none ]
 [ "$appearance_recovery" = none ]
+
+# A malformed text-scale record can pass the Appearance model's append-only
+# parser but must remain unavailable through the stricter Settings capability
+# contract. Removing the fault must refresh that strict gate from the
+# event-driven personalization selection change without a Settings refresh.
+test_stage='validating text-scale capability recovery synchronization'
+baseline_text_scale_capability=$(settings_ipc_retry capabilityStatus accessibility-text-scale)
+case $baseline_text_scale_capability in available | partial) ;; *) exit 1 ;; esac
+printf '%s\n' invalid-text-scale >"$appearance_failure_fixture"
+settings_ipc_retry appearanceRefresh >/dev/null
+i=0
+while [ "$i" -lt 100 ]; do
+	strict_text_scale_state=$(settings_ipc_retry capabilityStatus accessibility-text-scale)
+	live_text_scale_state=$(settings_ipc_retry appearancePersonalizationEffectiveState text-size)
+	[ "$strict_text_scale_state" = unavailable ] && [ "$live_text_scale_state" = available ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$strict_text_scale_state" = unavailable ]
+[ "$live_text_scale_state" = available ]
+rm -f -- "$appearance_failure_fixture"
+settings_ipc_retry appearanceRefresh >/dev/null
+i=0
+while [ "$i" -lt 100 ]; do
+	recovered_text_scale_capability=$(settings_ipc_retry capabilityStatus accessibility-text-scale)
+	[ "$recovered_text_scale_capability" = "$baseline_text_scale_capability" ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$recovered_text_scale_capability" = "$baseline_text_scale_capability" ]
 
 test_stage='validating shared panel widget persistence'
 panel_state=$(DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \


### PR DESCRIPTION
## Summary

- add a dedicated Accessibility group in Appearance settings
- keep application text scaling transactional while gating it with the strict capability provider
- refresh strict capability state after Appearance changes without polling and coalesce overlapping refreshes
- show read-only status cards for contrast, reduced motion, notifications, and input while later mutation slices remain open

## Validation

- `scripts/run-tests make clean all`
- `scripts/run-tests`
- `tests/test-quickshell-appearance-model.sh`
- `tests/test-quickshell-settings-xvfb.sh` (live malformed-state and recovery regression; 0.100% closed-idle CPU)
- `shellcheck tests/test-quickshell-appearance-model.sh tests/test-quickshell-settings-xvfb.sh`
- `shfmt -d tests/test-quickshell-appearance-model.sh tests/test-quickshell-settings-xvfb.sh`
- `mdbook build docs`
- `git diff --check`
- CodeRabbit local review: 0 findings
- Codex local review: no actionable defects

The existing PanelTooltip and RunningAppsArea qmllint warnings are unchanged. This slice does not require a live install, manual desktop test, or logout/login.