### PR TITLE
Phase 6: add bounded PackageKit update snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ versions from `config.mk`.
 
 ### Added
 
+- Add the Phase 6 system-management provider's first bounded PackageKit
+  snapshot. It reports sanitized update inventory, refresh age, restart scope,
+  dependency-preview records, and deterministic confirmation generations while
+  explicitly keeping refresh, installation, cancellation, and recovery actions
+  unavailable until their managed operation lifecycle lands.
+
 - Add persistent notification policy controls to Settings Appearance. Do Not
   Disturb suppresses low- and normal-urgency popups while retaining notification
   history, critical notifications bypass suppression, and a bounded duration

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ INSTALL_COMMANDS = \
 	scripts/dwm-quickshell-version-check \
 	scripts/dwm-status \
 	scripts/dwm-system-health \
+	scripts/dwm-system-management \
 	scripts/dwm-polkit \
 	scripts/dwm-packages.sh \
 	scripts/dwm-titus-release \
@@ -460,6 +461,9 @@ check-quickshell-qml:
 check-system-health:
 	tests/test-system-health.sh
 
+check-system-management:
+	/usr/bin/python3 tests/test-system-management.py
+
 check-settings:
 	tests/test-settings.sh
 	tests/test-settings-input.sh
@@ -627,6 +631,7 @@ check:
 	$(MAKE) check-quickshell-notifications
 	$(MAKE) check-quickshell-tray
 	$(MAKE) check-system-health
+	$(MAKE) check-system-management
 	$(MAKE) check-settings
 	$(MAKE) check-appearance
 	$(MAKE) check-quickshell-network

--- a/Makefile
+++ b/Makefile
@@ -657,6 +657,6 @@ check:
 	check-test-runner \
 	check-display-profile check-display-setup check-fedora-iso-builder check-fedora-packages check-fedora-platform check-format check-install \
 	check-gearlever-install check-herdr-install check-install-manifest check-install-preservation check-kickstart check-lock \
-	check-session-guards check-session-migration check-screenshot check-release-helper check-shell check-webapp-launch check-diagnostics check-status check-system-health check-settings \
+	check-session-guards check-session-migration check-screenshot check-release-helper check-shell check-webapp-launch check-diagnostics check-status check-system-health check-system-management check-settings \
 	check-quickshell-launcher check-quickshell-controls check-quickshell-audio check-quickshell-controlcenter check-quickshell-power check-quickshell-power-backend check-quickshell-power-model check-quickshell-session-actions check-quickshell-defaults-model check-quickshell-appearance-model check-quickshell-design-system check-quickshell-large-surfaces check-quickshell-large-surfaces-xvfb check-quickshell-panel-menus check-quickshell-panel-settings check-quickshell-command-menu check-quickshell-notifications check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-connectivity check-quickshell-qml check-lightdm-config check-terminal check-xvfb-runtime install install-system install-user \
 	install-cursors native release release-check uninstall

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -1,0 +1,827 @@
+#!/usr/bin/python3
+"""Bounded, machine-readable Phase 6 system-management provider."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import time
+from dataclasses import dataclass
+from typing import Iterable, Protocol, Sequence
+
+
+PROTOCOL_MAJOR = 1
+PROTOCOL_MINOR = 0
+MAX_TEXT_BYTES = 512
+MAX_LIST_RECORDS = 4096
+MAX_LIST_BYTES = 3 * 1024 * 1024
+READ_DEADLINE_SECONDS = 120
+REFRESH_AGE_DEADLINE_SECONDS = 10
+CANCEL_GRACE_SECONDS = 5
+
+PACKAGEKIT_NAME = "org.freedesktop.PackageKit"
+PACKAGEKIT_PATH = "/org/freedesktop/PackageKit"
+PACKAGEKIT_INTERFACE = "org.freedesktop.PackageKit"
+TRANSACTION_INTERFACE = "org.freedesktop.PackageKit.Transaction"
+PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
+
+ROLE_REFRESH_CACHE = 13
+EXIT_SUCCESS = 1
+G_MAXUINT = (1 << 32) - 1
+
+UPDATE_INFO = {
+    0: ("unknown", "installable"),
+    2: ("unknown", "installable"),
+    3: ("low", "installable"),
+    4: ("enhancement", "installable"),
+    5: ("normal", "installable"),
+    6: ("bugfix", "installable"),
+    7: ("important", "installable"),
+    8: ("security", "installable"),
+    9: ("unknown", "blocked"),
+    26: ("critical", "installable"),
+}
+PLAN_INFO = {
+    # The protocol accepts transaction-result classifications only. PackageKit
+    # intent enums INSTALL/REMOVE/OBSOLETE/DOWNGRADE (27-30) stay rejected.
+    11: "update",
+    12: "install",
+    13: "remove",
+    15: "obsolete",
+    19: "reinstall",
+    20: "downgrade",
+}
+RESTART_INFO = {
+    1: (0, False, "none"),
+    2: (1, False, "application"),
+    3: (2, False, "session"),
+    4: (3, False, "system"),
+    5: (2, True, "security-session"),
+    6: (3, True, "security-system"),
+}
+
+
+class SnapshotFailure(Exception):
+    """A normalized provider failure safe to expose in the protocol."""
+
+    def __init__(self, code: str, detail: str, status: str = "partial") -> None:
+        super().__init__(detail)
+        self.code = code
+        self.detail = clean_text(detail)
+        self.status = status
+
+
+@dataclass(frozen=True)
+class Package:
+    info: int
+    package_id: str
+    summary: str
+
+
+@dataclass(frozen=True)
+class TransactionResult:
+    packages: tuple[Package, ...]
+    restart_types: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
+class UpdateRow:
+    package_id: str
+    severity: str
+    installability: str
+    name: str
+    version: str
+    summary: str
+
+    def fields(self) -> tuple[str, ...]:
+        return (
+            "update",
+            self.package_id,
+            self.severity,
+            self.installability,
+            self.name,
+            self.version,
+            self.summary,
+        )
+
+
+@dataclass(frozen=True)
+class PlanRow:
+    package_id: str
+    action: str
+    name: str
+    version: str
+    summary: str
+
+    def fields(self) -> tuple[str, ...]:
+        return (
+            "package-change",
+            self.package_id,
+            self.action,
+            self.name,
+            self.version,
+            self.summary,
+        )
+
+    def generation_fields(self) -> tuple[str, ...]:
+        return (self.action, self.package_id, self.name, self.version, self.summary)
+
+
+class UpdateBackend(Protocol):
+    def last_refresh_age(self) -> int:
+        """Return PackageKit's seconds-since-refresh value."""
+
+    def updates(self) -> TransactionResult:
+        """Return the complete bounded GetUpdates result."""
+
+    def simulate(self, package_ids: Sequence[str]) -> TransactionResult:
+        """Return the complete bounded SIMULATE|ONLY_TRUSTED plan."""
+
+
+def clean_text(value: object, *, truncate: bool = True) -> str:
+    text = str(value).replace("\t", " ").replace("\r", " ").replace("\n", " ")
+    encoded = text.encode("utf-8", "replace")
+    if len(encoded) <= MAX_TEXT_BYTES:
+        return text
+    if not truncate:
+        raise SnapshotFailure("malformed", "PackageKit returned an oversized identity")
+    encoded = encoded[:MAX_TEXT_BYTES]
+    while True:
+        try:
+            return encoded.decode("utf-8")
+        except UnicodeDecodeError:
+            encoded = encoded[:-1]
+
+
+def canonical_identity(value: object) -> str:
+    text = str(value)
+    if clean_text(text, truncate=False) != text:
+        raise SnapshotFailure("malformed", "PackageKit returned an unsafe identity")
+    if not text:
+        raise SnapshotFailure(
+            "malformed", "PackageKit returned an empty package identity"
+        )
+    return text
+
+
+def package_display_fields(package_id: str) -> tuple[str, str]:
+    parts = package_id.split(";", 3)
+    if len(parts) != 4 or not parts[0] or not parts[1]:
+        raise SnapshotFailure(
+            "malformed", "PackageKit returned a malformed package identity"
+        )
+    return clean_text(parts[0]), clean_text(parts[1])
+
+
+def encoded_record_size(fields: Iterable[str]) -> int:
+    return len(("\t".join(fields) + "\n").encode("utf-8"))
+
+
+def enforce_list_budget(rows: Sequence[UpdateRow] | Sequence[PlanRow]) -> None:
+    if len(rows) > MAX_LIST_RECORDS:
+        raise SnapshotFailure(
+            "malformed", "PackageKit returned too many package records"
+        )
+    if sum(encoded_record_size(row.fields()) for row in rows) > MAX_LIST_BYTES:
+        raise SnapshotFailure(
+            "malformed", "PackageKit package records exceeded the protocol budget"
+        )
+
+
+def normalize_updates(packages: Sequence[Package]) -> list[UpdateRow]:
+    rows: list[UpdateRow] = []
+    seen: set[str] = set()
+    for package in packages:
+        package_id = canonical_identity(package.package_id)
+        if package_id in seen:
+            raise SnapshotFailure(
+                "malformed", "PackageKit returned a duplicate update identity"
+            )
+        seen.add(package_id)
+        try:
+            severity, installability = UPDATE_INFO[int(package.info)]
+        except (KeyError, TypeError, ValueError) as error:
+            raise SnapshotFailure(
+                "malformed", "PackageKit returned an unsupported update classification"
+            ) from error
+        name, version = package_display_fields(package_id)
+        rows.append(
+            UpdateRow(
+                package_id,
+                severity,
+                installability,
+                name,
+                version,
+                clean_text(package.summary),
+            )
+        )
+    rows.sort(key=lambda row: row.package_id.encode("utf-8"))
+    enforce_list_budget(rows)
+    return rows
+
+
+def normalize_plan(
+    packages: Sequence[Package], requested_ids: Sequence[str]
+) -> list[PlanRow]:
+    rows: list[PlanRow] = []
+    seen: set[str] = set()
+    for package in packages:
+        package_id = canonical_identity(package.package_id)
+        if package_id in seen:
+            raise SnapshotFailure(
+                "malformed", "PackageKit returned a duplicate plan identity"
+            )
+        seen.add(package_id)
+        try:
+            action = PLAN_INFO[int(package.info)]
+        except (KeyError, TypeError, ValueError) as error:
+            raise SnapshotFailure(
+                "malformed", "PackageKit returned an unsupported plan classification"
+            ) from error
+        name, version = package_display_fields(package_id)
+        rows.append(
+            PlanRow(package_id, action, name, version, clean_text(package.summary))
+        )
+
+    requested = set(requested_ids)
+    represented = {row.package_id for row in rows if row.action == "update"}
+    if requested != represented or any(
+        row.package_id in requested and row.action != "update" for row in rows
+    ):
+        raise SnapshotFailure(
+            "malformed", "PackageKit returned an incomplete update plan"
+        )
+    rows.sort(
+        key=lambda row: tuple(
+            field.encode("utf-8") for field in row.generation_fields()
+        )
+    )
+    enforce_list_budget(rows)
+    return rows
+
+
+def aggregate_restart(restart_types: Sequence[int]) -> str:
+    scope = 0
+    security = False
+    for value in restart_types:
+        try:
+            item_scope, item_security, _label = RESTART_INFO[int(value)]
+        except (KeyError, TypeError, ValueError) as error:
+            raise SnapshotFailure(
+                "malformed", "PackageKit returned an unsupported restart requirement"
+            ) from error
+        scope = max(scope, item_scope)
+        security = security or item_security
+    if security and scope >= 3:
+        return "security-system"
+    if security and scope >= 2:
+        return "security-session"
+    return {0: "none", 1: "application", 2: "session", 3: "system"}[scope]
+
+
+def snapshot_generation(update_ids: Sequence[str], plan: Sequence[PlanRow]) -> str:
+    digest = hashlib.sha256(b"dwm-titus-update-plan-v1")
+    for package_id in sorted(update_ids, key=lambda value: value.encode("utf-8")):
+        encoded = package_id.encode("utf-8")
+        digest.update(b"U")
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+    for row in sorted(
+        plan,
+        key=lambda value: tuple(
+            field.encode("utf-8") for field in value.generation_fields()
+        ),
+    ):
+        digest.update(b"P")
+        for field in row.generation_fields():
+            encoded = field.encode("utf-8")
+            digest.update(len(encoded).to_bytes(8, "big"))
+            digest.update(encoded)
+    return digest.hexdigest()
+
+
+def build_snapshot(backend: UpdateBackend) -> list[str]:
+    errors: list[tuple[str, str]] = []
+    last_refresh_status = "unavailable"
+    last_refresh_value = "unknown"
+    last_refresh_detail = "PackageKit refresh history is unavailable"
+    try:
+        refresh_age = backend.last_refresh_age()
+        if refresh_age == G_MAXUINT:
+            last_refresh_status = "partial"
+            last_refresh_detail = "PackageKit has no successful refresh history"
+        elif isinstance(refresh_age, int) and 0 <= refresh_age < G_MAXUINT:
+            last_refresh_status = "available"
+            last_refresh_value = str(refresh_age)
+            last_refresh_detail = "Seconds since PackageKit last refreshed metadata"
+        else:
+            raise SnapshotFailure(
+                "malformed", "PackageKit returned a malformed refresh age"
+            )
+    except SnapshotFailure as failure:
+        last_refresh_status = failure.status
+        last_refresh_detail = failure.detail
+        errors.append((failure.code, failure.detail))
+
+    update_rows: list[UpdateRow] = []
+    plan_rows: list[PlanRow] = []
+    summary_status = "unavailable"
+    restart_status = "unavailable"
+    restart_value = "unknown"
+    summary_detail = "PackageKit update discovery is unavailable"
+    restart_detail = "PackageKit restart guidance is unavailable"
+    inventory_ok = False
+    try:
+        result = backend.updates()
+    except SnapshotFailure as failure:
+        summary_status = failure.status
+        restart_status = failure.status
+        summary_detail = failure.detail
+        restart_detail = failure.detail
+        errors.append((failure.code, failure.detail))
+    else:
+        try:
+            update_rows = normalize_updates(result.packages)
+            summary_status = "available"
+            summary_detail = "PackageKit update discovery completed"
+            inventory_ok = True
+        except SnapshotFailure as failure:
+            summary_status = failure.status
+            summary_detail = failure.detail
+            errors.append((failure.code, failure.detail))
+        try:
+            restart_value = aggregate_restart(result.restart_types)
+            restart_status = "available"
+            restart_detail = "PackageKit restart guidance from update discovery"
+        except SnapshotFailure as failure:
+            restart_status = failure.status
+            restart_detail = failure.detail
+            errors.append((failure.code, failure.detail))
+
+    installable_ids = [
+        row.package_id for row in update_rows if row.installability == "installable"
+    ]
+    plan_detail = (
+        "No installable updates require a dependency preview"
+        if inventory_ok
+        else "PackageKit dependency preview is unavailable"
+    )
+    if inventory_ok and installable_ids:
+        try:
+            plan_rows = normalize_plan(
+                backend.simulate(installable_ids).packages, installable_ids
+            )
+            plan_detail = "PackageKit dependency preview completed"
+        except SnapshotFailure as failure:
+            plan_detail = failure.detail
+            errors.append((failure.code, failure.detail))
+
+    generation = snapshot_generation(installable_ids, plan_rows)
+    provider_status = "partial" if inventory_ok else summary_status
+    if provider_status not in {"partial", "restricted", "unavailable", "unsupported"}:
+        provider_status = "partial"
+
+    lines = [
+        f"system-management-protocol\t{PROTOCOL_MAJOR}\t{PROTOCOL_MINOR}",
+        f"snapshot-generation\t{generation}",
+        "\t".join(
+            (
+                "provider",
+                "updates",
+                provider_status,
+                "delegated",
+                "PackageKit",
+                clean_text(
+                    "Read-only update discovery is available; managed update operations "
+                    "are not enabled in this build"
+                    if inventory_ok
+                    else summary_detail
+                ),
+            )
+        ),
+        "provider\trecovery\tunsupported\tuser-session\tdwm-system-management\t"
+        "Managed update recovery is not enabled in this build",
+        "\t".join(
+            (
+                "state",
+                "update-summary",
+                summary_status,
+                str(len(update_rows)) if summary_status == "available" else "unknown",
+                clean_text(summary_detail),
+            )
+        ),
+        "\t".join(
+            (
+                "state",
+                "update-last-refresh",
+                last_refresh_status,
+                last_refresh_value,
+                clean_text(last_refresh_detail),
+            )
+        ),
+        "\t".join(
+            (
+                "state",
+                "update-restart",
+                restart_status,
+                restart_value if restart_status == "available" else "unknown",
+                clean_text(restart_detail),
+            )
+        ),
+        "action\tupdates-refresh\tunavailable\tdelegated\tupdates\tRefresh updates\t"
+        "Managed update operations are not enabled in this build",
+        "\t".join(
+            (
+                "action",
+                "updates-install-all",
+                "unavailable",
+                "delegated",
+                "updates",
+                "Install all updates",
+                clean_text(f"Managed update operations are not enabled; {plan_detail}"),
+            )
+        ),
+        "action\tupdates-cancel\tunavailable\tdelegated\tupdates\tCancel update\t"
+        "No managed update operation is active",
+    ]
+    lines.extend("\t".join(row.fields()) for row in update_rows)
+    lines.extend("\t".join(row.fields()) for row in plan_rows)
+    lines.extend(
+        f"error\tupdates\t{code}\t{clean_text(detail)}" for code, detail in errors
+    )
+    lines.append("complete\tsnapshot")
+    return lines
+
+
+class PackageKitBackend:
+    """Small direct D-Bus client with transaction-wide monotonic deadlines."""
+
+    def __init__(self) -> None:
+        try:
+            import gi
+
+            gi.require_version("Gio", "2.0")
+            gi.require_version("PackageKitGlib", "1.0")
+            from gi.repository import Gio, GLib, PackageKitGlib
+        except (ImportError, ValueError) as error:
+            raise SnapshotFailure(
+                "missing-provider",
+                "System Python GObject bindings are unavailable",
+                "unavailable",
+            ) from error
+        self.Gio = Gio
+        self.GLib = GLib
+        # PackageKit's D-Bus arguments are bitfields, not raw enum values. Let
+        # the installed API perform the stable enum-to-bitfield conversion.
+        self.filter_none = PackageKitGlib.filter_bitfield_from_string("none")
+        self.flags_simulate_only_trusted = (
+            PackageKitGlib.transaction_flag_bitfield_from_string(
+                "simulate;only-trusted"
+            )
+        )
+        try:
+            self.connection = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+        except GLib.Error as error:
+            raise self._dbus_failure(error) from error
+
+    def _timeout_ms(self, deadline: float) -> int:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise SnapshotFailure(
+                "timeout", "PackageKit request timed out", "unavailable"
+            )
+        return max(1, min(int(remaining * 1000), 2_147_483_647))
+
+    def _call(
+        self,
+        path: str,
+        interface: str,
+        method: str,
+        parameters: object,
+        deadline: float,
+    ) -> object:
+        try:
+            return self.connection.call_sync(
+                PACKAGEKIT_NAME,
+                path,
+                interface,
+                method,
+                parameters,
+                None,
+                self.Gio.DBusCallFlags.NONE,
+                self._timeout_ms(deadline),
+                None,
+            )
+        except self.GLib.Error as error:
+            if time.monotonic() >= deadline:
+                raise SnapshotFailure(
+                    "timeout", "PackageKit request timed out", "unavailable"
+                ) from error
+            raise self._dbus_failure(error) from error
+
+    def _dbus_failure(self, error: Exception) -> SnapshotFailure:
+        message = str(error)
+        lowered = message.lower()
+        if "serviceunknown" in lowered or "namehasnoowner" in lowered:
+            return SnapshotFailure(
+                "missing-provider", "PackageKit service is unavailable", "unavailable"
+            )
+        if "notauthorized" in lowered or "accessdenied" in lowered:
+            return SnapshotFailure(
+                "permission-denied",
+                "PackageKit denied the read-only request",
+                "restricted",
+            )
+        if "unknownmethod" in lowered:
+            return SnapshotFailure(
+                "unsupported",
+                "PackageKit does not support the required method",
+                "unsupported",
+            )
+        if "timedout" in lowered or "timeout" in lowered:
+            return SnapshotFailure(
+                "timeout", "PackageKit request timed out", "unavailable"
+            )
+        return SnapshotFailure(
+            "internal", "PackageKit D-Bus request failed", "unavailable"
+        )
+
+    def last_refresh_age(self) -> int:
+        deadline = time.monotonic() + REFRESH_AGE_DEADLINE_SECONDS
+        reply = self._call(
+            PACKAGEKIT_PATH,
+            PACKAGEKIT_INTERFACE,
+            "GetTimeSinceAction",
+            self.GLib.Variant("(u)", (ROLE_REFRESH_CACHE,)),
+            deadline,
+        )
+        values = reply.unpack()
+        if len(values) != 1 or not isinstance(values[0], int):
+            raise SnapshotFailure(
+                "malformed", "PackageKit returned a malformed refresh age"
+            )
+        return values[0]
+
+    def updates(self) -> TransactionResult:
+        return self._transaction(
+            "GetUpdates", self.GLib.Variant("(t)", (self.filter_none,))
+        )
+
+    def simulate(self, package_ids: Sequence[str]) -> TransactionResult:
+        return self._transaction(
+            "UpdatePackages",
+            self.GLib.Variant(
+                "(tas)",
+                (self.flags_simulate_only_trusted, list(package_ids)),
+            ),
+        )
+
+    def _transaction(self, method: str, parameters: object) -> TransactionResult:
+        deadline = time.monotonic() + READ_DEADLINE_SECONDS
+        created = self._call(
+            PACKAGEKIT_PATH,
+            PACKAGEKIT_INTERFACE,
+            "CreateTransaction",
+            None,
+            deadline,
+        ).unpack()
+        if (
+            len(created) != 1
+            or not isinstance(created[0], str)
+            or not created[0].startswith("/")
+        ):
+            raise SnapshotFailure(
+                "malformed", "PackageKit returned a malformed transaction path"
+            )
+        path = created[0]
+        packages: list[Package] = []
+        restart_types: list[int] = []
+        error_code: tuple[int, str] | None = None
+        finished_exit: int | None = None
+        collection_failure: SnapshotFailure | None = None
+        loop = self.GLib.MainLoop()
+
+        def signal_received(
+            _connection: object,
+            _sender: str,
+            _path: str,
+            _interface: str,
+            signal: str,
+            values: object,
+            _data: object,
+        ) -> None:
+            nonlocal collection_failure, error_code, finished_exit
+            try:
+                unpacked = values.unpack()
+                if collection_failure is not None and signal != "Finished":
+                    return
+                if signal == "Package":
+                    if len(unpacked) != 3:
+                        raise ValueError
+                    packages.append(Package(int(unpacked[0]), unpacked[1], unpacked[2]))
+                elif signal == "Packages":
+                    if len(unpacked) != 1:
+                        raise ValueError
+                    for item in unpacked[0]:
+                        if len(item) != 3:
+                            raise ValueError
+                        info, package_id, summary = item
+                        packages.append(Package(int(info), package_id, summary))
+                elif signal == "RequireRestart":
+                    if len(unpacked) != 2:
+                        raise ValueError
+                    restart_types.append(int(unpacked[0]))
+                elif signal == "ErrorCode":
+                    if len(unpacked) != 2:
+                        raise ValueError
+                    error_code = (int(unpacked[0]), clean_text(unpacked[1]))
+                elif signal == "Finished":
+                    if len(unpacked) != 2:
+                        raise ValueError
+                    finished_exit = int(unpacked[0])
+                    loop.quit()
+            except (TypeError, ValueError):
+                if collection_failure is None:
+                    collection_failure = SnapshotFailure(
+                        "malformed", "PackageKit sent a malformed transaction signal"
+                    )
+                loop.quit()
+                return
+            if len(packages) > MAX_LIST_RECORDS and collection_failure is None:
+                collection_failure = SnapshotFailure(
+                    "malformed", "PackageKit returned too many package records"
+                )
+                loop.quit()
+
+        subscription = self.connection.signal_subscribe(
+            PACKAGEKIT_NAME,
+            TRANSACTION_INTERFACE,
+            None,
+            path,
+            None,
+            self.Gio.DBusSignalFlags.NONE,
+            signal_received,
+            None,
+        )
+        timeout_source = 0
+        try:
+            try:
+                self._call(
+                    path,
+                    TRANSACTION_INTERFACE,
+                    "SetHints",
+                    self.GLib.Variant(
+                        "(as)",
+                        (
+                            [
+                                "background=true",
+                                "interactive=false",
+                                "cache-age=4294967295",
+                            ],
+                        ),
+                    ),
+                    deadline,
+                )
+                self._call(path, TRANSACTION_INTERFACE, method, parameters, deadline)
+            except SnapshotFailure as failure:
+                if failure.code == "timeout":
+                    self._cancel_with_grace(
+                        path, loop, lambda: finished_exit is not None
+                    )
+                raise
+
+            def timed_out() -> bool:
+                nonlocal timeout_source
+                timeout_source = 0
+                loop.quit()
+                return self.GLib.SOURCE_REMOVE
+
+            if collection_failure is None and finished_exit is None:
+                try:
+                    wait_ms = self._timeout_ms(deadline)
+                except SnapshotFailure:
+                    self._cancel_with_grace(
+                        path, loop, lambda: finished_exit is not None
+                    )
+                    raise
+                timeout_source = self.GLib.timeout_add(wait_ms, timed_out)
+                loop.run()
+            if collection_failure is not None:
+                self._cancel_with_grace(path, loop, lambda: finished_exit is not None)
+                raise collection_failure
+            if finished_exit is None:
+                self._cancel_with_grace(path, loop, lambda: finished_exit is not None)
+                raise SnapshotFailure("timeout", "PackageKit transaction timed out")
+        finally:
+            if timeout_source:
+                self.GLib.source_remove(timeout_source)
+            self.connection.signal_unsubscribe(subscription)
+
+        if error_code is not None:
+            raise self._transaction_failure(*error_code)
+        if finished_exit != EXIT_SUCCESS:
+            raise SnapshotFailure("internal", "PackageKit transaction did not succeed")
+        return TransactionResult(tuple(packages), tuple(restart_types))
+
+    def _cancel_with_grace(self, path: str, loop: object, finished: object) -> None:
+        grace_deadline = time.monotonic() + CANCEL_GRACE_SECONDS
+        allow_cancel = False
+        try:
+            reply = self._call(
+                path,
+                PROPERTIES_INTERFACE,
+                "Get",
+                self.GLib.Variant("(ss)", (TRANSACTION_INTERFACE, "AllowCancel")),
+                grace_deadline,
+            ).unpack()
+            allow_cancel = (
+                reply[0] if len(reply) == 1 and isinstance(reply[0], bool) else False
+            )
+            if allow_cancel:
+                self._call(path, TRANSACTION_INTERFACE, "Cancel", None, grace_deadline)
+        except SnapshotFailure:
+            pass
+        if finished():
+            return
+
+        def grace_expired() -> bool:
+            nonlocal source
+            source = 0
+            loop.quit()
+            return self.GLib.SOURCE_REMOVE
+
+        try:
+            grace_ms = self._timeout_ms(grace_deadline)
+        except SnapshotFailure:
+            return
+        source = self.GLib.timeout_add(grace_ms, grace_expired)
+        try:
+            loop.run()
+        finally:
+            if source:
+                self.GLib.source_remove(source)
+
+    def _transaction_failure(self, code: int, _detail: str) -> SnapshotFailure:
+        if code == 2:
+            return SnapshotFailure("network", "PackageKit could not reach the network")
+        if code in {18, 19, 28, 33, 37, 43, 64}:
+            return SnapshotFailure("repository", "PackageKit repository access failed")
+        if code in {13, 26, 35, 36, 61}:
+            return SnapshotFailure("conflict", "PackageKit reported a package conflict")
+        if code in {5, 30, 31, 50, 51}:
+            return SnapshotFailure(
+                "signature", "PackageKit rejected package trust data"
+            )
+        if code == 48:
+            return SnapshotFailure(
+                "permission-denied", "PackageKit denied the transaction", "restricted"
+            )
+        if code == 3:
+            return SnapshotFailure(
+                "unsupported",
+                "PackageKit does not support the transaction",
+                "unsupported",
+            )
+        if code in {17, 65}:
+            return SnapshotFailure("canceled", "PackageKit transaction was canceled")
+        if code in {6, 14}:
+            return SnapshotFailure(
+                "malformed", "PackageKit rejected the transaction input"
+            )
+        return SnapshotFailure("package", "PackageKit package processing failed")
+
+
+def usage() -> int:
+    print(f"usage: {sys.argv[0]} snapshot", file=sys.stderr)
+    return 2
+
+
+def main(argv: Sequence[str]) -> int:
+    if list(argv) != ["snapshot"]:
+        return usage()
+    try:
+        backend = PackageKitBackend()
+        lines = build_snapshot(backend)
+    except SnapshotFailure as failure:
+        # Backend construction can fail before a usable source exists. Reuse the
+        # normal snapshot shape so consumers still receive every mandatory ID.
+        class FailedBackend:
+            def __init__(self, backend_failure: SnapshotFailure) -> None:
+                self.failure = backend_failure
+
+            def last_refresh_age(self) -> int:
+                raise self.failure
+
+            def updates(self) -> TransactionResult:
+                raise self.failure
+
+            def simulate(self, _package_ids: Sequence[str]) -> TransactionResult:
+                raise self.failure
+
+        lines = build_snapshot(FailedBackend(failure))
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -371,7 +371,14 @@ def build_snapshot(backend: UpdateBackend) -> list[str]:
             plan_rows = normalize_plan(
                 backend.simulate(installable_ids).packages, installable_ids
             )
-            plan_detail = "PackageKit dependency preview completed"
+            if any(row.action in {"reinstall", "downgrade"} for row in plan_rows):
+                plan_detail = (
+                    "PackageKit dependency preview requires unsupported reinstall "
+                    "or downgrade flags"
+                )
+                errors.append(("unsupported", plan_detail))
+            else:
+                plan_detail = "PackageKit dependency preview completed"
         except SnapshotFailure as failure:
             plan_detail = failure.detail
             errors.append((failure.code, failure.detail))
@@ -766,7 +773,7 @@ class PackageKitBackend:
             return SnapshotFailure("network", "PackageKit could not reach the network")
         if code in {18, 19, 28, 33, 37, 43, 64}:
             return SnapshotFailure("repository", "PackageKit repository access failed")
-        if code in {13, 26, 35, 36, 61}:
+        if code in {13, 26, 35, 36, 61, 67}:
             return SnapshotFailure("conflict", "PackageKit reported a package conflict")
         if code in {5, 30, 31, 50, 51}:
             return SnapshotFailure(
@@ -788,7 +795,32 @@ class PackageKitBackend:
             return SnapshotFailure(
                 "malformed", "PackageKit rejected the transaction input"
             )
-        return SnapshotFailure("package", "PackageKit package processing failed")
+        if code in {
+            7,
+            8,
+            9,
+            10,
+            20,
+            27,
+            29,
+            32,
+            38,
+            39,
+            40,
+            41,
+            42,
+            45,
+            46,
+            49,
+            55,
+            56,
+            57,
+            58,
+            59,
+            60,
+        }:
+            return SnapshotFailure("package", "PackageKit package processing failed")
+        return SnapshotFailure("internal", "PackageKit transaction failed internally")
 
 
 def usage() -> int:

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -262,6 +262,41 @@ class SnapshotTests(unittest.TestCase):
                         (package(info, package_id, "Intent enum"),), (package_id,)
                     )
 
+    def test_reinstall_and_downgrade_plan_remains_visible_but_unsupported(self):
+        update = package(8, "openssl;4.0;x86_64;updates", "TLS library")
+        for extra_info, extra_id in (
+            (19, "openssl;4.0;x86_64;installed"),
+            (20, "compat-lib;1.0;x86_64;updates"),
+        ):
+            with self.subTest(extra_info=extra_info):
+                backend = FixtureBackend(
+                    updates=(update,),
+                    plan=(
+                        package(11, update.package_id, "TLS library"),
+                        package(extra_info, extra_id, "Unsupported change"),
+                    ),
+                )
+
+                output = provider.build_snapshot(backend)
+
+                self.assertEqual(
+                    {row[1] for row in rows(output, "package-change")},
+                    {update.package_id, extra_id},
+                )
+                self.assertIn("unsupported", [row[2] for row in rows(output, "error")])
+                install_action = next(
+                    row
+                    for row in rows(output, "action")
+                    if row[1] == "updates-install-all"
+                )
+                self.assertIn("unsupported reinstall or downgrade", install_action[-1])
+
+    def test_unlisted_packagekit_errors_fall_back_to_internal(self):
+        backend = object.__new__(provider.PackageKitBackend)
+
+        self.assertEqual(backend._transaction_failure(10, "download").code, "package")
+        self.assertEqual(backend._transaction_failure(4, "internal").code, "internal")
+
     def test_blocked_updates_are_not_simulated(self):
         backend = FixtureBackend(
             updates=(package(9, "held;2.0;x86_64;updates", "Blocked"),)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -1,0 +1,319 @@
+#!/usr/bin/python3
+"""Contract tests for the Phase 6 system-management snapshot."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import importlib.machinery
+import pathlib
+import sys
+import unittest
+
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+PROVIDER_PATH = REPO / "scripts" / "dwm-system-management"
+sys.dont_write_bytecode = True
+SPEC = importlib.util.spec_from_loader(
+    "dwm_system_management",
+    importlib.machinery.SourceFileLoader("dwm_system_management", str(PROVIDER_PATH)),
+)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("cannot load dwm-system-management")
+provider = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = provider
+SPEC.loader.exec_module(provider)
+
+
+class FixtureBackend:
+    def __init__(
+        self,
+        *,
+        refresh_age=42,
+        updates=(),
+        restart_types=(),
+        plan=(),
+        refresh_failure=None,
+        updates_failure=None,
+        plan_failure=None,
+    ):
+        self.refresh_age = refresh_age
+        self.update_records = tuple(updates)
+        self.restart_types = tuple(restart_types)
+        self.plan_records = tuple(plan)
+        self.refresh_failure = refresh_failure
+        self.updates_failure = updates_failure
+        self.plan_failure = plan_failure
+        self.simulated_ids = None
+
+    def last_refresh_age(self):
+        if self.refresh_failure:
+            raise self.refresh_failure
+        return self.refresh_age
+
+    def updates(self):
+        if self.updates_failure:
+            raise self.updates_failure
+        return provider.TransactionResult(self.update_records, self.restart_types)
+
+    def simulate(self, package_ids):
+        self.simulated_ids = tuple(package_ids)
+        if self.plan_failure:
+            raise self.plan_failure
+        return provider.TransactionResult(self.plan_records)
+
+
+def package(info, package_id, summary):
+    return provider.Package(info, package_id, summary)
+
+
+def rows(lines, kind):
+    return [line.split("\t") for line in lines if line.startswith(f"{kind}\t")]
+
+
+class SnapshotTests(unittest.TestCase):
+    def test_complete_read_only_snapshot(self):
+        backend = FixtureBackend(
+            updates=(
+                package(26, "kernel;6.18.1;x86_64;updates", "Critical kernel"),
+                package(9, "held;2.0;x86_64;updates", "Blocked update"),
+                package(2, "bash;5.3;x86_64;updates", "Shell\tupdate\nsummary"),
+            ),
+            restart_types=(2, 5, 4),
+            plan=(
+                package(11, "kernel;6.18.1;x86_64;updates", "Critical kernel"),
+                package(11, "bash;5.3;x86_64;updates", "Shell update"),
+                package(12, "dependency;1.0;x86_64;updates", "New dependency"),
+                package(15, "old-dependency;0.9;x86_64;installed", "Old dependency"),
+            ),
+        )
+
+        output = provider.build_snapshot(backend)
+
+        self.assertEqual(output[0], "system-management-protocol\t1\t0")
+        self.assertEqual(output[-1], "complete\tsnapshot")
+        self.assertEqual(len(rows(output, "provider")), 2)
+        self.assertEqual(len(rows(output, "state")), 3)
+        self.assertEqual(len(rows(output, "action")), 3)
+        self.assertEqual(len(rows(output, "update")), 3)
+        self.assertEqual(len(rows(output, "package-change")), 4)
+        self.assertEqual(rows(output, "error"), [])
+        self.assertEqual(
+            backend.simulated_ids,
+            ("bash;5.3;x86_64;updates", "kernel;6.18.1;x86_64;updates"),
+        )
+        self.assertIn(
+            [
+                "state",
+                "update-summary",
+                "available",
+                "3",
+                "PackageKit update discovery completed",
+            ],
+            rows(output, "state"),
+        )
+        self.assertIn(
+            [
+                "state",
+                "update-restart",
+                "available",
+                "security-system",
+                "PackageKit restart guidance from update discovery",
+            ],
+            rows(output, "state"),
+        )
+        bash_row = next(
+            row for row in rows(output, "update") if row[1].startswith("bash;")
+        )
+        self.assertEqual(bash_row[2:4], ["unknown", "installable"])
+        self.assertEqual(bash_row[-1], "Shell update summary")
+        self.assertEqual(
+            output[1],
+            "snapshot-generation\t"
+            "0626a3347e1e76f4394deb0948b444a89b9ec8875696a1735c893b0db7258bac",
+        )
+
+    def test_empty_snapshot_has_stable_generation_and_skips_simulation(self):
+        backend = FixtureBackend()
+        output = provider.build_snapshot(backend)
+
+        expected = hashlib.sha256(b"dwm-titus-update-plan-v1").hexdigest()
+        self.assertEqual(output[1], f"snapshot-generation\t{expected}")
+        self.assertEqual(backend.simulated_ids, None)
+        self.assertIn(
+            [
+                "state",
+                "update-summary",
+                "available",
+                "0",
+                "PackageKit update discovery completed",
+            ],
+            rows(output, "state"),
+        )
+
+    def test_generation_changes_with_dependency_preview(self):
+        update = package(8, "openssl;4.0;x86_64;updates", "TLS library")
+        first = FixtureBackend(
+            updates=(update,), plan=(package(11, update.package_id, "TLS library"),)
+        )
+        second = FixtureBackend(
+            updates=(update,),
+            plan=(
+                package(11, update.package_id, "TLS library"),
+                package(12, "crypto-policy;2;x86_64;updates", "Policy data"),
+            ),
+        )
+
+        first_generation = provider.build_snapshot(first)[1]
+        second_generation = provider.build_snapshot(second)[1]
+
+        self.assertNotEqual(first_generation, second_generation)
+
+    def test_no_refresh_history_is_explicit_without_an_error(self):
+        output = provider.build_snapshot(FixtureBackend(refresh_age=provider.G_MAXUINT))
+
+        self.assertIn(
+            [
+                "state",
+                "update-last-refresh",
+                "partial",
+                "unknown",
+                "PackageKit has no successful refresh history",
+            ],
+            rows(output, "state"),
+        )
+        self.assertEqual(rows(output, "error"), [])
+
+    def test_source_failures_preserve_the_complete_protocol_shape(self):
+        backend = FixtureBackend(
+            refresh_failure=provider.SnapshotFailure(
+                "timeout", "PackageKit refresh history timed out", "unavailable"
+            ),
+            updates_failure=provider.SnapshotFailure(
+                "missing-provider", "PackageKit service is unavailable", "unavailable"
+            ),
+        )
+
+        output = provider.build_snapshot(backend)
+
+        self.assertEqual(output[-1], "complete\tsnapshot")
+        self.assertEqual(len(rows(output, "provider")), 2)
+        self.assertEqual(len(rows(output, "state")), 3)
+        self.assertEqual(len(rows(output, "action")), 3)
+        self.assertEqual(rows(output, "update"), [])
+        self.assertEqual(rows(output, "package-change"), [])
+        self.assertEqual(
+            [row[2] for row in rows(output, "error")],
+            ["timeout", "missing-provider"],
+        )
+        install_action = next(
+            row for row in rows(output, "action") if row[1] == "updates-install-all"
+        )
+        self.assertIn("dependency preview is unavailable", install_action[-1])
+
+    def test_invalid_update_classification_discards_the_inventory(self):
+        backend = FixtureBackend(
+            updates=(package(999, "bad;1;x86_64;updates", "Invalid"),)
+        )
+
+        output = provider.build_snapshot(backend)
+
+        self.assertEqual(rows(output, "update"), [])
+        self.assertIn(
+            [
+                "state",
+                "update-summary",
+                "partial",
+                "unknown",
+                "PackageKit returned an unsupported update classification",
+            ],
+            rows(output, "state"),
+        )
+        self.assertEqual(rows(output, "error")[0][2], "malformed")
+
+    def test_duplicate_plan_preserves_readable_updates(self):
+        update = package(8, "openssl;4.0;x86_64;updates", "TLS library")
+        backend = FixtureBackend(
+            updates=(update,),
+            plan=(
+                package(11, update.package_id, "TLS library"),
+                package(11, update.package_id, "Duplicate"),
+            ),
+        )
+
+        output = provider.build_snapshot(backend)
+
+        self.assertEqual(len(rows(output, "update")), 1)
+        self.assertEqual(rows(output, "package-change"), [])
+        self.assertEqual(rows(output, "error")[0][2], "malformed")
+        install_action = next(
+            row for row in rows(output, "action") if row[1] == "updates-install-all"
+        )
+        self.assertIn("duplicate plan identity", install_action[-1])
+
+    def test_plan_rejects_packagekit_intent_enums(self):
+        package_id = "example;2;x86_64;updates"
+        for info in (27, 28, 29, 30):
+            with self.subTest(info=info):
+                with self.assertRaisesRegex(
+                    provider.SnapshotFailure, "unsupported plan classification"
+                ):
+                    provider.normalize_plan(
+                        (package(info, package_id, "Intent enum"),), (package_id,)
+                    )
+
+    def test_blocked_updates_are_not_simulated(self):
+        backend = FixtureBackend(
+            updates=(package(9, "held;2.0;x86_64;updates", "Blocked"),)
+        )
+
+        output = provider.build_snapshot(backend)
+
+        self.assertEqual(backend.simulated_ids, None)
+        self.assertEqual(rows(output, "update")[0][3], "blocked")
+
+    def test_unsafe_or_duplicate_identities_fail_closed(self):
+        cases = (
+            (package(8, "bad\tid;1;x86_64;updates", "Unsafe"),),
+            (
+                package(8, "same;1;x86_64;updates", "First"),
+                package(8, "same;1;x86_64;updates", "Second"),
+            ),
+        )
+        for records in cases:
+            with self.subTest(records=records):
+                output = provider.build_snapshot(FixtureBackend(updates=records))
+                self.assertEqual(rows(output, "update"), [])
+                self.assertEqual(rows(output, "error")[0][2], "malformed")
+
+    def test_restart_aggregation_rejects_unknown_values(self):
+        update = package(9, "held;2.0;x86_64;updates", "Blocked")
+        output = provider.build_snapshot(
+            FixtureBackend(updates=(update,), restart_types=(99,))
+        )
+
+        self.assertEqual(len(rows(output, "update")), 1)
+        summary = next(
+            row for row in rows(output, "state") if row[1] == "update-summary"
+        )
+        self.assertEqual(summary[2:4], ["available", "1"])
+        restart = next(
+            row for row in rows(output, "state") if row[1] == "update-restart"
+        )
+        self.assertEqual(restart[2:4], ["partial", "unknown"])
+        self.assertEqual(rows(output, "error")[0][2], "malformed")
+
+    def test_record_count_limit_discards_the_whole_inventory(self):
+        packages = tuple(
+            package(2, f"pkg-{number};1;x86_64;updates", "Update")
+            for number in range(provider.MAX_LIST_RECORDS + 1)
+        )
+
+        output = provider.build_snapshot(FixtureBackend(updates=packages))
+
+        self.assertEqual(rows(output, "update"), [])
+        self.assertEqual(rows(output, "error")[0][2], "malformed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the installable `dwm-system-management snapshot` provider for protocol 1.0
- read PackageKit update inventory, refresh age, restart guidance, and dependency preview through bounded direct D-Bus transactions
- validate and sanitize all records, enforce count/byte limits, and compute deterministic confirmation generations
- keep refresh, install, cancel, and recovery actions explicitly unavailable until their managed lifecycle lands in follow-up PRs
- add deterministic fixtures for success, degradation, malformed data, blocked packages, preview validation, restart aggregation, and protocol limits

## Validation

- `make check` (full managed repository suite)
- `make check-system-management check-dev-sync-install check-install-manifest`
- `/usr/bin/python3 tests/test-system-management.py` (12 tests)
- live Fedora 44 `scripts/dwm-system-management snapshot` against PackageKit 1.3.6
- `ruff check scripts/dwm-system-management tests/test-system-management.py`
- `ruff format --check scripts/dwm-system-management tests/test-system-management.py`
- `git diff --check`
- local CodeRabbit review: zero findings after fixes

## Scope boundary

This PR is read-only. It does not add Settings QML, mutable PackageKit transactions, operation journaling, cancellation commands, or recovery adoption. Those remain separate review boundaries.
