### PR TITLE
docs: close Phase 5 UI5 decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ versions from `config.mk`.
   display and capability cards, and using dense text-scale-aware rows while
   preserving the existing navigation, context, and controls.
 
+- Close the optional Phase 5 UI-5 decision boundary without runtime changes.
+  Clipboard history and reminders are deferred pending explicit privacy,
+  lifecycle, and recovery contracts; emoji/symbol and generic image pickers are
+  rejected because no current product workflow requires them.
+
 ### Added
 
 - Add persistent notification policy controls to Settings Appearance. Do Not

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,8 +55,8 @@ product roadmap.
   PR #159.
 - P3-UI4, Settings, System Health, notifications, and launcher: complete in
   PR #163.
-- UI-5, optional X11-native experiences: planned for Phase 5 personalization
-  and accessibility; split backend-heavy work when needed.
+- UI-5, optional X11-native experiences: candidate review complete in Phase 5
+  with no adopted runtime experience.
 - UI-6, whole-shell integration hardening: planned for Phase 7 image and
   release qualification, with no major features.
 
@@ -79,9 +79,10 @@ UI-1 is the merged foundation. UI-2 and UI-3 were parallel children and are
 now unified on `main`. `P3-UI4` established the shared large-surface language
 used by the completed Phase 3 provider work and the later power, defaults,
 personalization, accessibility, and system-management phases. Phases 3 and 4
-are complete and product Phase 5 is active. UI-5 candidates are evaluated in
-Phase 5 and approved experiences are delivered as separate review boundaries;
-UI-6 closes the desktop during Phase 7 release qualification.
+are complete and product Phase 5 is active. The UI-5 review adopted no runtime
+experience; any future reopening requires a new roadmap decision and an
+independent review boundary. UI-6 closes the desktop during Phase 7 release
+qualification.
 
 ### UI Overhaul Exit Criteria
 
@@ -297,7 +298,7 @@ Unify normal session behavior and application defaults.
 
 ## Phase 5: Personalization and Accessibility
 
-Status: Active (reconciled 2026-09-02; notification boundary in review)
+Status: Active (reconciled 2026-09-02; UI-5 review complete, final qualification pending)
 
 ### Current Checkpoint
 
@@ -306,10 +307,12 @@ wallpaper persistence, managed-shell fonts and scaling, and desktop font,
 cursor, icon, GTK, and Qt controls are merged through PR #184. Panel-widget
 persistence merged in PR #186, and cross-capability optional-component
 qualification merged in PR #188, completing `APPEARANCE-001`. Managed-shell
-contrast and motion controls merged in PR #202. The current review boundary
-adds notification Do Not Disturb and bounded popup duration after practical
-XKB input accessibility controls merged in PR #203. UI-5 decisions and the
-combined Phase 5 qualification remain open.
+contrast and motion controls merged in PR #202, practical XKB input
+accessibility controls merged in PR #203, and notification Do Not Disturb and
+bounded popup duration merged in PR #204. The current decision record defers
+clipboard history and reminders, rejects emoji/symbol and generic image
+pickers, and adopts no UI-5 runtime work. Combined Phase 5 qualification
+remains open.
 `docs/P5-STATUS.md` maps every active checkbox to its current evidence or next
 action.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -687,10 +687,10 @@ panel-widget persistence, plus persistent managed-shell contrast and motion
 policy with dedicated Settings controls, practical XKB input accessibility,
 and persistent notification Do Not Disturb and popup-duration controls.
 Cross-capability optional-component isolation and the accessibility capability
-contract are also qualified. The remaining Phase 5 surface begins with UI-5
-decisions, followed by selected implementation and final phase qualification.
-The ordered status is recorded in `ROADMAP.md`,
-`TASKS.md`, and `docs/P5-STATUS.md`.
+contract are also qualified. The optional UI-5 inventory adopts no runtime
+experience: clipboard history and reminders are deferred, while emoji/symbol
+and generic image pickers are rejected. Reopening a UI-5 candidate requires an
+explicit product requirement and a separately qualified X11-native boundary.
 
 The installer contains a Fedora-only package map and rejects other systems.
 The build uses `pkg-config`, supports staged installation with `DESTDIR`, and

--- a/SPEC.md
+++ b/SPEC.md
@@ -691,6 +691,8 @@ contract are also qualified. The optional UI-5 inventory adopts no runtime
 experience: clipboard history and reminders are deferred, while emoji/symbol
 and generic image pickers are rejected. Reopening a UI-5 candidate requires an
 explicit product requirement and a separately qualified X11-native boundary.
+Phase 5 is not complete until combined qualification maps every phase exit
+criterion to Section 9 evidence and records all untested or limited paths.
 
 The installer contains a Fedora-only package map and rejects other systems.
 The build uses `pkg-config`, supports staged installation with `DESTDIR`, and

--- a/TASKS.md
+++ b/TASKS.md
@@ -7,16 +7,15 @@ completion evidence is recorded in `ROADMAP.md`, `CHANGELOG.md`,
 
 ## Verified Checkpoint
 
-Status reconciled 2026-09-02 against `main` at `8b846fb`. Fifteen of the 25
-Phase 5 implementation checkboxes are merged. PR #203 completed practical XKB
-input accessibility controls after PR #202 exposed the managed-shell contrast
-and motion policy through accessible Settings controls. Only the primary
-worktree remains registered.
+Status reconciled 2026-09-02 against `main` at `ad47c20`. Sixteen of the 25
+Phase 5 implementation checkboxes are merged. PR #204 completed persistent
+notification policy after PR #203 completed practical XKB input accessibility
+controls. Only the primary worktree remains registered.
 
-The current notification boundary adds persistent Do Not Disturb and bounded
-popup-duration controls while preserving critical urgency and notification
-history. It completes the final ACCESSIBILITY-001 implementation checkbox;
-UI-5 decisions and combined Phase 5 qualification remain next.
+The current decision-only boundary inventories UI-5 candidates and adopts
+none. It completes all four optional UI-5 planning and compatibility
+checkboxes without adding a runtime surface; combined Phase 5 qualification is
+the only remaining boundary.
 
 ## Active Phase: Personalization and Accessibility
 
@@ -116,15 +115,15 @@ Acceptance:
 
 ### P5-UI5: Optional X11-Native Experience Integration
 
-- [ ] Inventory UI-5 candidates, beginning with event-driven clipboard history,
+- [x] Inventory UI-5 candidates, beginning with event-driven clipboard history,
   and record an adopt, defer, or reject decision for each candidate.
-- [ ] Evaluate every adopted UI-5 experience as an independent review boundary
+- [x] Evaluate every adopted UI-5 experience as an independent review boundary
   with an event-driven provider, explicit data ownership, bounded lifecycle,
   privacy model, and Fedora package impact before implementation.
-- [ ] Integrate only approved X11-native experiences into the existing semantic
+- [x] Integrate only approved X11-native experiences into the existing semantic
   design system and command surfaces; do not copy Wayland, Hyprland, layer-shell,
   UWSM, or Omarchy service/plugin backends.
-- [ ] Preserve current IPC names, X11 focus/click-away/stacking behavior, monitor
+- [x] Preserve current IPC names, X11 focus/click-away/stacking behavior, monitor
   selection, and closed-surface near-idle behavior.
 
 Acceptance:
@@ -134,6 +133,11 @@ Acceptance:
   package/install, and privacy tests.
 - Closing a surface leaves no resident scan, duplicate subscription, helper,
   sensitive history owner, or overlapping process.
+
+Decision: `docs/P5-UI5-DECISIONS.md` records four candidates. Clipboard history
+and reminders are deferred; emoji/symbol and general image pickers are
+rejected. Because the adopted set is empty, no implementation, package, or
+feature-specific qualification obligation is created.
 
 ### P5-VALIDATE: Phase 5 Validation
 

--- a/docs/OMARCHY-UI-ADAPTATION.md
+++ b/docs/OMARCHY-UI-ADAPTATION.md
@@ -89,19 +89,19 @@ scheduled in `ROADMAP.md`.
   complete in PR #158 and corrective PR #160.
 - UI-3, bar and existing quick panels: Phase 3 prerequisite, complete in
   PR #159.
-- P3-UI4, Settings, System Health, notifications, and launcher: next Phase 3
-  pull request from unified `main`.
-- UI-5, optional X11-native experiences: planned for Phase 5 personalization
-  and accessibility; split backend-heavy work when needed.
+- P3-UI4, Settings, System Health, notifications, and launcher: complete in
+  PR #163.
+- UI-5, optional X11-native experiences: Phase 5 candidate review complete
+  with no adopted runtime experience; see `P5-UI5-DECISIONS.md`.
 - UI-6, integration hardening and approved rollout: planned for Phase 7 release
   qualification, with no major features.
 
 UI-2 and UI-3 were the only parallel branches because they owned mostly
-separate surfaces after UI-1 established shared tokens. `P3-UI4` must reuse the
-merged components and interaction decisions from both. The remaining
-Connectivity and Audio tasks then build on those surfaces as separate Phase 3
-pull requests. UI-5 remains optional and must not make `P3-UI4` depend on a new
-service. UI-6 is a stabilization slice, not a feature catch-all.
+separate surfaces after UI-1 established shared tokens. `P3-UI4` reused the
+merged components and interaction decisions from both, and the later Phase 3
+provider slices built on those surfaces. UI-5 remains optional and its empty
+adopted set adds no service or shell surface. UI-6 is a stabilization slice,
+not a feature catch-all.
 
 ### P3-UI4 Boundary
 

--- a/docs/P5-STATUS.md
+++ b/docs/P5-STATUS.md
@@ -5,15 +5,16 @@ Date: 2026-09-02
 ## Verification Baseline
 
 This checkpoint was reconciled against `origin/main` at
-`8b846fb9594eb46587ce54281a31776284121552`. PR #203 merged practical XKB
-accessibility controls after PR #202 merged dedicated high-contrast and
-reduced-motion Settings controls. The primary checkout matched the remote
-revision before this notification-policy branch was created, no pull request
-remained open, and only the primary checkout was registered.
+`ad47c209ef67bfc462ad9a847ef4d41b524e9257`. PR #204 merged notification
+policy after PR #203 merged practical XKB accessibility controls and PR #202
+merged dedicated high-contrast and reduced-motion Settings controls. The
+primary checkout matched the remote revision before this UI-5 decision branch
+was created, no pull request remained open, and only the primary checkout was
+registered.
 
-The active `TASKS.md` contains 25 implementation checkboxes. Fifteen are
-complete on `main`; this boundary completes the sixteenth, leaving nine after
-merge.
+The active `TASKS.md` contains 25 implementation checkboxes. Sixteen are
+complete on `main`; this boundary closes four optional UI-5 checkboxes with an
+empty adopted set, leaving the five combined qualification checks after merge.
 
 The merged APPEARANCE-001 boundaries and their documentation passed. The
 historical documentation build has since been replaced by the current Astro
@@ -52,7 +53,8 @@ boundaries passed before merge.
 | ACCESSIBILITY-001 capability contract | Complete | PR #190 | Five hosted checks and exact-head Codex and CodeRabbit review passed; one conditional check skipped. |
 | ACCESSIBILITY-001 managed Settings controls | Complete | PRs #191, #201, and #202 | Capability grouping, managed contrast and motion policy, Settings mutations, nested-X11 persistence, hosted checks, and review loops passed. |
 | ACCESSIBILITY-001 practical input controls | Complete | PR #203 | AccessX preview, rollback, persistence, replay, reset, real-session rollback, hosted gates, and exact-head review passed. |
-| ACCESSIBILITY-001 notification policy | Current | Current branch | Persistent Do Not Disturb, bounded popup duration, owner-PID matching, history retention, urgency bypass, and reset are under review. |
+| ACCESSIBILITY-001 notification policy | Complete | PR #204 | Persistent Do Not Disturb, bounded popup duration, owner-PID matching, history retention, urgency bypass, transient-save recovery, installed-session evidence, hosted gates, and exact-head reviews passed. |
+| P5-UI5 candidate decisions | Current | Current branch | Four candidates have explicit defer or reject decisions and the adopted set is empty, so no runtime or package boundary follows. |
 
 The detailed contracts and focused validation commands remain in
 `P5-THEME-TRANSACTIONS.md`, `P5-APPEARANCE-INVENTORY.md`,
@@ -74,47 +76,50 @@ idle measured 0.000% CPU over five seconds. The current workstation session had
 one active monitor, so real multi-monitor persistence remains untested here;
 nested-X11 validation covers the shared-state path.
 
+## Merged Notification Evidence
+
+PR #204 kept the root NotificationModel as the sole delivery and history owner
+while adding user-owned Do Not Disturb and fixed popup-duration state without
+a poller or privilege boundary. Capability discovery resolves the D-Bus
+owner's machine-readable PID and verifies the Quickshell executable and managed
+configuration identity before exposing mutations.
+
+Focused provider, shell, QML, nested-X11, clean-build, and full managed-suite
+checks passed. The large-surface session retained suppressed notifications in
+history, allowed critical urgency through Do Not Disturb, recovered after a
+forced save failure, preserved visible popups across self-writes, and sampled
+0.00% closed idle CPU. The exact checkout was installed with rollback backup
+`20260902T203714Z-3846857`; the supported restart path left one healthy managed
+shell and five tray items. The live policy persisted 4,000 ms, suppressed an
+ordinary popup while retaining it in history, allowed a critical popup, reset
+to Do Not Disturb off at 6,000 ms, and measured 0.000% CPU over 30 seconds.
+Hosted validation passed on the exact merged head after one unrelated Settings
+Xvfb appearance-baseline flake passed unchanged on rerun. Exact-head Codex and
+CodeRabbit reviews completed without outstanding findings.
+
 ## Current Review Boundary
 
-The current `codex/phase5-notification-policy` boundary keeps the root
-NotificationModel as the sole delivery and history owner. It adds user-owned
-Do Not Disturb and fixed popup-duration state without a poller or privilege
-boundary. Capability discovery resolves the D-Bus owner's machine-readable PID
-and verifies the Quickshell executable and managed configuration identity
-before exposing mutations.
-
-Focused provider, shell, QML, and nested-X11 checks pass. The clean managed
-build and full managed repository suite pass. The Settings session persisted
-policy through restart and reset. The large-surface session delivered an
-ordinary notification, retained a suppressed notification in history, allowed
-a critical notification through Do Not Disturb, recovered the last confirmed
-state after a forced save failure, and sampled 0.00% closed idle CPU.
-
-The exact checkout was installed with rollback backup
-`20260902T203714Z-3846857`. The supported restart path removed two stale
-managed Quickshell instances, leaving one instance with healthy IPC and five
-tray items. Settings reported the notification capability available. The live
-policy persisted 4,000 ms, suppressed an ordinary popup while retaining it as
-the newest history entry, allowed a critical popup, and reset to Do Not Disturb
-off at 6,000 ms. Closed CPU measured 0.000% over 30 seconds. The previously
-absent policy migrated to its versioned default file. Installed files match the
-checkout; the newly installed `dwm` binary requires the expected logout and
-login before runtime parity can pass. Exact-head hosted validation remains
-required before merge.
+`docs/P5-UI5-DECISIONS.md` inventories event-driven clipboard history, an
+emoji/symbol picker, a reminder or timer overlay, and a general image picker.
+Clipboard history and reminders are deferred pending explicit data-retention,
+privacy, lifecycle, and recovery contracts. The two generic pickers are
+rejected because no current product workflow requires them. No candidate is
+adopted, so this decision-only branch changes no provider, resident process,
+package, IPC name, keybinding, focus rule, monitor behavior, or X11 surface.
 
 ## Open Task Boundaries
 
 | Boundary | Open checkboxes | Verified current state | Next evidence needed |
 | --- | ---: | --- | --- |
 | APPEARANCE-001 | 0 | Complete on `main` through PR #188. | Preserve the merged contracts while completing Phase 5. |
-| ACCESSIBILITY-001 | 0 | Five capability records, text-scale grouping, managed contrast and motion policy, and practical XKB input controls are merged. This boundary completes notification policy behavior plus nested-X11 and installed-session evidence. | Finish exact-head hosted review and validation. |
-| P5-UI5 | 4 | No candidate decision record is complete. | Inventory candidates, record adopt/defer/reject decisions, and qualify each adopted X11-native experience independently. |
+| ACCESSIBILITY-001 | 0 | Five capability records, text-scale grouping, managed contrast and motion policy, practical XKB input controls, and notification policy are merged through PR #204. | Preserve the merged contracts during final qualification. |
+| P5-UI5 | 0 | Four candidates have explicit decisions; none is adopted. This boundary adds no runtime or package work. | Preserve the recorded limitations and empty adopted set. |
 | P5-VALIDATE | 5 | Individual merged slices have focused and full-suite evidence, but the combined Phase 5 product is incomplete. | Run the final Fedora 44, clean build, full suite, QML, shell, install/parity, fresh-login, `startx`, multi-monitor, optional-loss, recovery, and 30-second CPU qualification after all selected Phase 5 work merges. |
 
 ## Phase Position
 
-Phase 5 remains active. THEME-001 and APPEARANCE-001 are complete on `main`.
-All ACCESSIBILITY-001 implementation checkboxes are complete with this
-boundary. No P5-UI5 or final Phase 5 qualification checkbox is complete. Phase
-6 must not begin until the Phase 5 exit criteria pass or an explicit roadmap
-decision defers named work and records the resulting limitation.
+Phase 5 remains active. THEME-001, APPEARANCE-001, and ACCESSIBILITY-001 are
+complete on `main`. This boundary closes P5-UI5 with no adopted experience.
+Only the five final Phase 5 qualification checkboxes remain. Phase 6 must not
+begin until the Phase 5 exit criteria pass and the resulting evidence and
+limitations are recorded.

--- a/docs/P5-UI5-DECISIONS.md
+++ b/docs/P5-UI5-DECISIONS.md
@@ -1,0 +1,40 @@
+# Phase 5 UI-5 Candidate Decisions
+
+Date: 2026-09-02
+
+## Decision Boundary
+
+UI-5 is an optional experience-integration boundary, not a Phase 5 exit
+criterion. A candidate is adopted only when it has a defined product consumer,
+an X11-native event source, explicit data ownership, a bounded lifecycle and
+privacy model, and a justified Fedora package impact. An adopted candidate
+would be implemented and qualified in its own pull request before final Phase 5
+validation.
+
+This inventory adopts no candidate. It therefore adds no provider, resident
+process, stored user data, dependency, command surface, IPC name, keybinding,
+or X11 surface. Existing focus, click-away, stacking, monitor selection, and
+closed-shell idle behavior remain unchanged.
+
+## Candidate Inventory
+
+| Candidate | Decision | Evaluation | Reconsideration gate |
+| --- | --- | --- | --- |
+| Event-driven clipboard history | Defer | A correct X11 implementation needs a long-lived selection observer or owner, bounded text and image retention, explicit exclusions and clear-all behavior, and a policy for password managers and other sensitive selections. The existing `xclip` screenshot transfer is a short-lived clipboard owner, not a safe history backend. The privacy and lifecycle contract is larger than an optional Phase 5 surface. | Reconsider only with an opt-in retention specification, sensitive-data exclusions, bounded storage and image sizes, a complete deletion contract, and a separately reviewable event-driven X11 backend. |
+| Emoji and symbol picker | Reject | The current roadmap defines no desktop workflow that requires a managed picker. Shipping Unicode search data, clipboard injection, focus restoration, and update policy would create a new product and package contract for convenience behavior already available through applications. | Reconsider only if a future accessibility or input requirement names a consumer and cannot be satisfied by a delegated Fedora application. |
+| Reminder or timer overlay | Defer | Reliable reminders require persistent scheduling, restart and missed-event behavior, timezone-change handling, and notification delivery ownership. Those responsibilities are not presentation-only and do not belong in the Phase 5 personalization boundary. | Reconsider in a future phase only after a durable scheduling and recovery contract is specified independently of Quickshell surface lifetime. |
+| General image picker | Reject | Phase 5 already provides a bounded wallpaper candidate chooser for its defined image consumer. A generic picker has no additional approved consumer and would duplicate file filtering, preview, focus, and lifecycle behavior without completing an exit criterion. | Reconsider only when a named workflow needs reusable image selection and the existing wallpaper contract cannot serve it. |
+
+## Adopted Set and Qualification
+
+The adopted set is empty. Consequently there is no UI-5 implementation or
+package-install boundary to qualify, and the requirements for adopted-feature
+source, helper, lifecycle, nested-X11, package, and privacy tests are not
+applicable. The repository's existing full-suite, QML, X11, and closed-idle
+gates remain authoritative for proving this documentation-only decision does
+not disturb existing shell behavior.
+
+Deferred candidates are not Phase 6 commitments. Reopening one requires an
+explicit roadmap decision and the independent pre-implementation evaluation
+described above. Rejected candidates remain outside the product plan unless a
+new requirement supplies a concrete consumer and acceptance criteria.


### PR DESCRIPTION
## Summary

- inventory four optional UI5 candidates and record explicit defer or reject decisions
- adopt no runtime experience, package, provider, IPC, keybinding, or X11 surface
- reconcile the Phase 5 roadmap, task counts, status, specification boundary, and changelog

## Validation

- `scripts/run-tests make clean all`
- `scripts/run-tests`
- `npm --prefix docs ci`
- `npm --prefix docs run build`
- `git diff --check`
- CodeRabbit local review: 0 findings after one planning-discipline fix
- Codex local review: 0 findings after one roadmap-consistency fix

## Scope

This is a decision-only boundary. The adopted UI5 set is empty, so final combined Phase 5 qualification is the only remaining Phase 5 pull request after this merges.