### PR TITLE
Phase 5: add contrast and motion policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ versions from `config.mk`.
 
 ### Added
 
+- Add versioned, user-owned accessibility policy state for managed-shell high
+  contrast and reduced motion. The root-scoped event-driven model applies
+  stronger semantic borders and zero-duration managed animations without
+  polling, while safe defaults, strict parsing, atomic writes, reset, and
+  unsafe-path rejection keep malformed or unavailable state isolated.
+
 - Group the existing bounded application text-scale choices under a dedicated
   Settings Accessibility section with keyboard-focusable apply and reset
   controls, wrapping actions for compact display sizes, and capability-scoped

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ OBJ = ${SRC:.c=.o}
 
 INSTALL_COMMANDS = \
 	scripts/active-audio \
+	scripts/dwm-accessibility-settings \
 	scripts/check-deps.sh \
 	scripts/disable-powersaving \
 	scripts/dwm-controlcenter \
@@ -322,10 +323,10 @@ release: dwm
 	echo "==> Created ${RELEASE_ARCHIVE}"
 
 check-shell:
-	shellcheck install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-panel-settings scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-pointer scripts/dwm-quickshell-state scripts/dwm-quickshell-version-check scripts/dwm-settings scripts/dwm-settings-appearance scripts/dwm-settings-font scripts/dwm-settings-personalization scripts/dwm-settings-wallpaper scripts/dwm-settings-theme scripts/dwm-settings-provider scripts/dwm-session-launch scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/dwm-xdg-autostart scripts/dwm-xsettings scripts/install-herdr scripts/quickshell-qmllint scripts/run-tests scripts/webapp-launch scripts/*.sh tests/*.sh
+	shellcheck install.sh scripts/dwm-accessibility-settings scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-panel-settings scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-pointer scripts/dwm-quickshell-state scripts/dwm-quickshell-version-check scripts/dwm-settings scripts/dwm-settings-appearance scripts/dwm-settings-font scripts/dwm-settings-personalization scripts/dwm-settings-wallpaper scripts/dwm-settings-theme scripts/dwm-settings-provider scripts/dwm-session-launch scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/dwm-xdg-autostart scripts/dwm-xsettings scripts/install-herdr scripts/quickshell-qmllint scripts/run-tests scripts/webapp-launch scripts/*.sh tests/*.sh
 
 check-format:
-	shfmt -d install.sh scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-panel-settings scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-pointer scripts/dwm-quickshell-state scripts/dwm-quickshell-version-check scripts/dwm-settings scripts/dwm-settings-appearance scripts/dwm-settings-font scripts/dwm-settings-personalization scripts/dwm-settings-wallpaper scripts/dwm-settings-theme scripts/dwm-settings-provider scripts/dwm-session-launch scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/dwm-xdg-autostart scripts/dwm-xsettings scripts/install-herdr scripts/quickshell-qmllint scripts/run-tests scripts/webapp-launch scripts/*.sh tests/*.sh
+	shfmt -d install.sh scripts/dwm-accessibility-settings scripts/dwm-default-apps scripts/dwm-diagnostics scripts/dwm-display-profile scripts/dwm-display-setup scripts/dwm-lock scripts/dwm-lock-watch scripts/dwm-keybinds scripts/dwm-panel-settings scripts/dwm-quickshell-launcher scripts/dwm-quickshell-controls scripts/dwm-quickshell-controlcenter scripts/dwm-quickshell-network scripts/dwm-quickshell-pointer scripts/dwm-quickshell-state scripts/dwm-quickshell-version-check scripts/dwm-settings scripts/dwm-settings-appearance scripts/dwm-settings-font scripts/dwm-settings-personalization scripts/dwm-settings-wallpaper scripts/dwm-settings-theme scripts/dwm-settings-provider scripts/dwm-session-launch scripts/dwm-status scripts/dwm-system-health scripts/dwm-terminal scripts/dwm-xdg-autostart scripts/dwm-xsettings scripts/install-herdr scripts/quickshell-qmllint scripts/run-tests scripts/webapp-launch scripts/*.sh tests/*.sh
 
 check-session-guards:
 	tests/test-autostart.sh
@@ -436,6 +437,10 @@ check-quickshell-panel-menus:
 
 check-quickshell-panel-settings:
 	tests/test-quickshell-panel-settings.sh
+
+check-accessibility:
+	tests/test-dwm-accessibility-settings.sh
+	tests/test-quickshell-accessibility.sh
 
 check-quickshell-command-menu:
 	tests/test-quickshell-command-menu.sh
@@ -616,6 +621,7 @@ check:
 	$(MAKE) check-quickshell-large-surfaces-xvfb
 	$(MAKE) check-quickshell-panel-menus
 	$(MAKE) check-quickshell-panel-settings
+	$(MAKE) check-accessibility
 	$(MAKE) check-quickshell-command-menu
 	$(MAKE) check-quickshell-qml
 	$(MAKE) check-quickshell-notifications
@@ -642,7 +648,7 @@ check:
 	$(MAKE) check-lightdm-config
 	$(MAKE) release-check
 
-.PHONY: clean all check check-appearance check-phase5-optional-components check-build-config check-build-deps check-default-apps check-xdg-autostart check-dev-sync-install \
+.PHONY: clean all check check-accessibility check-appearance check-phase5-optional-components check-build-config check-build-deps check-default-apps check-xdg-autostart check-dev-sync-install \
 	check-test-runner \
 	check-display-profile check-display-setup check-fedora-iso-builder check-fedora-packages check-fedora-platform check-format check-install \
 	check-gearlever-install check-herdr-install check-install-manifest check-install-preservation check-kickstart check-lock \

--- a/TASKS.md
+++ b/TASKS.md
@@ -13,12 +13,11 @@ accessibility capability contract after PR #188 completed `APPEARANCE-001` and
 PR #189 established the automatic small-PR workflow. Only the primary worktree
 remains registered.
 
-The current accessibility Settings boundary exposes the already-supported
-application text scale in a dedicated group with apply, reset, keyboard focus,
-and compact-width action wrapping. Contrast, reduced motion, notification
-policy, and practical keyboard or pointer access remain explanatory
-capability-scoped cards until their mutation contracts land separately. The
-overall Settings-controls checkbox remains open until those controls and the
+The current accessibility policy boundary adds persistent high-contrast and
+reduced-motion state and applies it to the managed shell without polling. The
+Settings pane still exposes those choices, notification policy, and practical
+keyboard or pointer access as explanatory capability cards. The overall
+Settings-controls checkbox remains open until dedicated controls and the
 required interaction evidence are complete.
 
 ## Active Phase: Personalization and Accessibility
@@ -102,7 +101,7 @@ Acceptance:
   available through supported Fedora/X11 interfaces.
 - [ ] Add accessible Settings controls with keyboard navigation, visible focus,
   usable common display sizes, explanatory unavailable states, and reset.
-- [ ] Apply reduced-motion and contrast choices consistently to managed
+- [x] Apply reduced-motion and contrast choices consistently to managed
   Quickshell surfaces without introducing a Wayland, compositor, or polling
   dependency.
 - [ ] Add notification behavior controls that preserve the existing D-Bus owner,

--- a/config/quickshell/accessibility/AccessibilityModel.qml
+++ b/config/quickshell/accessibility/AccessibilityModel.qml
@@ -1,0 +1,193 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.core
+
+Scope {
+    id: root
+
+    property string providerState: "idle"
+    property string providerDetail: "Loading accessibility policy"
+    property bool highContrast: false
+    property bool reducedMotion: false
+    property bool busy: false
+    property string message: ""
+    property bool statusParsed: false
+    property bool refreshPending: false
+    property bool mutationRefreshPending: false
+    property bool actionSucceeded: false
+    property bool watchReady: false
+    property string pendingSetting: ""
+    property string pendingValue: ""
+    readonly property string homeDir: Quickshell.env("HOME") || ""
+    readonly property string configuredConfigHome: Quickshell.env("XDG_CONFIG_HOME")
+    readonly property string configHome: root.configuredConfigHome.startsWith("/")
+        ? root.configuredConfigHome : root.homeDir + "/.config"
+    readonly property string configPath: root.configHome + "/dwm-titus/accessibility.conf"
+    readonly property bool mutationReady: root.providerState !== "unavailable"
+
+    function useDefaults() {
+        root.highContrast = false;
+        root.reducedMotion = false;
+        Theme.applyAccessibility(false, false);
+    }
+
+    function refresh() {
+        if (statusProcess.running) {
+            root.refreshPending = true;
+            return;
+        }
+        root.refreshPending = false;
+        root.statusParsed = false;
+        statusProcess.running = true;
+    }
+
+    function parseStatus(text) {
+        const lines = text.trim().split("\n");
+        if (lines.length !== 5 || lines[0] !== "accessibility-settings-protocol\t1\t0"
+                || lines[4] !== "complete\tstatus") return;
+        const state = lines[1].split("\t");
+        if (state.length !== 3 || state[0] !== "state"
+                || ["available", "defaults", "partial", "unavailable"].indexOf(state[1]) < 0)
+            return;
+        const parsed = {};
+        for (let index = 2; index < 4; index++) {
+            const fields = lines[index].split("\t");
+            if (fields.length !== 3 || fields[0] !== "setting"
+                    || parsed[fields[1]] !== undefined) return;
+            if (fields[1] === "contrast"
+                    && (fields[2] === "standard" || fields[2] === "high"))
+                parsed.contrast = fields[2];
+            else if (fields[1] === "motion"
+                    && (fields[2] === "full" || fields[2] === "reduced"))
+                parsed.motion = fields[2];
+            else return;
+        }
+        if (parsed.contrast === undefined || parsed.motion === undefined) return;
+        root.highContrast = parsed.contrast === "high";
+        root.reducedMotion = parsed.motion === "reduced";
+        Theme.applyAccessibility(root.highContrast, root.reducedMotion);
+        root.providerState = state[1];
+        root.providerDetail = state[2];
+        root.statusParsed = true;
+    }
+
+    function setSetting(setting, value) {
+        if (root.busy || !root.mutationReady) return;
+        if (!((setting === "contrast" && (value === "standard" || value === "high"))
+                || (setting === "motion" && (value === "full" || value === "reduced")))) return;
+        root.busy = true;
+        root.pendingSetting = setting;
+        root.pendingValue = value;
+        root.actionSucceeded = false;
+        actionProcess.command = Commands.checkedCommand(
+            Commands.accessibilitySettingsCommand("set", [setting, value]));
+        actionProcess.running = true;
+    }
+
+    function reset() {
+        if (root.busy || !root.mutationReady) return;
+        root.busy = true;
+        root.pendingSetting = "all";
+        root.pendingValue = "defaults";
+        root.actionSucceeded = false;
+        actionProcess.command = Commands.checkedCommand(
+            Commands.accessibilitySettingsCommand("reset", []));
+        actionProcess.running = true;
+    }
+
+    function parseAction(text) {
+        const lines = text.trim().split("\n");
+        if (lines.length !== 2
+                || lines[0] !== "accessibility-settings-action-protocol\t1\t0") return;
+        const fields = lines[1].split("\t");
+        if (fields.length !== 4 || fields[0] !== "result") return;
+        if (fields[1] === "set")
+            root.actionSucceeded = fields[2] === root.pendingSetting
+                && fields[3] === root.pendingValue;
+        else if (fields[1] === "reset")
+            root.actionSucceeded = root.pendingSetting === "all"
+                && fields[2] === "all" && fields[3] === "defaults";
+    }
+
+    Component.onCompleted: watchProcess.running = true
+
+    Process {
+        id: watchProcess
+        command: Commands.accessibilitySettingsCommand("watch", [])
+        running: false
+        stdout: SplitParser {
+            onRead: line => {
+                if (line === "ready\taccessibility") {
+                    root.watchReady = true;
+                    root.refresh();
+                    return;
+                }
+                if (!line.startsWith("changed\t")) return;
+                settleTimer.restart();
+                if (line.indexOf("DELETE_SELF") >= 0 || line.indexOf("MOVE_SELF") >= 0)
+                    watchProcess.running = false;
+            }
+        }
+        onRunningChanged: {
+            if (running) return;
+            const shouldRestart = root.watchReady;
+            if (!shouldRestart) root.refresh();
+            root.watchReady = false;
+            if (shouldRestart) watchRestartTimer.restart();
+        }
+    }
+
+    Timer {
+        id: settleTimer
+        interval: 75
+        repeat: false
+        onTriggered: root.refresh()
+    }
+
+    Timer {
+        id: watchRestartTimer
+        interval: 3000
+        repeat: false
+        onTriggered: {
+            if (!watchProcess.running) watchProcess.running = true;
+        }
+    }
+
+    Process {
+        id: statusProcess
+        command: Commands.accessibilitySettingsCommand("status", [])
+        running: false
+        stdout: StdioCollector { onStreamFinished: root.parseStatus(this.text) }
+        stderr: StdioCollector { id: statusError }
+        onRunningChanged: if (!running) {
+            if (!root.statusParsed) {
+                root.useDefaults();
+                root.providerState = "unavailable";
+                root.providerDetail = statusError.text.trim().length > 0
+                    ? statusError.text.trim()
+                    : "Accessibility settings provider returned invalid data";
+            }
+            if (root.refreshPending) {
+                Qt.callLater(root.refresh);
+            } else if (root.mutationRefreshPending) {
+                root.mutationRefreshPending = false;
+                root.busy = false;
+            }
+        }
+    }
+
+    Process {
+        id: actionProcess
+        running: false
+        stdout: StdioCollector { onStreamFinished: root.parseAction(this.text) }
+        stderr: StdioCollector { id: actionError }
+        onRunningChanged: if (!running && root.busy) {
+            root.message = root.actionSucceeded ? "Accessibility policy updated"
+                : actionError.text.trim().length > 0 ? actionError.text.trim()
+                : "Accessibility settings helper did not confirm the change";
+            root.mutationRefreshPending = true;
+            Qt.callLater(root.refresh);
+        }
+    }
+}

--- a/config/quickshell/accessibility/AccessibilityModel.qml
+++ b/config/quickshell/accessibility/AccessibilityModel.qml
@@ -17,6 +17,8 @@ Scope {
     property bool mutationRefreshPending: false
     property bool actionSucceeded: false
     property bool watchReady: false
+    property int watchSetupFailures: 0
+    readonly property int maxWatchSetupFailures: 5
     property string pendingSetting: ""
     property string pendingValue: ""
     readonly property string homeDir: Quickshell.env("HOME") || ""
@@ -120,6 +122,7 @@ Scope {
             onRead: line => {
                 if (line === "ready\taccessibility") {
                     root.watchReady = true;
+                    root.watchSetupFailures = 0;
                     root.refresh();
                     return;
                 }
@@ -134,7 +137,17 @@ Scope {
             const shouldRestart = root.watchReady;
             if (!shouldRestart) root.refresh();
             root.watchReady = false;
-            if (shouldRestart) watchRestartTimer.restart();
+            if (shouldRestart) {
+                watchRestartTimer.interval = 3000;
+                watchRestartTimer.restart();
+            } else {
+                root.watchSetupFailures += 1;
+                if (root.watchSetupFailures <= root.maxWatchSetupFailures) {
+                    watchRestartTimer.interval = Math.min(48000,
+                        3000 * Math.pow(2, root.watchSetupFailures - 1));
+                    watchRestartTimer.restart();
+                }
+            }
         }
     }
 

--- a/config/quickshell/core/Commands.qml
+++ b/config/quickshell/core/Commands.qml
@@ -122,4 +122,8 @@ Singleton {
     function panelSettingsCommand(action, args) {
         return helperCommand("dwm-panel-settings", action, args, true);
     }
+
+    function accessibilitySettingsCommand(action, args) {
+        return helperCommand("dwm-accessibility-settings", action, args, true);
+    }
 }

--- a/config/quickshell/core/Theme.qml
+++ b/config/quickshell/core/Theme.qml
@@ -6,6 +6,8 @@ Singleton {
     id: root
 
     property bool dark: true
+    property bool highContrast: false
+    property bool reducedMotion: false
 
     readonly property string transparent: "#00000000"
     property string bg: "#2E3440"
@@ -17,7 +19,8 @@ Singleton {
     property string borderStrong: "#81A1C1"
     property string text: "#D8DEE9"
     property string textStrong: "#ECEFF4"
-    property string textMuted: "#D8DEE9"
+    property string paletteTextMuted: "#D8DEE9"
+    readonly property string textMuted: highContrast ? text : paletteTextMuted
     property string placeholder: "#4C566A"
     property string accent: "#81A1C1"
     property string accentSecondary: "#81A1C1"
@@ -31,7 +34,7 @@ Singleton {
     // Semantic shell roles. Keep these derived from the existing dwm palette
     // so hot-reloaded themes remain the single source of color state.
     readonly property string popupBackground: bg
-    readonly property string popupBorder: borderStrong
+    readonly property string popupBorder: highContrast ? textStrong : borderStrong
     readonly property string popupText: text
     readonly property string menuBackground: bg
     readonly property string menuText: text
@@ -42,19 +45,19 @@ Singleton {
     readonly property string menuSelectedBackground: surfaceActive
     readonly property string menuSelectedText: accentSecondary
     readonly property string controlNormalFill: surface
-    readonly property string controlNormalBorder: border
+    readonly property string controlNormalBorder: highContrast ? textStrong : border
     readonly property string controlNormalText: text
     readonly property string controlHoverFill: surfaceHover
-    readonly property string controlHoverBorder: borderStrong
+    readonly property string controlHoverBorder: highContrast ? textStrong : borderStrong
     readonly property string controlHoverText: text
     readonly property string controlFocusFill: surface
-    readonly property string controlFocusBorder: accent
+    readonly property string controlFocusBorder: highContrast ? textStrong : accent
     readonly property string controlFocusText: text
     readonly property string controlSelectedFill: surfaceActive
-    readonly property string controlSelectedBorder: accentSecondary
+    readonly property string controlSelectedBorder: highContrast ? textStrong : accentSecondary
     readonly property string controlSelectedText: accentSecondary
     readonly property string controlDisabledFill: barBackground
-    readonly property string controlDisabledBorder: border
+    readonly property string controlDisabledBorder: highContrast ? textStrong : border
     readonly property string controlDisabledText: textMuted
 
     // AppearanceModel is the single owner of theme inventory and validation.
@@ -70,7 +73,7 @@ Singleton {
         root.borderStrong = colors["border-strong"];
         root.text = colors.text;
         root.textStrong = colors["text-strong"];
-        root.textMuted = colors["text-muted"];
+        root.paletteTextMuted = colors["text-muted"];
         root.placeholder = colors.placeholder;
         root.accent = colors.accent;
         root.accentSecondary = colors["accent-secondary"];
@@ -88,6 +91,11 @@ Singleton {
     function applyFontPreferences(family, scale) {
         root.fontFamily = family.length > 0 ? family : "MesloLGS Nerd Font Mono";
         root.fontScale = Math.max(0.8, Math.min(1.5, scale));
+    }
+
+    function applyAccessibility(highContrastEnabled, reducedMotionEnabled) {
+        root.highContrast = highContrastEnabled;
+        root.reducedMotion = reducedMotionEnabled;
     }
 
     // Shared spacing and type scales adapted from Omarchy's shell language.
@@ -113,8 +121,8 @@ Singleton {
     readonly property int controlHeight: 30
     readonly property int controlRowHeight: 32
     readonly property int controlPaddingX: 9
-    readonly property int controlBorderWidth: 1
-    readonly property int controlFocusBorderWidth: 2
+    readonly property int controlBorderWidth: highContrast ? 2 : 1
+    readonly property int controlFocusBorderWidth: highContrast ? 3 : 2
     readonly property int controlRadius: 6
     readonly property int menuHeaderHeight: 26
     readonly property int popupPadding: spacingHuge
@@ -152,8 +160,8 @@ Singleton {
     readonly property int compactWidgetHorizontalPadding: 6
     readonly property real networkWidgetHorizontalPadding: 4.5
     readonly property int pillBorderWidth: controlBorderWidth
-    readonly property int animationFast: 120
-    readonly property int animationNormal: 180
+    readonly property int animationFast: reducedMotion ? 0 : 120
+    readonly property int animationNormal: reducedMotion ? 0 : 180
     readonly property int buttonHeight: controlHeight
     readonly property int chipHeight: 28
     readonly property int workspaceButtonSize: 22

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -4,6 +4,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import Quickshell.Services.SystemTray
+import qs.accessibility
 import qs.appearance
 import qs.controlcenter
 import qs.controls
@@ -172,6 +173,10 @@ ShellRoot {
 
     AppearanceModel {
         id: appearanceModel
+    }
+
+    AccessibilityModel {
+        id: accessibilityModel
     }
 
     PanelSettingsModel {

--- a/docs/P5-ACCESSIBILITY-POLICY.md
+++ b/docs/P5-ACCESSIBILITY-POLICY.md
@@ -36,10 +36,12 @@ One root-scoped `AccessibilityModel` runs a bounded status command at startup.
 The helper emits readiness only after inotify confirms its watch on the
 validated owning configuration directory. QML then requests the initial
 validated status snapshot and repeats that request for later events without
-reading the state file itself. High contrast strengthens semantic borders and
-muted text through `Theme.qml`. Reduced motion sets the shared managed animation
-durations to zero. The model introduces no state polling, new privilege
-boundary, compositor dependency, or Wayland API.
+reading the state file itself. Watchers that were established restart after
+directory replacement or child failure; pre-readiness failures use five bounded
+exponential-backoff attempts and then stop. High contrast strengthens semantic
+borders and muted text through `Theme.qml`. Reduced motion sets the shared
+managed animation durations to zero. The model introduces no state polling, new
+privilege boundary, compositor dependency, or Wayland API.
 
 ## Validation
 
@@ -51,7 +53,8 @@ scripts/quickshell-qmllint --root config/quickshell
 ```
 
 The helper tests cover defaults, persistence, reset, file-mode preservation,
-inotify delivery, malformed and future state, unsafe symlink and hard-link
-paths, invalid values, runtime path validation, and mutation lock contention.
+inotify delivery and child failure, malformed and future state, unsafe symlink
+and hard-link paths, invalid values, runtime path validation, and mutation lock
+contention.
 The Quickshell checks cover strict protocol parsing, helper-owned event-driven
 refresh, semantic theme policy, and shell ownership.

--- a/docs/P5-ACCESSIBILITY-POLICY.md
+++ b/docs/P5-ACCESSIBILITY-POLICY.md
@@ -1,0 +1,57 @@
+# Phase 5 Managed Accessibility Policy
+
+## Scope
+
+This `ACCESSIBILITY-001` review boundary adds the persistent managed-shell
+policy used by later Settings controls. It covers high contrast and reduced
+motion only. Notification behavior and practical X11 input controls remain
+separate Phase 5 boundaries.
+
+## State Contract
+
+`dwm-accessibility-settings` owns
+`${XDG_CONFIG_HOME:-$HOME/.config}/dwm-titus/accessibility.conf` and exposes
+`accessibility-settings-protocol 1`. An absent file means standard contrast and
+full motion. A valid file stores exactly one contrast choice and one motion
+choice:
+
+```text
+accessibility-settings-protocol	1	0
+contrast	standard
+motion	full
+```
+
+The helper supports bounded `status`, `set`, and `reset` actions. It serializes
+mutations, publishes a complete file atomically, preserves the existing file
+mode, rejects symlinks, hard links, unsafe ownership and unsafe directories,
+and refuses to overwrite state that changes during a transaction. Malformed or
+incomplete version 1 data can be repaired by an explicit mutation. Future
+protocol versions are preserved and reject every mutation while the shell uses
+safe defaults. Its watch action may create only the missing user-owned
+`dwm-titus` configuration directory; it never creates policy state.
+
+## Shell Behavior
+
+One root-scoped `AccessibilityModel` runs a bounded status command at startup.
+The helper emits readiness only after inotify confirms its watch on the
+validated owning configuration directory. QML then requests the initial
+validated status snapshot and repeats that request for later events without
+reading the state file itself. High contrast strengthens semantic borders and
+muted text through `Theme.qml`. Reduced motion sets the shared managed animation
+durations to zero. The model introduces no state polling, new privilege
+boundary, compositor dependency, or Wayland API.
+
+## Validation
+
+Focused checks:
+
+```text
+make check-accessibility
+scripts/quickshell-qmllint --root config/quickshell
+```
+
+The helper tests cover defaults, persistence, reset, file-mode preservation,
+inotify delivery, malformed and future state, unsafe symlink and hard-link
+paths, invalid values, runtime path validation, and mutation lock contention.
+The Quickshell checks cover strict protocol parsing, helper-owned event-driven
+refresh, semantic theme policy, and shell ownership.

--- a/docs/P5-STATUS.md
+++ b/docs/P5-STATUS.md
@@ -1,15 +1,15 @@
 # Phase 5 Project Status
 
-Date: 2026-08-31
+Date: 2026-09-01
 
 ## Verification Baseline
 
 This checkpoint was reconciled against `origin/main` at
-`63e49ab5dc7f1e95d1da0667560a5fe9a4c35822`. PR #190 merged the accessibility
-capability contract after PR #188 merged optional-component qualification and
-PR #189 merged the automatic small-PR workflow. The primary checkout matched
-the remote revision before this continuation branch was created, no pull
-request remained open, and only the primary checkout was registered.
+`e2137c2cbb8415d9e839b28938847a62b30a9ced`. PR #191 merged the first accessible
+Settings grouping after PR #190 merged the accessibility capability contract.
+The primary checkout matched the remote revision before this continuation
+branch was created, no pull request remained open, and only the primary
+checkout was registered.
 
 The active `TASKS.md` contains 25 implementation checkboxes. Thirteen are
 complete on `main`, leaving 12 open.
@@ -49,6 +49,7 @@ boundaries passed before merge.
 | APPEARANCE-001 panel-widget persistence | Complete | PR #186 | Hosted CI, CodeQL, docs, focused panel, nested-X11, and live-session checks passed. |
 | APPEARANCE-001 optional-component isolation | Complete | PR #188 | Focused and full managed suites, nested X11, install, docs, lint, CodeQL, and hosted checks passed. |
 | ACCESSIBILITY-001 capability contract | Complete | PR #190 | Five hosted checks and exact-head Codex and CodeRabbit review passed; one conditional check skipped. |
+| ACCESSIBILITY-001 accessible Settings grouping | Open (partial) | PR #191 | Validate, Quickshell QML, analyze, CodeQL, and CodeRabbit passed; one conditional build skipped. |
 
 The detailed contracts and focused validation commands remain in
 `P5-THEME-TRANSACTIONS.md`, `P5-APPEARANCE-INVENTORY.md`,
@@ -72,20 +73,18 @@ nested-X11 validation covers the shared-state path.
 
 ## Current Review Boundary
 
-The current `codex/phase5-accessibility-settings` boundary groups the existing
-bounded application text-scale choices under Accessibility. Its apply and
-reset actions retain the shared personalization transaction, keyboard focus,
-and visible focus border, while action rows wrap at compact widths. The four
-remaining accessibility records render in the same group with explicit
-capability-scoped explanations and no implied mutation path.
+The current `codex/phase5-accessibility-policy` boundary adds versioned,
+user-owned high-contrast and reduced-motion state plus one root-scoped,
+event-driven shell model. Semantic borders and muted text strengthen under high
+contrast, and the existing shared animation durations become zero under reduced
+motion. The helper preserves safe defaults and rejects unsafe persistent state.
 
-Personalization selection changes coalesce a strict capability refresh, so a
-provider or XSETTINGS recovery updates the text-scale gate without polling or a
-second provider. This slice introduces no new persistent state, helper,
-watcher, polling loop, or privilege boundary. The overall Settings-controls
-checkbox stays open for dedicated contrast, reduced-motion,
-notification-policy, and practical input controls plus the required
-real-session interaction evidence.
+The merged text-scale grouping and capability cards remain unchanged. This
+slice introduces persistent helper and shell-model mutations, but no Settings
+UI controls, polling loop, privilege boundary, or compositor dependency. The
+overall Settings-controls checkbox stays open for those dedicated controls,
+practical input behavior, and required real-session interaction evidence.
+Notification policy remains a separate later boundary.
 
 ## Open Task Boundaries
 

--- a/docs/P5-STATUS.md
+++ b/docs/P5-STATUS.md
@@ -12,7 +12,8 @@ branch was created, no pull request remained open, and only the primary
 checkout was registered.
 
 The active `TASKS.md` contains 25 implementation checkboxes. Thirteen are
-complete on `main`, leaving 12 open.
+complete on `main`; this boundary completes the fourteenth, leaving 11 after
+merge.
 
 The merged APPEARANCE-001 boundaries and their documentation passed. The
 historical documentation build has since been replaced by the current Astro
@@ -91,14 +92,15 @@ Notification policy remains a separate later boundary.
 | Boundary | Open checkboxes | Verified current state | Next evidence needed |
 | --- | ---: | --- | --- |
 | APPEARANCE-001 | 0 | Complete on `main` through PR #188. | Preserve the merged contracts while completing Phase 5. |
-| ACCESSIBILITY-001 | 3 | The merged boundary defines five distinct capability records; the current UI slice groups text scale and truthful unavailable states without adding mutation. | Finish dedicated controls and interaction evidence, then apply contrast and reduced motion and add notification policy. |
+| ACCESSIBILITY-001 | 2 | Five capability records and the text-scale grouping are merged. This boundary adds persistent contrast and reduced-motion state and applies it event-first across the managed shell. | Finish dedicated Settings and practical-input controls, interaction evidence, and notification policy. |
 | P5-UI5 | 4 | No candidate decision record is complete. | Inventory candidates, record adopt/defer/reject decisions, and qualify each adopted X11-native experience independently. |
 | P5-VALIDATE | 5 | Individual merged slices have focused and full-suite evidence, but the combined Phase 5 product is incomplete. | Run the final Fedora 44, clean build, full suite, QML, shell, install/parity, fresh-login, `startx`, multi-monitor, optional-loss, recovery, and 30-second CPU qualification after all selected Phase 5 work merges. |
 
 ## Phase Position
 
 Phase 5 remains active. THEME-001 and APPEARANCE-001 are complete on `main`.
-The first ACCESSIBILITY-001 checkbox is complete on `main` through PR #190;
-no P5-UI5 or final Phase 5 qualification checkbox is complete. Phase 6 must not
-begin until the Phase 5 exit criteria pass or an explicit roadmap decision
-defers named work and records the resulting limitation.
+The first ACCESSIBILITY-001 checkbox is complete on `main` through PR #190, and
+this boundary completes its managed contrast and motion policy. No P5-UI5 or
+final Phase 5 qualification checkbox is complete. Phase 6 must not begin until
+the Phase 5 exit criteria pass or an explicit roadmap decision defers named work
+and records the resulting limitation.

--- a/scripts/dwm-accessibility-settings
+++ b/scripts/dwm-accessibility-settings
@@ -153,7 +153,7 @@ watch_cleanup() {
 		watch_child=
 	fi
 	if [[ $watch_fd_open == true ]]; then
-		exec 8>&- 8<&-
+		exec 8<&-
 		watch_fd_open=false
 	fi
 	if [[ -n $watch_work ]]; then
@@ -180,12 +180,12 @@ watch_config() {
 	trap 'exit 143' HUP INT TERM
 	mkfifo -- "$watch_work/events"
 	: >"$watch_work/ready"
-	exec 8<>"$watch_work/events"
-	watch_fd_open=true
 	inotifywait -m -P \
 		-e attrib,close_write,create,delete,delete_self,moved_from,moved_to,move_self \
 		--format $'changed\t%e' -- "$config_dir" >"$watch_work/events" 2>"$watch_work/ready" &
 	watch_child=$!
+	exec 8<"$watch_work/events"
+	watch_fd_open=true
 	until grep -Fq 'Watches established.' "$watch_work/ready" 2>/dev/null; do
 		if ! kill -0 "$watch_child" 2>/dev/null; then
 			wait "$watch_child" || status=$?

--- a/scripts/dwm-accessibility-settings
+++ b/scripts/dwm-accessibility-settings
@@ -1,0 +1,494 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export LC_ALL=C
+
+config_home=${XDG_CONFIG_HOME:-}
+[[ $config_home == /* ]] || config_home=${HOME:?HOME is required for XDG_CONFIG_HOME fallback}/.config
+config_dir=$config_home/dwm-titus
+config_file=$config_dir/accessibility.conf
+runtime_base=${XDG_RUNTIME_DIR:-/tmp/dwm-titus-$UID}
+[[ $runtime_base == /* ]] || {
+	printf 'dwm-accessibility-settings: XDG_RUNTIME_DIR must be absolute\n' >&2
+	exit 1
+}
+lock_file=$runtime_base/dwm-accessibility-settings.lock
+readonly max_config_size=4096
+readonly max_restore_attempts=8
+readonly protocol_header=$'accessibility-settings-protocol\t1\t0'
+
+declare -A setting_values=()
+config_state=defaults
+config_detail='Using standard contrast and full motion defaults'
+mutation_baseline_kind=absent
+mutation_baseline_hash=
+mutation_baseline_mode=600
+mutation_baseline_fingerprint=
+config_future_version=false
+watch_work=
+watch_child=
+watch_fd_open=false
+
+usage() {
+	printf 'usage: %s status | watch | set {contrast|motion} VALUE | reset\n' "${0##*/}" >&2
+}
+
+die() {
+	printf 'dwm-accessibility-settings: %s\n' "$*" >&2
+	exit 1
+}
+
+set_defaults() {
+	setting_values[contrast]=standard
+	setting_values[motion]=full
+}
+
+valid_setting_value() {
+	case $1:$2 in
+	contrast:standard | contrast:high | motion:full | motion:reduced) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+config_dir_safe() {
+	local mode
+	mode=$(stat -c %a -- "$config_dir" 2>/dev/null) || return 1
+	[[ -d $config_dir && ! -L $config_dir && $(stat -c %u -- "$config_dir") == "$UID" ]] &&
+		(((8#$mode & 022) == 0))
+}
+
+config_file_safe() {
+	local mode
+	mode=$(stat -c %a -- "$config_file" 2>/dev/null) || return 1
+	[[ -f $config_file && ! -L $config_file && -r $config_file &&
+		$(stat -c %u -- "$config_file") == "$UID" &&
+		$(stat -c %h -- "$config_file") == 1 &&
+		$(stat -c %s -- "$config_file") -le $max_config_size ]] &&
+		(((8#$mode & 022) == 0))
+}
+
+load_config() {
+	local line first=true setting value count=0
+	local -A seen=()
+	set_defaults
+	config_future_version=false
+	if [[ -e $config_dir || -L $config_dir ]] && ! config_dir_safe; then
+		config_state=unavailable
+		config_detail='Persistent accessibility state directory is unsafe; using safe defaults'
+		return 1
+	fi
+	if [[ ! -e $config_file && ! -L $config_file ]]; then
+		return 0
+	fi
+	if ! config_file_safe; then
+		config_state=unavailable
+		config_detail='Persistent accessibility state is unsafe; using safe defaults'
+		return 1
+	fi
+	while IFS= read -r line || [[ -n $line ]]; do
+		if [[ $first == true ]]; then
+			if [[ $line != "$protocol_header" ]]; then
+				config_state=partial
+				if [[ $line =~ ^accessibility-settings-protocol$'\t'[0-9]+$'\t'[0-9]+$ ]]; then
+					config_future_version=true
+					config_detail='Unsupported accessibility settings version was preserved; using safe defaults'
+				else
+					config_detail='Malformed accessibility settings were preserved; using safe defaults'
+				fi
+				return 1
+			fi
+			first=false
+			continue
+		fi
+		if [[ $line != *$'\t'* || ${line#*$'\t'} == *$'\t'* ]]; then
+			config_state=partial
+			config_detail='Malformed accessibility settings were preserved; using safe defaults'
+			set_defaults
+			return 1
+		fi
+		setting=${line%%$'\t'*}
+		value=${line#*$'\t'}
+		if ! valid_setting_value "$setting" "$value" || [[ -n ${seen[$setting]+x} ]]; then
+			config_state=partial
+			config_detail='Malformed accessibility settings were preserved; using safe defaults'
+			set_defaults
+			return 1
+		fi
+		seen[$setting]=1
+		setting_values[$setting]=$value
+		((count += 1))
+	done <"$config_file"
+	if [[ $first == true || $count -ne 2 ]]; then
+		config_state=partial
+		config_detail='Incomplete accessibility settings were preserved; using safe defaults'
+		set_defaults
+		return 1
+	fi
+	config_state=available
+	config_detail='Persistent managed-shell accessibility policy is active'
+}
+
+emit_status() {
+	load_config || true
+	printf '%s\n' "$protocol_header"
+	printf 'state\t%s\t%s\n' "$config_state" "$config_detail"
+	printf 'setting\tcontrast\t%s\n' "${setting_values[contrast]}"
+	printf 'setting\tmotion\t%s\n' "${setting_values[motion]}"
+	printf 'complete\tstatus\n'
+}
+
+ensure_runtime_dir() {
+	if [[ ! -e $runtime_base ]]; then
+		(umask 077 && mkdir -p -- "$runtime_base")
+	fi
+	[[ -d $runtime_base && ! -L $runtime_base && $(stat -c %u -- "$runtime_base") == "$UID" ]] ||
+		die "unsafe runtime directory: $runtime_base"
+	chmod 700 -- "$runtime_base"
+}
+
+watch_cleanup() {
+	local watch_path
+	if [[ -n $watch_child ]]; then
+		kill -TERM "$watch_child" 2>/dev/null || true
+		wait "$watch_child" 2>/dev/null || true
+		watch_child=
+	fi
+	if [[ $watch_fd_open == true ]]; then
+		exec 8>&- 8<&-
+		watch_fd_open=false
+	fi
+	if [[ -n $watch_work ]]; then
+		for watch_path in "$watch_work/events" "$watch_work/ready"; do
+			[[ ! -e $watch_path && ! -L $watch_path ]] || unlink -- "$watch_path"
+		done
+		rmdir -- "$watch_work" 2>/dev/null || true
+		watch_work=
+	fi
+}
+
+watch_config() {
+	local event status=0 attempts=0 restart=false
+	command -v inotifywait >/dev/null 2>&1 ||
+		die 'inotifywait is required for accessibility state watching'
+	if [[ ! -e $config_dir && ! -L $config_dir ]]; then
+		(umask 077 && mkdir -p -- "$config_dir")
+	fi
+	config_dir_safe || die "unsafe or unavailable configuration directory: $config_dir"
+	ensure_runtime_dir
+	watch_work=$(umask 077 && mktemp -d "$runtime_base/dwm-accessibility-watch.XXXXXX") ||
+		die 'cannot create accessibility watch workspace'
+	trap watch_cleanup EXIT
+	trap 'exit 143' HUP INT TERM
+	mkfifo -- "$watch_work/events"
+	: >"$watch_work/ready"
+	exec 8<>"$watch_work/events"
+	watch_fd_open=true
+	inotifywait -m -P \
+		-e attrib,close_write,create,delete,delete_self,moved_from,moved_to,move_self \
+		--format $'changed\t%e' -- "$config_dir" >"$watch_work/events" 2>"$watch_work/ready" &
+	watch_child=$!
+	until grep -Fq 'Watches established.' "$watch_work/ready" 2>/dev/null; do
+		if ! kill -0 "$watch_child" 2>/dev/null; then
+			wait "$watch_child" || status=$?
+			watch_child=
+			return "$status"
+		fi
+		((attempts += 1))
+		((attempts < 200)) || die 'timed out while establishing accessibility state watch'
+		sleep 0.01
+	done
+	printf 'ready\taccessibility\n'
+	while IFS= read -r event <&8; do
+		printf '%s\n' "$event"
+		if [[ $event == *DELETE_SELF* || $event == *MOVE_SELF* ]]; then
+			restart=true
+			break
+		fi
+	done
+	if [[ $restart == true ]]; then
+		kill -TERM "$watch_child" 2>/dev/null || true
+	fi
+	wait "$watch_child" || status=$?
+	watch_child=
+	[[ $restart == false ]] || return 10
+	return "$status"
+}
+
+ensure_mutation_paths() {
+	ensure_runtime_dir
+	if [[ -e $lock_file || -L $lock_file ]]; then
+		[[ -f $lock_file && ! -L $lock_file && $(stat -c %u -- "$lock_file") == "$UID" &&
+		$(stat -c %h -- "$lock_file") == 1 ]] || die "unsafe lock file: $lock_file"
+	fi
+	: >>"$lock_file"
+	chmod 600 -- "$lock_file"
+	exec 9>"$lock_file"
+	flock -w 5 9 || die 'another accessibility settings operation is still running'
+	if [[ ! -e $config_dir ]]; then
+		(umask 077 && mkdir -p -- "$config_dir")
+	fi
+	config_dir_safe || die "unsafe configuration directory: $config_dir"
+}
+
+file_hash() {
+	sha256sum -- "$1" | awk '{ print $1 }'
+}
+
+entry_fingerprint() {
+	local path=$1 metadata
+	metadata=$(stat -c '%d:%i:%h:%f:%s' -- "$path") || return 1
+	if [[ -L $path ]]; then
+		printf '%s:link:%s\n' "$metadata" "$(readlink -- "$path")"
+	elif [[ -f $path ]]; then
+		printf '%s:file:%s\n' "$metadata" "$(file_hash "$path")"
+	else
+		printf '%s:other\n' "$metadata"
+	fi
+}
+
+capture_mutation_baseline() {
+	mutation_baseline_kind=absent
+	mutation_baseline_hash=
+	mutation_baseline_mode=600
+	mutation_baseline_fingerprint=
+	if [[ -e $config_file || -L $config_file ]]; then
+		config_file_safe || die "unsafe persistent state: $config_file"
+		mutation_baseline_kind='file'
+		mutation_baseline_hash=$(file_hash "$config_file")
+		mutation_baseline_mode=$(stat -c %a -- "$config_file")
+		mutation_baseline_fingerprint=$(entry_fingerprint "$config_file")
+	fi
+}
+
+mutation_baseline_unchanged() {
+	if [[ $mutation_baseline_kind == file ]]; then
+		config_file_safe && [[ $(file_hash "$config_file") == "$mutation_baseline_hash" &&
+		$(stat -c %a -- "$config_file") == "$mutation_baseline_mode" ]]
+	else
+		[[ ! -e $config_file && ! -L $config_file ]]
+	fi
+}
+
+die_mutation_baseline_changed() {
+	if [[ $mutation_baseline_kind == file ]]; then
+		die 'accessibility state changed during the transaction; refusing to overwrite it'
+	else
+		die 'accessibility state appeared during the transaction; refusing to overwrite it'
+	fi
+}
+
+wait_for_baseline_test_release() {
+	if [[ -n ${DWM_TEST_ACCESSIBILITY_BASELINE_READY:-} ]]; then
+		: >"$DWM_TEST_ACCESSIBILITY_BASELINE_READY"
+		while [[ ! -e ${DWM_TEST_ACCESSIBILITY_BASELINE_RELEASE:-} ]]; do
+			sleep 0.01
+		done
+	fi
+}
+
+mv_exchange_options_supported() {
+	local help
+	help=$(LC_ALL=C mv --help 2>/dev/null) || return 1
+	[[ $help == *'--exchange'* && $help == *'--no-copy'* ]]
+}
+
+wait_for_rollback_test_release() {
+	if [[ -n ${DWM_TEST_ACCESSIBILITY_ROLLBACK_READY:-} ]]; then
+		: >"$DWM_TEST_ACCESSIBILITY_ROLLBACK_READY"
+		while [[ ! -e ${DWM_TEST_ACCESSIBILITY_ROLLBACK_RELEASE:-} ]]; do
+			sleep 0.01
+		done
+		DWM_TEST_ACCESSIBILITY_ROLLBACK_READY=
+		DWM_TEST_ACCESSIBILITY_ROLLBACK_RELEASE=
+	fi
+}
+
+restore_concurrent_config() {
+	local staged=$1 expected_fingerprint=$2 published_fingerprint=$3
+	local candidate_fingerprint displaced_fingerprint current_fingerprint attempt=0
+	while ((attempt < max_restore_attempts)); do
+		attempt=$((attempt + 1))
+		candidate_fingerprint=$(entry_fingerprint "$staged" 2>/dev/null || true)
+		if [[ -z $candidate_fingerprint ]]; then
+			printf 'dwm-accessibility-settings: concurrent accessibility state retained at %s\n' \
+				"$staged" >&2
+			return 1
+		fi
+		current_fingerprint=$(entry_fingerprint "$config_file" 2>/dev/null || true)
+		if [[ $current_fingerprint != "$expected_fingerprint" ]]; then
+			printf 'dwm-accessibility-settings: concurrent accessibility state retained at %s\n' \
+				"$staged" >&2
+			return 1
+		fi
+		wait_for_rollback_test_release
+		if ! mv --exchange --no-copy -- "$staged" "$config_file"; then
+			printf 'dwm-accessibility-settings: concurrent accessibility state retained at %s\n' \
+				"$staged" >&2
+			return 1
+		fi
+		displaced_fingerprint=$(entry_fingerprint "$staged" 2>/dev/null || true)
+		if [[ $displaced_fingerprint == "$expected_fingerprint" ]]; then
+			if [[ $displaced_fingerprint == "$published_fingerprint" ]]; then
+				unlink -- "$staged"
+			else
+				printf 'dwm-accessibility-settings: superseded accessibility state retained at %s\n' \
+					"$staged" >&2
+			fi
+			return 0
+		fi
+		expected_fingerprint=$candidate_fingerprint
+	done
+	candidate_fingerprint=$(entry_fingerprint "$staged" 2>/dev/null || true)
+	current_fingerprint=$(entry_fingerprint "$config_file" 2>/dev/null || true)
+	if [[ -n $candidate_fingerprint && $current_fingerprint == "$expected_fingerprint" ]] &&
+		mv --exchange --no-copy -- "$staged" "$config_file"; then
+		displaced_fingerprint=$(entry_fingerprint "$staged" 2>/dev/null || true)
+		if [[ $displaced_fingerprint == "$expected_fingerprint" ]]; then
+			if [[ $displaced_fingerprint == "$published_fingerprint" ]]; then
+				unlink -- "$staged"
+			else
+				printf 'dwm-accessibility-settings: superseded accessibility state retained at %s\n' \
+					"$staged" >&2
+			fi
+			printf 'dwm-accessibility-settings: concurrent accessibility state restored at %s after retry exhaustion\n' \
+				"$config_file" >&2
+			return 1
+		fi
+	fi
+	printf 'dwm-accessibility-settings: concurrent accessibility state retained at %s\n' \
+		"$staged" >&2
+	return 1
+}
+
+publish_config() {
+	local staged=$1 published_hash published_fingerprint captured_hash captured_mode captured_fingerprint
+	published_hash=$(file_hash "$staged") || die 'cannot hash temporary accessibility state'
+	published_fingerprint=$(entry_fingerprint "$staged") || die 'cannot identify temporary accessibility state'
+	if [[ $mutation_baseline_kind == absent ]]; then
+		mv --no-clobber --no-target-directory -- "$staged" "$config_file" ||
+			die 'cannot publish accessibility state'
+		if [[ -e $staged || -L $staged ]]; then
+			unlink -- "$staged"
+			die_mutation_baseline_changed
+		fi
+		[[ $(file_hash "$config_file" 2>/dev/null || true) == "$published_hash" ]] ||
+			die 'published accessibility state could not be verified'
+		return
+	fi
+	if ! mv_exchange_options_supported; then
+		unlink -- "$staged"
+		die 'GNU mv with --exchange and --no-copy is required (coreutils 9.5 or newer)'
+	fi
+	if ! mv --exchange --no-copy -- "$staged" "$config_file"; then
+		unlink -- "$staged"
+		die 'atomic accessibility state exchange is unavailable on the configuration filesystem'
+	fi
+	captured_hash=$(file_hash "$staged" 2>/dev/null || true)
+	captured_mode=$(stat -c %a -- "$staged" 2>/dev/null || true)
+	captured_fingerprint=$(entry_fingerprint "$staged" 2>/dev/null || true)
+	if [[ $captured_hash == "$mutation_baseline_hash" &&
+		$captured_mode == "$mutation_baseline_mode" &&
+		$captured_fingerprint == "$mutation_baseline_fingerprint" ]]; then
+		unlink -- "$staged"
+		return
+	fi
+	restore_concurrent_config "$staged" "$published_fingerprint" "$published_fingerprint" || true
+	die_mutation_baseline_changed
+}
+
+write_config() {
+	local temporary
+	temporary=$(umask 077 && mktemp "$config_dir/.accessibility.conf.XXXXXX") ||
+		die 'cannot create temporary accessibility state'
+	{
+		printf '%s\n' "$protocol_header"
+		printf 'contrast\t%s\n' "${setting_values[contrast]}"
+		printf 'motion\t%s\n' "${setting_values[motion]}"
+	} >"$temporary"
+	chmod "$mutation_baseline_mode" -- "$temporary"
+	if [[ -n ${DWM_TEST_ACCESSIBILITY_PUBLISH_READY:-} ]]; then
+		: >"$DWM_TEST_ACCESSIBILITY_PUBLISH_READY"
+		while [[ ! -e ${DWM_TEST_ACCESSIBILITY_PUBLISH_RELEASE:-} ]]; do
+			sleep 0.01
+		done
+	fi
+	if ! mutation_baseline_unchanged; then
+		unlink -- "$temporary"
+		die_mutation_baseline_changed
+	fi
+	if [[ -n ${DWM_TEST_ACCESSIBILITY_EXCHANGE_READY:-} ]]; then
+		: >"$DWM_TEST_ACCESSIBILITY_EXCHANGE_READY"
+		while [[ ! -e ${DWM_TEST_ACCESSIBILITY_EXCHANGE_RELEASE:-} ]]; do
+			sleep 0.01
+		done
+	fi
+	publish_config "$temporary"
+}
+
+set_setting() {
+	local setting=$1 value=$2
+	valid_setting_value "$setting" "$value" || die "unsupported accessibility setting: $setting=$value"
+	ensure_mutation_paths
+	capture_mutation_baseline
+	wait_for_baseline_test_release
+	load_config || {
+		[[ $config_state == partial && $config_future_version == false ]] ||
+			die 'persistent accessibility state is unsafe or uses an unsupported version'
+	}
+	mutation_baseline_unchanged || die_mutation_baseline_changed
+	setting_values[$setting]=$value
+	write_config
+	printf 'accessibility-settings-action-protocol\t1\t0\nresult\tset\t%s\t%s\n' \
+		"$setting" "$value"
+}
+
+reset_settings() {
+	ensure_mutation_paths
+	capture_mutation_baseline
+	wait_for_baseline_test_release
+	load_config || {
+		[[ $config_state == partial && $config_future_version == false ]] ||
+			die 'persistent accessibility state is unsafe or uses an unsupported version'
+	}
+	mutation_baseline_unchanged || die_mutation_baseline_changed
+	set_defaults
+	write_config
+	printf 'accessibility-settings-action-protocol\t1\t0\nresult\treset\tall\tdefaults\n'
+}
+
+case ${1:-} in
+status)
+	[[ $# -eq 1 ]] || {
+		usage
+		exit 2
+	}
+	emit_status
+	;;
+watch)
+	[[ $# -eq 1 ]] || {
+		usage
+		exit 2
+	}
+	watch_config
+	;;
+set)
+	[[ $# -eq 3 ]] || {
+		usage
+		exit 2
+	}
+	set_setting "$2" "$3"
+	;;
+reset)
+	[[ $# -eq 1 ]] || {
+		usage
+		exit 2
+	}
+	reset_settings
+	;;
+-h | --help | help)
+	usage
+	;;
+*)
+	usage
+	exit 2
+	;;
+esac

--- a/tests/test-dwm-accessibility-settings.sh
+++ b/tests/test-dwm-accessibility-settings.sh
@@ -1,0 +1,238 @@
+#!/bin/sh
+set -eu
+
+repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+helper=$repo/scripts/dwm-accessibility-settings
+work=$(mktemp -d)
+watch_pid=
+race_pid=
+lock_pid=
+
+cleanup() {
+	for cleanup_pid in "$watch_pid" "$race_pid" "$lock_pid"; do
+		[ -n "$cleanup_pid" ] || continue
+		kill "$cleanup_pid" 2>/dev/null || true
+		wait "$cleanup_pid" 2>/dev/null || true
+	done
+	rm -rf "$work"
+}
+trap cleanup EXIT
+
+home=$work/home
+config=$work/config
+runtime=$work/runtime
+mkdir -p "$home" "$config" "$runtime"
+
+run_helper() {
+	HOME=$home XDG_CONFIG_HOME=$config XDG_RUNTIME_DIR=$runtime "$helper" "$@"
+}
+
+wait_for_path() {
+	path=$1
+	for _ in $(seq 1 200); do
+		[ -e "$path" ] && return 0
+		sleep 0.01
+	done
+	return 1
+}
+
+wait_for_line() {
+	line_file=$1
+	line_value=$2
+	for _ in $(seq 1 200); do
+		grep -Fqx "$line_value" "$line_file" 2>/dev/null && return 0
+		sleep 0.01
+	done
+	return 1
+}
+
+status=$(run_helper status)
+printf '%s\n' "$status" | grep -Fqx 'accessibility-settings-protocol	1	0'
+printf '%s\n' "$status" | grep -Fqx \
+	'state	defaults	Using standard contrast and full motion defaults'
+printf '%s\n' "$status" | grep -Fqx 'setting	contrast	standard'
+printf '%s\n' "$status" | grep -Fqx 'setting	motion	full'
+printf '%s\n' "$status" | grep -Fqx 'complete	status'
+
+HOME=$home XDG_CONFIG_HOME=$config XDG_RUNTIME_DIR=$runtime \
+	"$helper" watch >"$work/first-watch.out" 2>"$work/first-watch.err" &
+watch_pid=$!
+wait_for_line "$work/first-watch.out" 'ready	accessibility'
+[ -d "$config/dwm-titus" ]
+kill "$watch_pid" 2>/dev/null || true
+wait "$watch_pid" 2>/dev/null || true
+watch_pid=
+
+contrast_action=$(run_helper set contrast high)
+printf '%s\n' "$contrast_action" | grep -Fqx 'accessibility-settings-action-protocol	1	0'
+printf '%s\n' "$contrast_action" | grep -Fqx 'result	set	contrast	high'
+[ "$(stat -c %a "$config/dwm-titus/accessibility.conf")" = 600 ]
+
+motion_action=$(run_helper set motion reduced)
+printf '%s\n' "$motion_action" | grep -Fqx 'result	set	motion	reduced'
+status=$(run_helper status)
+printf '%s\n' "$status" | grep -Fqx \
+	'state	available	Persistent managed-shell accessibility policy is active'
+printf '%s\n' "$status" | grep -Fqx 'setting	contrast	high'
+printf '%s\n' "$status" | grep -Fqx 'setting	motion	reduced'
+
+chmod 640 "$config/dwm-titus/accessibility.conf"
+run_helper set contrast standard >/dev/null
+[ "$(stat -c %a "$config/dwm-titus/accessibility.conf")" = 640 ]
+
+reset_action=$(run_helper reset)
+printf '%s\n' "$reset_action" | grep -Fqx 'result	reset	all	defaults'
+grep -Fqx 'contrast	standard' "$config/dwm-titus/accessibility.conf"
+grep -Fqx 'motion	full' "$config/dwm-titus/accessibility.conf"
+
+HOME=$home XDG_CONFIG_HOME=$config XDG_RUNTIME_DIR=$runtime \
+	"$helper" watch >"$work/watch.out" 2>"$work/watch.err" &
+watch_pid=$!
+wait_for_line "$work/watch.out" 'ready	accessibility'
+run_helper set contrast high >/dev/null
+for _ in $(seq 1 200); do
+	grep -Eq '^changed	' "$work/watch.out" 2>/dev/null && break
+	sleep 0.01
+done
+grep -Eq '^changed	' "$work/watch.out"
+rm "$config/dwm-titus/accessibility.conf"
+rmdir "$config/dwm-titus"
+for _ in $(seq 1 200); do
+	grep -Fq 'DELETE_SELF' "$work/watch.out" 2>/dev/null && break
+	sleep 0.01
+done
+grep -Fq 'DELETE_SELF' "$work/watch.out"
+kill "$watch_pid" 2>/dev/null || true
+wait "$watch_pid" 2>/dev/null || true
+watch_pid=
+mkdir "$config/dwm-titus"
+
+printf 'broken-protocol\n' >"$config/dwm-titus/accessibility.conf"
+malformed_status=$(run_helper status)
+printf '%s\n' "$malformed_status" | grep -Fqx \
+	'state	partial	Malformed accessibility settings were preserved; using safe defaults'
+printf '%s\n' "$malformed_status" | grep -Fqx 'setting	contrast	standard'
+printf '%s\n' "$malformed_status" | grep -Fqx 'setting	motion	full'
+run_helper set motion reduced >/dev/null
+grep -Fqx 'contrast	standard' "$config/dwm-titus/accessibility.conf"
+grep -Fqx 'motion	reduced' "$config/dwm-titus/accessibility.conf"
+
+printf 'accessibility-settings-protocol	1	0	extra\ncontrast	high\nmotion	reduced\n' \
+	>"$config/dwm-titus/accessibility.conf"
+malformed_header_status=$(run_helper status)
+printf '%s\n' "$malformed_header_status" | grep -Fqx \
+	'state	partial	Malformed accessibility settings were preserved; using safe defaults'
+run_helper reset >/dev/null
+grep -Fqx 'accessibility-settings-protocol	1	0' "$config/dwm-titus/accessibility.conf"
+grep -Fqx 'contrast	standard' "$config/dwm-titus/accessibility.conf"
+grep -Fqx 'motion	full' "$config/dwm-titus/accessibility.conf"
+
+printf 'accessibility-settings-protocol	2	0\ncontrast	high\nmotion	reduced\n' \
+	>"$config/dwm-titus/accessibility.conf"
+future_status=$(run_helper status)
+printf '%s\n' "$future_status" | grep -Fqx \
+	'state	partial	Unsupported accessibility settings version was preserved; using safe defaults'
+grep -Fqx 'accessibility-settings-protocol	2	0' "$config/dwm-titus/accessibility.conf"
+cp "$config/dwm-titus/accessibility.conf" "$work/future.before"
+if run_helper set contrast high >"$work/future-set.out" 2>"$work/future-set.err"; then
+	printf 'Future accessibility state was unexpectedly replaced by set\n' >&2
+	exit 1
+fi
+grep -Fq 'unsupported version' "$work/future-set.err"
+cmp "$work/future.before" "$config/dwm-titus/accessibility.conf"
+if run_helper reset >"$work/future-reset.out" 2>"$work/future-reset.err"; then
+	printf 'Future accessibility state was unexpectedly replaced by reset\n' >&2
+	exit 1
+fi
+grep -Fq 'unsupported version' "$work/future-reset.err"
+cmp "$work/future.before" "$config/dwm-titus/accessibility.conf"
+
+printf 'accessibility-settings-protocol	1	0\ncontrast	standard\nmotion	full\n' \
+	>"$config/dwm-titus/accessibility.conf"
+exchange_ready=$work/exchange.ready
+exchange_release=$work/exchange.release
+rollback_ready=$work/rollback.ready
+rollback_release=$work/rollback.release
+DWM_TEST_ACCESSIBILITY_EXCHANGE_READY=$exchange_ready \
+	DWM_TEST_ACCESSIBILITY_EXCHANGE_RELEASE=$exchange_release \
+	DWM_TEST_ACCESSIBILITY_ROLLBACK_READY=$rollback_ready \
+	DWM_TEST_ACCESSIBILITY_ROLLBACK_RELEASE=$rollback_release \
+	HOME=$home XDG_CONFIG_HOME=$config XDG_RUNTIME_DIR=$runtime \
+	"$helper" set contrast high >"$work/race.out" 2>"$work/race.err" &
+race_pid=$!
+wait_for_path "$exchange_ready"
+printf 'first last-moment edit\n' >"$config/dwm-titus/accessibility.conf"
+: >"$exchange_release"
+wait_for_path "$rollback_ready"
+printf 'second last-moment edit\n' >"$config/dwm-titus/accessibility.conf"
+: >"$rollback_release"
+if wait "$race_pid"; then
+	printf 'Accessibility transaction overwrote a two-edit race\n' >&2
+	exit 1
+fi
+race_pid=
+grep -Fq 'accessibility state changed during the transaction' "$work/race.err"
+grep -Fqx 'second last-moment edit' "$config/dwm-titus/accessibility.conf"
+
+target=$work/target
+printf 'do not replace\n' >"$target"
+rm "$config/dwm-titus/accessibility.conf"
+ln -s "$target" "$config/dwm-titus/accessibility.conf"
+unsafe_status=$(run_helper status)
+printf '%s\n' "$unsafe_status" | grep -Fqx \
+	'state	unavailable	Persistent accessibility state is unsafe; using safe defaults'
+if run_helper set contrast high >"$work/symlink.out" 2>"$work/symlink.err"; then
+	printf 'Accessibility mutation unexpectedly followed a symlink\n' >&2
+	exit 1
+fi
+grep -Fqx 'do not replace' "$target"
+
+rm "$config/dwm-titus/accessibility.conf"
+printf 'accessibility-settings-protocol	1	0\ncontrast	standard\nmotion	full\n' \
+	>"$config/dwm-titus/accessibility.conf"
+ln "$config/dwm-titus/accessibility.conf" "$work/accessibility-hardlink.conf"
+if run_helper reset >"$work/hardlink.out" 2>"$work/hardlink.err"; then
+	printf 'Accessibility mutation unexpectedly replaced a hard-linked file\n' >&2
+	exit 1
+fi
+grep -Fq 'unsafe persistent state' "$work/hardlink.err"
+rm "$work/accessibility-hardlink.conf"
+
+if HOME=$home XDG_CONFIG_HOME=$config XDG_RUNTIME_DIR=relative \
+	"$helper" status >"$work/runtime.out" 2>"$work/runtime.err"; then
+	printf 'Relative runtime directory unexpectedly succeeded\n' >&2
+	exit 1
+fi
+grep -Fq 'XDG_RUNTIME_DIR must be absolute' "$work/runtime.err"
+
+if run_helper set contrast invalid >"$work/invalid.out" 2>"$work/invalid.err"; then
+	printf 'Invalid contrast value unexpectedly succeeded\n' >&2
+	exit 1
+fi
+grep -Fq 'unsupported accessibility setting' "$work/invalid.err"
+
+lock_ready=$work/lock.ready
+lock_release=$work/lock.release
+(
+	exec 8>"$runtime/dwm-accessibility-settings.lock"
+	flock 8
+	: >"$lock_ready"
+	while [ ! -e "$lock_release" ]; do
+		sleep 0.01
+	done
+) &
+lock_pid=$!
+while [ ! -e "$lock_ready" ]; do
+	sleep 0.01
+done
+if run_helper set motion reduced >"$work/lock.out" 2>"$work/lock.err"; then
+	printf 'Concurrent accessibility mutation unexpectedly succeeded\n' >&2
+	kill "$lock_pid" 2>/dev/null || true
+	exit 1
+fi
+grep -Fq 'another accessibility settings operation is still running' "$work/lock.err"
+: >"$lock_release"
+wait "$lock_pid"
+lock_pid=
+
+printf 'dwm accessibility settings helper: PASS\n'

--- a/tests/test-dwm-accessibility-settings.sh
+++ b/tests/test-dwm-accessibility-settings.sh
@@ -59,8 +59,20 @@ HOME=$home XDG_CONFIG_HOME=$config XDG_RUNTIME_DIR=$runtime \
 watch_pid=$!
 wait_for_line "$work/first-watch.out" 'ready	accessibility'
 [ -d "$config/dwm-titus" ]
-kill "$watch_pid" 2>/dev/null || true
-wait "$watch_pid" 2>/dev/null || true
+watch_child=$(pgrep -P "$watch_pid" -x inotifywait)
+kill "$watch_child"
+for _ in $(seq 1 200); do
+	! kill -0 "$watch_pid" 2>/dev/null && break
+	sleep 0.01
+done
+if kill -0 "$watch_pid" 2>/dev/null; then
+	printf 'Accessibility watcher hid inotifywait termination\n' >&2
+	exit 1
+fi
+if wait "$watch_pid"; then
+	printf 'Accessibility watcher unexpectedly succeeded after inotifywait termination\n' >&2
+	exit 1
+fi
 watch_pid=
 
 contrast_action=$(run_helper set contrast high)

--- a/tests/test-quickshell-accessibility.sh
+++ b/tests/test-quickshell-accessibility.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+model=$repo/config/quickshell/accessibility/AccessibilityModel.qml
+theme=$repo/config/quickshell/core/Theme.qml
+commands=$repo/config/quickshell/core/Commands.qml
+shell=$repo/config/quickshell/shell.qml
+
+grep -Fq 'accessibility-settings-protocol\t1\t0' "$model"
+grep -Fq 'Commands.accessibilitySettingsCommand("watch", [])' "$model"
+grep -Fq 'stdout: SplitParser {' "$model"
+grep -Fq 'line === "ready\taccessibility"' "$model"
+grep -Fq 'line.indexOf("DELETE_SELF")' "$model"
+grep -Fq 'const shouldRestart = root.watchReady;' "$model"
+grep -Fq 'if (shouldRestart) watchRestartTimer.restart();' "$model"
+grep -Fq 'Component.onCompleted: watchProcess.running = true' "$model"
+grep -Fq 'Commands.accessibilitySettingsCommand("status", [])' "$model"
+grep -Fq 'Theme.applyAccessibility(root.highContrast, root.reducedMotion)' "$model"
+grep -Fq 'property bool highContrast: false' "$theme"
+grep -Fq 'property bool reducedMotion: false' "$theme"
+grep -Fq 'readonly property string textMuted: highContrast ? text : paletteTextMuted' "$theme"
+grep -Fq 'readonly property int animationFast: reducedMotion ? 0 : 120' "$theme"
+grep -Fq 'readonly property int animationNormal: reducedMotion ? 0 : 180' "$theme"
+grep -Fq 'readonly property int controlBorderWidth: highContrast ? 2 : 1' "$theme"
+grep -Fq 'readonly property string controlNormalBorder: highContrast ? textStrong : border' "$theme"
+grep -Fq 'function accessibilitySettingsCommand(action, args)' "$commands"
+grep -Fq 'import qs.accessibility' "$shell"
+grep -Fq 'AccessibilityModel {' "$shell"
+
+if grep -Fq 'FileView {' "$model"; then
+	printf 'Accessibility model reads the policy file without helper validation\n' >&2
+	exit 1
+fi
+
+if grep -Eq 'Timer[[:space:]]*\{[^}]*repeat:[[:space:]]*true' "$model"; then
+	printf 'Accessibility model introduced a polling timer\n' >&2
+	exit 1
+fi
+
+printf 'Quickshell accessibility policy model: PASS\n'

--- a/tests/test-quickshell-accessibility.sh
+++ b/tests/test-quickshell-accessibility.sh
@@ -13,7 +13,8 @@ grep -Fq 'stdout: SplitParser {' "$model"
 grep -Fq 'line === "ready\taccessibility"' "$model"
 grep -Fq 'line.indexOf("DELETE_SELF")' "$model"
 grep -Fq 'const shouldRestart = root.watchReady;' "$model"
-grep -Fq 'if (shouldRestart) watchRestartTimer.restart();' "$model"
+grep -Fq 'readonly property int maxWatchSetupFailures: 5' "$model"
+grep -Fq 'root.watchSetupFailures <= root.maxWatchSetupFailures' "$model"
 grep -Fq 'Component.onCompleted: watchProcess.running = true' "$model"
 grep -Fq 'Commands.accessibilitySettingsCommand("status", [])' "$model"
 grep -Fq 'Theme.applyAccessibility(root.highContrast, root.reducedMotion)' "$model"
@@ -33,7 +34,16 @@ if grep -Fq 'FileView {' "$model"; then
 	exit 1
 fi
 
-if grep -Eq 'Timer[[:space:]]*\{[^}]*repeat:[[:space:]]*true' "$model"; then
+if awk '
+	/^[[:space:]]*Timer[[:space:]]*\{/ { in_timer = 1; depth = 0 }
+	in_timer {
+		line = $0
+		depth += gsub(/\{/, "{", line) - gsub(/\}/, "}", line)
+		if ($0 ~ /repeat:[[:space:]]*true/) found = 1
+		if (depth == 0) in_timer = 0
+	}
+	END { exit !found }
+' "$model"; then
 	printf 'Accessibility model introduced a polling timer\n' >&2
 	exit 1
 fi


### PR DESCRIPTION
## Summary

- add a versioned, user-owned accessibility policy helper for high contrast and reduced motion
- apply policy through one event-driven root Quickshell model and shared semantic theme roles
- cover persistence, malformed and future state, concurrent edits, watch readiness, QML contracts, install, and rollback behavior

## Validation

- `scripts/run-tests make clean all`
- `scripts/run-tests`
- `make check-accessibility`
- `scripts/quickshell-qmllint --root config/quickshell` (only pre-existing PanelTooltip/RunningAppsArea warnings)
- `shellcheck scripts/dwm-accessibility-settings tests/test-dwm-accessibility-settings.sh tests/test-quickshell-accessibility.sh`
- `shfmt -d scripts/dwm-accessibility-settings tests/test-dwm-accessibility-settings.sh tests/test-quickshell-accessibility.sh`
- `scripts/run-tests make check-quickshell-settings-xvfb` (0.100% closed CPU)
- `codex review --base main` (clean)
- `coderabbit review --agent --base main` (clean)

## Scope

This boundary adds the persistent shell policy only. Settings UI controls, practical X11 input accessibility, and notification policy remain separate small Phase 5 pull requests.