### PR TITLE
Settings: add display resolution dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ versions from `config.mk`.
 
 ### Changed
 
+- Replace the combined display mode button in Settings with an accessible
+  resolution dropdown backed by each output's supported RandR sizes. Keep
+  refresh-rate selection separate and route both choices through the existing
+  display preview and rollback workflow.
+
 - Rebuild the published documentation as a themed Astro site while preserving
   the existing custom domain and public page URLs. Add responsive navigation,
   light and dark themes, clearer documentation layouts, and a visual project

--- a/config/quickshell/settings/DisplaySettingsPane.qml
+++ b/config/quickshell/settings/DisplaySettingsPane.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
+import QtQuick.Controls as Controls
 import qs.core
 
 pragma ComponentBehavior: Bound
@@ -10,6 +11,38 @@ Flickable {
     required property var settingsModel
     property string profileName: ""
     property string confirmation: ""
+
+	component DisplayComboBox: Controls.ComboBox {
+		id: comboBox
+
+		required property string accessibleLabel
+		property string valueSuffix: ""
+
+		implicitHeight: Theme.controlHeight
+		activeFocusOnTab: enabled
+		displayText: currentIndex >= 0 ? currentText + valueSuffix : ""
+		font.family: Theme.fontFamily
+		font.pixelSize: Theme.inputFontSize
+		palette.button: Theme.controlNormalFill
+		palette.buttonText: Theme.controlNormalText
+		palette.base: Theme.popupBackground
+		palette.window: Theme.popupBackground
+		palette.text: Theme.popupText
+		palette.highlight: Theme.controlSelectedFill
+		palette.highlightedText: Theme.controlSelectedText
+		Accessible.name: accessibleLabel
+
+		delegate: Controls.ItemDelegate {
+			required property var modelData
+			required property int index
+
+			width: comboBox.width
+			text: modelData + comboBox.valueSuffix
+			font: comboBox.font
+			highlighted: comboBox.highlightedIndex === index
+			hoverEnabled: comboBox.hoverEnabled
+		}
+	}
 
 		onVisibleChanged: {
 			if (!visible) root.confirmation = "";
@@ -115,10 +148,75 @@ Flickable {
                         ShellButton { label: outputCard.modelData.primary ? "Primary" : "Make primary"; enabled: outputCard.modelData.enabled; onActivated: root.settingsModel.updateDisplay(outputCard.index, "primary", true) }
                     }
 
+                    Flow {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: implicitHeight
+                        spacing: Theme.tightSpacing
+
+                        Row {
+                            spacing: Theme.tightSpacing
+
+                            Text {
+                                anchors.verticalCenter: parent.verticalCenter
+                                text: "Resolution"
+                                color: Theme.textMuted
+                                font.family: Theme.fontFamily
+                                font.pixelSize: Theme.bodyFontSize
+                            }
+                            DisplayComboBox {
+                                id: resolutionSelector
+
+                                width: 180
+                                accessibleLabel: "Resolution for " + outputCard.modelData.name
+                                enabled: outputCard.modelData.enabled
+                                model: root.settingsModel.displayResolutionChoices(outputCard.index)
+                                currentIndex: root.settingsModel.displayResolutionIndex(outputCard.index)
+                                onActivated: function(index) {
+                                    root.settingsModel.setDisplayResolution(outputCard.index, model[index]);
+                                }
+                            }
+                        }
+
+                        Row {
+                            spacing: Theme.tightSpacing
+
+                            Text {
+                                anchors.verticalCenter: parent.verticalCenter
+                                text: "Refresh rate"
+                                color: Theme.textMuted
+                                font.family: Theme.fontFamily
+                                font.pixelSize: Theme.bodyFontSize
+                            }
+                            DisplayComboBox {
+                                id: refreshRateSelector
+
+                                readonly property var rateChoices: root.settingsModel.displayRefreshRateChoices(outputCard.index)
+
+                                width: 110
+                                accessibleLabel: "Refresh rate for " + outputCard.modelData.name
+                                enabled: outputCard.modelData.enabled
+                                visible: rateChoices.length > 1
+                                model: rateChoices
+                                currentIndex: root.settingsModel.displayRefreshRateIndex(outputCard.index)
+                                valueSuffix: " Hz"
+                                onActivated: function(index) {
+                                    root.settingsModel.setDisplayRefreshRate(outputCard.index, model[index]);
+                                }
+                            }
+                            Text {
+                                anchors.verticalCenter: parent.verticalCenter
+                                visible: refreshRateSelector.rateChoices.length <= 1
+                                text: outputCard.modelData.rate + " Hz"
+                                color: outputCard.modelData.enabled ? Theme.textStrong : Theme.controlDisabledText
+                                font.family: Theme.fontFamily
+                                font.pixelSize: Theme.bodyFontSize
+                            }
+                        }
+                        ShellButton { label: "Rotation: " + outputCard.modelData.rotation; enabled: outputCard.modelData.enabled; onActivated: root.settingsModel.cycleRotation(outputCard.index) }
+                    }
+
                     RowLayout {
                         Layout.fillWidth: true
-                        ShellButton { label: outputCard.modelData.mode + " @ " + outputCard.modelData.rate + " Hz"; enabled: outputCard.modelData.enabled; onActivated: root.settingsModel.cycleDisplayMode(outputCard.index) }
-                        ShellButton { label: "Rotation: " + outputCard.modelData.rotation; enabled: outputCard.modelData.enabled; onActivated: root.settingsModel.cycleRotation(outputCard.index) }
                         Text { text: "X"; color: Theme.textMuted; font.family: Theme.fontFamily; font.pixelSize: Theme.bodyFontSize }
                         Rectangle {
                             Layout.preferredWidth: 60

--- a/config/quickshell/settings/SettingsModel.qml
+++ b/config/quickshell/settings/SettingsModel.qml
@@ -257,8 +257,11 @@ Scope {
     }
 
     function displaySizeLabel(modeName) {
-        const match = /^(\d+)x(\d+)/.exec(modeName);
-        return match ? match[1] + " x " + match[2] : modeName;
+        const match = /^(\d+)x(\d+)(.*)$/.exec(modeName);
+        if (!match) return modeName;
+        const scanVariant = /^([ip])/i.exec(match[3]);
+        return match[1] + " x " + match[2]
+            + (scanVariant ? scanVariant[1].toLowerCase() : "");
     }
 
     function displayResolutionChoices(index) {

--- a/config/quickshell/settings/SettingsModel.qml
+++ b/config/quickshell/settings/SettingsModel.qml
@@ -256,14 +256,81 @@ Scope {
         root.displayOutputs = outputs;
     }
 
-    function cycleDisplayMode(index) {
+    function displaySizeLabel(modeName) {
+        const match = /^(\d+)x(\d+)/.exec(modeName);
+        return match ? match[1] + " x " + match[2] : modeName;
+    }
+
+    function displayResolutionChoices(index) {
         const output = root.displayOutputs[index];
-        const choices = root.displayModes.filter(function(mode) { return mode.output === output.name; });
+        if (!output) return [];
+        const choices = [];
+        for (const mode of root.displayModes) {
+            if (mode.output !== output.name) continue;
+            const label = root.displaySizeLabel(mode.mode);
+            if (label.length > 0 && choices.indexOf(label) < 0) choices.push(label);
+        }
+        return choices;
+    }
+
+    function displayResolutionIndex(index) {
+        const output = root.displayOutputs[index];
+        if (!output) return -1;
+        return root.displayResolutionChoices(index).indexOf(root.displaySizeLabel(output.mode));
+    }
+
+    function displayRefreshRateChoices(index) {
+        const output = root.displayOutputs[index];
+        if (!output) return [];
+        const size = root.displaySizeLabel(output.mode);
+        const choices = [];
+        for (const mode of root.displayModes) {
+            if (mode.output !== output.name || root.displaySizeLabel(mode.mode) !== size) continue;
+            if (choices.indexOf(mode.rate) < 0) choices.push(mode.rate);
+        }
+        return choices;
+    }
+
+    function displayRefreshRateIndex(index) {
+        const output = root.displayOutputs[index];
+        if (!output) return -1;
+        return root.displayRefreshRateChoices(index).indexOf(output.rate);
+    }
+
+    function updateDisplayMode(index, mode) {
+        if (!mode) return;
+        const outputs = root.displayOutputs.slice();
+        const changed = Object.assign({}, outputs[index]);
+        changed.mode = mode.mode;
+        changed.rate = mode.rate;
+        outputs[index] = changed;
+        root.displayOutputs = outputs;
+    }
+
+    function setDisplayResolution(index, size) {
+        const output = root.displayOutputs[index];
+        if (!output) return;
+        const choices = root.displayModes.filter(function(mode) {
+            return mode.output === output.name && root.displaySizeLabel(mode.mode) === size;
+        });
         if (choices.length === 0) return;
-        let selected = choices.findIndex(function(mode) { return mode.mode === output.mode && mode.rate === output.rate; });
-        selected = (selected + 1) % choices.length;
-        root.updateDisplay(index, "mode", choices[selected].mode);
-        root.updateDisplay(index, "rate", choices[selected].rate);
+        const selected = choices.find(function(mode) { return mode.rate === output.rate; })
+            || choices.find(function(mode) { return mode.preferred; }) || choices[0];
+        root.updateDisplayMode(index, selected);
+    }
+
+    function setDisplayRefreshRate(index, rate) {
+        const output = root.displayOutputs[index];
+        if (!output) return;
+        const size = root.displaySizeLabel(output.mode);
+        const choices = root.displayModes.filter(function(mode) {
+            return mode.output === output.name && root.displaySizeLabel(mode.mode) === size
+                && mode.rate === rate;
+        });
+        if (choices.length === 0) return;
+        const selected = choices.find(function(mode) { return mode.mode === output.mode; })
+            || choices.find(function(mode) { return mode.preferred; }) || choices[0];
+        root.updateDisplayMode(index, selected);
     }
 
     function cycleRotation(index) {

--- a/tests/test-quickshell-appearance-model.sh
+++ b/tests/test-quickshell-appearance-model.sh
@@ -378,7 +378,7 @@ grep -Fq 'readonly property int panelIconFontSize: 13' "$theme"
 grep -Fq 'font.pixelSize: Theme.panelIconFontSize + 1' "$icon_text"
 test "$(grep -Fc 'Theme.panelIconFontSize' "$panel")" -eq 5
 grep -Fq 'Math.round(13 * fontScale)' "$theme"
-test "$(grep -Ec 'font\.pixelSize: Theme\.(bodyFontSize|inputFontSize)' "$display_pane")" -eq 9
+test "$(grep -Ec 'font\.pixelSize: Theme\.(bodyFontSize|inputFontSize)' "$display_pane")" -eq 13
 test "$(grep -Ec 'font\.pixelSize: Theme\.(bodyFontSize|inputFontSize)' "$input_pane")" -eq 5
 grep -Fq 'font.pixelSize: Theme.inputFontSize' "$network_pane"
 grep -Fq 'passwordInput.implicitHeight + 2 * Theme.spacingSm' "$network_pane"

--- a/tests/test-settings.sh
+++ b/tests/test-settings.sh
@@ -540,6 +540,10 @@ grep -Fq 'root.settingsModel.setDisplayRefreshRate(outputCard.index, model[index
 	"$repo/config/quickshell/settings/DisplaySettingsPane.qml"
 grep -Fq 'function displayResolutionChoices(index)' \
 	"$repo/config/quickshell/settings/SettingsModel.qml"
+grep -Fq 'const scanVariant = /^([ip])/i.exec(match[3]);' \
+	"$repo/config/quickshell/settings/SettingsModel.qml"
+grep -Fq '(scanVariant ? scanVariant[1].toLowerCase() : "")' \
+	"$repo/config/quickshell/settings/SettingsModel.qml"
 grep -Fq 'function displayRefreshRateChoices(index)' \
 	"$repo/config/quickshell/settings/SettingsModel.qml"
 if grep -Fq 'cycleDisplayMode' "$repo/config/quickshell/settings/DisplaySettingsPane.qml"; then

--- a/tests/test-settings.sh
+++ b/tests/test-settings.sh
@@ -518,6 +518,34 @@ grep -Fq 'fields.length >= 10 ? fields[9] : "unsupported"' \
 	"$repo/config/quickshell/settings/SettingsModel.qml"
 grep -Fq 'NVIDIA full composition on persistent install' \
 	"$repo/config/quickshell/settings/DisplaySettingsPane.qml"
+grep -Fq 'import QtQuick.Controls as Controls' \
+	"$repo/config/quickshell/settings/DisplaySettingsPane.qml"
+grep -Fq 'component DisplayComboBox: Controls.ComboBox' \
+	"$repo/config/quickshell/settings/DisplaySettingsPane.qml"
+grep -Fq 'Accessible.name: accessibleLabel' \
+	"$repo/config/quickshell/settings/DisplaySettingsPane.qml"
+grep -Fq 'palette.window: Theme.popupBackground' \
+	"$repo/config/quickshell/settings/DisplaySettingsPane.qml"
+grep -Fq 'highlighted: comboBox.highlightedIndex === index' \
+	"$repo/config/quickshell/settings/DisplaySettingsPane.qml"
+grep -Fq 'accessibleLabel: "Resolution for " + outputCard.modelData.name' \
+	"$repo/config/quickshell/settings/DisplaySettingsPane.qml"
+grep -Fq 'root.settingsModel.displayResolutionChoices(outputCard.index)' \
+	"$repo/config/quickshell/settings/DisplaySettingsPane.qml"
+grep -Fq 'root.settingsModel.setDisplayResolution(outputCard.index, model[index])' \
+	"$repo/config/quickshell/settings/DisplaySettingsPane.qml"
+grep -Fq 'root.settingsModel.displayRefreshRateChoices(outputCard.index)' \
+	"$repo/config/quickshell/settings/DisplaySettingsPane.qml"
+grep -Fq 'root.settingsModel.setDisplayRefreshRate(outputCard.index, model[index])' \
+	"$repo/config/quickshell/settings/DisplaySettingsPane.qml"
+grep -Fq 'function displayResolutionChoices(index)' \
+	"$repo/config/quickshell/settings/SettingsModel.qml"
+grep -Fq 'function displayRefreshRateChoices(index)' \
+	"$repo/config/quickshell/settings/SettingsModel.qml"
+if grep -Fq 'cycleDisplayMode' "$repo/config/quickshell/settings/DisplaySettingsPane.qml"; then
+	printf 'Display resolution must not be presented as a mode-cycling button.\n' >&2
+	exit 1
+fi
 grep -Fq 'migrate or remove it before installing a managed display profile' \
 	"$repo/scripts/dwm-settings-display-root"
 grep -Fq 'watch-apply' "$repo/scripts/autostart.sh"


### PR DESCRIPTION
Closes #195

## Summary

- replace the combined mode-cycling button with an accessible resolution combobox populated from each output's RandR sizes
- expose refresh rates separately for the selected size while preserving the pending Preview/Keep/Revert transaction
- wrap display controls at low resolutions and theme popup/focus states for keyboard and mouse use
- add Settings contracts and changelog coverage

## Validation

- `scripts/run-tests make clean all`
- `scripts/run-tests`
- `scripts/quickshell-qmllint --root config/quickshell`
- `DWM_SETTINGS_TEST_SCREEN_GEOMETRY=800x600x24 DWM_SETTINGS_EXPECTED_WINDOW_WIDTH=768 DWM_SETTINGS_EXPECTED_WINDOW_HEIGHT=568 DWM_SETTINGS_POWER_CPU_SECONDS=0 tests/test-quickshell-settings-xvfb.sh`
- `scripts/dev-sync-install.sh` (managed files match checkout; Quickshell IPC ready with 6 tray items; normal session restart required for the installed dwm binary)
- `codex review --uncommitted` (clean after review fixes)
- `coderabbit review --agent -t uncommitted` (0 findings)

## Manual evidence

- inspected the Displays pane at 800x600 in nested X11: resolution and refresh selectors remain visible, Rotation wraps without clipping, and X/Y controls remain reachable
- nested Settings lifecycle stayed near idle at 0.000% CPU with the launcher closed

The existing repository-wide qmllint warnings in `PanelTooltip.qml` and `RunningAppsArea.qml` remain unchanged.