### PR TITLE
docs: complete Phase 5 qualification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versions from `config.mk`.
 
 ### Changed
 
+- Complete Phase 5 personalization and accessibility qualification on Fedora 44
+  X11. The combined clean build, managed suite, QML and shell checks, nested-X11
+  workflows, install parity, live two-monitor panels, reversible theme and
+  AccessX changes, common-size Settings rendering, and closed-idle samples pass;
+  unsupported and deferred paths remain explicit in the closeout evidence.
+
 - Replace the combined display mode button in Settings with an accessible
   resolution dropdown backed by each output's supported RandR sizes. Keep
   refresh-rate selection separate and route both choices through the existing

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,10 +78,10 @@ product roadmap.
 UI-1 is the merged foundation. UI-2 and UI-3 were parallel children and are
 now unified on `main`. `P3-UI4` established the shared large-surface language
 used by the completed Phase 3 provider work and the later power, defaults,
-personalization, accessibility, and system-management phases. Phases 3 and 4
-are complete and product Phase 5 is active. The UI-5 review adopted no runtime
-experience; any future reopening requires a new roadmap decision and an
-independent review boundary. UI-6 closes the desktop during Phase 7 release
+personalization, accessibility, and system-management phases. Phases 3 through
+5 are complete and product Phase 6 is active. The UI-5 review adopted no
+runtime experience; any future reopening requires a new roadmap decision and
+an independent review boundary. UI-6 closes the desktop during Phase 7 release
 qualification.
 
 ### UI Overhaul Exit Criteria
@@ -298,23 +298,7 @@ Unify normal session behavior and application defaults.
 
 ## Phase 5: Personalization and Accessibility
 
-Status: Active (reconciled 2026-09-02; UI-5 review complete, final qualification pending)
-
-### Current Checkpoint
-
-The shared theme provider and transactions are complete. Appearance inventory,
-wallpaper persistence, managed-shell fonts and scaling, and desktop font,
-cursor, icon, GTK, and Qt controls are merged through PR #184. Panel-widget
-persistence merged in PR #186, and cross-capability optional-component
-qualification merged in PR #188, completing `APPEARANCE-001`. Managed-shell
-contrast and motion controls merged in PR #202, practical XKB input
-accessibility controls merged in PR #203, and notification Do Not Disturb and
-bounded popup duration merged in PR #204. The current decision record defers
-clipboard history and reminders, rejects emoji/symbol and generic image
-pickers, and adopts no UI-5 runtime work. Combined Phase 5 qualification
-remains open.
-`docs/P5-STATUS.md` maps every active checkbox to its current evidence or next
-action.
+Status: Complete (2026-09-02)
 
 ### Objective
 
@@ -334,7 +318,29 @@ Make the desktop appearance and interaction model configurable as one system.
 - Invalid themes or missing assets cannot prevent login or shell startup.
 - Accessibility choices persist and are usable at common display sizes.
 
+### Completion Evidence
+
+- Theme, wallpaper, managed-shell typography, desktop font and scale, cursor,
+  icon, GTK, Qt, panel-widget, contrast, reduced-motion, AccessX, and
+  notification-policy workflows are merged through PR #204. PR #205 recorded
+  an empty UI-5 adopted set, preserving deferred privacy and lifecycle work as
+  explicit limitations instead of adding an unqualified runtime owner.
+- The clean build, full managed repository suite, Quickshell lint, focused shell
+  checks, documentation build, nested-X11 workflows, staged and repeated
+  installs, and exact restoration checks passed. The 30-second Settings CPU
+  delta was 0.066 percentage points against the 0.5-point limit.
+- On Fedora 44 X11, the synchronized installed tree ran one managed Quickshell
+  process, five tray clients, and one 30-pixel panel on each of two active
+  monitors. Settings reached `ready` at 1180x760, and closed idle measured
+  0.000 percent CPU over 30 seconds.
+- Live theme and AccessX previews changed and restored their exact starting
+  state. The running, installed, and checkout DWM binaries were byte-identical.
+  Fresh-login, optional-package-removal, and incomplete installed GTK theme
+  limitations are recorded in `docs/P5-EVIDENCE.md`.
+
 ## Phase 6: System Management
+
+Status: Active (2026-09-02)
 
 ### Objective
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -330,13 +330,14 @@ Make the desktop appearance and interaction model configurable as one system.
   installs, and exact restoration checks passed. The 30-second Settings CPU
   delta was 0.066 percentage points against the 0.5-point limit.
 - On Fedora 44 X11, the synchronized installed tree ran one managed Quickshell
-  process, five tray clients, and one 30-pixel panel on each of two active
-  monitors. Settings reached `ready` at 1180x760, and closed idle measured
-  0.000 percent CPU over 30 seconds.
+  process and one 30-pixel panel on each of two active monitors. A fresh
+  LightDM login activated the installed DWM and registered four current tray
+  clients. Settings reached `ready` at 1180x760, and closed idle measured 0.000
+  percent CPU over 30 seconds.
 - Live theme and AccessX previews changed and restored their exact starting
   state. The running, installed, and checkout DWM binaries were byte-identical.
-  Fresh-login, optional-package-removal, and incomplete installed GTK theme
-  limitations are recorded in `docs/P5-EVIDENCE.md`.
+  Optional-package-removal and incomplete installed GTK theme limitations are
+  recorded in `docs/P5-EVIDENCE.md`.
 
 ## Phase 6: System Management
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -336,8 +336,9 @@ Make the desktop appearance and interaction model configurable as one system.
   percent CPU over 30 seconds.
 - Live theme and AccessX previews changed and restored their exact starting
   state. The running, installed, and checkout DWM binaries were byte-identical.
-  Optional-package-removal and incomplete installed GTK theme limitations are
-  recorded in `docs/P5-EVIDENCE.md`.
+  Actual optional-package removal was not performed, and some installed GTK
+  theme candidates remain incomplete; both limitations are recorded in
+  `docs/P5-EVIDENCE.md`.
 
 ## Phase 6: System Management
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -680,8 +680,8 @@ notifications, quick controls, power actions, network and Bluetooth surfaces,
 display helpers, a system-health dashboard, and the unified Settings platform.
 Settings includes the completed Phase 2 display and input mutation surface,
 Phase 3 NetworkManager, BlueZ, PipeWire, and media workflows, and Phase 4 power,
-session-action, default-application, MIME, and XDG autostart workflows. Active
-Phase 5 now includes merged theme transactions, wallpaper persistence,
+session-action, default-application, MIME, and XDG autostart workflows.
+Completed Phase 5 includes theme transactions, wallpaper persistence,
 managed-shell typography, desktop font, cursor, icon, GTK, and Qt controls,
 panel-widget persistence, plus persistent managed-shell contrast and motion
 policy with dedicated Settings controls, practical XKB input accessibility,
@@ -691,8 +691,11 @@ contract are also qualified. The optional UI-5 inventory adopts no runtime
 experience: clipboard history and reminders are deferred, while emoji/symbol
 and generic image pickers are rejected. Reopening a UI-5 candidate requires an
 explicit product requirement and a separately qualified X11-native boundary.
-Phase 5 is not complete until combined qualification maps every phase exit
-criterion to Section 9 evidence and records all untested or limited paths.
+Combined Fedora 44, nested-X11, live-session, install-parity, restoration, and
+idle-resource qualification is recorded in `docs/P5-EVIDENCE.md` with explicit
+limitations. The next product gap is Phase 6 system management: safe Fedora
+updates, regional and delegated administration entry points, and bounded
+system information, diagnostics, and recovery workflows.
 
 The installer contains a Fedora-only package map and rejects other systems.
 The build uses `pkg-config`, supports staged installation with `DESTDIR`, and

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,173 +1,138 @@
 # Active Project Tasks
 
 `SPEC.md` is the product contract and `ROADMAP.md` defines phase order. This
-file contains implementation work only for the active roadmap phase. Phase 4
-completion evidence is recorded in `ROADMAP.md`, `CHANGELOG.md`,
-`docs/P4-EVIDENCE.md`, and the four detailed Phase 4 evidence records.
+file contains implementation work only for the active roadmap phase. Phase 5
+completion evidence is recorded in `ROADMAP.md`, `CHANGELOG.md`, and
+`docs/P5-EVIDENCE.md`.
 
 ## Verified Checkpoint
 
-Status reconciled 2026-09-02 against `main` at `ad47c20`. Sixteen of the 25
-Phase 5 implementation checkboxes are merged. PR #204 completed persistent
-notification policy after PR #203 completed practical XKB input accessibility
-controls. Only the primary worktree remains registered.
+Phase 5 completed on 2026-09-02 after its final combined Fedora 44, nested-X11,
+live-session, install-parity, restoration, and idle-resource qualification.
+Deferred and unavailable paths remain explicit in `docs/P5-EVIDENCE.md`.
 
-The current decision-only boundary inventories UI-5 candidates and adopts
-none. It completes all four optional UI-5 planning and compatibility
-checkboxes without adding a runtime surface; combined Phase 5 qualification is
-the only remaining boundary.
+Phase 6 must keep Settings and all QML unprivileged. Read state through stable
+machine interfaces, delegate broad administration to trusted Fedora tools, and
+add a privileged helper only for a narrow allowlisted operation that cannot be
+completed safely through an existing service.
 
-## Active Phase: Personalization and Accessibility
+## Active Phase: System Management
 
-Phase 5 begins from the merged Settings platform and semantic theme adapter.
-Keep DWM, X11, Fedora providers, runtime TOML files, existing keybindings, panel
-geometry, and user-owned configuration compatible while adding the workflows
-below. Do not begin Phase 6 system-management work in Phase 5 changes.
-
-Keep Phase 5 reviewable through these ordered pull-request boundaries. Finish,
+Keep Phase 6 reviewable through these ordered pull-request boundaries. Finish,
 validate, and merge each boundary before starting the next one:
 
-1. Read-only appearance inventory and validation protocol.
-2. Transactional theme preview, apply, reset, and recovery helper.
-3. Shared root appearance model and Settings theme pane.
-4. Wallpaper, toolkit, font, cursor, icon, and panel-widget persistence slices,
-   split further when one slice cannot remain independently reviewable.
-5. Accessibility and notification policy, with UI-5 candidates kept in their
-   own later review boundaries.
+1. System-management capability and privilege inventory.
+2. Fedora update status, execution, interruption, and recovery.
+3. Regional, account, printer, and software-source entry points.
+4. System information, storage, privacy, security, diagnostics, and recovery.
+5. Combined Phase 6 qualification.
 
-### THEME-001: Shared Appearance Provider and Safe Theme Changes
+### SYSTEM-001: Capability and Privilege Inventory
 
-- [x] Define a versioned machine-readable provider for the active theme,
-  available themes, semantic colors, toolkit state, and per-capability errors.
-- [x] Add a user-session transaction helper for bounded preview, confirm,
-  automatic or explicit rollback, apply, reset, and interrupted-operation
-  recovery without replacing unrelated theme configuration.
-- [x] Add one root-scoped appearance model shared by Settings and existing shell
-  surfaces without duplicating the `Theme.qml` or `themes.toml` ownership path.
-- [x] Add a Settings Appearance pane with theme preview, apply, reset, and
-  recovery behavior. Preserve comments, custom themes, file mode, and unrelated
-  user configuration.
-- [x] Make partial GTK, Qt, terminal, cursor, or compositor application failures
-  visible without reporting the selected theme as fully applied.
+- [ ] Inventory every Phase 6 state source and mutation path. Classify each as
+  read-only, user-session, privileged, delegated, or unsupported.
+- [ ] Select stable Fedora service, D-Bus, package-manager, AccountsService,
+  CUPS, and system-information interfaces without parsing human-oriented output
+  when a machine interface exists.
+- [ ] Define the shared versioned provider records, per-capability failure
+  isolation, event sources, cancellation, authorization-denial behavior, and
+  audit fields before adding mutations.
+- [ ] Record which high-risk tasks remain delegated, including advanced storage,
+  firewall policy, and general service administration.
 
 Acceptance:
 
-- Invalid, missing, duplicate, or incomplete theme records cannot prevent DWM,
-  Quickshell, Settings, or an existing theme from loading.
-- Preview is bounded and rolls back automatically unless confirmed. Apply and
-  reset are transactional, attributed, and converge through hot reload.
-- Existing Control Center theme selection remains compatible with the shared
-  provider until its presentation can be migrated without behavior drift.
+- QML remains unprivileged and can render readable state when authorization or
+  an optional service is unavailable.
+- Every proposed mutation has one bounded owner, fixed arguments, explicit user
+  intent, and an actionable failure or recovery state.
 
-### APPEARANCE-001: Wallpaper, Fonts, Cursors, Icons, and Toolkit Integration
+### UPDATE-001: Fedora Updates
 
-- [x] Define event-driven inventory and state contracts for wallpaper, supported
-  fonts, cursors, icons, GTK, Qt, and compositor integration using stable Fedora
-  or X11 interfaces.
-- [x] Add wallpaper selection, fit mode, preview, reset, and missing-file
-  recovery without scanning while the Appearance pane is closed.
-- [x] Add bounded user-session controls for supported font, text-size, cursor,
-  icon, GTK, and Qt choices. Delegate advanced toolkit editing to a trusted
-  Fedora tool where a narrow project contract would be incomplete.
-  - [x] Persist managed-shell font family and bounded text scale with preview,
-    automatic rollback, reset, external-change protection, and event-driven
-    root-model updates.
-  - [x] Add cursor, icon, GTK, and Qt mutation controls without overwriting
-    unrelated toolkit configuration.
-- [x] Move the existing in-memory panel-widget visibility controls onto shared,
-  versioned user state with Settings integration, safe defaults, and migration
-  that preserves the current Control Center behavior.
-- [x] Preserve optional-component behavior: missing Picom, Feh, toolkit themes,
-  wallpaper directories, or delegated tools must fail only their capability.
+- [ ] Add user-initiated Fedora update discovery and status through the selected
+  stable package-management interface.
+- [ ] Add confirmed update execution with transparent progress and logs, strict
+  success detection, cancellation, and overlap rejection. Keep an operation
+  delegated when the platform cannot expose a safe cancellation contract.
+- [ ] Distinguish authorization denial, network or repository failure, package
+  conflicts, interrupted transactions, completed updates, and reboot guidance.
+- [ ] Preserve recovery guidance across Settings closure or helper interruption
+  without claiming ambiguous success.
 
 Acceptance:
 
-- Selected appearance state persists through a fresh session and follows the
-  shared theme where appropriate without overwriting unrelated toolkit files.
-- Panel-widget visibility persists through a fresh session, stays consistent on
-  every active monitor, and does not duplicate panel models or providers.
-- Preview, apply, interruption, rollback, reset, missing-asset, and external-
-  change paths converge with explicit status and no orphaned watcher.
-- Visible shell surfaces remain opaque, X11-native, correctly stacked, and
-  usable at the existing panel and popup geometry contracts.
+- No update begins from passive discovery or without explicit confirmation.
+- Read-only update status remains available after authorization denial.
+- Interrupted or failed updates identify the owning platform state and a safe
+  next action.
 
-### ACCESSIBILITY-001: Practical X11 Accessibility and Notification Policy
+### REGIONAL-ENTRY-001: Regional and Delegated Administration
 
-- [x] Define capability records for text scaling, contrast, reduced motion,
-  notification policy, and practical keyboard or pointer accessibility features
-  available through supported Fedora/X11 interfaces.
-- [x] Add accessible Settings controls with keyboard navigation, visible focus,
-  usable common display sizes, explanatory unavailable states, and reset.
-- [x] Apply reduced-motion and contrast choices consistently to managed
-  Quickshell surfaces without introducing a Wayland, compositor, or polling
-  dependency.
-- [x] Add notification behavior controls that preserve the existing D-Bus owner,
-  history lifecycle, urgency semantics, and safe failure isolation.
+- [ ] Add date, time, timezone, and locale status plus safe common actions
+  through stable platform services.
+- [ ] Add user-account, printer, and software-source entry points through trusted
+  Fedora tools or narrowly scoped helpers where the platform lacks a complete
+  delegated workflow.
+- [ ] Report missing tools, services, hardware, authorization, and unsupported
+  operations per capability without hiding readable state.
+- [ ] Preserve existing Settings navigation, keyboard accessibility, X11 focus,
+  and closed-pane lifecycle behavior.
 
 Acceptance:
 
-- Accessibility state persists and is observable through the owning platform or
-  managed interface after a fresh session.
-- Missing X11 extensions or optional tools degrade per capability and never make
-  Settings, notifications, or the shell unavailable.
-- Keyboard-only navigation, text scaling, contrast, reduced motion, notification
-  delivery/history, and reset behavior pass nested-X11 and real-session checks.
+- Delegated launches use fixed allowlisted desktop files or commands and report
+  launch failure without false success.
+- System changes are confirmed and auditable; QML never receives arbitrary
+  privileged command or path construction.
 
-### P5-UI5: Optional X11-Native Experience Integration
+### INFO-RECOVERY-001: Information, Diagnostics, and Recovery
 
-- [x] Inventory UI-5 candidates, beginning with event-driven clipboard history,
-  and record an adopt, defer, or reject decision for each candidate.
-- [x] Evaluate every adopted UI-5 experience as an independent review boundary
-  with an event-driven provider, explicit data ownership, bounded lifecycle,
-  privacy model, and Fedora package impact before implementation.
-- [x] Integrate only approved X11-native experiences into the existing semantic
-  design system and command surfaces; do not copy Wayland, Hyprland, layer-shell,
-  UWSM, or Omarchy service/plugin backends.
-- [x] Preserve current IPC names, X11 focus/click-away/stacking behavior, monitor
-  selection, and closed-surface near-idle behavior.
+- [ ] Add event-driven or bounded system information and storage overview state
+  without a new idle poller.
+- [ ] Add privacy and security status, diagnostics, recovery actions, and reset
+  guidance with clear ownership and limitations.
+- [ ] Keep advanced storage mutation, firewall policy, service administration,
+  and other broad or destructive operations delegated unless `SPEC.md` first
+  defines a safe narrow contract.
+- [ ] Add actionable unavailable, denied, failed, canceled, interrupted, and
+  recovery states for every surface.
 
 Acceptance:
 
-- Every inventoried candidate has a recorded adopt, defer, or reject decision.
-- Every adopted experience has focused source, helper, lifecycle, nested-X11,
-  package/install, and privacy tests.
-- Closing a surface leaves no resident scan, duplicate subscription, helper,
-  sensitive history owner, or overlapping process.
+- Information remains readable when a mutation is denied or unsupported.
+- Recovery and reset actions name their scope, consequences, and platform owner
+  before confirmation.
 
-Decision: `docs/P5-UI5-DECISIONS.md` records four candidates. Clipboard history
-and reminders are deferred; emoji/symbol and general image pickers are
-rejected. Because the adopted set is empty, no implementation, package, or
-feature-specific qualification obligation is created.
+### P6-VALIDATE: Phase 6 Validation
 
-### P5-VALIDATE: Phase 5 Validation
-
-- [ ] Run focused parser, helper, QML, lifecycle, rollback, and nested-X11 tests
-  for every Phase 5 workflow.
-- [ ] Exercise reversible appearance and accessibility changes on Fedora 44,
-  restore exact original state, and record unavailable toolkit or X11 paths.
-- [ ] Compare a 30-second closed baseline with a 30-second sample after opening
-  and closing every Phase 5 Settings workflow; the mean Quickshell CPU delta
-  must be no more than 0.5 percentage points of one CPU.
+- [ ] Run focused provider, parser, privilege, cancellation, lifecycle, failure,
+  recovery, QML, and nested-X11 tests for every Phase 6 workflow.
+- [ ] Prove every privileged action is allowlisted, explicitly confirmed,
+  auditable, cancelable, and unavailable from repository- or user-writable
+  helper copies. Exclude or delegate any operation that cannot meet that
+  contract.
+- [ ] Exercise authorization denial, interrupted updates, failed delegated tools,
+  missing services, and recovery without hiding readable status or reporting
+  false success.
 - [ ] Run the clean build, full managed repository suite, Quickshell lint,
   ShellCheck, shfmt, staged install, repeated install, and installed-runtime
   parity checks.
-- [ ] Qualify a fresh LightDM login, fixture or real `startx`, multi-monitor and
-  common display-size rendering, optional-component loss, and recovery after an
-  invalid theme or missing asset.
+- [ ] Qualify Fedora 44 real- or nested-X11 rendering, keyboard navigation,
+  common display sizes, closed-surface resource use, and all unavailable
+  hardware or service paths.
 
 Acceptance:
 
-- Every Phase 5 exit criterion maps to automated evidence or a named manual
+- Every Phase 6 exit criterion maps to automated evidence or a named manual
   check with Fedora release, session, restoration, and limitations.
-- Invalid themes or missing assets cannot prevent login or shell startup.
-- Accessibility choices persist, remain keyboard-usable, and do not add idle
-  polling, duplicate providers, or orphaned work.
+- Authorization denial preserves read-only state, and interrupted or failed
+  operations end with actionable recovery guidance.
 
 ## Phase Completion
 
-When all Phase 5 acceptance criteria pass:
+When all Phase 6 acceptance criteria pass:
 
 1. Record delivered behavior and validation in `CHANGELOG.md`.
-2. Update the Phase 5 status and limitations in `ROADMAP.md`.
-3. Replace this file's active task set with Phase 6 tasks.
+2. Update the Phase 6 status and limitations in `ROADMAP.md`.
+3. Replace this file's active task set with Phase 7 tasks.
 4. Preserve incomplete or deferred work as explicit roadmap limitations.

--- a/docs/P5-EVIDENCE.md
+++ b/docs/P5-EVIDENCE.md
@@ -63,12 +63,17 @@ then reported every managed file matching the checkout.
 
 The supported shell restart left one managed Quickshell process with working
 IPC, five tray clients, and the notification policy available. After closing
-all managed surfaces, a 30-second live sample consumed 0.000 percent CPU. The
-running DWM inode, installed binary, and checkout binary were byte-identical at
-SHA-256 `95e51d1378feefc9ff2c870ad7167dd335c7e52824ea284677810515ad8cbcbb`.
-The active inode retains the normal deleted suffix after same-content install
-replacement, so a later logout/login will refresh its pathname even though its
-executed bytes already match.
+all managed surfaces, a 30-second live sample consumed 0.000 percent CPU.
+
+A subsequent fresh LightDM login in the real X11 session activated
+`/usr/local/bin/dwm` without a deleted executable suffix. The running DWM,
+installed binary, and checkout binary were byte-identical at SHA-256
+`95e51d1378feefc9ff2c870ad7167dd335c7e52824ea284677810515ad8cbcbb`.
+The managed Quickshell process started with that session, exposed working IPC
+and four current tray clients, and owned the available notification policy.
+The graphical-session and XDG autostart targets were active with no failed user
+units. A stale nested Xvfb session from earlier qualification was terminated;
+no residual nested DWM or X server remained.
 
 The real X11 session exposed DP-0 at 2560x1440 and HDMI-0 at 1920x1080. It had
 one 30-pixel panel on each monitor. Installed IPC opened Settings at 1180x760;
@@ -87,16 +92,11 @@ previously absent input settings file remained absent.
 | Phase 5 exit criterion | Qualification evidence |
 | --- | --- |
 | Supported applications and shell surfaces follow the selected appearance. | The live transactional theme preview updated the shared provider and integrations, then restored 14 tracked paths exactly. Automated personalization, wallpaper, toolkit, panel, hot-reload, and nested-X11 tests passed. |
-| Invalid themes or missing assets cannot prevent login or shell startup. | The full suite passed malformed, duplicate, missing-asset, optional-loss, startup, display-manager, and `startx` fixtures. Existing real LightDM evidence reached the managed desktop, and the final installed shell restarted from the synchronized tree with one healthy owner. |
+| Invalid themes or missing assets cannot prevent login or shell startup. | The full suite passed malformed, duplicate, missing-asset, optional-loss, startup, display-manager, and `startx` fixtures. A fresh LightDM login in the real session activated the final installed DWM and managed shell with one healthy owner. |
 | Accessibility choices persist and are usable at common display sizes. | Nested X11 passed keyboard navigation, persistence, reset, notification delivery/history, and compact rendering. Live AccessX restoration, two-monitor panels, the 1180x760 Settings surface, and the 30-second closed-idle sample passed. |
 
 ## Explicit Limitations
 
-- The exact final documentation revision was not followed by another disruptive
-  LightDM logout/login. Earlier Phase 5 activation completed a real fresh
-  LightDM login; the final combined suite covers LightDM and `startx` fixtures,
-  the active DWM bytes match the final checkout, and the synchronized managed
-  Quickshell tree was restarted successfully.
 - Actual removal of optional host packages was not performed. Combined missing
   Picom, Feh, toolkit, wallpaper, and delegated-tool behavior is fixture- and
   nested-X11-qualified.

--- a/docs/P5-EVIDENCE.md
+++ b/docs/P5-EVIDENCE.md
@@ -1,0 +1,108 @@
+# Phase 5 Integration Evidence
+
+Date: 2026-09-02
+
+## Qualification Scope
+
+This record qualifies Phase 5 Personalization and Accessibility on Fedora Linux
+44 x86_64 under X11. The combined runtime baseline was `main` at
+`3770b04dee7b63e4401a391b91d06488018c215f`, after all selected Phase 5 work
+and the empty UI-5 adoption decision merged. This closeout changes planning and
+evidence only.
+
+## Delivered Workflows
+
+- One shared appearance provider and root model own theme inventory, semantic
+  color state, integration status, wallpaper, managed-shell typography, desktop
+  font and scale, cursor, icon, GTK, Qt, and panel-widget state.
+- Theme, wallpaper, font, toolkit, and accessibility mutations are serialized,
+  bounded, rollback-capable, and failure-attributed. Invalid records and missing
+  assets preserve the last usable state.
+- Managed high contrast and reduced motion update the existing shell surfaces.
+  Practical AccessX controls reuse the timed input preview and persistence path.
+- The root notification model remains the only delivery and history owner while
+  persistent Do Not Disturb and ordinary-popup duration policy preserve history
+  and critical-urgency delivery.
+- UI-5 adopted no runtime experience. Clipboard history and reminders remain
+  deferred; emoji/symbol and general image pickers remain rejected.
+
+## Automated Validation
+
+The exact combined baseline passed:
+
+```text
+scripts/run-tests make clean all
+scripts/run-tests
+scripts/quickshell-qmllint --root config/quickshell
+shellcheck install.sh scripts/*.sh tests/*.sh
+shfmt -d install.sh scripts/*.sh tests/*.sh
+npm --prefix docs ci
+npm --prefix docs run build
+git diff --check
+```
+
+The full managed suite covered every Phase 5 provider and helper, safe previews,
+keep/revert/reset, interrupted-operation recovery, malformed and missing state,
+optional-component isolation, QML lifecycle, nested X11, package and Kickstart
+parity, staged install, uninstall symmetry, and repeated install preservation.
+The Settings workflow sampled 0.133 percent of one CPU before the workflow and
+0.067 percent after it closed, a 0.066 percentage-point delta against the 0.5
+point limit. The large-surface run measured 0.00 percent closed CPU.
+
+Quickshell lint retained only the established `PanelTooltip.qml` incomplete
+qmltypes warnings and `RunningAppsArea.qml` property warnings. ShellCheck,
+shfmt, the Astro check, and the Astro build completed without findings.
+
+## Live Fedora, Restoration, and Parity Evidence
+
+The final checkout was synchronized through `scripts/dev-sync-install.sh`.
+The preflight correctly detected a stale installed notification provider and
+three stale managed QML files. The supported path created rollback backup
+`20260903T015133Z-2738591`, installed the complete system and user state, and
+then reported every managed file matching the checkout.
+
+The supported shell restart left one managed Quickshell process with working
+IPC, five tray clients, and the notification policy available. After closing
+all managed surfaces, a 30-second live sample consumed 0.000 percent CPU. The
+running DWM inode, installed binary, and checkout binary were byte-identical at
+SHA-256 `95e51d1378feefc9ff2c870ad7167dd335c7e52824ea284677810515ad8cbcbb`.
+The active inode retains the normal deleted suffix after same-content install
+replacement, so a later logout/login will refresh its pathname even though its
+executed bytes already match.
+
+The real X11 session exposed DP-0 at 2560x1440 and HDMI-0 at 1920x1080. It had
+one 30-pixel panel on each monitor. Installed IPC opened Settings at 1180x760;
+the application reached `ready`, remained keyboard-addressable through the
+qualified controls, and closed without adding another shell process.
+
+A live three-second Nord-to-Dracula theme preview converged to Dracula, timed
+out to Nord, and restored the exact content, mode, symlink target, or absence of
+`themes.toml` plus all 13 integration paths. Preview and recovery state both
+ended empty. A live sticky-keys preview changed the selected AccessX value and
+explicit revert restored the complete `xkbset q` snapshot byte-for-byte; the
+previously absent input settings file remained absent.
+
+## Exit-Criteria Mapping
+
+| Phase 5 exit criterion | Qualification evidence |
+| --- | --- |
+| Supported applications and shell surfaces follow the selected appearance. | The live transactional theme preview updated the shared provider and integrations, then restored 14 tracked paths exactly. Automated personalization, wallpaper, toolkit, panel, hot-reload, and nested-X11 tests passed. |
+| Invalid themes or missing assets cannot prevent login or shell startup. | The full suite passed malformed, duplicate, missing-asset, optional-loss, startup, display-manager, and `startx` fixtures. Existing real LightDM evidence reached the managed desktop, and the final installed shell restarted from the synchronized tree with one healthy owner. |
+| Accessibility choices persist and are usable at common display sizes. | Nested X11 passed keyboard navigation, persistence, reset, notification delivery/history, and compact rendering. Live AccessX restoration, two-monitor panels, the 1180x760 Settings surface, and the 30-second closed-idle sample passed. |
+
+## Explicit Limitations
+
+- The exact final documentation revision was not followed by another disruptive
+  LightDM logout/login. Earlier Phase 5 activation completed a real fresh
+  LightDM login; the final combined suite covers LightDM and `startx` fixtures,
+  the active DWM bytes match the final checkout, and the synchronized managed
+  Quickshell tree was restarted successfully.
+- Actual removal of optional host packages was not performed. Combined missing
+  Picom, Feh, toolkit, wallpaper, and delegated-tool behavior is fixture- and
+  nested-X11-qualified.
+- Several installed GTK theme candidates lack complete GTK 3 or GTK 4 assets.
+  Inventory reports those candidates as partial; supported complete candidates
+  and the rest of Settings remain available.
+- Hardware-specific behavior outside the two observed displays and available
+  XKB path is not claimed. Missing tool and extension behavior is covered by
+  scoped provider and nested-X11 fixtures.

--- a/docs/P5-NOTIFICATION-POLICY.md
+++ b/docs/P5-NOTIFICATION-POLICY.md
@@ -74,5 +74,6 @@ Disturb off with a 6,000 ms duration. Closed Quickshell CPU measured 0.000% over
 30 seconds. The previously absent policy migrated to the versioned default file
 and the validation restored those equivalent default values. Installed files
 match the checkout; activating the newly installed `dwm` binary still requires
-the expected logout and login. Exact-head hosted gates remain required before
-merge.
+the expected logout and login. Exact-head hosted gates and both review loops
+passed before PR #204 merged; combined Phase 5 results are recorded in
+`P5-EVIDENCE.md`.

--- a/docs/P5-NOTIFICATION-POLICY.md
+++ b/docs/P5-NOTIFICATION-POLICY.md
@@ -73,7 +73,8 @@ entry, allowed a critical popup through Do Not Disturb, and reset to Do Not
 Disturb off with a 6,000 ms duration. Closed Quickshell CPU measured 0.000% over
 30 seconds. The previously absent policy migrated to the versioned default file
 and the validation restored those equivalent default values. Installed files
-match the checkout; activating the newly installed `dwm` binary still requires
-the expected logout and login. Exact-head hosted gates and both review loops
-passed before PR #204 merged; combined Phase 5 results are recorded in
-`P5-EVIDENCE.md`.
+match the checkout. At this implementation boundary, activating the newly
+installed `dwm` binary still required the expected logout and login. The
+combined Phase 5 qualification completed that fresh LightDM activation and is
+recorded in `P5-EVIDENCE.md`. Exact-head hosted gates and both review loops
+passed before PR #204 merged.

--- a/docs/P5-STATUS.md
+++ b/docs/P5-STATUS.md
@@ -35,11 +35,12 @@ lifecycle. The 30-second Settings CPU delta was 0.066 percentage points; the
 large-surface closed sample was 0.00 percent.
 
 The final checkout was synchronized with rollback backup
-`20260903T015133Z-2738591`. On Fedora 44 X11, one managed Quickshell process
-owned working IPC and five tray clients, with one 30-pixel panel on each of two
-real monitors. Settings reached `ready` at 1180x760. Closed live CPU measured
-0.000 percent over 30 seconds. The running, installed, and checkout DWM bytes
-matched exactly.
+`20260903T015133Z-2738591`. A fresh LightDM login activated the installed DWM
+without a deleted executable suffix. On Fedora 44 X11, one managed Quickshell
+process owned working IPC, the available notification policy, and four current
+tray clients, with one 30-pixel panel on each of two real monitors. Settings
+reached `ready` at 1180x760. Closed live CPU measured 0.000 percent over 30
+seconds. The running, installed, and checkout DWM bytes matched exactly.
 
 A live Nord-to-Dracula preview timed out and restored Nord plus all 14 tracked
 theme and integration paths exactly. A live sticky-keys preview changed the
@@ -49,10 +50,6 @@ restart.
 
 ## Preserved Limitations
 
-- The exact final documentation revision did not trigger another disruptive
-  LightDM logout/login. Earlier Phase 5 work passed a fresh real LightDM login;
-  the final active DWM bytes match the checkout, the synchronized Quickshell
-  tree restarted successfully, and LightDM plus `startx` fixtures pass.
 - Actual host package removal was not performed; combined optional loss is
   fixture- and nested-X11-qualified.
 - Some installed GTK candidates are incomplete and correctly remain partial.

--- a/docs/P5-STATUS.md
+++ b/docs/P5-STATUS.md
@@ -2,124 +2,65 @@
 
 Date: 2026-09-02
 
-## Verification Baseline
+## Final Status
 
-This checkpoint was reconciled against `origin/main` at
-`ad47c209ef67bfc462ad9a847ef4d41b524e9257`. PR #204 merged notification
-policy after PR #203 merged practical XKB accessibility controls and PR #202
-merged dedicated high-contrast and reduced-motion Settings controls. The
-primary checkout matched the remote revision before this UI-5 decision branch
-was created, no pull request remained open, and only the primary checkout was
-registered.
+Phase 5 Personalization and Accessibility is complete. All 25 Phase 5
+checkboxes passed or were closed by an explicit product decision: 16 feature
+implementation tasks merged through PR #204, four UI-5 decision tasks merged in
+PR #205 with an empty adopted set, and five combined qualification tasks passed
+on `main` at `3770b04dee7b63e4401a391b91d06488018c215f`.
 
-The active `TASKS.md` contains 25 implementation checkboxes. Sixteen are
-complete on `main`; this boundary closes four optional UI-5 checkboxes with an
-empty adopted set, leaving the five combined qualification checks after merge.
+`docs/P5-EVIDENCE.md` is the combined acceptance record. Detailed contracts and
+focused results remain in the individual `P5-*` records, while `TASKS.md` now
+contains only the active Phase 6 work as required by the planning workflow.
 
-The merged APPEARANCE-001 boundaries and their documentation passed. The
-historical documentation build has since been replaced by the current Astro
-validation shown here:
+## Delivered Boundaries
 
-```text
-scripts/run-tests make clean all
-scripts/run-tests
-npm --prefix docs ci
-npm --prefix docs run build
-git diff --check
-```
+| Boundary | State | Evidence |
+| --- | --- | --- |
+| THEME-001 shared provider and safe theme changes | Complete | PRs #170, #172, #173, and #175; `P5-THEME-TRANSACTIONS.md` |
+| APPEARANCE-001 inventory, wallpaper, fonts, toolkit, panel, and optional isolation | Complete | PRs #176-#188; the appearance, font, panel, and optional-component records |
+| ACCESSIBILITY-001 capability, managed policy, input, and notifications | Complete | PRs #190-#204; the accessibility, input, and notification records |
+| P5-UI5 optional experience decisions | Complete | PR #205; `P5-UI5-DECISIONS.md`; no adopted runtime feature |
+| P5-VALIDATE combined qualification | Complete | `P5-EVIDENCE.md`; Fedora 44 source, nested-X11, install, live-session, restoration, multi-monitor, and resource evidence |
 
-The managed suite included the appearance provider, inventory, font,
-personalization, wallpaper, theme transaction, panel persistence, optional-loss,
-nested-X11, staged-install, and repeated-install checks. Quickshell lint retained
-only the already-documented `PanelTooltip.qml` qmltypes and
-`RunningAppsArea.qml` warnings. Exact-head hosted validation for both merged
-boundaries passed before merge.
+## Combined Result
 
-## Merged Task Evidence
+The clean build, full managed suite, QML lint, ShellCheck, shfmt, Astro check
+and build, staged install, repeated install, package and Kickstart parity, and
+nested-X11 workflows passed. The suite covered malformed state, missing assets,
+optional components, preview/revert/reset, interrupted-operation recovery,
+display-manager and `startx` fixtures, common display sizes, and provider
+lifecycle. The 30-second Settings CPU delta was 0.066 percentage points; the
+large-surface closed sample was 0.00 percent.
 
-| Task boundary | TASKS.md state | Merged evidence | Verification |
-| --- | --- | --- | --- |
-| THEME-001 appearance provider | Complete | PR #170 | Five hosted checks passed; one conditional check skipped. |
-| THEME-001 safe transactions | Complete | PR #172 | Six hosted checks passed; two conditional checks skipped. |
-| THEME-001 shared model and Settings pane | Complete | PR #173 | Five hosted checks passed; one conditional check skipped. |
-| THEME-001 partial integration status | Complete | PR #175 and the theme slices above | Five hosted checks passed on PR #175; one conditional check skipped. |
-| APPEARANCE-001 inventory | Complete | PR #176 | Five hosted checks passed; one conditional check skipped. |
-| APPEARANCE-001 wallpaper | Complete | PRs #177-#180 | Each pull request merged with all executed hosted checks passing. |
-| APPEARANCE-001 managed-shell font and scale | Complete | PR #181 | Six hosted checks passed; two conditional checks skipped. |
-| APPEARANCE-001 desktop font, cursor, icon, GTK, and Qt backend | Complete | PR #182 | Five hosted checks passed; one conditional check skipped. |
-| APPEARANCE-001 desktop controls | Complete | PRs #183 and #184 | All executed hosted checks passed; conditional checks skipped according to their paths. |
-| APPEARANCE-001 panel-widget persistence | Complete | PR #186 | Hosted CI, CodeQL, docs, focused panel, nested-X11, and live-session checks passed. |
-| APPEARANCE-001 optional-component isolation | Complete | PR #188 | Focused and full managed suites, nested X11, install, docs, lint, CodeQL, and hosted checks passed. |
-| ACCESSIBILITY-001 capability contract | Complete | PR #190 | Five hosted checks and exact-head Codex and CodeRabbit review passed; one conditional check skipped. |
-| ACCESSIBILITY-001 managed Settings controls | Complete | PRs #191, #201, and #202 | Capability grouping, managed contrast and motion policy, Settings mutations, nested-X11 persistence, hosted checks, and review loops passed. |
-| ACCESSIBILITY-001 practical input controls | Complete | PR #203 | AccessX preview, rollback, persistence, replay, reset, real-session rollback, hosted gates, and exact-head review passed. |
-| ACCESSIBILITY-001 notification policy | Complete | PR #204 | Persistent Do Not Disturb, bounded popup duration, owner-PID matching, history retention, urgency bypass, transient-save recovery, installed-session evidence, hosted gates, and exact-head reviews passed. |
-| P5-UI5 candidate decisions | Current | Current branch | Four candidates have explicit defer or reject decisions and the adopted set is empty, so no runtime or package boundary follows. |
+The final checkout was synchronized with rollback backup
+`20260903T015133Z-2738591`. On Fedora 44 X11, one managed Quickshell process
+owned working IPC and five tray clients, with one 30-pixel panel on each of two
+real monitors. Settings reached `ready` at 1180x760. Closed live CPU measured
+0.000 percent over 30 seconds. The running, installed, and checkout DWM bytes
+matched exactly.
 
-The detailed contracts and focused validation commands remain in
-`P5-THEME-TRANSACTIONS.md`, `P5-APPEARANCE-INVENTORY.md`,
-`P5-FONT-CONTROLS.md`, and `P5-APPEARANCE-CONTROLS.md`. The merged fixes and
-user-visible behavior are also recorded under the Unreleased changelog.
+A live Nord-to-Dracula preview timed out and restored Nord plus all 14 tracked
+theme and integration paths exactly. A live sticky-keys preview changed the
+AccessX setting and restored the complete XKB state; no input settings file was
+created. Notification policy remained available after the supported shell
+restart.
 
-## Merged Panel Live Evidence
+## Preserved Limitations
 
-The exact working tree was synchronized through `scripts/dev-sync-install.sh`.
-All managed files match, and rollback backup
-`20260828T153709Z-1472673` was created. After a full DWM logout/login, the
-active, installed, and checkout DWM binaries matched byte-for-byte. One managed
-Quickshell instance exposed the panel, five tray clients, the Control Center,
-and Settings Appearance. Settings reached `ready` on Fedora Linux 44 with the
-appearance provider available and all five configurable panel widgets enabled
-through the shared model. Its installed 1180x760 window displayed all nine
-sections and the compact display controls without reducing text scale; closed
-idle measured 0.000% CPU over five seconds. The current workstation session had
-one active monitor, so real multi-monitor persistence remains untested here;
-nested-X11 validation covers the shared-state path.
-
-## Merged Notification Evidence
-
-PR #204 kept the root NotificationModel as the sole delivery and history owner
-while adding user-owned Do Not Disturb and fixed popup-duration state without
-a poller or privilege boundary. Capability discovery resolves the D-Bus
-owner's machine-readable PID and verifies the Quickshell executable and managed
-configuration identity before exposing mutations.
-
-Focused provider, shell, QML, nested-X11, clean-build, and full managed-suite
-checks passed. The large-surface session retained suppressed notifications in
-history, allowed critical urgency through Do Not Disturb, recovered after a
-forced save failure, preserved visible popups across self-writes, and sampled
-0.00% closed idle CPU. The exact checkout was installed with rollback backup
-`20260902T203714Z-3846857`; the supported restart path left one healthy managed
-shell and five tray items. The live policy persisted 4,000 ms, suppressed an
-ordinary popup while retaining it in history, allowed a critical popup, reset
-to Do Not Disturb off at 6,000 ms, and measured 0.000% CPU over 30 seconds.
-Hosted validation passed on the exact merged head after one unrelated Settings
-Xvfb appearance-baseline flake passed unchanged on rerun. Exact-head Codex and
-CodeRabbit reviews completed without outstanding findings.
-
-## Current Review Boundary
-
-`docs/P5-UI5-DECISIONS.md` inventories event-driven clipboard history, an
-emoji/symbol picker, a reminder or timer overlay, and a general image picker.
-Clipboard history and reminders are deferred pending explicit data-retention,
-privacy, lifecycle, and recovery contracts. The two generic pickers are
-rejected because no current product workflow requires them. No candidate is
-adopted, so this decision-only branch changes no provider, resident process,
-package, IPC name, keybinding, focus rule, monitor behavior, or X11 surface.
-
-## Open Task Boundaries
-
-| Boundary | Open checkboxes | Verified current state | Next evidence needed |
-| --- | ---: | --- | --- |
-| APPEARANCE-001 | 0 | Complete on `main` through PR #188. | Preserve the merged contracts while completing Phase 5. |
-| ACCESSIBILITY-001 | 0 | Five capability records, text-scale grouping, managed contrast and motion policy, practical XKB input controls, and notification policy are merged through PR #204. | Preserve the merged contracts during final qualification. |
-| P5-UI5 | 0 | Four candidates have explicit decisions; none is adopted. This boundary adds no runtime or package work. | Preserve the recorded limitations and empty adopted set. |
-| P5-VALIDATE | 5 | Individual merged slices have focused and full-suite evidence, but the combined Phase 5 product is incomplete. | Run the final Fedora 44, clean build, full suite, QML, shell, install/parity, fresh-login, `startx`, multi-monitor, optional-loss, recovery, and 30-second CPU qualification after all selected Phase 5 work merges. |
+- The exact final documentation revision did not trigger another disruptive
+  LightDM logout/login. Earlier Phase 5 work passed a fresh real LightDM login;
+  the final active DWM bytes match the checkout, the synchronized Quickshell
+  tree restarted successfully, and LightDM plus `startx` fixtures pass.
+- Actual host package removal was not performed; combined optional loss is
+  fixture- and nested-X11-qualified.
+- Some installed GTK candidates are incomplete and correctly remain partial.
+- Clipboard history and reminders are deferred. Emoji/symbol and generic image
+  pickers are rejected. Reconsideration requires a new roadmap decision and an
+  independently qualified boundary.
 
 ## Phase Position
 
-Phase 5 remains active. THEME-001, APPEARANCE-001, and ACCESSIBILITY-001 are
-complete on `main`. This boundary closes P5-UI5 with no adopted experience.
-Only the five final Phase 5 qualification checkboxes remain. Phase 6 must not
-begin until the Phase 5 exit criteria pass and the resulting evidence and
-limitations are recorded.
+Phase 6 System Management is active. Phase 5 limitations remain evidence, not
+open Phase 6 implementation tasks.


### PR DESCRIPTION
## Summary

- record combined Phase 5 Fedora 44, nested-X11, live-session, restoration, install-parity, multi-monitor, and idle-resource evidence
- mark Phase 5 complete and preserve its exact untested, partial, deferred, and rejected paths
- replace the completed Phase 5 checklist with the active Phase 6 system-management task set

## Validation

- `scripts/run-tests make clean all`
- `scripts/run-tests`
- `scripts/quickshell-qmllint --root config/quickshell`
- `shellcheck install.sh scripts/*.sh tests/*.sh`
- `shfmt -d install.sh scripts/*.sh tests/*.sh`
- `npm --prefix docs ci`
- `npm --prefix docs run build`
- `git diff --check`
- local CodeRabbit review: clean after the review follow-up
- local Codex review: clean after tightening Phase 6 cancellation requirements and recording the final session activation

## Live Fedora 44 X11 evidence

- supported sync created rollback backup `20260903T015133Z-2738591` and left every managed file matching the checkout
- a fresh LightDM login activated `/usr/local/bin/dwm` without a deleted suffix; running, installed, and checkout bytes matched SHA-256 `95e51d1378feefc9ff2c870ad7167dd335c7e52824ea284677810515ad8cbcbb`
- one managed Quickshell process, four current tray clients, notification policy available, and active graphical-session and XDG autostart targets with no failed user units
- one 30-pixel panel on each of two active monitors; Settings reached ready at 1180x760
- live Nord-to-Dracula preview restored Nord plus all 14 tracked paths exactly
- live AccessX preview restored the complete XKB state and did not create a settings file
- a stale nested Xvfb qualification session was terminated; no residual nested DWM or X server remained

## Limitations

- actual optional-package removal was not performed; combined loss is fixture- and nested-X11-qualified
- incomplete installed GTK theme candidates remain explicitly partial
