### PR TITLE
Phase 6: add update journal frame codec

### DIFF
--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -96,7 +96,10 @@ def _journal_payload_bytes(payload: str) -> bytes:
         raise JournalFrameError("journal payload must be text")
     if "\0" in payload or "\r" in payload or "\n" in payload:
         raise JournalFrameError("journal payload contains a forbidden byte")
-    encoded = payload.encode("utf-8")
+    try:
+        encoded = payload.encode("utf-8")
+    except UnicodeEncodeError as error:
+        raise JournalFrameError("journal payload is not UTF-8") from error
     if len(encoded) > JOURNAL_PAYLOAD_MAX:
         raise JournalFrameError("journal payload is too large")
     return encoded

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import hashlib
+import struct
 import sys
 import time
 from dataclasses import dataclass
@@ -18,6 +19,15 @@ MAX_LIST_BYTES = 3 * 1024 * 1024
 READ_DEADLINE_SECONDS = 120
 REFRESH_AGE_DEADLINE_SECONDS = 10
 CANCEL_GRACE_SECONDS = 5
+
+JOURNAL_MAGIC = b"DWMJNL1\0"
+JOURNAL_FRAME_MAJOR = 1
+JOURNAL_FRAME_MINOR = 0
+JOURNAL_FRAME_SIZE = 8192
+JOURNAL_PAYLOAD_OFFSET = 64
+JOURNAL_PAYLOAD_MAX = JOURNAL_FRAME_SIZE - JOURNAL_PAYLOAD_OFFSET
+JOURNAL_FILE_SIZE = JOURNAL_FRAME_SIZE * 2
+JOURNAL_SEQUENCE_MAX = (1 << 64) - 1
 
 PACKAGEKIT_NAME = "org.freedesktop.PackageKit"
 PACKAGEKIT_PATH = "/org/freedesktop/PackageKit"
@@ -69,6 +79,108 @@ class SnapshotFailure(Exception):
         self.code = code
         self.detail = clean_text(detail)
         self.status = status
+
+
+class JournalFrameError(ValueError):
+    """A journal frame failed canonical validation."""
+
+
+@dataclass(frozen=True)
+class JournalFrame:
+    sequence: int
+    payload: str
+
+
+def _journal_payload_bytes(payload: str) -> bytes:
+    if not isinstance(payload, str):
+        raise JournalFrameError("journal payload must be text")
+    if "\0" in payload or "\r" in payload or "\n" in payload:
+        raise JournalFrameError("journal payload contains a forbidden byte")
+    encoded = payload.encode("utf-8")
+    if len(encoded) > JOURNAL_PAYLOAD_MAX:
+        raise JournalFrameError("journal payload is too large")
+    return encoded
+
+
+def encode_journal_frame(sequence: int, payload: str) -> bytes:
+    """Return one canonical fixed-size journal frame."""
+    if not isinstance(sequence, int) or isinstance(sequence, bool):
+        raise JournalFrameError("journal sequence must be an integer")
+    if sequence < 1 or sequence > JOURNAL_SEQUENCE_MAX:
+        raise JournalFrameError("journal sequence is out of range")
+    encoded = _journal_payload_bytes(payload)
+    header = struct.pack(
+        "<8sHHIQQ",
+        JOURNAL_MAGIC,
+        JOURNAL_FRAME_MAJOR,
+        JOURNAL_FRAME_MINOR,
+        len(encoded),
+        sequence,
+        0,
+    )
+    digest = hashlib.sha256(header + encoded).digest()
+    return header + digest + encoded + bytes(JOURNAL_PAYLOAD_MAX - len(encoded))
+
+
+def decode_journal_frame(image: bytes) -> JournalFrame:
+    """Validate and decode one canonical fixed-size journal frame."""
+    if not isinstance(image, bytes) or len(image) != JOURNAL_FRAME_SIZE:
+        raise JournalFrameError("journal frame has an invalid size")
+    magic, major, minor, length, sequence, reserved = struct.unpack(
+        "<8sHHIQQ", image[:32]
+    )
+    if magic != JOURNAL_MAGIC:
+        raise JournalFrameError("journal frame has invalid magic")
+    if major != JOURNAL_FRAME_MAJOR or minor != JOURNAL_FRAME_MINOR:
+        raise JournalFrameError("journal frame has an unsupported version")
+    if reserved != 0:
+        raise JournalFrameError("journal frame has nonzero reserved bytes")
+    if length > JOURNAL_PAYLOAD_MAX:
+        raise JournalFrameError("journal frame has an invalid payload length")
+    if sequence < 1:
+        raise JournalFrameError("journal frame has an invalid sequence")
+    payload_end = JOURNAL_PAYLOAD_OFFSET + length
+    encoded = image[JOURNAL_PAYLOAD_OFFSET:payload_end]
+    if any(image[payload_end:]):
+        raise JournalFrameError("journal frame has nonzero padding")
+    expected = hashlib.sha256(image[:32] + encoded).digest()
+    if image[32:JOURNAL_PAYLOAD_OFFSET] != expected:
+        raise JournalFrameError("journal frame digest does not match")
+    try:
+        payload = encoded.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise JournalFrameError("journal payload is not UTF-8") from error
+    _journal_payload_bytes(payload)
+    return JournalFrame(sequence, payload)
+
+
+def initial_journal_image(payload: str = "") -> bytes:
+    """Return the canonical sequence-one image for a newly created path."""
+    return encode_journal_frame(1, payload) + bytes(JOURNAL_FRAME_SIZE)
+
+
+def select_journal_frame(image: bytes) -> tuple[int, JournalFrame]:
+    """Select the authoritative valid frame from one dual-frame image."""
+    if not isinstance(image, bytes) or len(image) != JOURNAL_FILE_SIZE:
+        raise JournalFrameError("journal file has an invalid size")
+    decoded: list[tuple[int, JournalFrame, bytes]] = []
+    for index in range(2):
+        raw = image[index * JOURNAL_FRAME_SIZE : (index + 1) * JOURNAL_FRAME_SIZE]
+        try:
+            decoded.append((index, decode_journal_frame(raw), raw))
+        except JournalFrameError:
+            continue
+    if not decoded:
+        raise JournalFrameError("journal file has no valid frame")
+    if len(decoded) == 2 and decoded[0][1].sequence == decoded[1][1].sequence:
+        if decoded[0][2] != decoded[1][2]:
+            raise JournalFrameError("journal frames have conflicting sequences")
+        selected = decoded[0]
+    else:
+        selected = max(decoded, key=lambda candidate: candidate[1].sequence)
+    if selected[1].sequence == JOURNAL_SEQUENCE_MAX:
+        raise JournalFrameError("journal sequence is exhausted")
+    return selected[0], selected[1]
 
 
 @dataclass(frozen=True)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -286,6 +286,8 @@ class JournalFrameTests(unittest.TestCase):
             with self.subTest(payload=payload):
                 with self.assertRaises(provider.JournalFrameError):
                     provider.encode_journal_frame(1, payload)
+        with self.assertRaisesRegex(provider.JournalFrameError, "not UTF-8"):
+            provider.encode_journal_frame(1, "unpaired-\udcff")
         for sequence in (0, -1, provider.JOURNAL_SEQUENCE_MAX + 1, True):
             with self.subTest(sequence=sequence):
                 with self.assertRaises(provider.JournalFrameError):

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -231,6 +231,136 @@ class SnapshotTests(unittest.TestCase):
         )
         self.assertEqual(rows(output, "error")[0][2], "malformed")
 
+
+class JournalFrameTests(unittest.TestCase):
+    def frame_with_header(self, frame, *, offset, value):
+        changed = bytearray(frame)
+        changed[offset : offset + len(value)] = value
+        length = int.from_bytes(changed[12:16], "little")
+        payload = changed[provider.JOURNAL_PAYLOAD_OFFSET :][:length]
+        changed[32:64] = hashlib.sha256(changed[:32] + payload).digest()
+        return bytes(changed)
+
+    def test_golden_frame_layout_and_initial_image(self):
+        payload = "op-0123456789abcdef0123456789abcdef\tupdate"
+        frame = provider.encode_journal_frame(0x0102030405060708, payload)
+
+        self.assertEqual(len(frame), 8192)
+        self.assertEqual(frame[:8], b"DWMJNL1\0")
+        self.assertEqual(frame[8:10], b"\x01\x00")
+        self.assertEqual(frame[10:12], b"\x00\x00")
+        self.assertEqual(
+            int.from_bytes(frame[12:16], "little"), len(payload.encode("utf-8"))
+        )
+        self.assertEqual(frame[16:24], b"\x08\x07\x06\x05\x04\x03\x02\x01")
+        self.assertEqual(frame[24:32], bytes(8))
+        self.assertEqual(
+            frame[32:64],
+            hashlib.sha256(frame[:32] + payload.encode("utf-8")).digest(),
+        )
+        self.assertEqual(frame[64 : 64 + len(payload)], payload.encode("utf-8"))
+        self.assertEqual(frame[64 + len(payload) :], bytes(8128 - len(payload)))
+        self.assertEqual(
+            provider.decode_journal_frame(frame),
+            provider.JournalFrame(0x0102030405060708, payload),
+        )
+
+        initial = provider.initial_journal_image("00")
+        self.assertEqual(len(initial), 16384)
+        self.assertEqual(initial[8192:], bytes(8192))
+        self.assertEqual(
+            provider.select_journal_frame(initial),
+            (0, provider.JournalFrame(1, "00")),
+        )
+
+    def test_maximum_utf8_payload_round_trips(self):
+        payload = "x" * provider.JOURNAL_PAYLOAD_MAX
+        frame = provider.encode_journal_frame(2, payload)
+
+        self.assertEqual(provider.decode_journal_frame(frame).payload, payload)
+        with self.assertRaisesRegex(provider.JournalFrameError, "too large"):
+            provider.encode_journal_frame(2, payload + "x")
+
+    def test_payload_and_sequence_validation(self):
+        for payload in ("nul\0byte", "line\nbreak", "carriage\rreturn"):
+            with self.subTest(payload=payload):
+                with self.assertRaises(provider.JournalFrameError):
+                    provider.encode_journal_frame(1, payload)
+        for sequence in (0, -1, provider.JOURNAL_SEQUENCE_MAX + 1, True):
+            with self.subTest(sequence=sequence):
+                with self.assertRaises(provider.JournalFrameError):
+                    provider.encode_journal_frame(sequence, "")
+
+    def test_decoder_rejects_every_canonical_boundary_violation(self):
+        base = provider.encode_journal_frame(4, "payload")
+        cases = {
+            "size": base[:-1],
+            "magic": self.frame_with_header(base, offset=0, value=b"BADJNL1\0"),
+            "major": self.frame_with_header(base, offset=8, value=b"\x02\x00"),
+            "minor": self.frame_with_header(base, offset=10, value=b"\x01\x00"),
+            "length": self.frame_with_header(
+                base,
+                offset=12,
+                value=(provider.JOURNAL_PAYLOAD_MAX + 1).to_bytes(4, "little"),
+            ),
+            "sequence": self.frame_with_header(base, offset=16, value=bytes(8)),
+            "reserved": self.frame_with_header(base, offset=24, value=b"\x01"),
+            "digest": base[:32] + bytes(32) + base[64:],
+            "padding": base[:-1] + b"\x01",
+        }
+        for name, image in cases.items():
+            with self.subTest(name=name):
+                with self.assertRaises(provider.JournalFrameError):
+                    provider.decode_journal_frame(image)
+
+        invalid_utf8 = bytearray(provider.encode_journal_frame(4, "x"))
+        invalid_utf8[64] = 0xFF
+        invalid_utf8[32:64] = hashlib.sha256(
+            invalid_utf8[:32] + invalid_utf8[64:65]
+        ).digest()
+        with self.assertRaisesRegex(provider.JournalFrameError, "not UTF-8"):
+            provider.decode_journal_frame(bytes(invalid_utf8))
+
+        forbidden = bytearray(provider.encode_journal_frame(4, "x"))
+        forbidden[64] = 0
+        forbidden[32:64] = hashlib.sha256(forbidden[:32] + forbidden[64:65]).digest()
+        with self.assertRaisesRegex(provider.JournalFrameError, "forbidden"):
+            provider.decode_journal_frame(bytes(forbidden))
+
+    def test_selector_uses_highest_valid_sequence_and_survives_torn_peer(self):
+        older = provider.encode_journal_frame(9, "older")
+        newer = provider.encode_journal_frame(10, "newer")
+
+        self.assertEqual(
+            provider.select_journal_frame(older + newer),
+            (1, provider.JournalFrame(10, "newer")),
+        )
+        torn = newer[:40] + bytes(provider.JOURNAL_FRAME_SIZE - 40)
+        self.assertEqual(
+            provider.select_journal_frame(older + torn),
+            (0, provider.JournalFrame(9, "older")),
+        )
+
+    def test_selector_rejects_ambiguous_or_exhausted_files(self):
+        first = provider.encode_journal_frame(7, "first")
+        second = provider.encode_journal_frame(7, "second")
+        exhausted = provider.encode_journal_frame(provider.JOURNAL_SEQUENCE_MAX, "")
+
+        with self.assertRaisesRegex(provider.JournalFrameError, "conflicting"):
+            provider.select_journal_frame(first + second)
+        with self.assertRaisesRegex(provider.JournalFrameError, "no valid"):
+            provider.select_journal_frame(bytes(provider.JOURNAL_FILE_SIZE))
+        with self.assertRaisesRegex(provider.JournalFrameError, "exhausted"):
+            provider.select_journal_frame(
+                exhausted + bytes(provider.JOURNAL_FRAME_SIZE)
+            )
+        self.assertEqual(
+            provider.select_journal_frame(first + first),
+            (0, provider.JournalFrame(7, "first")),
+        )
+
+
+class SnapshotValidationTests(unittest.TestCase):
     def test_duplicate_plan_preserves_readable_updates(self):
         update = package(8, "openssl;4.0;x86_64;updates", "TLS library")
         backend = FixtureBackend(


### PR DESCRIPTION
## Summary

- encode and decode the canonical fixed-size Phase 6 journal frame format
- validate magic, version, payload length, sequence, reserved bytes, SHA-256 digest, UTF-8 payloads, and zero padding
- select the authoritative frame from each fixed dual-frame image while tolerating one torn peer and rejecting ambiguity or sequence exhaustion
- add no journal filesystem writes or user-visible update mutation commands in this boundary

## Validation

- `scripts/run-tests make clean all`
- `scripts/run-tests`
- `make check-system-management`
- `ruff format --check scripts/dwm-system-management tests/test-system-management.py`
- `ruff check scripts/dwm-system-management tests/test-system-management.py`
- CodeRabbit local review: 0 findings
- built-in Codex review: no actionable defects

## Scope

This is the internal frame-codec prerequisite for the UPDATE-001 durable operation journal. Descriptor-safe creation, locking, commits, recovery, and PackageKit mutations remain in later small pull requests.