### PR TITLE
Phase 6: add crash-safe journal file commits

### DIFF
--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -3,12 +3,17 @@
 
 from __future__ import annotations
 
+import contextlib
+import errno
+import fcntl
 import hashlib
+import os
+import stat
 import struct
 import sys
 import time
 from dataclasses import dataclass
-from typing import Iterable, Protocol, Sequence
+from typing import Iterable, Iterator, Protocol, Sequence
 
 
 PROTOCOL_MAJOR = 1
@@ -28,6 +33,7 @@ JOURNAL_PAYLOAD_OFFSET = 64
 JOURNAL_PAYLOAD_MAX = JOURNAL_FRAME_SIZE - JOURNAL_PAYLOAD_OFFSET
 JOURNAL_FILE_SIZE = JOURNAL_FRAME_SIZE * 2
 JOURNAL_SEQUENCE_MAX = (1 << 64) - 1
+JOURNAL_LOCK_DEADLINE_SECONDS = 5
 
 PACKAGEKIT_NAME = "org.freedesktop.PackageKit"
 PACKAGEKIT_PATH = "/org/freedesktop/PackageKit"
@@ -83,6 +89,18 @@ class SnapshotFailure(Exception):
 
 class JournalFrameError(ValueError):
     """A journal frame failed canonical validation."""
+
+
+class JournalFileError(OSError):
+    """A journal file descriptor failed bounded validation or I/O."""
+
+
+class JournalCommitError(JournalFileError):
+    """A frame commit may have reached storage and requires recovery."""
+
+
+class JournalLockError(JournalFileError):
+    """The bounded journal directory lock could not be acquired or released."""
 
 
 @dataclass(frozen=True)
@@ -184,6 +202,203 @@ def select_journal_frame(image: bytes) -> tuple[int, JournalFrame]:
     if selected[1].sequence == JOURNAL_SEQUENCE_MAX:
         raise JournalFrameError("journal sequence is exhausted")
     return selected[0], selected[1]
+
+
+def _validate_journal_descriptor(
+    descriptor: int, expected_size: int, *, writable: bool
+) -> os.stat_result:
+    if (
+        not isinstance(descriptor, int)
+        or isinstance(descriptor, bool)
+        or descriptor < 0
+    ):
+        raise JournalFileError("journal file descriptor is invalid")
+    try:
+        metadata = os.fstat(descriptor)
+        flags = fcntl.fcntl(descriptor, fcntl.F_GETFL)
+    except (OSError, OverflowError) as error:
+        raise JournalFileError("journal file descriptor is unavailable") from error
+    access = flags & os.O_ACCMODE
+    if (
+        access == os.O_WRONLY
+        or (writable and access != os.O_RDWR)
+        or (writable and flags & os.O_APPEND)
+    ):
+        raise JournalFileError("journal file descriptor has unsafe access")
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+        or metadata.st_nlink != 1
+        or metadata.st_size != expected_size
+    ):
+        raise JournalFileError("journal file metadata is unsafe")
+    return metadata
+
+
+def _validate_journal_lock_descriptor(descriptor: int) -> os.stat_result:
+    if (
+        not isinstance(descriptor, int)
+        or isinstance(descriptor, bool)
+        or descriptor < 0
+    ):
+        raise JournalLockError("journal lock descriptor is invalid")
+    try:
+        metadata = os.fstat(descriptor)
+        flags = fcntl.fcntl(descriptor, fcntl.F_GETFL)
+    except (OSError, OverflowError) as error:
+        raise JournalLockError("journal lock descriptor is unavailable") from error
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+        or (flags & os.O_ACCMODE) == os.O_WRONLY
+    ):
+        raise JournalLockError("journal lock directory metadata is unsafe")
+    return metadata
+
+
+@contextlib.contextmanager
+def _journal_lock(descriptor: int, *, exclusive: bool) -> Iterator[None]:
+    held = _validate_journal_lock_descriptor(descriptor)
+    try:
+        lock_descriptor = os.open(
+            ".",
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=descriptor,
+        )
+    except OSError as error:
+        raise JournalLockError("journal lock handle is unavailable") from error
+    try:
+        lock_metadata = _validate_journal_lock_descriptor(lock_descriptor)
+        if (lock_metadata.st_dev, lock_metadata.st_ino) != (
+            held.st_dev,
+            held.st_ino,
+        ):
+            raise JournalLockError("journal lock directory identity changed")
+        deadline = time.monotonic() + JOURNAL_LOCK_DEADLINE_SECONDS
+        operation = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+        while True:
+            try:
+                fcntl.flock(lock_descriptor, operation | fcntl.LOCK_NB)
+                break
+            except OSError as error:
+                if error.errno not in {errno.EACCES, errno.EAGAIN}:
+                    raise JournalLockError("journal lock acquisition failed") from error
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise JournalLockError(
+                        "journal lock acquisition timed out"
+                    ) from error
+                time.sleep(min(remaining, 0.01))
+
+        try:
+            current = _validate_journal_lock_descriptor(descriptor)
+            if (current.st_dev, current.st_ino) != (
+                lock_metadata.st_dev,
+                lock_metadata.st_ino,
+            ):
+                raise JournalLockError("journal lock directory identity changed")
+            yield
+        finally:
+            try:
+                fcntl.flock(lock_descriptor, fcntl.LOCK_UN)
+            except OSError as error:
+                raise JournalLockError("journal lock release failed") from error
+    finally:
+        try:
+            os.close(lock_descriptor)
+        except OSError as error:
+            raise JournalLockError("journal lock handle close failed") from error
+
+
+def _read_journal_image(descriptor: int) -> bytes:
+    _validate_journal_descriptor(descriptor, JOURNAL_FILE_SIZE, writable=False)
+    chunks: list[bytes] = []
+    offset = 0
+    while offset < JOURNAL_FILE_SIZE:
+        try:
+            chunk = os.pread(descriptor, JOURNAL_FILE_SIZE - offset, offset)
+        except OSError as error:
+            raise JournalFileError("journal file read failed") from error
+        if not isinstance(chunk, bytes) or not chunk:
+            raise JournalFileError("journal file read was incomplete")
+        chunks.append(chunk)
+        offset += len(chunk)
+    image = b"".join(chunks)
+    _validate_journal_descriptor(descriptor, JOURNAL_FILE_SIZE, writable=False)
+    return image
+
+
+def _read_journal_file_unlocked(descriptor: int) -> tuple[int, JournalFrame]:
+    return select_journal_frame(_read_journal_image(descriptor))
+
+
+def read_journal_file(
+    lock_descriptor: int, descriptor: int
+) -> tuple[int, JournalFrame]:
+    """Load one journal file while holding the shared directory lock."""
+    with _journal_lock(lock_descriptor, exclusive=False):
+        return _read_journal_file_unlocked(descriptor)
+
+
+def _initialize_journal_file_unlocked(
+    descriptor: int, payload: str = ""
+) -> JournalFrame:
+    image = initial_journal_image(payload)
+    _validate_journal_descriptor(descriptor, 0, writable=True)
+    try:
+        written = os.pwrite(descriptor, image, 0)
+        if written != len(image):
+            raise OSError("short journal initialization write")
+        os.fsync(descriptor)
+        _validate_journal_descriptor(descriptor, JOURNAL_FILE_SIZE, writable=True)
+        if _read_journal_image(descriptor) != image:
+            raise OSError("journal initialization readback mismatch")
+    except OSError as error:
+        raise JournalFileError("journal file initialization failed") from error
+    return JournalFrame(1, payload)
+
+
+def initialize_journal_file(
+    lock_descriptor: int, descriptor: int, payload: str = ""
+) -> JournalFrame:
+    """Initialize one empty file while holding the exclusive directory lock."""
+    with _journal_lock(lock_descriptor, exclusive=True):
+        return _initialize_journal_file_unlocked(descriptor, payload)
+
+
+def _commit_journal_file_unlocked(
+    descriptor: int, payload: str
+) -> tuple[int, JournalFrame]:
+    active_index, active = _read_journal_file_unlocked(descriptor)
+    next_frame = JournalFrame(active.sequence + 1, payload)
+    encoded = encode_journal_frame(next_frame.sequence, next_frame.payload)
+    inactive_index = 1 - active_index
+    offset = inactive_index * JOURNAL_FRAME_SIZE
+    _validate_journal_descriptor(descriptor, JOURNAL_FILE_SIZE, writable=True)
+    try:
+        written = os.pwrite(descriptor, encoded, offset)
+        if written != len(encoded):
+            raise OSError("short journal frame write")
+        os.fsync(descriptor)
+        image = _read_journal_image(descriptor)
+        if image[offset : offset + JOURNAL_FRAME_SIZE] != encoded:
+            raise OSError("journal frame readback mismatch")
+        selected_index, selected = select_journal_frame(image)
+        if selected_index != inactive_index or selected != next_frame:
+            raise OSError("journal frame did not become authoritative")
+    except (OSError, JournalFrameError) as error:
+        raise JournalCommitError("journal frame commit is indeterminate") from error
+    return inactive_index, next_frame
+
+
+def commit_journal_file(
+    lock_descriptor: int, descriptor: int, payload: str
+) -> tuple[int, JournalFrame]:
+    """Commit one frame while holding the exclusive directory lock."""
+    with _journal_lock(lock_descriptor, exclusive=True):
+        return _commit_journal_file_unlocked(descriptor, payload)
 
 
 @dataclass(frozen=True)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -6,9 +6,13 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import importlib.machinery
+import os
 import pathlib
 import sys
+import tempfile
+import threading
 import unittest
+from unittest import mock
 
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
@@ -360,6 +364,254 @@ class JournalFrameTests(unittest.TestCase):
             provider.select_journal_frame(first + first),
             (0, provider.JournalFrame(7, "first")),
         )
+
+
+class JournalFileTests(unittest.TestCase):
+    def open_empty(self, directory, name="journal"):
+        path = pathlib.Path(directory) / name
+        lock_descriptor = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
+        descriptor = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600)
+        return path, lock_descriptor, descriptor
+
+    def test_initialize_and_load_exact_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path, lock_descriptor, descriptor = self.open_empty(directory)
+            try:
+                initialized = provider.initialize_journal_file(
+                    lock_descriptor, descriptor, "initial"
+                )
+                selected = provider.read_journal_file(lock_descriptor, descriptor)
+            finally:
+                os.close(descriptor)
+                os.close(lock_descriptor)
+
+            self.assertEqual(initialized, provider.JournalFrame(1, "initial"))
+            self.assertEqual(selected, (0, initialized))
+            self.assertEqual(path.stat().st_size, provider.JOURNAL_FILE_SIZE)
+            self.assertEqual(path.stat().st_mode & 0o7777, 0o600)
+
+    def test_commits_alternate_frames_without_resizing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path, lock_descriptor, descriptor = self.open_empty(directory)
+            try:
+                provider.initialize_journal_file(lock_descriptor, descriptor)
+                self.assertEqual(
+                    provider.commit_journal_file(lock_descriptor, descriptor, "second"),
+                    (1, provider.JournalFrame(2, "second")),
+                )
+                self.assertEqual(
+                    provider.commit_journal_file(lock_descriptor, descriptor, "third"),
+                    (0, provider.JournalFrame(3, "third")),
+                )
+                self.assertEqual(
+                    provider.read_journal_file(lock_descriptor, descriptor),
+                    (0, provider.JournalFrame(3, "third")),
+                )
+            finally:
+                os.close(descriptor)
+                os.close(lock_descriptor)
+
+            self.assertEqual(path.stat().st_size, provider.JOURNAL_FILE_SIZE)
+
+    def test_reads_until_the_exact_image_is_complete(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _path, lock_descriptor, descriptor = self.open_empty(directory)
+            try:
+                provider.initialize_journal_file(lock_descriptor, descriptor, "chunked")
+                original_pread = os.pread
+
+                def chunked_pread(fd, length, offset):
+                    return original_pread(fd, min(length, 17), offset)
+
+                with mock.patch.object(provider.os, "pread", side_effect=chunked_pread):
+                    self.assertEqual(
+                        provider.read_journal_file(lock_descriptor, descriptor),
+                        (0, provider.JournalFrame(1, "chunked")),
+                    )
+            finally:
+                os.close(descriptor)
+                os.close(lock_descriptor)
+
+    def test_rejects_unsafe_metadata_and_descriptor_access(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path, lock_descriptor, descriptor = self.open_empty(directory)
+            provider.initialize_journal_file(lock_descriptor, descriptor)
+            os.close(descriptor)
+
+            os.chmod(path, 0o644)
+            descriptor = os.open(path, os.O_RDONLY)
+            try:
+                with self.assertRaisesRegex(provider.JournalFileError, "metadata"):
+                    provider.read_journal_file(lock_descriptor, descriptor)
+            finally:
+                os.close(descriptor)
+
+            os.chmod(path, 0o600)
+            descriptor = os.open(path, os.O_RDONLY)
+            try:
+                with self.assertRaisesRegex(provider.JournalFileError, "access"):
+                    provider.commit_journal_file(lock_descriptor, descriptor, "new")
+            finally:
+                os.close(descriptor)
+
+            descriptor = os.open(path, os.O_RDWR | os.O_APPEND)
+            try:
+                with self.assertRaisesRegex(provider.JournalFileError, "access"):
+                    provider.commit_journal_file(lock_descriptor, descriptor, "new")
+                self.assertEqual(path.stat().st_size, provider.JOURNAL_FILE_SIZE)
+            finally:
+                os.close(descriptor)
+
+            os.link(path, pathlib.Path(directory) / "extra-link")
+            descriptor = os.open(path, os.O_RDWR)
+            try:
+                with self.assertRaisesRegex(provider.JournalFileError, "metadata"):
+                    provider.read_journal_file(lock_descriptor, descriptor)
+            finally:
+                os.close(descriptor)
+                os.close(lock_descriptor)
+
+    def test_torn_inactive_frame_preserves_previous_frame(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _path, lock_descriptor, descriptor = self.open_empty(directory)
+            try:
+                provider.initialize_journal_file(
+                    lock_descriptor, descriptor, "previous"
+                )
+                original_pwrite = os.pwrite
+
+                def short_pwrite(fd, data, offset):
+                    return original_pwrite(fd, data[:32], offset)
+
+                with mock.patch.object(provider.os, "pwrite", side_effect=short_pwrite):
+                    with self.assertRaisesRegex(
+                        provider.JournalCommitError, "indeterminate"
+                    ):
+                        provider.commit_journal_file(lock_descriptor, descriptor, "new")
+                self.assertEqual(
+                    provider.read_journal_file(lock_descriptor, descriptor),
+                    (0, provider.JournalFrame(1, "previous")),
+                )
+            finally:
+                os.close(descriptor)
+                os.close(lock_descriptor)
+
+    def test_concurrent_writers_are_serialized_by_directory_lock(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path, first_lock, first_file = self.open_empty(directory)
+            second_file = os.open(path, os.O_RDWR)
+            first_in_sync = threading.Event()
+            release_first = threading.Event()
+            second_done = threading.Event()
+            failures = []
+            original_fsync = os.fsync
+
+            def blocking_fsync(fd):
+                if fd == first_file and not first_in_sync.is_set():
+                    first_in_sync.set()
+                    if not release_first.wait(2):
+                        raise OSError("test did not release the first writer")
+                return original_fsync(fd)
+
+            def write(lock_descriptor, descriptor, payload, done=None):
+                try:
+                    provider.commit_journal_file(lock_descriptor, descriptor, payload)
+                except Exception as error:  # unittest thread boundary
+                    failures.append(error)
+                finally:
+                    if done is not None:
+                        done.set()
+
+            try:
+                provider.initialize_journal_file(first_lock, first_file, "initial")
+                with mock.patch.object(
+                    provider.os, "fsync", side_effect=blocking_fsync
+                ):
+                    first = threading.Thread(
+                        target=write,
+                        args=(first_lock, first_file, "first"),
+                    )
+                    second = threading.Thread(
+                        target=write,
+                        args=(first_lock, second_file, "second", second_done),
+                    )
+                    first.start()
+                    self.assertTrue(first_in_sync.wait(1))
+                    second.start()
+                    self.assertFalse(second_done.wait(0.05))
+                    release_first.set()
+                    first.join(2)
+                    second.join(2)
+
+                self.assertFalse(first.is_alive())
+                self.assertFalse(second.is_alive())
+                self.assertEqual(failures, [])
+                self.assertEqual(
+                    provider.read_journal_file(first_lock, first_file),
+                    (0, provider.JournalFrame(3, "second")),
+                )
+            finally:
+                release_first.set()
+                os.close(second_file)
+                os.close(first_file)
+                os.close(first_lock)
+
+    def test_sync_failure_can_leave_new_frame_authoritative(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _path, lock_descriptor, descriptor = self.open_empty(directory)
+            try:
+                provider.initialize_journal_file(
+                    lock_descriptor, descriptor, "previous"
+                )
+                with mock.patch.object(
+                    provider.os, "fsync", side_effect=OSError("injected sync failure")
+                ):
+                    with self.assertRaisesRegex(
+                        provider.JournalCommitError, "indeterminate"
+                    ):
+                        provider.commit_journal_file(lock_descriptor, descriptor, "new")
+                self.assertEqual(
+                    provider.read_journal_file(lock_descriptor, descriptor),
+                    (1, provider.JournalFrame(2, "new")),
+                )
+            finally:
+                os.close(descriptor)
+                os.close(lock_descriptor)
+
+    def test_readback_mismatch_is_indeterminate(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _path, lock_descriptor, descriptor = self.open_empty(directory)
+            try:
+                provider.initialize_journal_file(
+                    lock_descriptor, descriptor, "previous"
+                )
+                original_read = provider._read_journal_image
+                read_count = 0
+
+                def mismatched_readback(fd):
+                    nonlocal read_count
+                    read_count += 1
+                    image = original_read(fd)
+                    if read_count == 2:
+                        changed = bytearray(image)
+                        changed[provider.JOURNAL_FRAME_SIZE + 32] ^= 1
+                        return bytes(changed)
+                    return image
+
+                with mock.patch.object(
+                    provider, "_read_journal_image", side_effect=mismatched_readback
+                ):
+                    with self.assertRaisesRegex(
+                        provider.JournalCommitError, "indeterminate"
+                    ):
+                        provider.commit_journal_file(lock_descriptor, descriptor, "new")
+                self.assertEqual(
+                    provider.read_journal_file(lock_descriptor, descriptor),
+                    (1, provider.JournalFrame(2, "new")),
+                )
+            finally:
+                os.close(descriptor)
+                os.close(lock_descriptor)
 
 
 class SnapshotValidationTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add bounded shared/exclusive locking through independent handles derived from the held journal-directory descriptor
- validate journal file ownership, type, mode, link count, size, and descriptor access before fixed-offset I/O
- initialize, read, and commit dual-frame journal files with fsync and byte-for-byte readback
- cover concurrent writers, torn writes, sync failures, readback mismatch, short reads, and unsafe descriptors

This is a preparatory storage boundary only. It does not create the journal directory, expose a new provider command, or start a PackageKit mutation.

## Validation

- `ruff format --check scripts/dwm-system-management tests/test-system-management.py`
- `ruff check scripts/dwm-system-management tests/test-system-management.py`
- `/usr/bin/python3 tests/test-system-management.py` (28 tests)
- `make check-system-management`
- `scripts/run-tests make clean all`
- `scripts/run-tests`
- CodeRabbit uncommitted review: clean
- built-in Codex review: clean
