### PR TITLE
Phase 6: anchor the update journal state path

### DIFF
--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -307,6 +307,15 @@ def _chmod_directory_descriptor(descriptor: int, mode: int) -> None:
         raise JournalLayoutError("journal directory mode update failed") from error
 
 
+def _mkdir_private_directory(parent_descriptor: int, name: str) -> None:
+    """Create a mode-0700 directory without an umask interruption window."""
+    previous_umask = os.umask(0)
+    try:
+        os.mkdir(name, 0o700, dir_fd=parent_descriptor)
+    finally:
+        os.umask(previous_umask)
+
+
 def _open_directory_component(
     parent_descriptor: int, name: str, *, private: bool
 ) -> int:
@@ -323,7 +332,7 @@ def _open_directory_component(
     if not exists:
         _sync_directory_descriptor(parent_descriptor)
         try:
-            os.mkdir(name, 0o700, dir_fd=parent_descriptor)
+            _mkdir_private_directory(parent_descriptor, name)
             created = True
         except FileExistsError:
             pass

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -14,7 +14,7 @@ import struct
 import sys
 import time
 from dataclasses import dataclass
-from typing import Iterable, Iterator, Protocol, Sequence
+from typing import Iterable, Iterator, Mapping, Protocol, Sequence
 
 
 PROTOCOL_MAJOR = 1
@@ -37,6 +37,9 @@ JOURNAL_SEQUENCE_MAX = (1 << 64) - 1
 JOURNAL_LOCK_DEADLINE_SECONDS = 5
 JOURNAL_TERMINAL_COUNT = 32
 JOURNAL_CURSOR_NAME = "cursor"
+JOURNAL_PATH_MAX = 4095
+JOURNAL_COMPONENT_MAX = 255
+JOURNAL_DIRECTORY_SUFFIX = ("dwm-titus", "system-management")
 JOURNAL_DATA_NAMES = (
     "active",
     "restart",
@@ -124,6 +127,271 @@ class JournalLayoutError(JournalFileError):
 class JournalFrame:
     sequence: int
     payload: str
+
+
+@dataclass
+class JournalDirectoryChain:
+    """Held root-to-journal directory descriptors and their child names."""
+
+    path: str
+    names: tuple[str, ...]
+    descriptors: tuple[int, ...]
+    closed: bool = False
+
+    @property
+    def directory_descriptor(self) -> int:
+        if self.closed:
+            raise JournalLayoutError("journal directory chain is closed")
+        return self.descriptors[-1]
+
+    def validate(self) -> None:
+        validate_journal_directory_chain(self)
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        first_error: OSError | None = None
+        for descriptor in reversed(self.descriptors):
+            try:
+                os.close(descriptor)
+            except OSError as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise JournalLayoutError(
+                "journal directory chain close failed"
+            ) from first_error
+
+    def __enter__(self) -> JournalDirectoryChain:
+        if self.closed:
+            raise JournalLayoutError("journal directory chain is closed")
+        return self
+
+    def __exit__(self, _type: object, _value: object, _traceback: object) -> None:
+        self.close()
+
+
+def _absolute_path_components(path: str) -> tuple[str, ...]:
+    if not isinstance(path, str) or not path.startswith("/") or path.startswith("//"):
+        raise JournalLayoutError("journal state path must be absolute")
+    if "\0" in path:
+        raise JournalLayoutError("journal state path contains a forbidden byte")
+    if path != "/" and os.path.normpath(path) != path:
+        raise JournalLayoutError("journal state path must be canonical")
+    try:
+        encoded = path.encode("utf-8")
+    except UnicodeEncodeError as error:
+        raise JournalLayoutError("journal state path must be UTF-8") from error
+    if not encoded or len(encoded) > JOURNAL_PATH_MAX:
+        raise JournalLayoutError("journal state path is too long")
+    components = tuple(component for component in path.split("/") if component)
+    if any(
+        len(component.encode("utf-8")) > JOURNAL_COMPONENT_MAX
+        for component in components
+    ):
+        raise JournalLayoutError("journal state path component is too long")
+    return components
+
+
+def journal_directory_path(environment: Mapping[str, str] | None = None) -> str:
+    """Resolve the canonical absolute journal directory from XDG state inputs."""
+    source = os.environ if environment is None else environment
+    state_home = source.get("XDG_STATE_HOME", "")
+    if not state_home:
+        home = source.get("HOME", "")
+        if not home:
+            raise JournalLayoutError("HOME is required for journal state")
+        state_home = os.path.join(home, ".local", "state")
+    _absolute_path_components(state_home)
+    path = os.path.join(state_home, *JOURNAL_DIRECTORY_SUFFIX)
+    _absolute_path_components(path)
+    return path
+
+
+def _validate_directory_component(
+    parent_descriptor: int,
+    name: str,
+    descriptor: int,
+    *,
+    private: bool,
+) -> None:
+    try:
+        held = os.fstat(descriptor)
+        flags = fcntl.fcntl(descriptor, fcntl.F_GETFL)
+        descriptor_flags = fcntl.fcntl(descriptor, fcntl.F_GETFD)
+        reachable = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+    except (OSError, OverflowError) as error:
+        raise JournalLayoutError(
+            f"journal directory component {name} is unavailable"
+        ) from error
+    if (
+        not stat.S_ISDIR(held.st_mode)
+        or not stat.S_ISDIR(reachable.st_mode)
+        or (held.st_dev, held.st_ino) != (reachable.st_dev, reachable.st_ino)
+        or (flags & os.O_ACCMODE) == os.O_WRONLY
+        or not descriptor_flags & fcntl.FD_CLOEXEC
+    ):
+        raise JournalLayoutError(f"journal directory component {name} is unsafe")
+    if private and (
+        held.st_uid != os.geteuid()
+        or stat.S_IMODE(held.st_mode) != 0o700
+        or reachable.st_uid != held.st_uid
+        or stat.S_IMODE(reachable.st_mode) != 0o700
+    ):
+        raise JournalLayoutError(f"journal directory component {name} is not private")
+
+
+def _sync_directory_descriptor(descriptor: int) -> None:
+    try:
+        held = os.fstat(descriptor)
+        flags = fcntl.fcntl(descriptor, fcntl.F_GETFL)
+    except (OSError, OverflowError) as error:
+        raise JournalLayoutError(
+            "journal directory sync handle is unavailable"
+        ) from error
+    if not flags & os.O_PATH:
+        try:
+            os.fsync(descriptor)
+        except OSError as error:
+            raise JournalLayoutError("journal directory sync failed") from error
+        return
+    try:
+        sync_descriptor = os.open(
+            ".",
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=descriptor,
+        )
+    except OSError as error:
+        raise JournalLayoutError(
+            "journal directory sync handle is unavailable"
+        ) from error
+    try:
+        current = os.fstat(sync_descriptor)
+        if (current.st_dev, current.st_ino) != (held.st_dev, held.st_ino):
+            raise JournalLayoutError("journal directory sync identity changed")
+        os.fsync(sync_descriptor)
+    except OSError as error:
+        if isinstance(error, JournalLayoutError):
+            raise
+        raise JournalLayoutError("journal directory sync failed") from error
+    finally:
+        try:
+            os.close(sync_descriptor)
+        except OSError as error:
+            raise JournalLayoutError(
+                "journal directory sync handle close failed"
+            ) from error
+
+
+def _open_directory_component(
+    parent_descriptor: int, name: str, *, private: bool
+) -> int:
+    created = False
+    try:
+        os.mkdir(name, 0o700, dir_fd=parent_descriptor)
+        created = True
+    except FileExistsError:
+        pass
+    except OSError as error:
+        raise JournalLayoutError(
+            f"journal directory component {name} creation failed"
+        ) from error
+    try:
+        access = os.O_RDONLY if private or created else os.O_PATH
+        descriptor = os.open(
+            name,
+            access | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=parent_descriptor,
+        )
+    except OSError as error:
+        raise JournalLayoutError(
+            f"journal directory component {name} open failed"
+        ) from error
+    try:
+        _validate_directory_component(
+            parent_descriptor, name, descriptor, private=False
+        )
+        if created:
+            os.fchmod(descriptor, 0o700)
+            _sync_directory_descriptor(descriptor)
+            _sync_directory_descriptor(parent_descriptor)
+        _validate_directory_component(
+            parent_descriptor, name, descriptor, private=private or created
+        )
+    except OSError as error:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        if isinstance(error, JournalLayoutError):
+            raise
+        raise JournalLayoutError(
+            f"journal directory component {name} initialization failed"
+        ) from error
+    return descriptor
+
+
+def validate_journal_directory_chain(chain: JournalDirectoryChain) -> None:
+    """Prove every retained child is still reachable from its held parent."""
+    if chain.closed or len(chain.descriptors) != len(chain.names) + 1:
+        raise JournalLayoutError("journal directory chain is invalid")
+    try:
+        root = os.fstat(chain.descriptors[0])
+        root_flags = fcntl.fcntl(chain.descriptors[0], fcntl.F_GETFL)
+        root_descriptor_flags = fcntl.fcntl(chain.descriptors[0], fcntl.F_GETFD)
+    except (OSError, OverflowError) as error:
+        raise JournalLayoutError("journal root descriptor is unavailable") from error
+    if (
+        not stat.S_ISDIR(root.st_mode)
+        or (root_flags & os.O_ACCMODE) == os.O_WRONLY
+        or not root_descriptor_flags & fcntl.FD_CLOEXEC
+    ):
+        raise JournalLayoutError("journal root descriptor is unsafe")
+    for index, name in enumerate(chain.names):
+        _validate_directory_component(
+            chain.descriptors[index],
+            name,
+            chain.descriptors[index + 1],
+            private=index == len(chain.names) - 1,
+        )
+
+
+def open_journal_directory_chain(path: str) -> JournalDirectoryChain:
+    """Open or create a root-anchored journal directory descriptor chain."""
+    names = _absolute_path_components(path)
+    if not names:
+        raise JournalLayoutError("journal directory path must not be root")
+    descriptors: list[int] = []
+    try:
+        descriptors.append(
+            os.open("/", os.O_PATH | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC)
+        )
+        for index, name in enumerate(names):
+            descriptors.append(
+                _open_directory_component(
+                    descriptors[-1], name, private=index == len(names) - 1
+                )
+            )
+        chain = JournalDirectoryChain(path, names, tuple(descriptors))
+        chain.validate()
+        return chain
+    except (OSError, JournalLayoutError) as error:
+        for descriptor in reversed(descriptors):
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        if isinstance(error, JournalLayoutError):
+            raise
+        raise JournalLayoutError("journal directory chain open failed") from error
+
+
+def open_journal_directory(
+    environment: Mapping[str, str] | None = None,
+) -> JournalDirectoryChain:
+    """Resolve and open the fixed journal directory from XDG state inputs."""
+    return open_journal_directory_chain(journal_directory_path(environment))
 
 
 def _journal_payload_bytes(payload: str) -> bytes:

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -198,10 +198,20 @@ def journal_directory_path(environment: Mapping[str, str] | None = None) -> str:
     """Resolve the canonical absolute journal directory from XDG state inputs."""
     source = os.environ if environment is None else environment
     state_home = source.get("XDG_STATE_HOME", "")
+    if (
+        isinstance(state_home, str)
+        and state_home not in {"", "/"}
+        and not state_home.startswith("//")
+    ):
+        state_home = state_home.rstrip("/")
+    if not isinstance(state_home, str) or not state_home.startswith("/"):
+        state_home = ""
     if not state_home:
         home = source.get("HOME", "")
-        if not home:
+        if not isinstance(home, str) or not home:
             raise JournalLayoutError("HOME is required for journal state")
+        if isinstance(home, str) and home != "/":
+            home = home.rstrip("/")
         state_home = os.path.join(home, ".local", "state")
     _absolute_path_components(state_home)
     path = os.path.join(state_home, *JOURNAL_DIRECTORY_SUFFIX)
@@ -242,7 +252,9 @@ def _validate_directory_component(
         raise JournalLayoutError(f"journal directory component {name} is not private")
 
 
-def _sync_directory_descriptor(descriptor: int) -> None:
+def _sync_directory_descriptor(
+    descriptor: int, *, allow_unreadable: bool = False
+) -> bool:
     try:
         held = os.fstat(descriptor)
         flags = fcntl.fcntl(descriptor, fcntl.F_GETFL)
@@ -255,7 +267,7 @@ def _sync_directory_descriptor(descriptor: int) -> None:
             os.fsync(descriptor)
         except OSError as error:
             raise JournalLayoutError("journal directory sync failed") from error
-        return
+        return True
     try:
         sync_descriptor = os.open(
             ".",
@@ -263,6 +275,8 @@ def _sync_directory_descriptor(descriptor: int) -> None:
             dir_fd=descriptor,
         )
     except OSError as error:
+        if allow_unreadable and error.errno in {errno.EACCES, errno.EPERM}:
+            return False
         raise JournalLayoutError(
             "journal directory sync handle is unavailable"
         ) from error
@@ -282,6 +296,15 @@ def _sync_directory_descriptor(descriptor: int) -> None:
             raise JournalLayoutError(
                 "journal directory sync handle close failed"
             ) from error
+    return True
+
+
+def _chmod_directory_descriptor(descriptor: int, mode: int) -> None:
+    """Change a held directory's mode without reopening its mutable pathname."""
+    try:
+        os.chmod(f"/proc/self/fd/{descriptor}", mode)
+    except (OSError, ValueError) as error:
+        raise JournalLayoutError("journal directory mode update failed") from error
 
 
 def _open_directory_component(
@@ -289,19 +312,29 @@ def _open_directory_component(
 ) -> int:
     created = False
     try:
-        os.mkdir(name, 0o700, dir_fd=parent_descriptor)
-        created = True
-    except FileExistsError:
-        pass
+        os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+        exists = True
+    except FileNotFoundError:
+        exists = False
     except OSError as error:
         raise JournalLayoutError(
-            f"journal directory component {name} creation failed"
+            f"journal directory component {name} lookup failed"
         ) from error
+    if not exists:
+        _sync_directory_descriptor(parent_descriptor)
+        try:
+            os.mkdir(name, 0o700, dir_fd=parent_descriptor)
+            created = True
+        except FileExistsError:
+            pass
+        except OSError as error:
+            raise JournalLayoutError(
+                f"journal directory component {name} creation failed"
+            ) from error
     try:
-        access = os.O_RDONLY if private or created else os.O_PATH
         descriptor = os.open(
             name,
-            access | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            os.O_PATH | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
             dir_fd=parent_descriptor,
         )
     except OSError as error:
@@ -313,9 +346,31 @@ def _open_directory_component(
             parent_descriptor, name, descriptor, private=False
         )
         if created:
-            os.fchmod(descriptor, 0o700)
+            _chmod_directory_descriptor(descriptor, 0o700)
+            _validate_directory_component(
+                parent_descriptor, name, descriptor, private=True
+            )
+        if private or created:
+            readable_descriptor = os.open(
+                ".",
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+                dir_fd=descriptor,
+            )
+            readable = os.fstat(readable_descriptor)
+            held = os.fstat(descriptor)
+            if (readable.st_dev, readable.st_ino) != (held.st_dev, held.st_ino):
+                os.close(readable_descriptor)
+                raise JournalLayoutError(
+                    f"journal directory component {name} identity changed"
+                )
+            os.close(descriptor)
+            descriptor = readable_descriptor
+        if created:
             _sync_directory_descriptor(descriptor)
             _sync_directory_descriptor(parent_descriptor)
+        else:
+            _sync_directory_descriptor(descriptor, allow_unreadable=not private)
+            _sync_directory_descriptor(parent_descriptor, allow_unreadable=True)
         _validate_directory_component(
             parent_descriptor, name, descriptor, private=private or created
         )

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import importlib.util
 import importlib.machinery
@@ -809,12 +810,21 @@ class JournalDirectoryChainTests(unittest.TestCase):
             provider.journal_directory_path({"HOME": "/var/tmp/home"}),
             "/var/tmp/home/.local/state/dwm-titus/system-management",
         )
+        self.assertEqual(
+            provider.journal_directory_path(
+                {"XDG_STATE_HOME": "relative", "HOME": "/var/tmp/home/"}
+            ),
+            "/var/tmp/home/.local/state/dwm-titus/system-management",
+        )
+        self.assertEqual(
+            provider.journal_directory_path({"XDG_STATE_HOME": "/var/tmp/state/"}),
+            "/var/tmp/state/dwm-titus/system-management",
+        )
 
     def test_invalid_state_inputs_fail_before_filesystem_access(self):
         cases = (
             {},
             {"HOME": "relative"},
-            {"XDG_STATE_HOME": "relative", "HOME": "/ignored"},
             {"XDG_STATE_HOME": "/tmp/../state"},
             {"XDG_STATE_HOME": "/tmp//state"},
             {"XDG_STATE_HOME": "/tmp/state\0suffix"},
@@ -868,6 +878,156 @@ class JournalDirectoryChainTests(unittest.TestCase):
                     chain.validate()
             finally:
                 os.chmod(ancestor, 0o700)
+
+    def test_execute_only_parent_is_rejected_before_child_creation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            ancestor = pathlib.Path(directory) / "traverse-only"
+            ancestor.mkdir()
+            os.chmod(ancestor, 0o311)
+            ancestor_identity = (ancestor.stat().st_dev, ancestor.stat().st_ino)
+            original_open = os.open
+
+            def reject_readable_ancestor(path, flags, *args, **kwargs):
+                descriptor = kwargs.get("dir_fd")
+                if path == "." and descriptor is not None:
+                    metadata = os.fstat(descriptor)
+                    if (metadata.st_dev, metadata.st_ino) == ancestor_identity:
+                        raise PermissionError(errno.EACCES, "injected access denial")
+                return original_open(path, flags, *args, **kwargs)
+
+            try:
+                journal = ancestor / "state" / "dwm-titus" / "system-management"
+                with mock.patch.object(
+                    provider.os, "open", side_effect=reject_readable_ancestor
+                ):
+                    with self.assertRaisesRegex(
+                        provider.JournalLayoutError, "sync handle"
+                    ):
+                        provider.open_journal_directory_chain(str(journal))
+                self.assertFalse((ancestor / "state").exists())
+            finally:
+                os.chmod(ancestor, 0o700)
+
+    def test_restrictive_umask_cannot_remove_created_owner_access(self):
+        with tempfile.TemporaryDirectory() as directory:
+            journal = (
+                pathlib.Path(directory) / "state" / "dwm-titus" / "system-management"
+            )
+            previous_umask = os.umask(0o777)
+            try:
+                with provider.open_journal_directory_chain(str(journal)) as chain:
+                    self.assertEqual(
+                        stat.S_IMODE(os.fstat(chain.directory_descriptor).st_mode),
+                        0o700,
+                    )
+            finally:
+                os.umask(previous_umask)
+
+    def test_retry_resyncs_an_indeterminate_created_parent_entry(self):
+        with tempfile.TemporaryDirectory() as directory:
+            parent = pathlib.Path(directory) / "state" / "dwm-titus"
+            parent.mkdir(parents=True)
+            journal = parent / "system-management"
+            parent_identity = (parent.stat().st_dev, parent.stat().st_ino)
+            original_fsync = os.fsync
+            failed_parent_sync = False
+
+            def fail_created_entry_sync(descriptor):
+                nonlocal failed_parent_sync
+                metadata = os.fstat(descriptor)
+                if (
+                    not failed_parent_sync
+                    and journal.exists()
+                    and (metadata.st_dev, metadata.st_ino) == parent_identity
+                ):
+                    failed_parent_sync = True
+                    raise OSError("injected parent sync failure")
+                return original_fsync(descriptor)
+
+            with mock.patch.object(
+                provider.os, "fsync", side_effect=fail_created_entry_sync
+            ):
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "directory sync failed"
+                ):
+                    provider.open_journal_directory_chain(str(journal))
+            self.assertTrue(journal.is_dir())
+
+            observed_parent_sync = False
+
+            def observe_parent_sync(descriptor):
+                nonlocal observed_parent_sync
+                metadata = os.fstat(descriptor)
+                if (metadata.st_dev, metadata.st_ino) == parent_identity:
+                    observed_parent_sync = True
+                return original_fsync(descriptor)
+
+            with mock.patch.object(
+                provider.os, "fsync", side_effect=observe_parent_sync
+            ):
+                with provider.open_journal_directory_chain(str(journal)) as chain:
+                    chain.validate()
+            self.assertTrue(observed_parent_sync)
+
+    def test_retry_resyncs_an_indeterminate_created_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            parent = pathlib.Path(directory) / "state" / "dwm-titus"
+            parent.mkdir(parents=True)
+            journal = parent / "system-management"
+            original_fsync = os.fsync
+
+            def fail_final_sync(descriptor):
+                metadata = os.fstat(descriptor)
+                if journal.exists():
+                    current = journal.stat()
+                    if (metadata.st_dev, metadata.st_ino) == (
+                        current.st_dev,
+                        current.st_ino,
+                    ):
+                        raise OSError("injected directory sync failure")
+                return original_fsync(descriptor)
+
+            with mock.patch.object(provider.os, "fsync", side_effect=fail_final_sync):
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "directory sync failed"
+                ):
+                    provider.open_journal_directory_chain(str(journal))
+            journal_identity = (journal.stat().st_dev, journal.stat().st_ino)
+
+            observed_directory_sync = False
+
+            def observe_directory_sync(descriptor):
+                nonlocal observed_directory_sync
+                metadata = os.fstat(descriptor)
+                if (metadata.st_dev, metadata.st_ino) == journal_identity:
+                    observed_directory_sync = True
+                return original_fsync(descriptor)
+
+            with mock.patch.object(
+                provider.os, "fsync", side_effect=observe_directory_sync
+            ):
+                with provider.open_journal_directory_chain(str(journal)) as chain:
+                    chain.validate()
+            self.assertTrue(observed_directory_sync)
+
+    def test_created_directory_mode_update_follows_the_held_descriptor(self):
+        with tempfile.TemporaryDirectory() as directory:
+            original = pathlib.Path(directory) / "original"
+            replacement = pathlib.Path(directory) / "replacement"
+            original.mkdir(mode=0o755)
+            replacement.mkdir(mode=0o755)
+            os.chmod(original, 0o755)
+            os.chmod(replacement, 0o755)
+            descriptor = os.open(original, os.O_PATH | os.O_DIRECTORY)
+            try:
+                moved = pathlib.Path(directory) / "moved"
+                original.rename(moved)
+                replacement.rename(original)
+                provider._chmod_directory_descriptor(descriptor, 0o700)
+                self.assertEqual(stat.S_IMODE(moved.stat().st_mode), 0o700)
+                self.assertEqual(stat.S_IMODE(original.stat().st_mode), 0o755)
+            finally:
+                os.close(descriptor)
 
     def test_existing_nonprivate_ancestor_is_not_modified(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -923,6 +923,30 @@ class JournalDirectoryChainTests(unittest.TestCase):
             finally:
                 os.umask(previous_umask)
 
+    def test_interrupted_mode_repair_leaves_a_retryable_private_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            parent = pathlib.Path(directory) / "state" / "dwm-titus"
+            parent.mkdir(parents=True)
+            journal = parent / "system-management"
+            previous_umask = os.umask(0o777)
+            try:
+                with mock.patch.object(
+                    provider,
+                    "_chmod_directory_descriptor",
+                    side_effect=provider.JournalLayoutError(
+                        "injected mode update interruption"
+                    ),
+                ):
+                    with self.assertRaisesRegex(
+                        provider.JournalLayoutError, "mode update interruption"
+                    ):
+                        provider.open_journal_directory_chain(str(journal))
+                self.assertEqual(stat.S_IMODE(journal.stat().st_mode), 0o700)
+                with provider.open_journal_directory_chain(str(journal)) as chain:
+                    chain.validate()
+            finally:
+                os.umask(previous_umask)
+
     def test_retry_resyncs_an_indeterminate_created_parent_entry(self):
         with tempfile.TemporaryDirectory() as directory:
             parent = pathlib.Path(directory) / "state" / "dwm-titus"

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -8,6 +8,7 @@ import importlib.util
 import importlib.machinery
 import os
 import pathlib
+import stat
 import sys
 import tempfile
 import threading
@@ -794,6 +795,151 @@ class JournalLayoutTests(unittest.TestCase):
                     )
             finally:
                 os.close(directory_descriptor)
+
+
+class JournalDirectoryChainTests(unittest.TestCase):
+    def test_xdg_state_path_and_home_fallback_are_canonical(self):
+        self.assertEqual(
+            provider.journal_directory_path(
+                {"XDG_STATE_HOME": "/var/tmp/state", "HOME": "/ignored"}
+            ),
+            "/var/tmp/state/dwm-titus/system-management",
+        )
+        self.assertEqual(
+            provider.journal_directory_path({"HOME": "/var/tmp/home"}),
+            "/var/tmp/home/.local/state/dwm-titus/system-management",
+        )
+
+    def test_invalid_state_inputs_fail_before_filesystem_access(self):
+        cases = (
+            {},
+            {"HOME": "relative"},
+            {"XDG_STATE_HOME": "relative", "HOME": "/ignored"},
+            {"XDG_STATE_HOME": "/tmp/../state"},
+            {"XDG_STATE_HOME": "/tmp//state"},
+            {"XDG_STATE_HOME": "/tmp/state\0suffix"},
+            {"XDG_STATE_HOME": f"/tmp/{'x' * 256}"},
+        )
+        for environment in cases:
+            with self.subTest(environment=environment):
+                with self.assertRaises(provider.JournalLayoutError):
+                    provider.journal_directory_path(environment)
+
+    def test_fresh_chain_creates_private_journal_and_retains_each_component(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state_home = pathlib.Path(directory) / "new" / "state"
+            chain = provider.open_journal_directory(
+                {"XDG_STATE_HOME": str(state_home), "HOME": "/ignored"}
+            )
+            descriptors = chain.descriptors
+            try:
+                self.assertEqual(
+                    chain.path,
+                    str(state_home / "dwm-titus" / "system-management"),
+                )
+                self.assertEqual(len(descriptors), len(chain.names) + 1)
+                self.assertEqual(
+                    stat.S_IMODE(os.fstat(chain.directory_descriptor).st_mode), 0o700
+                )
+                chain.validate()
+            finally:
+                chain.close()
+            for descriptor in descriptors:
+                with self.assertRaises(OSError):
+                    os.fstat(descriptor)
+
+    def test_root_path_is_rejected_before_opening_a_descriptor(self):
+        with mock.patch.object(provider.os, "open") as open_mock:
+            with self.assertRaisesRegex(
+                provider.JournalLayoutError, "must not be root"
+            ):
+                provider.open_journal_directory_chain("/")
+        open_mock.assert_not_called()
+
+    def test_execute_only_existing_ancestor_can_be_retained(self):
+        with tempfile.TemporaryDirectory() as directory:
+            ancestor = pathlib.Path(directory) / "traverse-only"
+            journal = ancestor / "state" / "dwm-titus" / "system-management"
+            journal.mkdir(parents=True, mode=0o700)
+            os.chmod(journal, 0o700)
+            os.chmod(ancestor, 0o311)
+            try:
+                with provider.open_journal_directory_chain(str(journal)) as chain:
+                    chain.validate()
+            finally:
+                os.chmod(ancestor, 0o700)
+
+    def test_existing_nonprivate_ancestor_is_not_modified(self):
+        with tempfile.TemporaryDirectory() as directory:
+            ancestor = pathlib.Path(directory) / "shared"
+            ancestor.mkdir(mode=0o755)
+            os.chmod(ancestor, 0o755)
+            with provider.open_journal_directory_chain(
+                str(ancestor / "state" / "dwm-titus" / "system-management")
+            ) as chain:
+                chain.validate()
+                self.assertEqual(stat.S_IMODE(ancestor.stat().st_mode), 0o755)
+
+    def test_nonprivate_existing_journal_is_rejected_without_chmod(self):
+        with tempfile.TemporaryDirectory() as directory:
+            journal = pathlib.Path(directory) / "dwm-titus" / "system-management"
+            journal.mkdir(parents=True, mode=0o755)
+            os.chmod(journal, 0o755)
+            with self.assertRaisesRegex(
+                provider.JournalLayoutError, "system-management is not private"
+            ):
+                provider.open_journal_directory_chain(str(journal))
+            self.assertEqual(stat.S_IMODE(journal.stat().st_mode), 0o755)
+
+    def test_symlink_and_nondirectory_components_fail_closed(self):
+        for collision in ("symlink", "file"):
+            with (
+                self.subTest(collision=collision),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                state = pathlib.Path(directory) / "state"
+                if collision == "symlink":
+                    target = pathlib.Path(directory) / "target"
+                    target.mkdir()
+                    state.symlink_to(target, target_is_directory=True)
+                else:
+                    state.write_text("not a directory", encoding="utf-8")
+                with self.assertRaises(provider.JournalLayoutError):
+                    provider.open_journal_directory_chain(
+                        str(state / "dwm-titus" / "system-management")
+                    )
+
+    def test_renamed_ancestor_fails_identity_validation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state = pathlib.Path(directory) / "state"
+            journal = state / "dwm-titus" / "system-management"
+            chain = provider.open_journal_directory_chain(str(journal))
+            try:
+                moved = pathlib.Path(directory) / "state-moved"
+                state.rename(moved)
+                state.mkdir()
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "state is unsafe"
+                ):
+                    chain.validate()
+            finally:
+                chain.close()
+
+    def test_renamed_journal_fails_identity_validation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state = pathlib.Path(directory) / "state"
+            journal = state / "dwm-titus" / "system-management"
+            chain = provider.open_journal_directory_chain(str(journal))
+            try:
+                moved = journal.with_name("system-management-moved")
+                journal.rename(moved)
+                journal.mkdir(mode=0o700)
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "system-management is unsafe"
+                ):
+                    chain.validate()
+            finally:
+                chain.close()
 
 
 class SnapshotValidationTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- resolve the fixed journal directory from canonical absolute XDG state inputs
- open or create every path component from a held root descriptor without following symlinks
- retain and revalidate the full parent-child descriptor chain, including execute-only ancestors
- require the final journal directory to remain user-owned mode 0700 and sync new directory entries

## Validation

- `ruff format --check scripts/dwm-system-management tests/test-system-management.py`
- `ruff check scripts/dwm-system-management tests/test-system-management.py`
- `python3 -B -m unittest tests.test-system-management` (45 tests)
- `scripts/run-tests make clean all`
- `scripts/run-tests`
- built-in Codex review: clean
- CodeRabbit CLI review: clean

## Review boundary

This PR only establishes safe state-path resolution, directory creation, retained descriptors, and ancestor identity checks. Partial-layout recovery, opening the 36 fixed files as a set, and PackageKit mutations remain deferred to later Phase 6 PRs.