### PR TITLE
Phase 6: validate journal control records

### DIFF
--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -45,6 +45,12 @@ JOURNAL_RESTART_ALL_CLEAR_TAIL = ("-", "none", "none", "0", "no", "0")
 JOURNAL_RESTART_ALL_CLEAR_SUFFIX = (
     "\t" + "\t".join(JOURNAL_RESTART_ALL_CLEAR_TAIL)
 ).encode("ascii")
+JOURNAL_OPERATION_ID_PATTERN = re.compile(r"op-[0-9a-f]{32}")
+JOURNAL_SLOT_PATTERN = re.compile(r"(?:0[0-9]|[12][0-9]|3[01])")
+JOURNAL_RESTART_SYSTEM_VALUES = frozenset(
+    ("none", "system", "security-system", "unknown")
+)
+JOURNAL_RESTART_SESSION_VALUES = frozenset(("none", "session", "security-session"))
 JOURNAL_DATA_NAMES = (
     "active",
     "restart",
@@ -112,6 +118,10 @@ class JournalFrameError(ValueError):
     """A journal frame failed canonical validation."""
 
 
+class JournalRecordError(ValueError):
+    """A journal control record failed canonical validation."""
+
+
 class JournalFileError(OSError):
     """A journal file descriptor failed bounded validation or I/O."""
 
@@ -132,6 +142,23 @@ class JournalLayoutError(JournalFileError):
 class JournalFrame:
     sequence: int
     payload: str
+
+
+@dataclass(frozen=True)
+class JournalHandoff:
+    operation_id: str
+    slot: int
+
+
+@dataclass(frozen=True)
+class JournalRestart:
+    boot_id: str
+    last_applied_operation_id: str | None
+    system: str
+    session: str
+    session_cutoff: int
+    application: bool
+    application_cutoff: int
 
 
 @dataclass
@@ -558,6 +585,149 @@ def select_journal_frame(image: bytes) -> tuple[int, JournalFrame]:
     return selected[0], selected[1]
 
 
+def _validate_journal_record_payload(payload: str) -> None:
+    try:
+        _journal_payload_bytes(payload)
+    except JournalFrameError as error:
+        raise JournalRecordError("journal control record is not valid text") from error
+
+
+def _decode_journal_uint64(value: str, field: str) -> int:
+    if re.fullmatch(r"0|[1-9][0-9]*", value) is None:
+        raise JournalRecordError(f"journal {field} is not canonical")
+    maximum = str(JOURNAL_SEQUENCE_MAX)
+    if len(value) > len(maximum) or (len(value) == len(maximum) and value > maximum):
+        raise JournalRecordError(f"journal {field} is out of range")
+    return int(value)
+
+
+def _encode_journal_uint64(value: int, field: str) -> str:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise JournalRecordError(f"journal {field} must be an integer")
+    if value < 0 or value > JOURNAL_SEQUENCE_MAX:
+        raise JournalRecordError(f"journal {field} is out of range")
+    return str(value)
+
+
+def encode_journal_cursor(slot: int) -> str:
+    """Encode one canonical two-digit terminal-ring cursor."""
+    if not isinstance(slot, int) or isinstance(slot, bool):
+        raise JournalRecordError("journal cursor must be an integer")
+    if slot < 0 or slot >= JOURNAL_TERMINAL_COUNT:
+        raise JournalRecordError("journal cursor is out of range")
+    return f"{slot:02d}"
+
+
+def decode_journal_cursor(payload: str) -> int:
+    """Decode one canonical two-digit terminal-ring cursor."""
+    _validate_journal_record_payload(payload)
+    if JOURNAL_SLOT_PATTERN.fullmatch(payload) is None:
+        raise JournalRecordError("journal cursor is not canonical")
+    return int(payload)
+
+
+def encode_journal_handoff(record: JournalHandoff | None) -> str:
+    """Encode an empty or exact operation-to-terminal-slot handoff."""
+    if record is None:
+        return ""
+    if not isinstance(record, JournalHandoff):
+        raise JournalRecordError("journal handoff record is invalid")
+    if (
+        not isinstance(record.operation_id, str)
+        or JOURNAL_OPERATION_ID_PATTERN.fullmatch(record.operation_id) is None
+    ):
+        raise JournalRecordError("journal handoff operation ID is invalid")
+    return f"{record.operation_id}\t{encode_journal_cursor(record.slot)}"
+
+
+def decode_journal_handoff(payload: str) -> JournalHandoff | None:
+    """Decode an empty or exact operation-to-terminal-slot handoff."""
+    _validate_journal_record_payload(payload)
+    if payload == "":
+        return None
+    fields = payload.split("\t")
+    if len(fields) != 2:
+        raise JournalRecordError("journal handoff field count is invalid")
+    if JOURNAL_OPERATION_ID_PATTERN.fullmatch(fields[0]) is None:
+        raise JournalRecordError("journal handoff operation ID is invalid")
+    return JournalHandoff(fields[0], decode_journal_cursor(fields[1]))
+
+
+def encode_journal_restart(record: JournalRestart) -> str:
+    """Encode one canonical restart-guidance control record."""
+    if not isinstance(record, JournalRestart):
+        raise JournalRecordError("journal restart record is invalid")
+    if (
+        not isinstance(record.boot_id, str)
+        or BOOT_ID_PATTERN.fullmatch(record.boot_id) is None
+    ):
+        raise JournalRecordError("journal restart boot identity is invalid")
+    operation_id = record.last_applied_operation_id
+    if operation_id is None:
+        operation_id = "-"
+    elif (
+        not isinstance(operation_id, str)
+        or JOURNAL_OPERATION_ID_PATTERN.fullmatch(operation_id) is None
+    ):
+        raise JournalRecordError("journal restart operation ID is invalid")
+    if (
+        not isinstance(record.system, str)
+        or record.system not in JOURNAL_RESTART_SYSTEM_VALUES
+    ):
+        raise JournalRecordError("journal system restart value is invalid")
+    if (
+        not isinstance(record.session, str)
+        or record.session not in JOURNAL_RESTART_SESSION_VALUES
+    ):
+        raise JournalRecordError("journal session restart value is invalid")
+    if not isinstance(record.application, bool):
+        raise JournalRecordError("journal application restart value is invalid")
+    fields = (
+        record.boot_id,
+        operation_id,
+        record.system,
+        record.session,
+        _encode_journal_uint64(record.session_cutoff, "session cutoff"),
+        "yes" if record.application else "no",
+        _encode_journal_uint64(record.application_cutoff, "application cutoff"),
+    )
+    return "\t".join(fields)
+
+
+def decode_journal_restart(payload: str) -> JournalRestart:
+    """Decode one canonical restart-guidance control record."""
+    _validate_journal_record_payload(payload)
+    fields = payload.split("\t")
+    if len(fields) != 7:
+        raise JournalRecordError("journal restart field count is invalid")
+    boot_id, operation_id, system, session, session_cutoff, application, app_cutoff = (
+        fields
+    )
+    if BOOT_ID_PATTERN.fullmatch(boot_id) is None:
+        raise JournalRecordError("journal restart boot identity is invalid")
+    if operation_id == "-":
+        decoded_operation_id = None
+    elif JOURNAL_OPERATION_ID_PATTERN.fullmatch(operation_id) is not None:
+        decoded_operation_id = operation_id
+    else:
+        raise JournalRecordError("journal restart operation ID is invalid")
+    if system not in JOURNAL_RESTART_SYSTEM_VALUES:
+        raise JournalRecordError("journal system restart value is invalid")
+    if session not in JOURNAL_RESTART_SESSION_VALUES:
+        raise JournalRecordError("journal session restart value is invalid")
+    if application not in ("yes", "no"):
+        raise JournalRecordError("journal application restart value is invalid")
+    return JournalRestart(
+        boot_id,
+        decoded_operation_id,
+        system,
+        session,
+        _decode_journal_uint64(session_cutoff, "session cutoff"),
+        application == "yes",
+        _decode_journal_uint64(app_cutoff, "application cutoff"),
+    )
+
+
 def _validate_journal_descriptor(
     descriptor: int, expected_size: int, *, writable: bool
 ) -> os.stat_result:
@@ -759,8 +929,10 @@ def _initial_journal_payloads(boot_id: str) -> dict[str, str]:
     if not isinstance(boot_id, str) or BOOT_ID_PATTERN.fullmatch(boot_id) is None:
         raise JournalLayoutError("journal boot identity is invalid")
     payloads = {name: "" for name in JOURNAL_DATA_NAMES}
-    payloads["restart"] = "\t".join((boot_id, *JOURNAL_RESTART_ALL_CLEAR_TAIL))
-    payloads[JOURNAL_CURSOR_NAME] = "00"
+    payloads["restart"] = encode_journal_restart(
+        JournalRestart(boot_id, None, "none", "none", 0, False, 0)
+    )
+    payloads[JOURNAL_CURSOR_NAME] = encode_journal_cursor(0)
     return payloads
 
 
@@ -1029,11 +1201,17 @@ def _is_safe_initial_fragment(image: bytes, expected: bytes) -> bool:
 
 
 def _is_all_clear_restart_payload(payload: str) -> bool:
-    fields = payload.split("\t")
+    try:
+        record = decode_journal_restart(payload)
+    except JournalRecordError:
+        return False
     return (
-        len(fields) == 7
-        and BOOT_ID_PATTERN.fullmatch(fields[0]) is not None
-        and tuple(fields[1:]) == JOURNAL_RESTART_ALL_CLEAR_TAIL
+        record.last_applied_operation_id is None
+        and record.system == "none"
+        and record.session == "none"
+        and record.session_cutoff == 0
+        and not record.application
+        and record.application_cutoff == 0
     )
 
 

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -368,6 +368,112 @@ class JournalFrameTests(unittest.TestCase):
         )
 
 
+class JournalControlRecordTests(unittest.TestCase):
+    boot_id = "01234567-89ab-cdef-0123-456789abcdef"
+    operation_id = "op-0123456789abcdef0123456789abcdef"
+
+    def test_cursor_round_trips_every_terminal_slot(self):
+        for slot in range(provider.JOURNAL_TERMINAL_COUNT):
+            with self.subTest(slot=slot):
+                payload = provider.encode_journal_cursor(slot)
+                self.assertEqual(payload, f"{slot:02d}")
+                self.assertEqual(provider.decode_journal_cursor(payload), slot)
+
+    def test_cursor_rejects_noncanonical_or_out_of_range_values(self):
+        for payload in ("", "0", "00 ", "01\t", "32", "-1", "aa"):
+            with self.subTest(payload=payload):
+                with self.assertRaises(provider.JournalRecordError):
+                    provider.decode_journal_cursor(payload)
+        for slot in (-1, 32, True, "00"):
+            with self.subTest(slot=slot):
+                with self.assertRaises(provider.JournalRecordError):
+                    provider.encode_journal_cursor(slot)
+
+    def test_handoff_round_trips_empty_and_exact_identity(self):
+        self.assertEqual(provider.encode_journal_handoff(None), "")
+        self.assertIsNone(provider.decode_journal_handoff(""))
+        record = provider.JournalHandoff(self.operation_id, 31)
+        payload = f"{self.operation_id}\t31"
+        self.assertEqual(provider.encode_journal_handoff(record), payload)
+        self.assertEqual(provider.decode_journal_handoff(payload), record)
+
+    def test_handoff_rejects_malformed_identity_or_extra_fields(self):
+        invalid = (
+            f"{self.operation_id}",
+            f"{self.operation_id}\t32",
+            f"{self.operation_id}\t00\textra",
+            f"op-{'A' * 32}\t00",
+            f"op-{'0' * 31}\t00",
+        )
+        for payload in invalid:
+            with self.subTest(payload=payload):
+                with self.assertRaises(provider.JournalRecordError):
+                    provider.decode_journal_handoff(payload)
+
+    def test_restart_round_trips_all_closed_values_and_uint64_boundary(self):
+        for system in provider.JOURNAL_RESTART_SYSTEM_VALUES:
+            for session in provider.JOURNAL_RESTART_SESSION_VALUES:
+                for application in (False, True):
+                    record = provider.JournalRestart(
+                        self.boot_id,
+                        self.operation_id,
+                        system,
+                        session,
+                        provider.JOURNAL_SEQUENCE_MAX,
+                        application,
+                        provider.JOURNAL_SEQUENCE_MAX,
+                    )
+                    with self.subTest(
+                        system=system, session=session, application=application
+                    ):
+                        payload = provider.encode_journal_restart(record)
+                        self.assertEqual(
+                            provider.decode_journal_restart(payload), record
+                        )
+
+        initial = provider.JournalRestart(
+            self.boot_id, None, "none", "none", 0, False, 0
+        )
+        self.assertEqual(
+            provider.decode_journal_restart(self.boot_id + "\t-\tnone\tnone\t0\tno\t0"),
+            initial,
+        )
+
+    def test_restart_rejects_noncanonical_or_kind_invalid_fields(self):
+        base = provider.encode_journal_restart(
+            provider.JournalRestart(self.boot_id, None, "none", "none", 0, False, 0)
+        ).split("\t")
+        cases = {
+            "field count": base[:-1],
+            "boot": ["not-a-boot-id", *base[1:]],
+            "operation": [base[0], "op-bad", *base[2:]],
+            "system": [*base[:2], "session", *base[3:]],
+            "session": [*base[:3], "system", *base[4:]],
+            "session cutoff": [*base[:4], "01", *base[5:]],
+            "application": [*base[:5], "true", base[6]],
+            "application cutoff": [*base[:6], str(1 << 64)],
+            "oversized cutoff": [*base[:6], "9" * 5000],
+        }
+        for name, fields in cases.items():
+            with self.subTest(name=name):
+                with self.assertRaises(provider.JournalRecordError):
+                    provider.decode_journal_restart("\t".join(fields))
+
+    def test_restart_encoder_rejects_invalid_typed_values(self):
+        invalid = (
+            provider.JournalRestart(self.boot_id, None, "none", "none", True, False, 0),
+            provider.JournalRestart(self.boot_id, None, "none", "none", 0, "no", 0),
+            provider.JournalRestart(self.boot_id, None, "none", "none", 0, False, -1),
+            provider.JournalRestart(None, None, "none", "none", 0, False, 0),
+            provider.JournalRestart(self.boot_id, 1, "none", "none", 0, False, 0),
+            provider.JournalRestart(self.boot_id, None, [], "none", 0, False, 0),
+        )
+        for record in invalid:
+            with self.subTest(record=record):
+                with self.assertRaises(provider.JournalRecordError):
+                    provider.encode_journal_restart(record)
+
+
 class JournalFileTests(unittest.TestCase):
     def open_empty(self, directory, name="journal"):
         path = pathlib.Path(directory) / name


### PR DESCRIPTION
## Summary
- add strict typed codecs for cursor, handoff, and restart journal payloads
- reject malformed IDs, slots, enums, field counts, noncanonical integers, and out-of-range cutoffs
- derive initial cursor and restart payloads through the canonical encoders

This is a storage-format boundary only. It adds no update command, PackageKit mutation, or whole-journal recovery transition.

## Validation
- `ruff format scripts/dwm-system-management tests/test-system-management.py`
- `ruff check scripts/dwm-system-management tests/test-system-management.py`
- `python3 -B -m unittest tests/test-system-management.py` (72 tests)
- `sudo -n /usr/bin/python3 -B -m unittest tests/test-system-management.py` (72 tests)
- `scripts/run-tests make clean all`
- `scripts/run-tests`
- `coderabbit review --agent --uncommitted` (0 findings)
- `codex review --uncommitted` (no actionable defects)