### PR TITLE
Phase 6: add read-only update status pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versions from `config.mk`.
 
 ### Changed
 
+- Show the Phase 6 Fedora update snapshot in a dedicated read-only System
+  Settings pane with provider state, update and plan details, diagnostics,
+  restart guidance, recovery ownership, and existing administration boundaries.
+  Update mutations remain unavailable until their confirmed operation workflow
+  is implemented.
+
 - Begin Phase 6 with a complete system-management capability and privilege
   inventory. Select PackageKit, systemd regional services, AccountsService,
   CUPS, and fixed Fedora tools as bounded owners; define provider, audit,

--- a/config/quickshell/settings/SettingsWindow.qml
+++ b/config/quickshell/settings/SettingsWindow.qml
@@ -20,6 +20,7 @@ FloatingWindow {
     required property var accessibilityModel
     required property var notificationModel
     required property var panelSettingsModel
+    required property var systemManagementModel
 
     title: "dwm settings"
     visible: settingsModel.visible
@@ -395,6 +396,14 @@ FloatingWindow {
                                     })
                             }
 
+                            SystemSettingsPane {
+                                Layout.fillWidth: true
+                                Layout.fillHeight: true
+                                visible: root.settingsModel.selectedSectionId === "system"
+                                systemManagementModel: root.systemManagementModel
+                                capabilities: root.settingsModel.capabilitiesForSection("system")
+                            }
+
                             ListView {
                                 id: capabilityList
 
@@ -408,6 +417,7 @@ FloatingWindow {
                                     && root.settingsModel.selectedSectionId !== "power"
                                     && root.settingsModel.selectedSectionId !== "defaults"
                                     && root.settingsModel.selectedSectionId !== "appearance"
+                                    && root.settingsModel.selectedSectionId !== "system"
                                 clip: true
                                 spacing: Theme.spacingSm
                                 model: root.settingsModel.capabilitiesForSection(root.settingsModel.selectedSectionId)

--- a/config/quickshell/settings/SystemSettingsPane.qml
+++ b/config/quickshell/settings/SystemSettingsPane.qml
@@ -1,0 +1,391 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.core
+
+pragma ComponentBehavior: Bound
+
+Flickable {
+    id: root
+
+    required property var systemManagementModel
+    required property var capabilities
+    contentWidth: width
+    contentHeight: content.implicitHeight
+    clip: true
+    boundsBehavior: Flickable.StopAtBounds
+    activeFocusOnTab: true
+
+    function scrollTo(position) {
+        root.contentY = Math.max(0, Math.min(position, Math.max(0, root.contentHeight - root.height)));
+    }
+
+    Keys.onPressed: event => {
+        const lineStep = Math.max(Theme.spacingXl, 40);
+        const pageStep = Math.max(lineStep, root.height - Theme.spacingXl);
+        if (event.key === Qt.Key_Down) root.scrollTo(root.contentY + lineStep);
+        else if (event.key === Qt.Key_Up) root.scrollTo(root.contentY - lineStep);
+        else if (event.key === Qt.Key_PageDown) root.scrollTo(root.contentY + pageStep);
+        else if (event.key === Qt.Key_PageUp) root.scrollTo(root.contentY - pageStep);
+        else if (event.key === Qt.Key_Home) root.scrollTo(0);
+        else if (event.key === Qt.Key_End) root.scrollTo(root.contentHeight - root.height);
+        else return;
+        event.accepted = true;
+    }
+
+    function statusColor(status) {
+        if (status === "available" || status === "ready") return Theme.success;
+        if (status === "partial" || status === "restricted") return Theme.warning;
+        if (status === "unavailable" || status === "failure") return Theme.danger;
+        return Theme.menuMutedText;
+    }
+
+    function severityColor(severity) {
+        if (severity === "critical" || severity === "security") return Theme.danger;
+        if (severity === "important" || severity === "bugfix") return Theme.warning;
+        return Theme.accent;
+    }
+
+    function restartLabel(value) {
+        if (value === "none") return "No restart required";
+        if (value === "application") return "Restart applications";
+        if (value === "session") return "Log out and back in";
+        if (value === "system") return "Restart the computer";
+        if (value === "security-session") return "Security update / log out required";
+        if (value === "security-system") return "Security update / restart required";
+        return "Restart requirement unknown";
+    }
+
+    function ageLabel(value) {
+        if (!/^(0|[1-9][0-9]*)$/.test(value)) return "Unknown";
+        const seconds = Number(value);
+        if (seconds < 60) return seconds + "s ago";
+        if (seconds < 3600) return Math.floor(seconds / 60) + "m ago";
+        if (seconds < 86400) return Math.floor(seconds / 3600) + "h ago";
+        return Math.floor(seconds / 86400) + "d ago";
+    }
+
+    component StatusCard: Rectangle {
+        id: statusCard
+
+        required property string label
+        required property string status
+        required property string value
+        required property string detail
+        Layout.fillWidth: true
+        Layout.preferredHeight: Math.max(72, statusContent.implicitHeight + Theme.spacingLg * 2)
+        color: Theme.controlNormalFill
+        border.color: root.statusColor(status)
+        border.width: Theme.controlBorderWidth
+        radius: Theme.controlRadius
+
+        ColumnLayout {
+            id: statusContent
+            anchors.fill: parent
+            anchors.margins: Theme.spacingLg
+            spacing: Theme.spacingXs
+
+            RowLayout {
+                Layout.fillWidth: true
+                PlainText {
+                    Layout.fillWidth: true
+                    text: statusCard.label
+                    color: Theme.controlNormalText
+                    font.bold: true
+                    elide: Text.ElideRight
+                }
+                PlainText {
+                    text: statusCard.value
+                    color: root.statusColor(statusCard.status)
+                    font.bold: true
+                }
+            }
+            PlainText {
+                Layout.fillWidth: true
+                text: statusCard.detail
+                color: Theme.menuMutedText
+                wrapMode: Text.WordWrap
+            }
+        }
+    }
+
+    component DataList: ListView {
+        Layout.fillWidth: true
+        Layout.preferredHeight: Math.min(contentHeight, 320)
+        clip: true
+        spacing: Theme.spacingSm
+        boundsBehavior: Flickable.StopAtBounds
+        activeFocusOnTab: true
+        keyNavigationEnabled: true
+    }
+
+    component PlainText: UiText {
+        textFormat: Text.PlainText
+    }
+
+    ColumnLayout {
+        id: content
+        width: root.width
+        spacing: Theme.spacingLg
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacingMd
+
+            PlainText {
+                Layout.fillWidth: true
+                text: root.systemManagementModel.providerDetail
+                color: root.statusColor(root.systemManagementModel.providerState)
+                font.bold: true
+                elide: Text.ElideRight
+            }
+            PlainText {
+                text: "READ-ONLY STATUS"
+                color: Theme.menuMutedText
+                font.pixelSize: Theme.fontCaptionSize
+                font.bold: true
+            }
+            ShellButton {
+                label: root.systemManagementModel.busy ? "Loading..." : "Reload status"
+                enabled: !root.systemManagementModel.busy
+                onActivated: root.systemManagementModel.refresh()
+            }
+        }
+
+        PlainText {
+            Layout.fillWidth: true
+            visible: root.systemManagementModel.snapshotState === "loading"
+                || root.systemManagementModel.snapshotState === "failure"
+                || root.systemManagementModel.snapshotState === "partial"
+            text: root.systemManagementModel.message
+            color: root.statusColor(root.systemManagementModel.snapshotState)
+            wrapMode: Text.WordWrap
+        }
+
+        SectionLabel { label: "Fedora updates" }
+
+        GridLayout {
+            Layout.fillWidth: true
+            columns: root.width < 720 ? 1 : 3
+            rowSpacing: Theme.spacingMd
+            columnSpacing: Theme.spacingMd
+
+            StatusCard {
+                label: "Available updates"
+                status: root.systemManagementModel.updateSummary.status
+                value: root.systemManagementModel.updateSummary.value === "unknown"
+                    ? "Unknown" : root.systemManagementModel.updateSummary.value
+                detail: root.systemManagementModel.updateSummary.detail
+            }
+            StatusCard {
+                label: "Last refresh"
+                status: root.systemManagementModel.updateLastRefresh.status
+                value: root.ageLabel(root.systemManagementModel.updateLastRefresh.value)
+                detail: root.systemManagementModel.updateLastRefresh.detail
+            }
+            StatusCard {
+                label: "Restart guidance"
+                status: root.systemManagementModel.updateRestart.status
+                value: root.restartLabel(root.systemManagementModel.updateRestart.value)
+                detail: root.systemManagementModel.updateRestart.detail
+            }
+        }
+
+        StatusCard {
+            visible: root.systemManagementModel.activeOperation !== null
+            label: root.systemManagementModel.activeOperation === null ? "Active operation"
+                : root.systemManagementModel.activeOperation.actionId
+            status: "partial"
+            value: root.systemManagementModel.activeOperation === null ? ""
+                : root.systemManagementModel.activeOperation.percent === "unknown"
+                    ? root.systemManagementModel.activeOperation.state
+                    : root.systemManagementModel.activeOperation.state + " / "
+                        + root.systemManagementModel.activeOperation.percent + "%"
+            detail: root.systemManagementModel.activeOperation === null ? ""
+                : root.systemManagementModel.activeOperation.detail
+        }
+
+        StatusCard {
+            visible: root.systemManagementModel.terminalHandoff !== null
+            label: "Update result awaiting recovery"
+            status: "partial"
+            value: root.systemManagementModel.terminalHandoff === null ? ""
+                : root.systemManagementModel.terminalHandoff.kind
+            detail: "The durable operation result is being reconciled before another update action can start."
+        }
+
+        SectionLabel {
+            visible: root.systemManagementModel.updates.length > 0
+            label: "Update details"
+        }
+
+        DataList {
+            visible: count > 0
+            model: root.systemManagementModel.updates
+
+            delegate: Rectangle {
+                id: updateRow
+                required property var modelData
+                width: ListView.view.width
+                height: Math.max(66, updateContent.implicitHeight + Theme.spacingMd * 2)
+                color: Theme.controlNormalFill
+                border.color: Theme.controlNormalBorder
+                border.width: Theme.controlBorderWidth
+                radius: Theme.controlRadius
+
+                ColumnLayout {
+                    id: updateContent
+                    anchors.fill: parent
+                    anchors.margins: Theme.spacingMd
+                    spacing: Theme.spacingXs
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        PlainText {
+                            Layout.fillWidth: true
+                            text: updateRow.modelData.name + " " + updateRow.modelData.version
+                            color: Theme.controlNormalText
+                            font.bold: true
+                            elide: Text.ElideRight
+                        }
+                        PlainText {
+                            text: updateRow.modelData.installability === "blocked"
+                                ? "BLOCKED" : updateRow.modelData.severity.toUpperCase()
+                            color: updateRow.modelData.installability === "blocked"
+                                ? Theme.danger : root.severityColor(updateRow.modelData.severity)
+                            font.pixelSize: Theme.fontCaptionSize
+                            font.bold: true
+                        }
+                    }
+                    PlainText {
+                        Layout.fillWidth: true
+                        text: updateRow.modelData.summary
+                        color: Theme.menuMutedText
+                        wrapMode: Text.WordWrap
+                    }
+                }
+            }
+        }
+
+        SectionLabel {
+            visible: root.systemManagementModel.packageChanges.length > 0
+            label: "Planned package changes"
+        }
+
+        DataList {
+            visible: count > 0
+            model: root.systemManagementModel.packageChanges
+
+            delegate: Rectangle {
+                id: changeRow
+                required property var modelData
+                width: ListView.view.width
+                height: Math.max(58, changeContent.implicitHeight + Theme.spacingMd * 2)
+                color: Theme.controlNormalFill
+                border.color: Theme.controlNormalBorder
+                border.width: Theme.controlBorderWidth
+                radius: Theme.controlRadius
+
+                RowLayout {
+                    id: changeContent
+                    anchors.fill: parent
+                    anchors.margins: Theme.spacingMd
+                    spacing: Theme.spacingMd
+
+                    PlainText {
+                        text: changeRow.modelData.action.toUpperCase()
+                        color: Theme.accent
+                        font.pixelSize: Theme.fontCaptionSize
+                        font.bold: true
+                    }
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.spacingXxs
+                        PlainText {
+                            Layout.fillWidth: true
+                            text: changeRow.modelData.name + " " + changeRow.modelData.version
+                            color: Theme.controlNormalText
+                            font.bold: true
+                            elide: Text.ElideRight
+                        }
+                        PlainText {
+                            Layout.fillWidth: true
+                            text: changeRow.modelData.summary
+                            color: Theme.menuMutedText
+                            elide: Text.ElideRight
+                        }
+                    }
+                }
+            }
+        }
+
+        SectionLabel {
+            visible: root.systemManagementModel.errors.length > 0
+            label: "System diagnostics"
+        }
+
+        DataList {
+            visible: count > 0
+            model: root.systemManagementModel.errors
+
+            delegate: Rectangle {
+                id: errorRow
+                required property var modelData
+                width: ListView.view.width
+                height: Math.max(58, errorContent.implicitHeight + Theme.spacingMd * 2)
+                color: Theme.controlNormalFill
+                border.color: Theme.danger
+                border.width: Theme.controlBorderWidth
+                radius: Theme.controlRadius
+
+                RowLayout {
+                    id: errorContent
+                    anchors.fill: parent
+                    anchors.margins: Theme.spacingMd
+                    spacing: Theme.spacingMd
+                    PlainText {
+                        text: errorRow.modelData.provider.toUpperCase() + " / "
+                            + errorRow.modelData.code.toUpperCase()
+                        color: Theme.danger
+                        font.pixelSize: Theme.fontCaptionSize
+                        font.bold: true
+                    }
+                    PlainText {
+                        Layout.fillWidth: true
+                        text: errorRow.modelData.detail
+                        color: Theme.menuText
+                        wrapMode: Text.WordWrap
+                    }
+                }
+            }
+        }
+
+        SectionLabel { label: "Administration boundaries" }
+
+        Repeater {
+            model: root.capabilities
+            delegate: StatusCard {
+                id: capabilityCard
+                required property var modelData
+                label: capabilityCard.modelData.label
+                status: capabilityCard.modelData.status
+                value: capabilityCard.modelData.capabilityClass.toUpperCase()
+                detail: capabilityCard.modelData.detail + " / " + capabilityCard.modelData.provider
+            }
+        }
+
+        StatusCard {
+            label: "Operation recovery"
+            status: root.systemManagementModel.recoveryProvider.status
+            value: root.systemManagementModel.recoveryProvider.status.toUpperCase()
+            detail: root.systemManagementModel.recoveryProvider.detail
+        }
+
+        PlainText {
+            Layout.fillWidth: true
+            text: "This pane only reads PackageKit and recovery state. Update installation, cache refresh, and cancellation require a separate confirmed operation workflow."
+            color: Theme.menuMutedText
+            font.pixelSize: Theme.fontCaptionSize
+            wrapMode: Text.WordWrap
+        }
+    }
+}

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -1169,5 +1169,6 @@ ShellRoot {
         accessibilityModel: accessibilityModel
         notificationModel: notificationModel
         panelSettingsModel: panelSettingsModel
+        systemManagementModel: systemManagementModel
     }
 }

--- a/tests/test-quickshell-system-management-xvfb.sh
+++ b/tests/test-quickshell-system-management-xvfb.sh
@@ -355,7 +355,7 @@ if pgrep -af "$helper snapshot" >/dev/null 2>&1; then
 	printf 'System-management helper remained after Settings closure\n' >&2
 	exit 1
 fi
-if grep -F 'SystemManagementModel.qml' "$work/quickshell.log" | grep -Fq 'ERROR'; then
+if grep -E 'System(ManagementModel|SettingsPane)\.qml' "$work/quickshell.log" | grep -Fq 'ERROR'; then
 	tail -60 "$work/quickshell.log" >&2
 	exit 1
 fi

--- a/tests/test-quickshell-system-management.sh
+++ b/tests/test-quickshell-system-management.sh
@@ -3,11 +3,14 @@ set -eu
 
 repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 model=$repo/config/quickshell/systemmanagement/SystemManagementModel.qml
+pane=$repo/config/quickshell/settings/SystemSettingsPane.qml
 commands=$repo/config/quickshell/core/Commands.qml
 settings=$repo/config/quickshell/settings/SettingsModel.qml
+settings_window=$repo/config/quickshell/settings/SettingsWindow.qml
 shell=$repo/config/quickshell/shell.qml
 
 test -f "$model"
+test -f "$pane"
 grep -Fq 'function systemManagementCommand(action, args)' "$commands"
 grep -Fq 'function terminatingCheckedCommand(command)' "$commands"
 grep -Fq 'trap terminate HUP INT TERM' "$commands"
@@ -72,6 +75,52 @@ grep -Fq 'snapshotProcess.running = false;' "$model"
 grep -Fq 'root.snapshotState === "failure"' "$model"
 grep -Fq 'root.parseSnapshot(snapshotOutput.text, snapshotProcess.generation);' "$model"
 
+grep -Fq 'required property var systemManagementModel' "$pane"
+grep -Fq 'required property var capabilities' "$pane"
+grep -Fq 'READ-ONLY STATUS' "$pane"
+grep -Fq 'component PlainText: UiText {' "$pane"
+grep -Fq 'textFormat: Text.PlainText' "$pane"
+[ "$(grep -Fc 'UiText {' "$pane")" -eq 1 ]
+grep -Fq 'activeFocusOnTab: true' "$pane"
+grep -Fq 'Keys.onPressed: event =>' "$pane"
+for key_name in Down Up PageDown PageUp Home End; do
+	grep -Fq "Qt.Key_$key_name" "$pane"
+done
+grep -Fq 'Math.max(0, Math.min(position, Math.max(0, root.contentHeight - root.height)))' "$pane"
+grep -Fq 'columns: root.width < 720 ? 1 : 3' "$pane"
+grep -Fq 'model: root.systemManagementModel.updates' "$pane"
+grep -Fq 'model: root.systemManagementModel.packageChanges' "$pane"
+grep -Fq 'model: root.systemManagementModel.errors' "$pane"
+grep -Fq 'errorRow.modelData.provider.toUpperCase()' "$pane"
+grep -Fq 'This pane only reads PackageKit and recovery state.' "$pane"
+if grep -Eq 'Quickshell\.Io|\bProcess\b|\bCommands\.|systemManagementCommand' "$pane"; then
+	printf 'System Settings pane must not construct or run commands.\n' >&2
+	exit 1
+fi
+pane_model_members=$(grep -Eo 'systemManagementModel\.[A-Za-z][A-Za-z0-9]*' "$pane" |
+	sort -u)
+expected_pane_model_members=$(printf '%s\n' \
+	'systemManagementModel.activeOperation' \
+	'systemManagementModel.busy' \
+	'systemManagementModel.errors' \
+	'systemManagementModel.message' \
+	'systemManagementModel.packageChanges' \
+	'systemManagementModel.providerDetail' \
+	'systemManagementModel.providerState' \
+	'systemManagementModel.recoveryProvider' \
+	'systemManagementModel.refresh' \
+	'systemManagementModel.snapshotState' \
+	'systemManagementModel.terminalHandoff' \
+	'systemManagementModel.updateLastRefresh' \
+	'systemManagementModel.updateRestart' \
+	'systemManagementModel.updateSummary' \
+	'systemManagementModel.updates')
+if [ "$pane_model_members" != "$expected_pane_model_members" ]; then
+	printf 'System Settings pane accessed a non-read-only model member.\n' >&2
+	exit 1
+fi
+[ "$(grep -Fc 'onActivated: root.systemManagementModel.refresh()' "$pane")" -eq 1 ]
+
 grep -Fq 'property var systemManagementModel: null' "$settings"
 grep -Fq 'root.systemManagementModel.openSettings()' "$settings"
 grep -Fq 'root.systemManagementModel.closeSettings()' "$settings"
@@ -79,6 +128,7 @@ grep -Fq 'root.systemManagementModel.refresh()' "$settings"
 grep -Fq 'import qs.systemmanagement' "$shell"
 [ "$(grep -Fc 'SystemManagementModel {' "$shell")" -eq 1 ]
 grep -Fq 'systemManagementModel: systemManagementModel' "$shell"
+grep -Fq 'SystemSettingsPane {' "$settings_window"
 grep -Fq 'function systemManagementProviderStatus(): string' "$shell"
 grep -Fq 'function systemManagementUpdateCount(): int' "$shell"
 grep -Fq 'function systemManagementPackageChangeCount(): int' "$shell"


### PR DESCRIPTION
## Summary

- render the validated PackageKit snapshot in a dedicated read-only System Settings pane
- show update inventory, simulated package changes, restart/recovery state, diagnostics, and existing administration boundaries
- keep provider-controlled text plain, bound list rendering, support keyboard scrolling, and stack summary cards on compact displays
- expose no cache-refresh, install, cancel, command-construction, or privileged mutation controls in this boundary

## Validation

- `scripts/run-tests make clean all`
- `scripts/run-tests`
- `make check-quickshell-system-management`
- `scripts/quickshell-qmllint --root config/quickshell`
- `shellcheck tests/test-quickshell-system-management.sh tests/test-quickshell-system-management-xvfb.sh`
- `shfmt -d tests/test-quickshell-system-management.sh tests/test-quickshell-system-management-xvfb.sh`
- nested-X11 rendering at 1024x768 and 800x600
- CodeRabbit local review: 0 findings
- built-in Codex review: no actionable defects

## Scope

This is the read-only presentation boundary for UPDATE-001. Confirmed PackageKit mutations, operation progress/cancellation, and durable recovery remain for subsequent small pull requests.