### PR TITLE
Phase 6: initialize fixed update journal layout

### DIFF
--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -8,6 +8,7 @@ import errno
 import fcntl
 import hashlib
 import os
+import re
 import stat
 import struct
 import sys
@@ -34,6 +35,18 @@ JOURNAL_PAYLOAD_MAX = JOURNAL_FRAME_SIZE - JOURNAL_PAYLOAD_OFFSET
 JOURNAL_FILE_SIZE = JOURNAL_FRAME_SIZE * 2
 JOURNAL_SEQUENCE_MAX = (1 << 64) - 1
 JOURNAL_LOCK_DEADLINE_SECONDS = 5
+JOURNAL_TERMINAL_COUNT = 32
+JOURNAL_CURSOR_NAME = "cursor"
+JOURNAL_DATA_NAMES = (
+    "active",
+    "restart",
+    "handoff",
+    *(f"terminal-{index:02d}" for index in range(JOURNAL_TERMINAL_COUNT)),
+)
+JOURNAL_NAMES = (*JOURNAL_DATA_NAMES, JOURNAL_CURSOR_NAME)
+BOOT_ID_PATTERN = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+)
 
 PACKAGEKIT_NAME = "org.freedesktop.PackageKit"
 PACKAGEKIT_PATH = "/org/freedesktop/PackageKit"
@@ -101,6 +114,10 @@ class JournalCommitError(JournalFileError):
 
 class JournalLockError(JournalFileError):
     """The bounded journal directory lock could not be acquired or released."""
+
+
+class JournalLayoutError(JournalFileError):
+    """The fixed journal path set could not be initialized safely."""
 
 
 @dataclass(frozen=True)
@@ -399,6 +416,130 @@ def commit_journal_file(
     """Commit one frame while holding the exclusive directory lock."""
     with _journal_lock(lock_descriptor, exclusive=True):
         return _commit_journal_file_unlocked(descriptor, payload)
+
+
+def _initial_journal_payloads(boot_id: str) -> dict[str, str]:
+    if not isinstance(boot_id, str) or BOOT_ID_PATTERN.fullmatch(boot_id) is None:
+        raise JournalLayoutError("journal boot identity is invalid")
+    payloads = {name: "" for name in JOURNAL_DATA_NAMES}
+    payloads["restart"] = f"{boot_id}\t-\tnone\tnone\t0\tno\t0"
+    payloads[JOURNAL_CURSOR_NAME] = "00"
+    return payloads
+
+
+def _validate_journal_path_identity(
+    directory_descriptor: int,
+    name: str,
+    descriptor: int,
+    expected_size: int,
+) -> None:
+    held = _validate_journal_descriptor(descriptor, expected_size, writable=True)
+    try:
+        reachable = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
+    except OSError as error:
+        raise JournalLayoutError(f"journal path {name} is unavailable") from error
+    if (
+        (reachable.st_dev, reachable.st_ino) != (held.st_dev, held.st_ino)
+        or not stat.S_ISREG(reachable.st_mode)
+        or reachable.st_uid != os.geteuid()
+        or stat.S_IMODE(reachable.st_mode) != 0o600
+        or reachable.st_nlink != 1
+        or reachable.st_size != expected_size
+    ):
+        raise JournalLayoutError(f"journal path {name} identity is unsafe")
+
+
+def _create_journal_path_unlocked(
+    directory_descriptor: int, name: str, payload: str
+) -> None:
+    try:
+        descriptor = os.open(
+            name,
+            os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC | os.O_RDWR,
+            0o600,
+            dir_fd=directory_descriptor,
+        )
+    except OSError as error:
+        raise JournalLayoutError(f"journal path {name} creation failed") from error
+    try:
+        try:
+            os.fchmod(descriptor, 0o600)
+            _validate_journal_path_identity(directory_descriptor, name, descriptor, 0)
+            _initialize_journal_file_unlocked(descriptor, payload)
+            _validate_journal_path_identity(
+                directory_descriptor, name, descriptor, JOURNAL_FILE_SIZE
+            )
+        except (OSError, JournalFrameError) as error:
+            raise JournalLayoutError(
+                f"journal path {name} initialization failed"
+            ) from error
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError as error:
+            raise JournalLayoutError(f"journal path {name} close failed") from error
+
+
+def _validate_initial_journal_path_unlocked(
+    directory_descriptor: int, name: str, expected_payload: str
+) -> None:
+    try:
+        descriptor = os.open(
+            name,
+            os.O_NOFOLLOW | os.O_CLOEXEC | os.O_RDWR,
+            dir_fd=directory_descriptor,
+        )
+    except OSError as error:
+        raise JournalLayoutError(f"journal path {name} open failed") from error
+    try:
+        _validate_journal_path_identity(
+            directory_descriptor, name, descriptor, JOURNAL_FILE_SIZE
+        )
+        if _read_journal_file_unlocked(descriptor) != (
+            0,
+            JournalFrame(1, expected_payload),
+        ):
+            raise JournalLayoutError(f"journal path {name} is not initial")
+        _validate_journal_path_identity(
+            directory_descriptor, name, descriptor, JOURNAL_FILE_SIZE
+        )
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError as error:
+            raise JournalLayoutError(f"journal path {name} close failed") from error
+
+
+def initialize_journal_layout(directory_descriptor: int, boot_id: str) -> None:
+    """Create and verify the fixed journal layout with cursor committed last."""
+    payloads = _initial_journal_payloads(boot_id)
+    with _journal_lock(directory_descriptor, exclusive=True):
+        for name in JOURNAL_DATA_NAMES:
+            _create_journal_path_unlocked(directory_descriptor, name, payloads[name])
+        try:
+            os.fsync(directory_descriptor)
+        except OSError as error:
+            raise JournalLayoutError("journal directory sync failed") from error
+        for name in JOURNAL_DATA_NAMES:
+            _validate_initial_journal_path_unlocked(
+                directory_descriptor, name, payloads[name]
+            )
+        _create_journal_path_unlocked(
+            directory_descriptor,
+            JOURNAL_CURSOR_NAME,
+            payloads[JOURNAL_CURSOR_NAME],
+        )
+        for name in JOURNAL_NAMES:
+            _validate_initial_journal_path_unlocked(
+                directory_descriptor, name, payloads[name]
+            )
+        try:
+            os.fsync(directory_descriptor)
+        except OSError as error:
+            # A readable cursor does not prove its directory entry reached
+            # storage. Recovery must decide after a later open; this initializer
+            # cannot report success from an indeterminate sync.
+            raise JournalLayoutError("journal directory sync failed") from error
 
 
 @dataclass(frozen=True)

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -495,10 +495,11 @@ def _validate_initial_journal_path_unlocked(
         _validate_journal_path_identity(
             directory_descriptor, name, descriptor, JOURNAL_FILE_SIZE
         )
-        if _read_journal_file_unlocked(descriptor) != (
-            0,
-            JournalFrame(1, expected_payload),
-        ):
+        try:
+            observed = _read_journal_file_unlocked(descriptor)
+        except JournalFrameError as error:
+            raise JournalLayoutError(f"journal path {name} is not initial") from error
+        if observed != (0, JournalFrame(1, expected_payload)):
             raise JournalLayoutError(f"journal path {name} is not initial")
         _validate_journal_path_identity(
             directory_descriptor, name, descriptor, JOURNAL_FILE_SIZE

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -779,6 +779,22 @@ class JournalLayoutTests(unittest.TestCase):
             finally:
                 os.close(directory_descriptor)
 
+    def test_invalid_initial_frame_uses_layout_error_contract(self):
+        with tempfile.TemporaryDirectory() as directory:
+            active = pathlib.Path(directory) / "active"
+            active.write_bytes(b"\0" * provider.JOURNAL_FILE_SIZE)
+            os.chmod(active, 0o600)
+            directory_descriptor = self.open_directory(directory)
+            try:
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "active is not initial"
+                ):
+                    provider._validate_initial_journal_path_unlocked(
+                        directory_descriptor, "active", "0"
+                    )
+            finally:
+                os.close(directory_descriptor)
+
 
 class SnapshotValidationTests(unittest.TestCase):
     def test_duplicate_plan_preserves_readable_updates(self):

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -614,6 +614,172 @@ class JournalFileTests(unittest.TestCase):
                 os.close(lock_descriptor)
 
 
+class JournalLayoutTests(unittest.TestCase):
+    boot_id = "01234567-89ab-cdef-0123-456789abcdef"
+
+    def open_directory(self, directory):
+        return os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
+
+    def read_path(self, directory_descriptor, name):
+        descriptor = os.open(
+            name,
+            os.O_NOFOLLOW | os.O_CLOEXEC | os.O_RDWR,
+            dir_fd=directory_descriptor,
+        )
+        try:
+            return provider.read_journal_file(directory_descriptor, descriptor)
+        finally:
+            os.close(descriptor)
+
+    def test_fresh_layout_has_exact_initial_records(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory_descriptor = self.open_directory(directory)
+            try:
+                provider.initialize_journal_layout(directory_descriptor, self.boot_id)
+                self.assertEqual(
+                    set(os.listdir(directory)), set(provider.JOURNAL_NAMES)
+                )
+                payloads = provider._initial_journal_payloads(self.boot_id)
+                for name in provider.JOURNAL_NAMES:
+                    with self.subTest(name=name):
+                        path = pathlib.Path(directory) / name
+                        metadata = path.stat()
+                        self.assertEqual(metadata.st_mode & 0o7777, 0o600)
+                        self.assertEqual(metadata.st_nlink, 1)
+                        self.assertEqual(metadata.st_size, provider.JOURNAL_FILE_SIZE)
+                        self.assertEqual(
+                            self.read_path(directory_descriptor, name),
+                            (0, provider.JournalFrame(1, payloads[name])),
+                        )
+            finally:
+                os.close(directory_descriptor)
+
+    def test_invalid_boot_identity_creates_nothing(self):
+        invalid = (
+            "",
+            "01234567-89AB-cdef-0123-456789abcdef",
+            "0123456789ab-cdef-0123-456789abcdef",
+            "01234567-89ab-cdef-0123-456789abcdeg",
+        )
+        for boot_id in invalid:
+            with self.subTest(boot_id=boot_id):
+                with tempfile.TemporaryDirectory() as directory:
+                    directory_descriptor = self.open_directory(directory)
+                    try:
+                        with self.assertRaisesRegex(
+                            provider.JournalLayoutError, "boot identity"
+                        ):
+                            provider.initialize_journal_layout(
+                                directory_descriptor, boot_id
+                            )
+                        self.assertEqual(os.listdir(directory), [])
+                    finally:
+                        os.close(directory_descriptor)
+
+    def test_fixed_symlink_collision_is_not_followed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            victim = pathlib.Path(directory) / "victim"
+            victim.write_bytes(b"do not modify")
+            os.symlink("victim", pathlib.Path(directory) / "active")
+            directory_descriptor = self.open_directory(directory)
+            try:
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "active creation"
+                ):
+                    provider.initialize_journal_layout(
+                        directory_descriptor, self.boot_id
+                    )
+                self.assertEqual(victim.read_bytes(), b"do not modify")
+                self.assertFalse(
+                    (pathlib.Path(directory) / provider.JOURNAL_CURSOR_NAME).exists()
+                )
+            finally:
+                os.close(directory_descriptor)
+
+    def test_directory_sync_failure_leaves_cursor_absent(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory_descriptor = self.open_directory(directory)
+            original_fsync = os.fsync
+
+            def fail_directory_sync(descriptor):
+                if descriptor == directory_descriptor:
+                    raise OSError("injected directory sync failure")
+                return original_fsync(descriptor)
+
+            try:
+                with mock.patch.object(
+                    provider.os, "fsync", side_effect=fail_directory_sync
+                ):
+                    with self.assertRaisesRegex(
+                        provider.JournalLayoutError, "directory sync"
+                    ):
+                        provider.initialize_journal_layout(
+                            directory_descriptor, self.boot_id
+                        )
+                self.assertEqual(
+                    set(os.listdir(directory)), set(provider.JOURNAL_DATA_NAMES)
+                )
+                self.assertFalse(
+                    (pathlib.Path(directory) / provider.JOURNAL_CURSOR_NAME).exists()
+                )
+            finally:
+                os.close(directory_descriptor)
+
+    def test_final_directory_sync_failure_is_not_accepted_as_success(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory_descriptor = self.open_directory(directory)
+            original_fsync = os.fsync
+            directory_syncs = 0
+
+            def fail_final_directory_sync(descriptor):
+                nonlocal directory_syncs
+                if descriptor == directory_descriptor:
+                    directory_syncs += 1
+                    if directory_syncs == 2:
+                        raise OSError("injected final directory sync failure")
+                return original_fsync(descriptor)
+
+            try:
+                with mock.patch.object(
+                    provider.os, "fsync", side_effect=fail_final_directory_sync
+                ):
+                    with self.assertRaisesRegex(
+                        provider.JournalLayoutError, "directory sync"
+                    ):
+                        provider.initialize_journal_layout(
+                            directory_descriptor, self.boot_id
+                        )
+                self.assertEqual(
+                    set(os.listdir(directory)), set(provider.JOURNAL_NAMES)
+                )
+                self.assertEqual(
+                    self.read_path(directory_descriptor, provider.JOURNAL_CURSOR_NAME),
+                    (0, provider.JournalFrame(1, "00")),
+                )
+            finally:
+                os.close(directory_descriptor)
+
+    def test_existing_fixed_file_is_never_replaced(self):
+        with tempfile.TemporaryDirectory() as directory:
+            active = pathlib.Path(directory) / "active"
+            active.write_bytes(b"legacy record")
+            os.chmod(active, 0o600)
+            directory_descriptor = self.open_directory(directory)
+            try:
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "active creation"
+                ):
+                    provider.initialize_journal_layout(
+                        directory_descriptor, self.boot_id
+                    )
+                self.assertEqual(active.read_bytes(), b"legacy record")
+                self.assertFalse(
+                    (pathlib.Path(directory) / provider.JOURNAL_CURSOR_NAME).exists()
+                )
+            finally:
+                os.close(directory_descriptor)
+
+
 class SnapshotValidationTests(unittest.TestCase):
     def test_duplicate_plan_preserves_readable_updates(self):
         update = package(8, "openssl;4.0;x86_64;updates", "TLS library")


### PR DESCRIPTION
## Summary

- define the fixed active, restart, handoff, cursor, and 32 terminal journal names
- initialize all non-cursor records first, sync and verify them, then create and sync the cursor commit marker last
- validate boot identity, descriptor/path identity, ownership, mode, link count, size, and initial payloads without enumerating production state
- fail closed for fixed-name symlinks, legacy collisions, file/directory sync failures, and indeterminate final cursor sync

This remains a preparatory storage boundary. It does not resolve the user state path, recover partial layouts, expose commands, or start PackageKit mutations.

## Validation

- `ruff format --check scripts/dwm-system-management tests/test-system-management.py`
- `ruff check scripts/dwm-system-management tests/test-system-management.py`
- `/usr/bin/python3 tests/test-system-management.py` (34 tests)
- `make check-system-management`
- `scripts/run-tests make clean all`
- `scripts/run-tests`
- CodeRabbit uncommitted review: clean
- built-in Codex review: clean
