### PR TITLE
Fix floating windows falling behind tiled clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,10 @@ versions from `config.mk`.
 
 ### Fixed
 
+- Keep visible floating windows above the tiled stack when focus changes while
+  retaining focus-based ordering within the floating layer and the existing
+  fullscreen and shell-surface priorities.
+
 - Stop automatic theme-preview status retries after their bounded failure
   budget is exhausted. Reopening Appearance or using its refresh action still
   performs one explicit retry, and successful preview lifecycle actions re-arm

--- a/dwm.c
+++ b/dwm.c
@@ -2661,6 +2661,11 @@ restack(Monitor *m)
 		wc.stack_mode = Below;
 		wc.sibling = m->barwin;
 		for (c = m->stack; c; c = c->snext)
+			if (c->isfloating && !isvisiblefullscreen(c) && ISVISIBLE(c)) {
+				XConfigureWindow(dpy, c->win, CWSibling|CWStackMode, &wc);
+				wc.sibling = c->win;
+			}
+		for (c = m->stack; c; c = c->snext)
 			if (!c->isfloating && ISVISIBLE(c)) {
 				XConfigureWindow(dpy, c->win, CWSibling|CWStackMode, &wc);
 				wc.sibling = c->win;

--- a/tests/test-xvfb-runtime.sh
+++ b/tests/test-xvfb-runtime.sh
@@ -206,7 +206,7 @@ require_cmd Xvfb awk cc pkg-config xdotool xprop sed grep tail
 pkg-config --exists x11
 
 work=$(mktemp -d)
-trap 'set +e; [ -n "${swallow_client_pid:-}" ] && kill "$swallow_client_pid" 2>/dev/null; [ -n "${many_state_client_pid:-}" ] && kill "$many_state_client_pid" 2>/dev/null; [ -n "${fullscreen_client_pid:-}" ] && kill "$fullscreen_client_pid" 2>/dev/null; [ -n "${panel_pid:-}" ] && kill "$panel_pid" 2>/dev/null; [ -n "${popup_client_pid:-}" ] && kill "$popup_client_pid" 2>/dev/null; [ -n "${second_above_client_pid:-}" ] && kill "$second_above_client_pid" 2>/dev/null; [ -n "${stack_client_pid:-}" ] && kill "$stack_client_pid" 2>/dev/null; [ -n "${above_client_pid:-}" ] && kill "$above_client_pid" 2>/dev/null; [ -n "${second_client_pid:-}" ] && kill "$second_client_pid" 2>/dev/null; [ -n "${client_pid:-}" ] && kill "$client_pid" 2>/dev/null; [ -n "${dwm_pid:-}" ] && kill "$dwm_pid" 2>/dev/null; [ -n "${xvfb_pid:-}" ] && kill "$xvfb_pid" 2>/dev/null; rm -rf "$work"' EXIT HUP INT TERM
+trap 'set +e; [ -n "${swallow_client_pid:-}" ] && kill "$swallow_client_pid" 2>/dev/null; [ -n "${many_state_client_pid:-}" ] && kill "$many_state_client_pid" 2>/dev/null; [ -n "${fullscreen_client_pid:-}" ] && kill "$fullscreen_client_pid" 2>/dev/null; [ -n "${panel_pid:-}" ] && kill "$panel_pid" 2>/dev/null; [ -n "${popup_client_pid:-}" ] && kill "$popup_client_pid" 2>/dev/null; [ -n "${second_above_client_pid:-}" ] && kill "$second_above_client_pid" 2>/dev/null; [ -n "${stack_client_pid:-}" ] && kill "$stack_client_pid" 2>/dev/null; [ -n "${above_client_pid:-}" ] && kill "$above_client_pid" 2>/dev/null; [ -n "${floating_peer_pid:-}" ] && kill "$floating_peer_pid" 2>/dev/null; [ -n "${second_client_pid:-}" ] && kill "$second_client_pid" 2>/dev/null; [ -n "${client_pid:-}" ] && kill "$client_pid" 2>/dev/null; [ -n "${dwm_pid:-}" ] && kill "$dwm_pid" 2>/dev/null; [ -n "${xvfb_pid:-}" ] && kill "$xvfb_pid" 2>/dev/null; rm -rf "$work"' EXIT HUP INT TERM
 
 home="$work/home"
 mkdir -p "$home/.config/dwm-titus" "$home/.local/share/dwm-titus/config"
@@ -576,6 +576,68 @@ win=$(cat "$work/window-id")
 
 wait_for_active_window "$win"
 DISPLAY=$display xprop -root _NET_CLIENT_LIST | grep -q "$win"
+
+# Keep the floating layer above tiled clients while preserving focus order
+# within that layer and the higher real-fullscreen priority.
+DISPLAY=$display "$work/xclient" >"$work/floating-window-id" \
+	2>"$work/floating-client.log" &
+second_client_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ ! -s "$work/floating-window-id" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+floating_win=$(cat "$work/floating-window-id")
+[ -n "$floating_win" ]
+wait_for_active_window "$floating_win"
+
+DISPLAY=$display xdotool key Super+space
+DISPLAY=$display xdotool key Super+k
+wait_for_active_window "$win"
+wait_for_window_above "$floating_win" "$win"
+
+DISPLAY=$display xdotool key Super+j
+wait_for_active_window "$floating_win"
+DISPLAY=$display "$work/xclient" >"$work/floating-peer-window-id" \
+	2>"$work/floating-peer-client.log" &
+floating_peer_pid=$!
+i=0
+while [ "$i" -lt 100 ] && [ ! -s "$work/floating-peer-window-id" ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+floating_peer_win=$(cat "$work/floating-peer-window-id")
+[ -n "$floating_peer_win" ]
+wait_for_active_window "$floating_peer_win"
+DISPLAY=$display xdotool key Super+space
+wait_for_window_above "$floating_peer_win" "$floating_win"
+wait_for_window_above "$floating_win" "$win"
+
+DISPLAY=$display xdotool key Super+k
+wait_for_active_window "$floating_win"
+wait_for_window_above "$floating_win" "$floating_peer_win"
+DISPLAY=$display xdotool key Super+k
+wait_for_active_window "$win"
+wait_for_window_above "$floating_win" "$floating_peer_win"
+wait_for_window_above "$floating_peer_win" "$win"
+
+DISPLAY=$display "$work/xclient" fullscreen "$win"
+wait_for_window_state "$win" _NET_WM_STATE_FULLSCREEN
+wait_for_window_above "$win" "$floating_win"
+wait_for_window_above "$win" "$floating_peer_win"
+DISPLAY=$display "$work/xclient" state "$win" 0 _NET_WM_STATE_FULLSCREEN
+wait_for_window_state_absent "$win" _NET_WM_STATE_FULLSCREEN
+wait_for_window_above "$floating_win" "$floating_peer_win"
+wait_for_window_above "$floating_peer_win" "$win"
+
+kill "$floating_peer_pid"
+wait "$floating_peer_pid" 2>/dev/null || true
+floating_peer_pid=
+wait_for_active_window "$win"
+kill "$second_client_pid"
+wait "$second_client_pid" 2>/dev/null || true
+second_client_pid=
+wait_for_active_window "$win"
 
 DISPLAY=$display xdotool key Super+2
 wait_for_current_desktop 1


### PR DESCRIPTION
## Summary

- stack visible floating clients above tiled clients in tiled layouts
- preserve focus-history ordering within the floating layer
- preserve existing always-on-top, panel/tray, popup, and real-fullscreen priority layers
- add nested-X11 regression coverage for focus changes, multiple floating clients, and fullscreen restoration

Closes #185

## Automated validation

- `scripts/run-tests make clean all check-monitor-tags`
- `shellcheck tests/test-xvfb-runtime.sh`
- `shfmt -d tests/test-xvfb-runtime.sh`
- `git diff --check`
- `scripts/run-tests`
- `codex review --uncommitted` (no actionable findings; reviewer also reran the full suite)

The new issue-specific assertions in `make check-xvfb-runtime` pass. The local script later stops at the pre-existing hotkey-reload assertion `current desktop did not become 4`; the same failure reproduces from an untouched `origin/main` worktree. Hosted CI is expected to provide the clean-environment Xvfb result, as it does on the current main head.

## Manual validation

Pending maintainer testing in the real DWM session before merge.

Suggested checks:

1. Float a window, focus a tiled window, and confirm the floating window remains above it.
2. Open two floating windows and confirm the most recently focused floating window is highest in the floating layer.
3. Enter and exit real fullscreen and confirm fullscreen remains highest while active, then the floating layer is restored.
4. Repeat with a scratchpad and, if available, across multiple monitors.
