### PR TITLE
Phase 6: recover partial update journal layouts

### DIFF
--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -781,16 +781,25 @@ def _validate_journal_path_identity(
         raise JournalLayoutError(f"journal path {name} identity is unsafe")
 
 
-def _create_journal_path_unlocked(
-    directory_descriptor: int, name: str, payload: str
-) -> None:
+def _create_private_journal_descriptor(directory_descriptor: int, name: str) -> int:
+    """Create a mode-0600 fixed path without an umask interruption window."""
+    previous_umask = os.umask(0)
     try:
-        descriptor = os.open(
+        return os.open(
             name,
             os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC | os.O_RDWR,
             0o600,
             dir_fd=directory_descriptor,
         )
+    finally:
+        os.umask(previous_umask)
+
+
+def _create_journal_path_unlocked(
+    directory_descriptor: int, name: str, payload: str
+) -> None:
+    try:
+        descriptor = _create_private_journal_descriptor(directory_descriptor, name)
     except OSError as error:
         raise JournalLayoutError(f"journal path {name} creation failed") from error
     try:
@@ -810,6 +819,259 @@ def _create_journal_path_unlocked(
             os.close(descriptor)
         except OSError as error:
             raise JournalLayoutError(f"journal path {name} close failed") from error
+
+
+def _open_partial_journal_path_unlocked(
+    directory_descriptor: int, name: str
+) -> int | None:
+    try:
+        return os.open(
+            name,
+            os.O_NOFOLLOW | os.O_CLOEXEC | os.O_RDWR,
+            dir_fd=directory_descriptor,
+        )
+    except FileNotFoundError:
+        return None
+    except OSError as error:
+        raise JournalLayoutError(f"journal path {name} open failed") from error
+
+
+def _validate_partial_journal_path_identity(
+    directory_descriptor: int, name: str, descriptor: int
+) -> os.stat_result:
+    try:
+        held = os.fstat(descriptor)
+        flags = fcntl.fcntl(descriptor, fcntl.F_GETFL)
+        descriptor_flags = fcntl.fcntl(descriptor, fcntl.F_GETFD)
+        reachable = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
+    except (OSError, OverflowError) as error:
+        raise JournalLayoutError(f"journal path {name} is unavailable") from error
+    if (
+        not stat.S_ISREG(held.st_mode)
+        or not stat.S_ISREG(reachable.st_mode)
+        or (held.st_dev, held.st_ino) != (reachable.st_dev, reachable.st_ino)
+        or held.st_uid != os.geteuid()
+        or reachable.st_uid != held.st_uid
+        or stat.S_IMODE(held.st_mode) != 0o600
+        or stat.S_IMODE(reachable.st_mode) != 0o600
+        or held.st_nlink != 1
+        or reachable.st_nlink != 1
+        or held.st_size != reachable.st_size
+        or held.st_size < 0
+        or held.st_size > JOURNAL_FILE_SIZE
+        or (flags & os.O_ACCMODE) != os.O_RDWR
+        or flags & os.O_APPEND
+        or not descriptor_flags & fcntl.FD_CLOEXEC
+    ):
+        raise JournalLayoutError(f"journal path {name} partial metadata is unsafe")
+    return held
+
+
+def _read_partial_journal_image_unlocked(
+    directory_descriptor: int, name: str, descriptor: int
+) -> bytes:
+    before = _validate_partial_journal_path_identity(
+        directory_descriptor, name, descriptor
+    )
+    chunks: list[bytes] = []
+    offset = 0
+    while offset < before.st_size:
+        try:
+            chunk = os.pread(descriptor, before.st_size - offset, offset)
+        except OSError as error:
+            raise JournalLayoutError(f"journal path {name} read failed") from error
+        if not chunk:
+            raise JournalLayoutError(f"journal path {name} read was incomplete")
+        chunks.append(chunk)
+        offset += len(chunk)
+    after = _validate_partial_journal_path_identity(
+        directory_descriptor, name, descriptor
+    )
+    if (before.st_dev, before.st_ino, before.st_size) != (
+        after.st_dev,
+        after.st_ino,
+        after.st_size,
+    ):
+        raise JournalLayoutError(f"journal path {name} changed while reading")
+    return b"".join(chunks)
+
+
+def _is_safe_initial_fragment(image: bytes, expected: bytes) -> bool:
+    if len(image) > len(expected):
+        return False
+    if image == expected[: len(image)]:
+        return True
+    if len(image) != len(expected):
+        return False
+    common = 0
+    while common < len(expected) and image[common] == expected[common]:
+        common += 1
+    return common > 0 and not any(image[common:])
+
+
+def _is_all_clear_restart_payload(payload: str) -> bool:
+    fields = payload.split("\t")
+    return (
+        len(fields) == 7
+        and BOOT_ID_PATTERN.fullmatch(fields[0]) is not None
+        and fields[1:] == ["-", "none", "none", "0", "no", "0"]
+    )
+
+
+def _restart_initial_header() -> bytes:
+    payload_size = len(
+        "01234567-89ab-cdef-0123-456789abcdef\t-\tnone\tnone\t0\tno\t0".encode()
+    )
+    return struct.pack(
+        "<8sHHIQQ",
+        JOURNAL_MAGIC,
+        JOURNAL_FRAME_MAJOR,
+        JOURNAL_FRAME_MINOR,
+        payload_size,
+        1,
+        0,
+    )
+
+
+def _is_all_clear_restart_payload_prefix(encoded: bytes) -> bool:
+    uuid_template = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    suffix = b"\t-\tnone\tnone\t0\tno\t0"
+    if len(encoded) > len(uuid_template) + len(suffix):
+        return False
+    for index, byte in enumerate(encoded):
+        if index < len(uuid_template):
+            marker = uuid_template[index]
+            if marker == "-":
+                if byte != ord("-"):
+                    return False
+            elif not (ord("0") <= byte <= ord("9") or ord("a") <= byte <= ord("f")):
+                return False
+        elif byte != suffix[index - len(uuid_template)]:
+            return False
+    return True
+
+
+def _is_safe_restart_initial_fragment(image: bytes) -> bool:
+    if len(image) > JOURNAL_FILE_SIZE:
+        return False
+    header = _restart_initial_header()
+    if len(image) <= len(header):
+        return image == header[: len(image)]
+    if image[: len(header)] != header:
+        return False
+    if len(image) <= JOURNAL_PAYLOAD_OFFSET:
+        return True
+    payload_size = struct.unpack("<I", header[12:16])[0]
+    payload_end = JOURNAL_PAYLOAD_OFFSET + payload_size
+    payload_prefix = image[JOURNAL_PAYLOAD_OFFSET : min(len(image), payload_end)]
+    if not _is_all_clear_restart_payload_prefix(payload_prefix):
+        return False
+    if len(image) < payload_end:
+        return True
+    try:
+        frame = decode_journal_frame(
+            image[:JOURNAL_FRAME_SIZE].ljust(JOURNAL_FRAME_SIZE, b"\0")
+        )
+    except JournalFrameError:
+        return False
+    return (
+        frame.sequence == 1
+        and _is_all_clear_restart_payload(frame.payload)
+        and not any(image[JOURNAL_FRAME_SIZE:])
+    )
+
+
+def _is_safe_restart_rewrite_fragment(image: bytes, expected: bytes) -> bool:
+    header = _restart_initial_header()
+    payload_size = struct.unpack("<I", header[12:16])[0]
+    payload_end = JOURNAL_PAYLOAD_OFFSET + payload_size
+    if len(image) < payload_end or len(image) > JOURNAL_FILE_SIZE:
+        return False
+    try:
+        payload = image[JOURNAL_PAYLOAD_OFFSET:payload_end].decode("ascii")
+    except UnicodeDecodeError:
+        return False
+    if not _is_all_clear_restart_payload(payload):
+        return False
+    previous = initial_journal_image(payload)[: len(image)]
+    current = expected[: len(image)]
+    current_prefix = 0
+    while (
+        current_prefix < len(image) and image[current_prefix] == current[current_prefix]
+    ):
+        current_prefix += 1
+    previous_suffix = len(image)
+    while (
+        previous_suffix > 0
+        and image[previous_suffix - 1] == previous[previous_suffix - 1]
+    ):
+        previous_suffix -= 1
+    return previous_suffix <= current_prefix
+
+
+def _is_safe_initial_path_fragment(name: str, image: bytes, expected: bytes) -> bool:
+    if _is_safe_initial_fragment(image, expected):
+        return True
+    if name != "restart":
+        return False
+    if len(image) == JOURNAL_FILE_SIZE and any(image[JOURNAL_FRAME_SIZE:]):
+        return False
+    if len(image) == JOURNAL_FILE_SIZE:
+        nonzero = image.rstrip(b"\0")
+        if not nonzero:
+            return False
+        payload_size = struct.unpack("<I", _restart_initial_header()[12:16])[0]
+        if len(nonzero) < JOURNAL_PAYLOAD_OFFSET + payload_size:
+            return _is_safe_restart_initial_fragment(nonzero)
+    return _is_safe_restart_initial_fragment(
+        image
+    ) or _is_safe_restart_rewrite_fragment(image, expected)
+
+
+def _rewrite_initial_journal_path_unlocked(
+    directory_descriptor: int,
+    name: str,
+    descriptor: int,
+    payload: str,
+) -> None:
+    expected = initial_journal_image(payload)
+    observed = _read_partial_journal_image_unlocked(
+        directory_descriptor, name, descriptor
+    )
+    if not _is_safe_initial_path_fragment(name, observed, expected):
+        raise JournalLayoutError(f"journal path {name} is not recoverable")
+    try:
+        written = os.pwrite(descriptor, expected, 0)
+        if written != len(expected):
+            raise OSError("short journal recovery write")
+        os.fsync(descriptor)
+        _validate_journal_path_identity(
+            directory_descriptor, name, descriptor, JOURNAL_FILE_SIZE
+        )
+        if _read_journal_image(descriptor) != expected:
+            raise OSError("journal recovery readback mismatch")
+        _validate_journal_path_identity(
+            directory_descriptor, name, descriptor, JOURNAL_FILE_SIZE
+        )
+    except OSError as error:
+        if isinstance(error, JournalLayoutError):
+            raise
+        raise JournalLayoutError(f"journal path {name} recovery failed") from error
+
+
+def _validate_initialized_journal_path_unlocked(
+    directory_descriptor: int, name: str, descriptor: int
+) -> None:
+    try:
+        _validate_journal_path_identity(
+            directory_descriptor, name, descriptor, JOURNAL_FILE_SIZE
+        )
+        select_journal_frame(_read_journal_image(descriptor))
+        _validate_journal_path_identity(
+            directory_descriptor, name, descriptor, JOURNAL_FILE_SIZE
+        )
+    except (JournalFileError, JournalFrameError) as error:
+        raise JournalLayoutError(f"journal path {name} is malformed") from error
 
 
 def _validate_initial_journal_path_unlocked(
@@ -844,35 +1106,119 @@ def _validate_initial_journal_path_unlocked(
 
 
 def initialize_journal_layout(directory_descriptor: int, boot_id: str) -> None:
-    """Create and verify the fixed journal layout with cursor committed last."""
+    """Create or recover the fixed journal layout with cursor committed last."""
     payloads = _initial_journal_payloads(boot_id)
     with _journal_lock(directory_descriptor, exclusive=True):
-        for name in JOURNAL_DATA_NAMES:
-            _create_journal_path_unlocked(directory_descriptor, name, payloads[name])
+        descriptors: dict[str, int] = {}
+        images: dict[str, bytes] = {}
         try:
-            os.fsync(directory_descriptor)
-        except OSError as error:
-            raise JournalLayoutError("journal directory sync failed") from error
-        for name in JOURNAL_DATA_NAMES:
-            _validate_initial_journal_path_unlocked(
-                directory_descriptor, name, payloads[name]
-            )
-        _create_journal_path_unlocked(
-            directory_descriptor,
-            JOURNAL_CURSOR_NAME,
-            payloads[JOURNAL_CURSOR_NAME],
-        )
-        for name in JOURNAL_NAMES:
-            _validate_initial_journal_path_unlocked(
-                directory_descriptor, name, payloads[name]
-            )
-        try:
-            os.fsync(directory_descriptor)
-        except OSError as error:
-            # A readable cursor does not prove its directory entry reached
-            # storage. Recovery must decide after a later open; this initializer
-            # cannot report success from an indeterminate sync.
-            raise JournalLayoutError("journal directory sync failed") from error
+            for name in JOURNAL_NAMES:
+                descriptor = _open_partial_journal_path_unlocked(
+                    directory_descriptor, name
+                )
+                if descriptor is None:
+                    continue
+                descriptors[name] = descriptor
+                images[name] = _read_partial_journal_image_unlocked(
+                    directory_descriptor, name, descriptor
+                )
+
+            cursor = images.get(JOURNAL_CURSOR_NAME)
+            cursor_expected = initial_journal_image(payloads[JOURNAL_CURSOR_NAME])
+            cursor_present = cursor == cursor_expected
+            if cursor is not None and not cursor_present:
+                if _is_safe_initial_fragment(cursor, cursor_expected):
+                    cursor_present = False
+                elif len(cursor) == JOURNAL_FILE_SIZE:
+                    try:
+                        select_journal_frame(cursor)
+                    except JournalFrameError as error:
+                        raise JournalLayoutError(
+                            "journal path cursor is not recoverable"
+                        ) from error
+                    cursor_present = True
+                else:
+                    raise JournalLayoutError("journal path cursor is not recoverable")
+
+            if cursor_present:
+                for name in JOURNAL_NAMES:
+                    descriptor = descriptors.get(name)
+                    if descriptor is None:
+                        raise JournalLayoutError(
+                            f"journal path {name} is missing after cursor"
+                        )
+                    _validate_initialized_journal_path_unlocked(
+                        directory_descriptor, name, descriptor
+                    )
+                try:
+                    os.fsync(directory_descriptor)
+                except OSError as error:
+                    raise JournalLayoutError("journal directory sync failed") from error
+                return
+
+            for name, image in images.items():
+                expected = initial_journal_image(payloads[name])
+                if not _is_safe_initial_path_fragment(name, image, expected):
+                    raise JournalLayoutError(f"journal path {name} is not recoverable")
+
+            for name in JOURNAL_DATA_NAMES:
+                descriptor = descriptors.get(name)
+                if descriptor is None:
+                    _create_journal_path_unlocked(
+                        directory_descriptor, name, payloads[name]
+                    )
+                elif images[name] != initial_journal_image(payloads[name]):
+                    _rewrite_initial_journal_path_unlocked(
+                        directory_descriptor,
+                        name,
+                        descriptor,
+                        payloads[name],
+                    )
+            try:
+                os.fsync(directory_descriptor)
+            except OSError as error:
+                raise JournalLayoutError("journal directory sync failed") from error
+            for name in JOURNAL_DATA_NAMES:
+                _validate_initial_journal_path_unlocked(
+                    directory_descriptor, name, payloads[name]
+                )
+
+            cursor_descriptor = descriptors.get(JOURNAL_CURSOR_NAME)
+            if cursor_descriptor is None:
+                _create_journal_path_unlocked(
+                    directory_descriptor,
+                    JOURNAL_CURSOR_NAME,
+                    payloads[JOURNAL_CURSOR_NAME],
+                )
+            elif cursor != cursor_expected:
+                _rewrite_initial_journal_path_unlocked(
+                    directory_descriptor,
+                    JOURNAL_CURSOR_NAME,
+                    cursor_descriptor,
+                    payloads[JOURNAL_CURSOR_NAME],
+                )
+            for name in JOURNAL_NAMES:
+                _validate_initial_journal_path_unlocked(
+                    directory_descriptor, name, payloads[name]
+                )
+            try:
+                os.fsync(directory_descriptor)
+            except OSError as error:
+                # A readable cursor does not prove its directory entry reached
+                # storage. A later initialization retries the directory sync.
+                raise JournalLayoutError("journal directory sync failed") from error
+        finally:
+            first_error: OSError | None = None
+            for descriptor in reversed(tuple(descriptors.values())):
+                try:
+                    os.close(descriptor)
+                except OSError as error:
+                    if first_error is None:
+                        first_error = error
+            if first_error is not None:
+                raise JournalLayoutError(
+                    "journal partial descriptor close failed"
+                ) from first_error
 
 
 @dataclass(frozen=True)

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -40,6 +40,11 @@ JOURNAL_CURSOR_NAME = "cursor"
 JOURNAL_PATH_MAX = 4095
 JOURNAL_COMPONENT_MAX = 255
 JOURNAL_DIRECTORY_SUFFIX = ("dwm-titus", "system-management")
+JOURNAL_BOOT_ID_TEMPLATE = "00000000-0000-0000-0000-000000000000"
+JOURNAL_RESTART_ALL_CLEAR_TAIL = ("-", "none", "none", "0", "no", "0")
+JOURNAL_RESTART_ALL_CLEAR_SUFFIX = (
+    "\t" + "\t".join(JOURNAL_RESTART_ALL_CLEAR_TAIL)
+).encode("ascii")
 JOURNAL_DATA_NAMES = (
     "active",
     "restart",
@@ -754,7 +759,7 @@ def _initial_journal_payloads(boot_id: str) -> dict[str, str]:
     if not isinstance(boot_id, str) or BOOT_ID_PATTERN.fullmatch(boot_id) is None:
         raise JournalLayoutError("journal boot identity is invalid")
     payloads = {name: "" for name in JOURNAL_DATA_NAMES}
-    payloads["restart"] = f"{boot_id}\t-\tnone\tnone\t0\tno\t0"
+    payloads["restart"] = "\t".join((boot_id, *JOURNAL_RESTART_ALL_CLEAR_TAIL))
     payloads[JOURNAL_CURSOR_NAME] = "00"
     return payloads
 
@@ -781,25 +786,16 @@ def _validate_journal_path_identity(
         raise JournalLayoutError(f"journal path {name} identity is unsafe")
 
 
-def _create_private_journal_descriptor(directory_descriptor: int, name: str) -> int:
-    """Create a mode-0600 fixed path without an umask interruption window."""
-    previous_umask = os.umask(0)
+def _create_journal_path_unlocked(
+    directory_descriptor: int, name: str, payload: str
+) -> None:
     try:
-        return os.open(
+        descriptor = os.open(
             name,
             os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC | os.O_RDWR,
             0o600,
             dir_fd=directory_descriptor,
         )
-    finally:
-        os.umask(previous_umask)
-
-
-def _create_journal_path_unlocked(
-    directory_descriptor: int, name: str, payload: str
-) -> None:
-    try:
-        descriptor = _create_private_journal_descriptor(directory_descriptor, name)
     except OSError as error:
         raise JournalLayoutError(f"journal path {name} creation failed") from error
     try:
@@ -822,18 +818,110 @@ def _create_journal_path_unlocked(
 
 
 def _open_partial_journal_path_unlocked(
-    directory_descriptor: int, name: str
+    directory_descriptor: int,
+    name: str,
+    *,
+    allow_empty_mode_repair: bool,
 ) -> int | None:
     try:
-        return os.open(
+        path_descriptor = os.open(
             name,
-            os.O_NOFOLLOW | os.O_CLOEXEC | os.O_RDWR,
+            os.O_PATH | os.O_NOFOLLOW | os.O_CLOEXEC,
             dir_fd=directory_descriptor,
         )
     except FileNotFoundError:
         return None
     except OSError as error:
         raise JournalLayoutError(f"journal path {name} open failed") from error
+    descriptor: int | None = None
+    try:
+        try:
+            held = os.fstat(path_descriptor)
+            descriptor_flags = fcntl.fcntl(path_descriptor, fcntl.F_GETFD)
+            reachable = os.stat(
+                name, dir_fd=directory_descriptor, follow_symlinks=False
+            )
+        except (OSError, OverflowError) as error:
+            raise JournalLayoutError(f"journal path {name} is unavailable") from error
+        if (
+            not stat.S_ISREG(held.st_mode)
+            or not stat.S_ISREG(reachable.st_mode)
+            or (held.st_dev, held.st_ino) != (reachable.st_dev, reachable.st_ino)
+            or held.st_uid != os.geteuid()
+            or reachable.st_uid != held.st_uid
+            or held.st_nlink != 1
+            or reachable.st_nlink != 1
+            or held.st_size != reachable.st_size
+            or held.st_size < 0
+            or held.st_size > JOURNAL_FILE_SIZE
+            or not descriptor_flags & fcntl.FD_CLOEXEC
+        ):
+            raise JournalLayoutError(f"journal path {name} partial metadata is unsafe")
+        mode = stat.S_IMODE(held.st_mode)
+        if (
+            allow_empty_mode_repair
+            and held.st_size == 0
+            and mode != 0o600
+            and mode & ~0o600 == 0
+        ):
+            try:
+                os.chmod(f"/proc/self/fd/{path_descriptor}", 0o600)
+                held = os.fstat(path_descriptor)
+                reachable = os.stat(
+                    name, dir_fd=directory_descriptor, follow_symlinks=False
+                )
+            except OSError as error:
+                raise JournalLayoutError(
+                    f"journal path {name} mode recovery failed"
+                ) from error
+            if (
+                (held.st_dev, held.st_ino) != (reachable.st_dev, reachable.st_ino)
+                or stat.S_IMODE(held.st_mode) != 0o600
+                or stat.S_IMODE(reachable.st_mode) != 0o600
+                or held.st_uid != os.geteuid()
+                or reachable.st_uid != held.st_uid
+                or held.st_nlink != 1
+                or reachable.st_nlink != 1
+                or held.st_size != 0
+                or reachable.st_size != 0
+            ):
+                raise JournalLayoutError(f"journal path {name} mode recovery is unsafe")
+        elif mode != 0o600 or stat.S_IMODE(reachable.st_mode) != 0o600:
+            raise JournalLayoutError(f"journal path {name} partial metadata is unsafe")
+        try:
+            descriptor = os.open(
+                name,
+                os.O_NOFOLLOW | os.O_CLOEXEC | os.O_RDWR,
+                dir_fd=directory_descriptor,
+            )
+        except OSError as error:
+            raise JournalLayoutError(
+                f"journal path {name} writable open failed"
+            ) from error
+        active = _validate_partial_journal_path_identity(
+            directory_descriptor, name, descriptor
+        )
+        if (active.st_dev, active.st_ino) != (held.st_dev, held.st_ino):
+            raise JournalLayoutError(f"journal path {name} identity changed")
+        result = descriptor
+        descriptor = None
+        return result
+    finally:
+        first_error: OSError | None = None
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError as error:
+                first_error = error
+        try:
+            os.close(path_descriptor)
+        except OSError as error:
+            if first_error is None:
+                first_error = error
+        if first_error is not None:
+            raise JournalLayoutError(
+                f"journal path {name} open descriptor close failed"
+            ) from first_error
 
 
 def _validate_partial_journal_path_identity(
@@ -914,13 +1002,13 @@ def _is_all_clear_restart_payload(payload: str) -> bool:
     return (
         len(fields) == 7
         and BOOT_ID_PATTERN.fullmatch(fields[0]) is not None
-        and fields[1:] == ["-", "none", "none", "0", "no", "0"]
+        and tuple(fields[1:]) == JOURNAL_RESTART_ALL_CLEAR_TAIL
     )
 
 
 def _restart_initial_header() -> bytes:
-    payload_size = len(
-        "01234567-89ab-cdef-0123-456789abcdef\t-\tnone\tnone\t0\tno\t0".encode()
+    payload_size = len(JOURNAL_BOOT_ID_TEMPLATE.encode("ascii")) + len(
+        JOURNAL_RESTART_ALL_CLEAR_SUFFIX
     )
     return struct.pack(
         "<8sHHIQQ",
@@ -934,8 +1022,8 @@ def _restart_initial_header() -> bytes:
 
 
 def _is_all_clear_restart_payload_prefix(encoded: bytes) -> bool:
-    uuid_template = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-    suffix = b"\t-\tnone\tnone\t0\tno\t0"
+    uuid_template = JOURNAL_BOOT_ID_TEMPLATE
+    suffix = JOURNAL_RESTART_ALL_CLEAR_SUFFIX
     if len(encoded) > len(uuid_template) + len(suffix):
         return False
     for index, byte in enumerate(encoded):
@@ -1112,18 +1200,18 @@ def initialize_journal_layout(directory_descriptor: int, boot_id: str) -> None:
         descriptors: dict[str, int] = {}
         images: dict[str, bytes] = {}
         try:
-            for name in JOURNAL_NAMES:
-                descriptor = _open_partial_journal_path_unlocked(
-                    directory_descriptor, name
+            cursor_descriptor = _open_partial_journal_path_unlocked(
+                directory_descriptor,
+                JOURNAL_CURSOR_NAME,
+                allow_empty_mode_repair=True,
+            )
+            cursor = None
+            if cursor_descriptor is not None:
+                descriptors[JOURNAL_CURSOR_NAME] = cursor_descriptor
+                cursor = _read_partial_journal_image_unlocked(
+                    directory_descriptor, JOURNAL_CURSOR_NAME, cursor_descriptor
                 )
-                if descriptor is None:
-                    continue
-                descriptors[name] = descriptor
-                images[name] = _read_partial_journal_image_unlocked(
-                    directory_descriptor, name, descriptor
-                )
-
-            cursor = images.get(JOURNAL_CURSOR_NAME)
+                images[JOURNAL_CURSOR_NAME] = cursor
             cursor_expected = initial_journal_image(payloads[JOURNAL_CURSOR_NAME])
             cursor_present = cursor == cursor_expected
             if cursor is not None and not cursor_present:
@@ -1139,6 +1227,19 @@ def initialize_journal_layout(directory_descriptor: int, boot_id: str) -> None:
                     cursor_present = True
                 else:
                     raise JournalLayoutError("journal path cursor is not recoverable")
+
+            for name in JOURNAL_DATA_NAMES:
+                descriptor = _open_partial_journal_path_unlocked(
+                    directory_descriptor,
+                    name,
+                    allow_empty_mode_repair=not cursor_present,
+                )
+                if descriptor is None:
+                    continue
+                descriptors[name] = descriptor
+                images[name] = _read_partial_journal_image_unlocked(
+                    directory_descriptor, name, descriptor
+                )
 
             if cursor_present:
                 for name in JOURNAL_NAMES:

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -817,12 +817,39 @@ def _create_journal_path_unlocked(
             raise JournalLayoutError(f"journal path {name} close failed") from error
 
 
+def _inspect_partial_journal_path_unlocked(
+    directory_descriptor: int, name: str, path_descriptor: int
+) -> os.stat_result:
+    try:
+        held = os.fstat(path_descriptor)
+        descriptor_flags = fcntl.fcntl(path_descriptor, fcntl.F_GETFD)
+        reachable = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
+    except (OSError, OverflowError) as error:
+        raise JournalLayoutError(f"journal path {name} is unavailable") from error
+    if (
+        not stat.S_ISREG(held.st_mode)
+        or not stat.S_ISREG(reachable.st_mode)
+        or (held.st_dev, held.st_ino) != (reachable.st_dev, reachable.st_ino)
+        or held.st_uid != os.geteuid()
+        or reachable.st_uid != held.st_uid
+        or stat.S_IMODE(reachable.st_mode) != stat.S_IMODE(held.st_mode)
+        or held.st_nlink != 1
+        or reachable.st_nlink != 1
+        or held.st_size != reachable.st_size
+        or held.st_size < 0
+        or held.st_size > JOURNAL_FILE_SIZE
+        or not descriptor_flags & fcntl.FD_CLOEXEC
+    ):
+        raise JournalLayoutError(f"journal path {name} partial metadata is unsafe")
+    return held
+
+
 def _open_partial_journal_path_unlocked(
     directory_descriptor: int,
     name: str,
     *,
     allow_empty_mode_repair: bool,
-) -> int | None:
+) -> tuple[int, bool] | None:
     try:
         path_descriptor = os.open(
             name,
@@ -834,29 +861,11 @@ def _open_partial_journal_path_unlocked(
     except OSError as error:
         raise JournalLayoutError(f"journal path {name} open failed") from error
     descriptor: int | None = None
+    retained_path_descriptor = False
     try:
-        try:
-            held = os.fstat(path_descriptor)
-            descriptor_flags = fcntl.fcntl(path_descriptor, fcntl.F_GETFD)
-            reachable = os.stat(
-                name, dir_fd=directory_descriptor, follow_symlinks=False
-            )
-        except (OSError, OverflowError) as error:
-            raise JournalLayoutError(f"journal path {name} is unavailable") from error
-        if (
-            not stat.S_ISREG(held.st_mode)
-            or not stat.S_ISREG(reachable.st_mode)
-            or (held.st_dev, held.st_ino) != (reachable.st_dev, reachable.st_ino)
-            or held.st_uid != os.geteuid()
-            or reachable.st_uid != held.st_uid
-            or held.st_nlink != 1
-            or reachable.st_nlink != 1
-            or held.st_size != reachable.st_size
-            or held.st_size < 0
-            or held.st_size > JOURNAL_FILE_SIZE
-            or not descriptor_flags & fcntl.FD_CLOEXEC
-        ):
-            raise JournalLayoutError(f"journal path {name} partial metadata is unsafe")
+        held = _inspect_partial_journal_path_unlocked(
+            directory_descriptor, name, path_descriptor
+        )
         mode = stat.S_IMODE(held.st_mode)
         if (
             allow_empty_mode_repair
@@ -864,29 +873,9 @@ def _open_partial_journal_path_unlocked(
             and mode != 0o600
             and mode & ~0o600 == 0
         ):
-            try:
-                os.chmod(f"/proc/self/fd/{path_descriptor}", 0o600)
-                held = os.fstat(path_descriptor)
-                reachable = os.stat(
-                    name, dir_fd=directory_descriptor, follow_symlinks=False
-                )
-            except OSError as error:
-                raise JournalLayoutError(
-                    f"journal path {name} mode recovery failed"
-                ) from error
-            if (
-                (held.st_dev, held.st_ino) != (reachable.st_dev, reachable.st_ino)
-                or stat.S_IMODE(held.st_mode) != 0o600
-                or stat.S_IMODE(reachable.st_mode) != 0o600
-                or held.st_uid != os.geteuid()
-                or reachable.st_uid != held.st_uid
-                or held.st_nlink != 1
-                or reachable.st_nlink != 1
-                or held.st_size != 0
-                or reachable.st_size != 0
-            ):
-                raise JournalLayoutError(f"journal path {name} mode recovery is unsafe")
-        elif mode != 0o600 or stat.S_IMODE(reachable.st_mode) != 0o600:
+            retained_path_descriptor = True
+            return path_descriptor, True
+        if mode != 0o600:
             raise JournalLayoutError(f"journal path {name} partial metadata is unsafe")
         try:
             descriptor = os.open(
@@ -905,7 +894,7 @@ def _open_partial_journal_path_unlocked(
             raise JournalLayoutError(f"journal path {name} identity changed")
         result = descriptor
         descriptor = None
-        return result
+        return result, False
     finally:
         first_error: OSError | None = None
         if descriptor is not None:
@@ -913,15 +902,57 @@ def _open_partial_journal_path_unlocked(
                 os.close(descriptor)
             except OSError as error:
                 first_error = error
-        try:
-            os.close(path_descriptor)
-        except OSError as error:
-            if first_error is None:
-                first_error = error
+        if not retained_path_descriptor:
+            try:
+                os.close(path_descriptor)
+            except OSError as error:
+                if first_error is None:
+                    first_error = error
         if first_error is not None:
             raise JournalLayoutError(
                 f"journal path {name} open descriptor close failed"
             ) from first_error
+
+
+def _repair_empty_journal_path_mode_unlocked(
+    directory_descriptor: int, name: str, path_descriptor: int
+) -> int:
+    held = _inspect_partial_journal_path_unlocked(
+        directory_descriptor, name, path_descriptor
+    )
+    mode = stat.S_IMODE(held.st_mode)
+    if held.st_size != 0 or mode == 0o600 or mode & ~0o600:
+        raise JournalLayoutError(f"journal path {name} mode recovery is unsafe")
+    try:
+        os.chmod(f"/proc/self/fd/{path_descriptor}", 0o600)
+    except OSError as error:
+        raise JournalLayoutError(f"journal path {name} mode recovery failed") from error
+    held = _inspect_partial_journal_path_unlocked(
+        directory_descriptor, name, path_descriptor
+    )
+    if held.st_size != 0 or stat.S_IMODE(held.st_mode) != 0o600:
+        raise JournalLayoutError(f"journal path {name} mode recovery is unsafe")
+    try:
+        descriptor = os.open(
+            name,
+            os.O_NOFOLLOW | os.O_CLOEXEC | os.O_RDWR,
+            dir_fd=directory_descriptor,
+        )
+    except OSError as error:
+        raise JournalLayoutError(f"journal path {name} writable open failed") from error
+    try:
+        active = _validate_partial_journal_path_identity(
+            directory_descriptor, name, descriptor
+        )
+        if (active.st_dev, active.st_ino) != (held.st_dev, held.st_ino):
+            raise JournalLayoutError(f"journal path {name} identity changed")
+    except OSError:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        raise
+    return descriptor
 
 
 def _validate_partial_journal_path_identity(
@@ -1198,19 +1229,25 @@ def initialize_journal_layout(directory_descriptor: int, boot_id: str) -> None:
     payloads = _initial_journal_payloads(boot_id)
     with _journal_lock(directory_descriptor, exclusive=True):
         descriptors: dict[str, int] = {}
+        mode_repair_descriptors: dict[str, int] = {}
         images: dict[str, bytes] = {}
         try:
-            cursor_descriptor = _open_partial_journal_path_unlocked(
+            cursor_path = _open_partial_journal_path_unlocked(
                 directory_descriptor,
                 JOURNAL_CURSOR_NAME,
                 allow_empty_mode_repair=True,
             )
             cursor = None
-            if cursor_descriptor is not None:
-                descriptors[JOURNAL_CURSOR_NAME] = cursor_descriptor
-                cursor = _read_partial_journal_image_unlocked(
-                    directory_descriptor, JOURNAL_CURSOR_NAME, cursor_descriptor
-                )
+            if cursor_path is not None:
+                cursor_descriptor, cursor_mode_repair = cursor_path
+                if cursor_mode_repair:
+                    mode_repair_descriptors[JOURNAL_CURSOR_NAME] = cursor_descriptor
+                    cursor = b""
+                else:
+                    descriptors[JOURNAL_CURSOR_NAME] = cursor_descriptor
+                    cursor = _read_partial_journal_image_unlocked(
+                        directory_descriptor, JOURNAL_CURSOR_NAME, cursor_descriptor
+                    )
                 images[JOURNAL_CURSOR_NAME] = cursor
             cursor_expected = initial_journal_image(payloads[JOURNAL_CURSOR_NAME])
             cursor_present = cursor == cursor_expected
@@ -1229,17 +1266,22 @@ def initialize_journal_layout(directory_descriptor: int, boot_id: str) -> None:
                     raise JournalLayoutError("journal path cursor is not recoverable")
 
             for name in JOURNAL_DATA_NAMES:
-                descriptor = _open_partial_journal_path_unlocked(
+                path = _open_partial_journal_path_unlocked(
                     directory_descriptor,
                     name,
                     allow_empty_mode_repair=not cursor_present,
                 )
-                if descriptor is None:
+                if path is None:
                     continue
-                descriptors[name] = descriptor
-                images[name] = _read_partial_journal_image_unlocked(
-                    directory_descriptor, name, descriptor
-                )
+                descriptor, mode_repair = path
+                if mode_repair:
+                    mode_repair_descriptors[name] = descriptor
+                    images[name] = b""
+                else:
+                    descriptors[name] = descriptor
+                    images[name] = _read_partial_journal_image_unlocked(
+                        directory_descriptor, name, descriptor
+                    )
 
             if cursor_present:
                 for name in JOURNAL_NAMES:
@@ -1261,6 +1303,11 @@ def initialize_journal_layout(directory_descriptor: int, boot_id: str) -> None:
                 expected = initial_journal_image(payloads[name])
                 if not _is_safe_initial_path_fragment(name, image, expected):
                     raise JournalLayoutError(f"journal path {name} is not recoverable")
+
+            for name, path_descriptor in mode_repair_descriptors.items():
+                descriptors[name] = _repair_empty_journal_path_mode_unlocked(
+                    directory_descriptor, name, path_descriptor
+                )
 
             for name in JOURNAL_DATA_NAMES:
                 descriptor = descriptors.get(name)
@@ -1311,6 +1358,12 @@ def initialize_journal_layout(directory_descriptor: int, boot_id: str) -> None:
         finally:
             first_error: OSError | None = None
             for descriptor in reversed(tuple(descriptors.values())):
+                try:
+                    os.close(descriptor)
+                except OSError as error:
+                    if first_error is None:
+                        first_error = error
+            for descriptor in reversed(tuple(mode_repair_descriptors.values())):
                 try:
                     os.close(descriptor)
                 except OSError as error:

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -633,6 +633,12 @@ class JournalLayoutTests(unittest.TestCase):
         finally:
             os.close(descriptor)
 
+    def write_path(self, directory, name, image):
+        path = pathlib.Path(directory) / name
+        path.write_bytes(image)
+        os.chmod(path, 0o600)
+        return path
+
     def test_fresh_layout_has_exact_initial_records(self):
         with tempfile.TemporaryDirectory() as directory:
             directory_descriptor = self.open_directory(directory)
@@ -685,9 +691,7 @@ class JournalLayoutTests(unittest.TestCase):
             os.symlink("victim", pathlib.Path(directory) / "active")
             directory_descriptor = self.open_directory(directory)
             try:
-                with self.assertRaisesRegex(
-                    provider.JournalLayoutError, "active creation"
-                ):
+                with self.assertRaisesRegex(provider.JournalLayoutError, "active open"):
                     provider.initialize_journal_layout(
                         directory_descriptor, self.boot_id
                     )
@@ -758,10 +762,25 @@ class JournalLayoutTests(unittest.TestCase):
                     self.read_path(directory_descriptor, provider.JOURNAL_CURSOR_NAME),
                     (0, provider.JournalFrame(1, "00")),
                 )
+                observed_directory_sync = False
+
+                def observe_retry_sync(descriptor):
+                    nonlocal observed_directory_sync
+                    if descriptor == directory_descriptor:
+                        observed_directory_sync = True
+                    return original_fsync(descriptor)
+
+                with mock.patch.object(
+                    provider.os, "fsync", side_effect=observe_retry_sync
+                ):
+                    provider.initialize_journal_layout(
+                        directory_descriptor, self.boot_id
+                    )
+                self.assertTrue(observed_directory_sync)
             finally:
                 os.close(directory_descriptor)
 
-    def test_existing_fixed_file_is_never_replaced(self):
+    def test_legacy_plaintext_is_rejected_without_mutation(self):
         with tempfile.TemporaryDirectory() as directory:
             active = pathlib.Path(directory) / "active"
             active.write_bytes(b"legacy record")
@@ -769,7 +788,7 @@ class JournalLayoutTests(unittest.TestCase):
             directory_descriptor = self.open_directory(directory)
             try:
                 with self.assertRaisesRegex(
-                    provider.JournalLayoutError, "active creation"
+                    provider.JournalLayoutError, "active is not recoverable"
                 ):
                     provider.initialize_journal_layout(
                         directory_descriptor, self.boot_id
@@ -779,6 +798,301 @@ class JournalLayoutTests(unittest.TestCase):
                     (pathlib.Path(directory) / provider.JOURNAL_CURSOR_NAME).exists()
                 )
             finally:
+                os.close(directory_descriptor)
+
+    def test_missing_and_short_initial_fragments_are_recovered(self):
+        with tempfile.TemporaryDirectory() as directory:
+            payloads = provider._initial_journal_payloads(self.boot_id)
+            active_image = provider.initial_journal_image(payloads["active"])
+            cursor_image = provider.initial_journal_image(
+                payloads[provider.JOURNAL_CURSOR_NAME]
+            )
+            active = self.write_path(directory, "active", active_image[:113])
+            cursor = self.write_path(
+                directory, provider.JOURNAL_CURSOR_NAME, cursor_image[:31]
+            )
+            active_identity = (active.stat().st_dev, active.stat().st_ino)
+            cursor_identity = (cursor.stat().st_dev, cursor.stat().st_ino)
+            directory_descriptor = self.open_directory(directory)
+            try:
+                provider.initialize_journal_layout(directory_descriptor, self.boot_id)
+                self.assertEqual(
+                    set(os.listdir(directory)), set(provider.JOURNAL_NAMES)
+                )
+                self.assertEqual(
+                    (active.stat().st_dev, active.stat().st_ino), active_identity
+                )
+                self.assertEqual(
+                    (cursor.stat().st_dev, cursor.stat().st_ino), cursor_identity
+                )
+                for name in provider.JOURNAL_NAMES:
+                    with self.subTest(name=name):
+                        self.assertEqual(
+                            self.read_path(directory_descriptor, name),
+                            (0, provider.JournalFrame(1, payloads[name])),
+                        )
+            finally:
+                os.close(directory_descriptor)
+
+    def test_previous_boot_restart_fragments_are_recovered(self):
+        previous_boot = "11234567-89ab-cdef-0123-456789abcdef"
+        previous_payload = provider._initial_journal_payloads(previous_boot)["restart"]
+        previous_image = provider.initial_journal_image(previous_payload)
+        for image in (
+            previous_image,
+            previous_image[:48],
+            previous_image[:100],
+            previous_image[:100] + bytes(len(previous_image) - 100),
+        ):
+            with (
+                self.subTest(size=len(image)),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                restart = self.write_path(directory, "restart", image)
+                identity = (restart.stat().st_dev, restart.stat().st_ino)
+                directory_descriptor = self.open_directory(directory)
+                try:
+                    provider.initialize_journal_layout(
+                        directory_descriptor, self.boot_id
+                    )
+                    self.assertEqual(
+                        (restart.stat().st_dev, restart.stat().st_ino), identity
+                    )
+                    current_payload = provider._initial_journal_payloads(self.boot_id)[
+                        "restart"
+                    ]
+                    self.assertEqual(
+                        self.read_path(directory_descriptor, "restart"),
+                        (0, provider.JournalFrame(1, current_payload)),
+                    )
+                finally:
+                    os.close(directory_descriptor)
+
+    def test_noninitial_restart_records_still_block_recovery(self):
+        previous_boot = "11234567-89ab-cdef-0123-456789abcdef"
+        previous_payload = provider._initial_journal_payloads(previous_boot)["restart"]
+        cases = (
+            provider.encode_journal_frame(1, "not-an-all-clear-record")
+            + bytes(provider.JOURNAL_FRAME_SIZE),
+            provider.encode_journal_frame(1, previous_payload)
+            + provider.encode_journal_frame(2, previous_payload),
+        )
+        for image in cases:
+            with (
+                self.subTest(image=image[:72]),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                restart = self.write_path(directory, "restart", image)
+                before = restart.read_bytes()
+                directory_descriptor = self.open_directory(directory)
+                try:
+                    with self.assertRaisesRegex(
+                        provider.JournalLayoutError, "restart is not recoverable"
+                    ):
+                        provider.initialize_journal_layout(
+                            directory_descriptor, self.boot_id
+                        )
+                    self.assertEqual(restart.read_bytes(), before)
+                    self.assertEqual(os.listdir(directory), ["restart"])
+                finally:
+                    os.close(directory_descriptor)
+
+    def test_interrupted_previous_boot_rewrite_remains_retryable(self):
+        previous_boot = "11234567-89ab-cdef-0123-456789abcdef"
+        previous_payload = provider._initial_journal_payloads(previous_boot)["restart"]
+        with tempfile.TemporaryDirectory() as directory:
+            restart = self.write_path(
+                directory, "restart", provider.initial_journal_image(previous_payload)
+            )
+            restart_identity = (restart.stat().st_dev, restart.stat().st_ino)
+            directory_descriptor = self.open_directory(directory)
+            original_pwrite = os.pwrite
+            injected = False
+
+            def interrupt_restart_rewrite(descriptor, image, offset):
+                nonlocal injected
+                metadata = os.fstat(descriptor)
+                if (
+                    not injected
+                    and (metadata.st_dev, metadata.st_ino) == restart_identity
+                    and offset == 0
+                    and len(image) == provider.JOURNAL_FILE_SIZE
+                ):
+                    injected = True
+                    self.assertEqual(
+                        original_pwrite(descriptor, image[:40], offset), 40
+                    )
+                    return 40
+                return original_pwrite(descriptor, image, offset)
+
+            try:
+                with mock.patch.object(
+                    provider.os, "pwrite", side_effect=interrupt_restart_rewrite
+                ):
+                    with self.assertRaisesRegex(
+                        provider.JournalLayoutError, "restart recovery failed"
+                    ):
+                        provider.initialize_journal_layout(
+                            directory_descriptor, self.boot_id
+                        )
+                provider.initialize_journal_layout(directory_descriptor, self.boot_id)
+                current_payload = provider._initial_journal_payloads(self.boot_id)[
+                    "restart"
+                ]
+                self.assertEqual(
+                    self.read_path(directory_descriptor, "restart"),
+                    (0, provider.JournalFrame(1, current_payload)),
+                )
+            finally:
+                os.close(directory_descriptor)
+
+    def test_safe_fragments_cover_short_and_torn_initial_writes(self):
+        expected = provider.initial_journal_image("payload")
+        for length in (0, 1, 7, 8, 31, 64, 8191, 8192, 10000, 16383):
+            with self.subTest(length=length):
+                self.assertTrue(
+                    provider._is_safe_initial_fragment(expected[:length], expected)
+                )
+        first_difference = next(
+            index for index, byte in enumerate(expected) if byte != 0
+        )
+        torn = expected[: first_difference + 1] + bytes(
+            len(expected) - first_difference - 1
+        )
+        self.assertTrue(provider._is_safe_initial_fragment(torn, expected))
+        self.assertFalse(provider._is_safe_initial_fragment(b"legacy record", expected))
+        self.assertFalse(
+            provider._is_safe_initial_fragment(expected + b"extra", expected)
+        )
+
+    def test_invalid_precursor_file_blocks_all_recovery_mutation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            expected = provider.initial_journal_image("")
+            active = self.write_path(directory, "active", expected[:47])
+            restart = self.write_path(directory, "restart", b"legacy record")
+            active_before = active.read_bytes()
+            restart_before = restart.read_bytes()
+            directory_descriptor = self.open_directory(directory)
+            try:
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "restart is not recoverable"
+                ):
+                    provider.initialize_journal_layout(
+                        directory_descriptor, self.boot_id
+                    )
+                self.assertEqual(active.read_bytes(), active_before)
+                self.assertEqual(restart.read_bytes(), restart_before)
+                self.assertEqual(set(os.listdir(directory)), {"active", "restart"})
+            finally:
+                os.close(directory_descriptor)
+
+    def test_advanced_precursor_file_blocks_reinitialization(self):
+        with tempfile.TemporaryDirectory() as directory:
+            advanced = provider.encode_journal_frame(
+                1, ""
+            ) + provider.encode_journal_frame(2, "changed")
+            active = self.write_path(directory, "active", advanced)
+            before = active.read_bytes()
+            directory_descriptor = self.open_directory(directory)
+            try:
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "active is not recoverable"
+                ):
+                    provider.initialize_journal_layout(
+                        directory_descriptor, self.boot_id
+                    )
+                self.assertEqual(active.read_bytes(), before)
+                self.assertEqual(os.listdir(directory), ["active"])
+            finally:
+                os.close(directory_descriptor)
+
+    def test_missing_file_after_cursor_is_not_recreated(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory_descriptor = self.open_directory(directory)
+            try:
+                provider.initialize_journal_layout(directory_descriptor, self.boot_id)
+                active = pathlib.Path(directory) / "active"
+                active.unlink()
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "active is missing after cursor"
+                ):
+                    provider.initialize_journal_layout(
+                        directory_descriptor, self.boot_id
+                    )
+                self.assertFalse(active.exists())
+            finally:
+                os.close(directory_descriptor)
+
+    def test_damaged_file_after_cursor_is_not_rewritten(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory_descriptor = self.open_directory(directory)
+            try:
+                provider.initialize_journal_layout(directory_descriptor, self.boot_id)
+                active = pathlib.Path(directory) / "active"
+                active.write_bytes(b"damage")
+                damaged = active.read_bytes()
+                with self.assertRaises(provider.JournalLayoutError):
+                    provider.initialize_journal_layout(
+                        directory_descriptor, self.boot_id
+                    )
+                self.assertEqual(active.read_bytes(), damaged)
+            finally:
+                os.close(directory_descriptor)
+
+    def test_valid_advanced_file_after_cursor_is_preserved(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory_descriptor = self.open_directory(directory)
+            try:
+                provider.initialize_journal_layout(directory_descriptor, self.boot_id)
+                active_descriptor = os.open(
+                    "active",
+                    os.O_NOFOLLOW | os.O_CLOEXEC | os.O_RDWR,
+                    dir_fd=directory_descriptor,
+                )
+                try:
+                    provider.commit_journal_file(
+                        directory_descriptor, active_descriptor, "changed"
+                    )
+                finally:
+                    os.close(active_descriptor)
+                active = pathlib.Path(directory) / "active"
+                before = active.read_bytes()
+                provider.initialize_journal_layout(directory_descriptor, self.boot_id)
+                self.assertEqual(active.read_bytes(), before)
+                self.assertEqual(
+                    self.read_path(directory_descriptor, "active"),
+                    (1, provider.JournalFrame(2, "changed")),
+                )
+            finally:
+                os.close(directory_descriptor)
+
+    def test_interrupted_creation_is_private_and_retryable_under_strict_umask(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory_descriptor = self.open_directory(directory)
+            previous_umask = os.umask(0o777)
+            try:
+                with mock.patch.object(
+                    provider,
+                    "_initialize_journal_file_unlocked",
+                    side_effect=provider.JournalFrameError(
+                        "injected initialization interruption"
+                    ),
+                ):
+                    with self.assertRaisesRegex(
+                        provider.JournalLayoutError, "active initialization"
+                    ):
+                        provider.initialize_journal_layout(
+                            directory_descriptor, self.boot_id
+                        )
+                active = pathlib.Path(directory) / "active"
+                self.assertEqual(stat.S_IMODE(active.stat().st_mode), 0o600)
+                self.assertEqual(active.stat().st_size, 0)
+                provider.initialize_journal_layout(directory_descriptor, self.boot_id)
+                self.assertEqual(
+                    set(os.listdir(directory)), set(provider.JOURNAL_NAMES)
+                )
+            finally:
+                os.umask(previous_umask)
                 os.close(directory_descriptor)
 
     def test_invalid_initial_frame_uses_layout_error_contract(self):

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -691,7 +691,9 @@ class JournalLayoutTests(unittest.TestCase):
             os.symlink("victim", pathlib.Path(directory) / "active")
             directory_descriptor = self.open_directory(directory)
             try:
-                with self.assertRaisesRegex(provider.JournalLayoutError, "active open"):
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "active partial metadata is unsafe"
+                ):
                     provider.initialize_journal_layout(
                         directory_descriptor, self.boot_id
                     )
@@ -1039,6 +1041,24 @@ class JournalLayoutTests(unittest.TestCase):
             finally:
                 os.close(directory_descriptor)
 
+    def test_empty_mode_zero_file_after_cursor_is_not_repaired(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory_descriptor = self.open_directory(directory)
+            try:
+                provider.initialize_journal_layout(directory_descriptor, self.boot_id)
+                active = pathlib.Path(directory) / "active"
+                active.write_bytes(b"")
+                os.chmod(active, 0)
+                with self.assertRaises(provider.JournalLayoutError):
+                    provider.initialize_journal_layout(
+                        directory_descriptor, self.boot_id
+                    )
+                self.assertEqual(stat.S_IMODE(active.stat().st_mode), 0)
+                self.assertEqual(active.stat().st_size, 0)
+            finally:
+                os.chmod(pathlib.Path(directory) / "active", 0o600)
+                os.close(directory_descriptor)
+
     def test_valid_advanced_file_after_cursor_is_preserved(self):
         with tempfile.TemporaryDirectory() as directory:
             directory_descriptor = self.open_directory(directory)
@@ -1094,6 +1114,27 @@ class JournalLayoutTests(unittest.TestCase):
             finally:
                 os.umask(previous_umask)
                 os.close(directory_descriptor)
+
+    def test_empty_owner_mode_precursors_are_repaired_through_held_descriptors(self):
+        for mode in (0, 0o200, 0o400):
+            with (
+                self.subTest(mode=oct(mode)),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                active = self.write_path(directory, "active", b"")
+                os.chmod(active, mode)
+                directory_descriptor = self.open_directory(directory)
+                try:
+                    provider.initialize_journal_layout(
+                        directory_descriptor, self.boot_id
+                    )
+                    self.assertEqual(stat.S_IMODE(active.stat().st_mode), 0o600)
+                    self.assertEqual(
+                        self.read_path(directory_descriptor, "active"),
+                        (0, provider.JournalFrame(1, "")),
+                    )
+                finally:
+                    os.close(directory_descriptor)
 
     def test_invalid_initial_frame_uses_layout_error_contract(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -1136,6 +1136,25 @@ class JournalLayoutTests(unittest.TestCase):
                 finally:
                     os.close(directory_descriptor)
 
+    def test_mode_repair_waits_until_every_path_is_recoverable(self):
+        with tempfile.TemporaryDirectory() as directory:
+            active = self.write_path(directory, "active", b"")
+            os.chmod(active, 0)
+            restart = self.write_path(directory, "restart", b"legacy record")
+            directory_descriptor = self.open_directory(directory)
+            try:
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "restart is not recoverable"
+                ):
+                    provider.initialize_journal_layout(
+                        directory_descriptor, self.boot_id
+                    )
+                self.assertEqual(stat.S_IMODE(active.stat().st_mode), 0)
+                self.assertEqual(active.stat().st_size, 0)
+                self.assertEqual(restart.read_bytes(), b"legacy record")
+            finally:
+                os.close(directory_descriptor)
+
     def test_invalid_initial_frame_uses_layout_error_contract(self):
         with tempfile.TemporaryDirectory() as directory:
             active = pathlib.Path(directory) / "active"


### PR DESCRIPTION
## Summary

- recover missing, short, and provably torn fixed journal files only before the cursor commit marker
- retain and revalidate fixed-path descriptors, reject unsafe metadata and noninitial or advanced state before mutation, and preserve all post-cursor damage for explicit recovery
- make interrupted file creation private under restrictive umasks and keep previous-boot all-clear restart rewrites retryable across every short-write splice
- create and sync data records before committing the cursor last, while resyncing an already complete layout after an indeterminate final directory sync

This remains a journal-storage boundary. It does not expose new commands or start PackageKit mutations.

## Validation

- `ruff format --check scripts/dwm-system-management tests/test-system-management.py`
- `ruff check scripts/dwm-system-management tests/test-system-management.py`
- `python3 -B -m unittest tests/test-system-management.py` (62 tests)
- `sudo -n /usr/bin/python3 -B -m unittest tests/test-system-management.py` (62 tests)
- `scripts/run-tests make clean all`
- `scripts/run-tests`
- CodeRabbit uncommitted review: clean
- built-in Codex review: clean