### PR TITLE
Validate complete journal state

### DIFF
--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -1155,6 +1155,7 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
         and operation.boot_id == restart.boot_id
     ]
     matching_updates: list[JournalOperation] = []
+    ring_may_have_evicted = len(filled_slots) == JOURNAL_TERMINAL_COUNT
     if (
         active is not None
         and active.kind in ("update", "refresh")
@@ -1218,7 +1219,7 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
             for operation in applied_updates
             if operation.operation_id == restart_operation_id
         ]
-        if not matching_updates and len(filled_slots) < JOURNAL_TERMINAL_COUNT:
+        if not matching_updates and not ring_may_have_evicted:
             raise JournalRecordError("journal restart identity is not retained")
         if applied_updates and not matching_updates:
             raise JournalRecordError("journal restart identity is stale")
@@ -1233,8 +1234,20 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
         for operation in applied_updates
     ):
         raise JournalRecordError("journal restart contribution is incomplete")
+    if not ring_may_have_evicted:
+        expected_system = max(
+            ("none", *(operation.system_restart for operation in applied_updates)),
+            key=JOURNAL_RESTART_SYSTEM_STRENGTH.__getitem__,
+        )
+        if restart.system != expected_system:
+            raise JournalRecordError("journal system restart bucket is unsupported")
     if restart.session == "none" and restart.session_cutoff != 0:
         raise JournalRecordError("journal cleared session restart has a cutoff")
+    session_contributors = [
+        operation
+        for operation in applied_updates
+        if operation.session_restart != "none"
+    ]
     if restart.session != "none" and (
         restart.session_cutoff == 0
         or (
@@ -1257,8 +1270,32 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
         )
     ):
         raise JournalRecordError("journal session restart contribution is incomplete")
+    if not ring_may_have_evicted and restart.session != "none":
+        if (
+            not session_contributors
+            or restart.session
+            not in {operation.session_restart for operation in session_contributors}
+        ):
+            raise JournalRecordError("journal session restart bucket is unsupported")
+        latest_session_cutoff = max(
+            operation.terminal_monotonic for operation in session_contributors
+        )
+        latest_session_strength = max(
+            JOURNAL_RESTART_SESSION_STRENGTH[operation.session_restart]
+            for operation in session_contributors
+            if operation.terminal_monotonic == latest_session_cutoff
+        )
+        if (
+            restart.session_cutoff != latest_session_cutoff
+            or JOURNAL_RESTART_SESSION_STRENGTH[restart.session]
+            < latest_session_strength
+        ):
+            raise JournalRecordError("journal session restart state is not derivable")
     if not restart.application and restart.application_cutoff != 0:
         raise JournalRecordError("journal cleared application restart has a cutoff")
+    application_contributors = [
+        operation for operation in applied_updates if operation.application_restart
+    ]
     if restart.application and (
         restart.application_cutoff == 0
         or (
@@ -1272,6 +1309,14 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
         )
     ):
         raise JournalRecordError("journal application restart cutoff is stale")
+    if not ring_may_have_evicted and restart.application and (
+        not application_contributors
+        or restart.application_cutoff
+        != max(
+            operation.terminal_monotonic for operation in application_contributors
+        )
+    ):
+        raise JournalRecordError("journal application restart state is not derivable")
 
     return JournalState(cursor, restart, active, handoff, tuple(terminals))
 

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -1058,6 +1058,14 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
 
     cursor = decode_journal_cursor(payloads[JOURNAL_CURSOR_NAME])
     restart = decode_journal_restart(payloads["restart"])
+    restart_is_all_clear = (
+        restart.last_applied_operation_id is None
+        and restart.system == "none"
+        and restart.session == "none"
+        and restart.session_cutoff == 0
+        and not restart.application
+        and restart.application_cutoff == 0
+    )
     active_payload = payloads["active"]
     active = None if active_payload == "" else decode_journal_operation(active_payload)
     handoff = decode_journal_handoff(payloads["handoff"])
@@ -1105,16 +1113,12 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
             and restart.last_applied_operation_id != handoff_terminal.operation_id
         ):
             raise JournalRecordError("journal update handoff has no restart commit")
-        if handoff_terminal.kind == "update" and handoff_terminal.boot_id != restart.boot_id:
-            if (
-                restart.last_applied_operation_id is not None
-                or restart.system != "none"
-                or restart.session != "none"
-                or restart.session_cutoff != 0
-                or restart.application
-                or restart.application_cutoff != 0
-            ):
-                raise JournalRecordError("journal old-boot handoff is not all-clear")
+        if (
+            handoff_terminal.kind == "update"
+            and handoff_terminal.boot_id != restart.boot_id
+            and not restart_is_all_clear
+        ):
+            raise JournalRecordError("journal old-boot handoff is not all-clear")
         if active is not None and (
             active.state not in JOURNAL_OPERATION_TERMINAL_STATES
             or active != handoff_terminal
@@ -1134,6 +1138,13 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
         selected = terminals[active.slot]
         if active.state not in JOURNAL_OPERATION_TERMINAL_STATES or selected != active:
             raise JournalRecordError("journal active operation ID is duplicated")
+    if (
+        active is not None
+        and active.kind == "update"
+        and active.boot_id != restart.boot_id
+        and not restart_is_all_clear
+    ):
+        raise JournalRecordError("journal old-boot active update is not all-clear")
 
     restart_operation_id = restart.last_applied_operation_id
     applied_updates = [
@@ -1146,8 +1157,8 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
     matching_updates: list[JournalOperation] = []
     if (
         active is not None
-        and active.kind == "update"
-        and active.boot_id == restart.boot_id
+        and active.kind in ("update", "refresh")
+        and (active.kind == "refresh" or active.boot_id == restart.boot_id)
         and active.state in JOURNAL_OPERATION_TERMINAL_STATES
         and any(
             operation.terminal_monotonic > active.terminal_monotonic
@@ -1155,7 +1166,7 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
             if operation != active
         )
     ):
-        raise JournalRecordError("journal active update timestamp is stale")
+        raise JournalRecordError("journal active timestamp is stale")
     if (
         handoff_terminal is not None
         and handoff_terminal.kind in ("update", "refresh")
@@ -1222,6 +1233,10 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
         raise JournalRecordError("journal restart contribution is incomplete")
     if restart.session != "none" and (
         restart.session_cutoff == 0
+        or (
+            matching_updates
+            and restart.session_cutoff > matching_updates[0].terminal_monotonic
+        )
         or any(
             operation.session_restart != "none"
             and restart.session_cutoff < operation.terminal_monotonic
@@ -1240,6 +1255,10 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
         raise JournalRecordError("journal session restart contribution is incomplete")
     if restart.application and (
         restart.application_cutoff == 0
+        or (
+            matching_updates
+            and restart.application_cutoff > matching_updates[0].terminal_monotonic
+        )
         or any(
             operation.application_restart
             and restart.application_cutoff < operation.terminal_monotonic

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -58,6 +58,12 @@ JOURNAL_PACKAGEKIT_PATH_PATTERN = re.compile(
 JOURNAL_RESTART_SYSTEM_VALUES = frozenset(
     ("none", "system", "security-system", "unknown")
 )
+JOURNAL_RESTART_SYSTEM_STRENGTH = {
+    "none": 0,
+    "unknown": 1,
+    "system": 2,
+    "security-system": 3,
+}
 JOURNAL_RESTART_SESSION_VALUES = frozenset(("none", "session", "security-session"))
 JOURNAL_OPERATION_ACTION_KINDS = {
     "updates-refresh": "refresh",
@@ -231,6 +237,15 @@ class JournalOperation:
     boot_id: str | None
     terminal_monotonic: int | None
     slot: int
+
+
+@dataclass(frozen=True)
+class JournalState:
+    cursor: int
+    restart: JournalRestart
+    active: JournalOperation | None
+    handoff: JournalHandoff | None
+    terminals: tuple[JournalOperation | None, ...]
 
 
 @dataclass
@@ -1029,6 +1044,146 @@ def decode_journal_operation(payload: str) -> JournalOperation:
     if encode_journal_operation(record) != payload:
         raise JournalRecordError("journal operation record is not canonical")
     return record
+
+
+def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
+    """Validate the complete fixed journal payload set without changing it."""
+    if not isinstance(payloads, Mapping) or set(payloads) != set(JOURNAL_NAMES):
+        raise JournalRecordError("journal state path set is invalid")
+    if any(not isinstance(value, str) for value in payloads.values()):
+        raise JournalRecordError("journal state payload is invalid")
+
+    cursor = decode_journal_cursor(payloads[JOURNAL_CURSOR_NAME])
+    restart = decode_journal_restart(payloads["restart"])
+    active_payload = payloads["active"]
+    active = None if active_payload == "" else decode_journal_operation(active_payload)
+    handoff = decode_journal_handoff(payloads["handoff"])
+    terminals: list[JournalOperation | None] = []
+    retained_ids: set[str] = set()
+    for slot in range(JOURNAL_TERMINAL_COUNT):
+        payload = payloads[f"terminal-{slot:02d}"]
+        if payload == "":
+            terminals.append(None)
+            continue
+        operation = decode_journal_operation(payload)
+        if operation.state not in JOURNAL_OPERATION_TERMINAL_STATES:
+            raise JournalRecordError("journal terminal slot is nonterminal")
+        if operation.slot != slot:
+            raise JournalRecordError("journal terminal slot identity does not match")
+        if operation.operation_id in retained_ids:
+            raise JournalRecordError("journal terminal operation ID is duplicated")
+        retained_ids.add(operation.operation_id)
+        terminals.append(operation)
+
+    if handoff is not None:
+        terminal = terminals[handoff.slot]
+        if terminal is None or terminal.operation_id != handoff.operation_id:
+            raise JournalRecordError("journal handoff has no matching terminal")
+        if cursor != (handoff.slot + 1) % JOURNAL_TERMINAL_COUNT:
+            raise JournalRecordError("journal handoff cursor has not advanced")
+        if (
+            terminal.kind == "update"
+            and terminal.boot_id == restart.boot_id
+            and restart.last_applied_operation_id != terminal.operation_id
+        ):
+            raise JournalRecordError("journal update handoff has no restart commit")
+        if active is not None and (
+            active.state not in JOURNAL_OPERATION_TERMINAL_STATES or active != terminal
+        ):
+            raise JournalRecordError("journal active and handoff records conflict")
+
+    if active is not None and active.state in JOURNAL_OPERATION_TERMINAL_STATES:
+        selected = terminals[active.slot]
+        if (
+            selected == active
+            and active.kind == "update"
+            and active.boot_id == restart.boot_id
+            and restart.last_applied_operation_id != active.operation_id
+        ):
+            raise JournalRecordError("journal terminal update has no restart commit")
+    if active is not None and active.operation_id in retained_ids:
+        selected = terminals[active.slot]
+        if active.state not in JOURNAL_OPERATION_TERMINAL_STATES or selected != active:
+            raise JournalRecordError("journal active operation ID is duplicated")
+
+    restart_operation_id = restart.last_applied_operation_id
+    applied_updates = [
+        operation
+        for operation in terminals
+        if operation is not None
+        and operation.kind == "update"
+        and operation.boot_id == restart.boot_id
+    ]
+    if restart_operation_id is None:
+        if (
+            restart.system != "none"
+            or restart.session != "none"
+            or restart.session_cutoff != 0
+            or restart.application
+            or restart.application_cutoff != 0
+        ):
+            raise JournalRecordError("journal restart guidance has no identity")
+        if applied_updates:
+            raise JournalRecordError("journal update history has no restart identity")
+    else:
+        matching_operations = [
+            operation
+            for operation in (*terminals, active)
+            if operation is not None and operation.operation_id == restart_operation_id
+        ]
+        if any(
+            operation.kind != "update"
+            or operation.boot_id != restart.boot_id
+            or operation.state not in JOURNAL_OPERATION_TERMINAL_STATES
+            for operation in matching_operations
+        ):
+            raise JournalRecordError("journal operation ID reuses restart identity")
+        if (
+            active is not None
+            and active.operation_id == restart_operation_id
+            and active.kind == "update"
+            and active.boot_id == restart.boot_id
+            and active not in applied_updates
+        ):
+            applied_updates.append(active)
+        matching_updates = [
+            operation
+            for operation in applied_updates
+            if operation.operation_id == restart_operation_id
+        ]
+        if applied_updates and not matching_updates:
+            raise JournalRecordError("journal restart identity is stale")
+        if matching_updates and any(
+            operation.terminal_monotonic > matching_updates[0].terminal_monotonic
+            for operation in applied_updates
+        ):
+            raise JournalRecordError("journal restart identity is stale")
+    if any(
+        JOURNAL_RESTART_SYSTEM_STRENGTH[restart.system]
+        < JOURNAL_RESTART_SYSTEM_STRENGTH[operation.system_restart]
+        for operation in applied_updates
+    ):
+        raise JournalRecordError("journal restart contribution is incomplete")
+    if restart.session != "none" and (
+        restart.session_cutoff == 0
+        or any(
+            operation.session_restart != "none"
+            and restart.session_cutoff < operation.terminal_monotonic
+            for operation in applied_updates
+        )
+    ):
+        raise JournalRecordError("journal session restart cutoff is stale")
+    if restart.application and (
+        restart.application_cutoff == 0
+        or any(
+            operation.application_restart
+            and restart.application_cutoff < operation.terminal_monotonic
+            for operation in applied_updates
+        )
+    ):
+        raise JournalRecordError("journal application restart cutoff is stale")
+
+    return JournalState(cursor, restart, active, handoff, tuple(terminals))
 
 
 def _validate_journal_descriptor(

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -55,15 +55,13 @@ JOURNAL_TIMESTAMP_PATTERN = re.compile(
 JOURNAL_PACKAGEKIT_PATH_PATTERN = re.compile(
     r"/org/freedesktop/PackageKit/transactions/[A-Za-z0-9_]+"
 )
-JOURNAL_RESTART_SYSTEM_VALUES = frozenset(
-    ("none", "system", "security-system", "unknown")
-)
 JOURNAL_RESTART_SYSTEM_STRENGTH = {
     "none": 0,
     "unknown": 1,
     "system": 2,
     "security-system": 3,
 }
+JOURNAL_RESTART_SYSTEM_VALUES = frozenset(JOURNAL_RESTART_SYSTEM_STRENGTH)
 JOURNAL_RESTART_SESSION_VALUES = frozenset(("none", "session", "security-session"))
 JOURNAL_OPERATION_ACTION_KINDS = {
     "updates-refresh": "refresh",

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -62,7 +62,12 @@ JOURNAL_RESTART_SYSTEM_STRENGTH = {
     "security-system": 3,
 }
 JOURNAL_RESTART_SYSTEM_VALUES = frozenset(JOURNAL_RESTART_SYSTEM_STRENGTH)
-JOURNAL_RESTART_SESSION_VALUES = frozenset(("none", "session", "security-session"))
+JOURNAL_RESTART_SESSION_STRENGTH = {
+    "none": 0,
+    "session": 1,
+    "security-session": 2,
+}
+JOURNAL_RESTART_SESSION_VALUES = frozenset(JOURNAL_RESTART_SESSION_STRENGTH)
 JOURNAL_OPERATION_ACTION_KINDS = {
     "updates-refresh": "refresh",
     "updates-install-all": "update",
@@ -1073,20 +1078,46 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
         retained_ids.add(operation.operation_id)
         terminals.append(operation)
 
+    filled_slots = [
+        slot for slot, operation in enumerate(terminals) if operation is not None
+    ]
+    if (
+        active is None
+        and handoff is None
+        and len(filled_slots) == 1
+        and cursor != (filled_slots[0] + 1) % JOURNAL_TERMINAL_COUNT
+    ):
+        raise JournalRecordError("journal cursor is stale")
+
+    handoff_terminal = None
     if handoff is not None:
-        terminal = terminals[handoff.slot]
-        if terminal is None or terminal.operation_id != handoff.operation_id:
+        handoff_terminal = terminals[handoff.slot]
+        if (
+            handoff_terminal is None
+            or handoff_terminal.operation_id != handoff.operation_id
+        ):
             raise JournalRecordError("journal handoff has no matching terminal")
         if cursor != (handoff.slot + 1) % JOURNAL_TERMINAL_COUNT:
             raise JournalRecordError("journal handoff cursor has not advanced")
         if (
-            terminal.kind == "update"
-            and terminal.boot_id == restart.boot_id
-            and restart.last_applied_operation_id != terminal.operation_id
+            handoff_terminal.kind == "update"
+            and handoff_terminal.boot_id == restart.boot_id
+            and restart.last_applied_operation_id != handoff_terminal.operation_id
         ):
             raise JournalRecordError("journal update handoff has no restart commit")
+        if handoff_terminal.kind == "update" and handoff_terminal.boot_id != restart.boot_id:
+            if (
+                restart.last_applied_operation_id is not None
+                or restart.system != "none"
+                or restart.session != "none"
+                or restart.session_cutoff != 0
+                or restart.application
+                or restart.application_cutoff != 0
+            ):
+                raise JournalRecordError("journal old-boot handoff is not all-clear")
         if active is not None and (
-            active.state not in JOURNAL_OPERATION_TERMINAL_STATES or active != terminal
+            active.state not in JOURNAL_OPERATION_TERMINAL_STATES
+            or active != handoff_terminal
         ):
             raise JournalRecordError("journal active and handoff records conflict")
 
@@ -1112,6 +1143,33 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
         and operation.kind == "update"
         and operation.boot_id == restart.boot_id
     ]
+    matching_updates: list[JournalOperation] = []
+    if (
+        active is not None
+        and active.kind == "update"
+        and active.boot_id == restart.boot_id
+        and active.state in JOURNAL_OPERATION_TERMINAL_STATES
+        and any(
+            operation.terminal_monotonic > active.terminal_monotonic
+            for operation in applied_updates
+            if operation != active
+        )
+    ):
+        raise JournalRecordError("journal active update timestamp is stale")
+    if (
+        handoff_terminal is not None
+        and handoff_terminal.kind in ("update", "refresh")
+        and (
+            handoff_terminal.kind == "refresh"
+            or handoff_terminal.boot_id == restart.boot_id
+        )
+        and any(
+            operation.operation_id != handoff_terminal.operation_id
+            and operation.terminal_monotonic > handoff_terminal.terminal_monotonic
+            for operation in applied_updates
+        )
+    ):
+        raise JournalRecordError("journal handoff is superseded")
     if restart_operation_id is None:
         if (
             restart.system != "none"
@@ -1171,6 +1229,15 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
         )
     ):
         raise JournalRecordError("journal session restart cutoff is stale")
+    if (
+        restart.session != "none"
+        and any(
+            JOURNAL_RESTART_SESSION_STRENGTH[restart.session]
+            < JOURNAL_RESTART_SESSION_STRENGTH[operation.session_restart]
+            for operation in matching_updates
+        )
+    ):
+        raise JournalRecordError("journal session restart contribution is incomplete")
     if restart.application and (
         restart.application_cutoff == 0
         or any(

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -1218,6 +1218,8 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
             for operation in applied_updates
             if operation.operation_id == restart_operation_id
         ]
+        if not matching_updates and len(filled_slots) < JOURNAL_TERMINAL_COUNT:
+            raise JournalRecordError("journal restart identity is not retained")
         if applied_updates and not matching_updates:
             raise JournalRecordError("journal restart identity is stale")
         if matching_updates and any(
@@ -1231,6 +1233,8 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
         for operation in applied_updates
     ):
         raise JournalRecordError("journal restart contribution is incomplete")
+    if restart.session == "none" and restart.session_cutoff != 0:
+        raise JournalRecordError("journal cleared session restart has a cutoff")
     if restart.session != "none" and (
         restart.session_cutoff == 0
         or (
@@ -1253,6 +1257,8 @@ def decode_journal_state(payloads: Mapping[str, str]) -> JournalState:
         )
     ):
         raise JournalRecordError("journal session restart contribution is incomplete")
+    if not restart.application and restart.application_cutoff != 0:
+        raise JournalRecordError("journal cleared application restart has a cutoff")
     if restart.application and (
         restart.application_cutoff == 0
         or (

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -740,6 +740,26 @@ class JournalControlRecordTests(unittest.TestCase):
         self.assertEqual(state.restart.session, "none")
         self.assertFalse(state.restart.application)
 
+        later = replace(
+            terminal,
+            operation_id="op-ffffffffffffffffffffffffffffffff",
+            session_restart="session",
+            application_restart=False,
+            terminal_monotonic=200,
+            slot=8,
+        )
+        payloads["terminal-08"] = provider.encode_journal_operation(later)
+        payloads["cursor"] = "09"
+        payloads["restart"] = provider.encode_journal_restart(
+            replace(
+                state.restart,
+                last_applied_operation_id=later.operation_id,
+                session="session",
+                session_cutoff=later.terminal_monotonic,
+            )
+        )
+        self.assertEqual(provider.decode_journal_state(payloads).restart.session, "session")
+
     def test_state_rejects_missing_extra_or_wrong_typed_paths(self):
         payloads = self.state_payloads()
         invalid = []
@@ -849,6 +869,7 @@ class JournalControlRecordTests(unittest.TestCase):
         missing_retained_restart["terminal-07"] = provider.encode_journal_operation(
             terminal
         )
+        missing_retained_restart["cursor"] = "08"
         cases["retained update restart identity missing"] = missing_retained_restart
         reused = self.state_payloads()
         reused["restart"] = provider.encode_journal_restart(
@@ -876,18 +897,21 @@ class JournalControlRecordTests(unittest.TestCase):
         reused_terminal = self.state_payloads()
         reused_terminal["restart"] = reused["restart"]
         reused_terminal["terminal-07"] = provider.encode_journal_operation(non_update)
+        reused_terminal["cursor"] = "08"
         cases["non-update terminal reuses restart identity"] = reused_terminal
         previous_boot = self.state_payloads()
         previous_boot["restart"] = reused["restart"]
         previous_boot["terminal-07"] = provider.encode_journal_operation(
             replace(terminal, boot_id="11234567-89ab-cdef-0123-456789abcdef")
         )
+        previous_boot["cursor"] = "08"
         cases["previous-boot update reuses restart identity"] = previous_boot
         missing_contribution = self.state_payloads()
         missing_contribution["restart"] = reused["restart"]
         missing_contribution["terminal-07"] = provider.encode_journal_operation(
             replace(terminal, system_restart="security-system")
         )
+        missing_contribution["cursor"] = "08"
         cases["system contribution missing"] = missing_contribution
         older_contribution = self.state_payloads()
         newer = replace(
@@ -948,6 +972,7 @@ class JournalControlRecordTests(unittest.TestCase):
                     application_restart=field == "application",
                 )
             )
+            stale_cutoff["cursor"] = "08"
             cases[f"{field} cutoff is stale"] = stale_cutoff
         for field, changes in (
             (
@@ -980,7 +1005,62 @@ class JournalControlRecordTests(unittest.TestCase):
                     application_restart=field == "application",
                 )
             )
+            future_cutoff["cursor"] = "08"
             cases[f"{field} cutoff is newer than the last update"] = future_cutoff
+        for field, restart_changes in (
+            ("system", {"system": "security-system"}),
+            (
+                "session",
+                {"session": "security-session", "session_cutoff": 123},
+            ),
+            ("application", {"application": True, "application_cutoff": 123}),
+        ):
+            unsupported_bucket = self.state_payloads()
+            unsupported_bucket["restart"] = provider.encode_journal_restart(
+                replace(
+                    provider.decode_journal_restart(unsupported_bucket["restart"]),
+                    last_applied_operation_id=terminal.operation_id,
+                    **restart_changes,
+                )
+            )
+            unsupported_bucket["terminal-07"] = provider.encode_journal_operation(
+                terminal
+            )
+            unsupported_bucket["cursor"] = "08"
+            cases[f"{field} bucket is unsupported by retained history"] = (
+                unsupported_bucket
+            )
+        for field, contribution_changes, restart_changes in (
+            (
+                "session",
+                {"session_restart": "session"},
+                {"session": "session", "session_cutoff": 150},
+            ),
+            (
+                "application",
+                {"application_restart": True},
+                {"application": True, "application_cutoff": 150},
+            ),
+        ):
+            inexact_cutoff = self.state_payloads()
+            older = replace(terminal, terminal_monotonic=100, **contribution_changes)
+            latest = replace(
+                terminal,
+                operation_id="op-ffffffffffffffffffffffffffffffff",
+                terminal_monotonic=200,
+                slot=8,
+            )
+            inexact_cutoff["restart"] = provider.encode_journal_restart(
+                replace(
+                    provider.decode_journal_restart(inexact_cutoff["restart"]),
+                    last_applied_operation_id=latest.operation_id,
+                    **restart_changes,
+                )
+            )
+            inexact_cutoff["terminal-07"] = provider.encode_journal_operation(older)
+            inexact_cutoff["terminal-08"] = provider.encode_journal_operation(latest)
+            inexact_cutoff["cursor"] = "09"
+            cases[f"{field} cutoff is not a retained contribution"] = inexact_cutoff
         unidentified_guidance = self.state_payloads()
         unidentified_guidance["restart"] = provider.encode_journal_restart(
             replace(
@@ -1015,9 +1095,44 @@ class JournalControlRecordTests(unittest.TestCase):
             )
             cleared_cutoff["cursor"] = "08"
             cases[f"cleared {field} bucket retains cutoff"] = cleared_cutoff
+        expected_errors = {
+            "system contribution missing": "restart contribution is incomplete",
+            "session cutoff is stale": "session restart cutoff is stale",
+            "application cutoff is stale": "application restart cutoff is stale",
+            "session cutoff is newer than the last update": (
+                "session restart cutoff is stale"
+            ),
+            "application cutoff is newer than the last update": (
+                "application restart cutoff is stale"
+            ),
+            "system bucket is unsupported by retained history": (
+                "system restart bucket is unsupported"
+            ),
+            "session bucket is unsupported by retained history": (
+                "session restart bucket is unsupported"
+            ),
+            "application bucket is unsupported by retained history": (
+                "application restart state is not derivable"
+            ),
+            "session cutoff is not a retained contribution": (
+                "session restart state is not derivable"
+            ),
+            "application cutoff is not a retained contribution": (
+                "application restart state is not derivable"
+            ),
+            "cleared session bucket retains cutoff": (
+                "cleared session restart has a cutoff"
+            ),
+            "cleared application bucket retains cutoff": (
+                "cleared application restart has a cutoff"
+            ),
+        }
         for name, payloads in cases.items():
             with self.subTest(name=name):
-                with self.assertRaises(provider.JournalRecordError):
+                with self.assertRaisesRegex(
+                    provider.JournalRecordError,
+                    expected_errors.get(name, "journal"),
+                ):
                     provider.decode_journal_state(payloads)
 
     def test_state_rejects_cross_record_recovery_conflicts(self):

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -989,6 +989,32 @@ class JournalControlRecordTests(unittest.TestCase):
             )
         )
         cases["restart guidance has no identity"] = unidentified_guidance
+        orphan_identity = self.state_payloads()
+        orphan_identity["restart"] = provider.encode_journal_restart(
+            replace(
+                provider.decode_journal_restart(orphan_identity["restart"]),
+                last_applied_operation_id="op-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                system="unknown",
+            )
+        )
+        cases["restart identity is absent before ring wrap"] = orphan_identity
+        for field, changes in (
+            ("session", {"session_cutoff": 123}),
+            ("application", {"application_cutoff": 123}),
+        ):
+            cleared_cutoff = self.state_payloads()
+            cleared_cutoff["restart"] = provider.encode_journal_restart(
+                replace(
+                    provider.decode_journal_restart(cleared_cutoff["restart"]),
+                    last_applied_operation_id=terminal.operation_id,
+                    **changes,
+                )
+            )
+            cleared_cutoff["terminal-07"] = provider.encode_journal_operation(
+                terminal
+            )
+            cleared_cutoff["cursor"] = "08"
+            cases[f"cleared {field} bucket retains cutoff"] = cleared_cutoff
         for name, payloads in cases.items():
             with self.subTest(name=name):
                 with self.assertRaises(provider.JournalRecordError):
@@ -1060,6 +1086,29 @@ class JournalControlRecordTests(unittest.TestCase):
                 boot_id="11234567-89ab-cdef-0123-456789abcdef",
             )
         )
+        old_boot_active["cursor"] = "07"
+        regional_terminal = replace(
+            terminal,
+            action_id="timezone-set",
+            kind="timezone",
+            generation=None,
+            transaction_path=None,
+            system_restart=None,
+            session_restart=None,
+            application_restart=None,
+            boot_id=None,
+            terminal_monotonic=None,
+        )
+        for slot in range(provider.JOURNAL_TERMINAL_COUNT):
+            old_boot_active[f"terminal-{slot:02d}"] = (
+                provider.encode_journal_operation(
+                    replace(
+                        regional_terminal,
+                        operation_id=f"op-{slot + 1:032x}",
+                        slot=slot,
+                    )
+                )
+            )
         cases["old-boot active update restart is not clear"] = old_boot_active
 
         old_boot_handoff = self.state_payloads()

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -495,6 +495,9 @@ class JournalControlRecordTests(unittest.TestCase):
         )
         return replace(record, **changes)
 
+    def state_payloads(self):
+        return provider._initial_journal_payloads(self.boot_id)
+
     def test_operation_round_trips_nonterminal_and_terminal_update(self):
         active = self.update_operation()
         active_payload = provider.encode_journal_operation(active)
@@ -640,6 +643,302 @@ class JournalControlRecordTests(unittest.TestCase):
             with self.subTest(name=name):
                 with self.assertRaises(provider.JournalRecordError):
                     provider.decode_journal_operation("\t".join(changed))
+
+    def test_state_round_trips_initial_and_nonterminal_active_payloads(self):
+        payloads = self.state_payloads()
+        state = provider.decode_journal_state(payloads)
+        self.assertEqual(state.cursor, 0)
+        self.assertIsNone(state.active)
+        self.assertIsNone(state.handoff)
+        self.assertEqual(state.restart.boot_id, self.boot_id)
+        self.assertEqual(state.terminals, (None,) * provider.JOURNAL_TERMINAL_COUNT)
+
+        active = self.update_operation(slot=7)
+        payloads["active"] = provider.encode_journal_operation(active)
+        self.assertEqual(provider.decode_journal_state(payloads).active, active)
+
+    def test_state_accepts_each_terminalization_checkpoint(self):
+        active = replace(
+            self.update_operation(slot=7),
+            finished_at="2026-02-28T01:03:04Z",
+            state="succeeded",
+            terminal_monotonic=123,
+        )
+        active_payload = provider.encode_journal_operation(active)
+        checkpoints = []
+
+        payloads = self.state_payloads()
+        payloads["active"] = active_payload
+        checkpoints.append(payloads.copy())
+        payloads["restart"] = provider.encode_journal_restart(
+            replace(
+                provider.decode_journal_restart(payloads["restart"]),
+                last_applied_operation_id=active.operation_id,
+            )
+        )
+        payloads["terminal-07"] = active_payload
+        checkpoints.append(payloads.copy())
+        payloads["cursor"] = "08"
+        checkpoints.append(payloads.copy())
+        payloads["handoff"] = provider.encode_journal_handoff(
+            provider.JournalHandoff(active.operation_id, 7)
+        )
+        checkpoints.append(payloads.copy())
+        payloads["active"] = ""
+        checkpoints.append(payloads.copy())
+
+        for index, checkpoint in enumerate(checkpoints):
+            with self.subTest(checkpoint=index):
+                state = provider.decode_journal_state(checkpoint)
+                self.assertEqual(state.terminals[7], active if index >= 1 else None)
+
+    def test_state_accepts_old_selected_slot_before_terminal_overwrite(self):
+        payloads = self.state_payloads()
+        old = replace(
+            self.update_operation(
+                operation_id="op-ffffffffffffffffffffffffffffffff", slot=7
+            ),
+            finished_at="2026-02-27T01:03:04Z",
+            state="succeeded",
+            terminal_monotonic=100,
+        )
+        current = replace(
+            self.update_operation(slot=7),
+            finished_at="2026-02-28T01:03:04Z",
+            state="succeeded",
+            terminal_monotonic=123,
+        )
+        payloads["active"] = provider.encode_journal_operation(current)
+        payloads["terminal-07"] = provider.encode_journal_operation(old)
+        payloads["restart"] = provider.encode_journal_restart(
+            replace(
+                provider.decode_journal_restart(payloads["restart"]),
+                last_applied_operation_id=old.operation_id,
+            )
+        )
+        self.assertEqual(provider.decode_journal_state(payloads).active, current)
+
+    def test_state_rejects_missing_extra_or_wrong_typed_paths(self):
+        payloads = self.state_payloads()
+        invalid = []
+        missing = payloads.copy()
+        del missing["active"]
+        invalid.append(missing)
+        extra = payloads.copy()
+        extra["terminal-32"] = ""
+        invalid.append(extra)
+        wrong_type = payloads.copy()
+        wrong_type["active"] = None
+        invalid.append(wrong_type)
+        for state in invalid:
+            with self.subTest(paths=state.keys()):
+                with self.assertRaises(provider.JournalRecordError):
+                    provider.decode_journal_state(state)
+
+    def test_state_rejects_invalid_terminal_slot_records(self):
+        terminal = replace(
+            self.update_operation(slot=7),
+            finished_at="2026-02-28T01:03:04Z",
+            state="succeeded",
+            terminal_monotonic=123,
+        )
+        cases = []
+        nonterminal = self.state_payloads()
+        nonterminal["terminal-07"] = provider.encode_journal_operation(
+            self.update_operation(slot=7)
+        )
+        cases.append(nonterminal)
+        wrong_slot = self.state_payloads()
+        wrong_slot["terminal-06"] = provider.encode_journal_operation(terminal)
+        cases.append(wrong_slot)
+        duplicate = self.state_payloads()
+        duplicate["terminal-07"] = provider.encode_journal_operation(terminal)
+        duplicate["terminal-08"] = provider.encode_journal_operation(
+            replace(terminal, slot=8)
+        )
+        cases.append(duplicate)
+        active_duplicate = self.state_payloads()
+        active_duplicate["active"] = provider.encode_journal_operation(
+            self.update_operation(slot=7)
+        )
+        active_duplicate["terminal-07"] = provider.encode_journal_operation(terminal)
+        cases.append(active_duplicate)
+        for index, payloads in enumerate(cases):
+            with self.subTest(index=index):
+                with self.assertRaises(provider.JournalRecordError):
+                    provider.decode_journal_state(payloads)
+
+    def test_state_rejects_handoff_and_terminalization_conflicts(self):
+        terminal = replace(
+            self.update_operation(slot=7),
+            finished_at="2026-02-28T01:03:04Z",
+            state="succeeded",
+            terminal_monotonic=123,
+        )
+        other = replace(
+            terminal,
+            operation_id="op-ffffffffffffffffffffffffffffffff",
+        )
+        cases = []
+        missing = self.state_payloads()
+        missing["handoff"] = provider.encode_journal_handoff(
+            provider.JournalHandoff(terminal.operation_id, 7)
+        )
+        cases.append(missing)
+        mismatch = self.state_payloads()
+        mismatch["terminal-07"] = provider.encode_journal_operation(terminal)
+        mismatch["cursor"] = "08"
+        mismatch["handoff"] = provider.encode_journal_handoff(
+            provider.JournalHandoff(other.operation_id, 7)
+        )
+        cases.append(mismatch)
+        active_conflict = self.state_payloads()
+        active_conflict["active"] = provider.encode_journal_operation(other)
+        active_conflict["terminal-07"] = provider.encode_journal_operation(terminal)
+        active_conflict["cursor"] = "08"
+        active_conflict["handoff"] = provider.encode_journal_handoff(
+            provider.JournalHandoff(terminal.operation_id, 7)
+        )
+        cases.append(active_conflict)
+        for payloads in cases:
+            with self.subTest():
+                with self.assertRaises(provider.JournalRecordError):
+                    provider.decode_journal_state(payloads)
+
+    def test_state_rejects_stale_cursor_restart_and_restart_id_reuse(self):
+        terminal = replace(
+            self.update_operation(slot=7),
+            finished_at="2026-02-28T01:03:04Z",
+            state="succeeded",
+            terminal_monotonic=123,
+        )
+        cases = []
+        stale_cursor = self.state_payloads()
+        stale_cursor["terminal-07"] = provider.encode_journal_operation(terminal)
+        stale_cursor["handoff"] = provider.encode_journal_handoff(
+            provider.JournalHandoff(terminal.operation_id, 7)
+        )
+        cases.append(stale_cursor)
+        missing_restart = self.state_payloads()
+        missing_restart["active"] = provider.encode_journal_operation(terminal)
+        missing_restart["terminal-07"] = provider.encode_journal_operation(terminal)
+        cases.append(missing_restart)
+        missing_retained_restart = self.state_payloads()
+        missing_retained_restart["terminal-07"] = provider.encode_journal_operation(
+            terminal
+        )
+        cases.append(missing_retained_restart)
+        reused = self.state_payloads()
+        reused["restart"] = provider.encode_journal_restart(
+            replace(
+                provider.decode_journal_restart(reused["restart"]),
+                last_applied_operation_id=terminal.operation_id,
+            )
+        )
+        reused["active"] = provider.encode_journal_operation(
+            self.update_operation(slot=8)
+        )
+        cases.append(reused)
+        non_update = replace(
+            terminal,
+            action_id="timezone-set",
+            kind="timezone",
+            generation=None,
+            transaction_path=None,
+            system_restart=None,
+            session_restart=None,
+            application_restart=None,
+            boot_id=None,
+            terminal_monotonic=None,
+        )
+        reused_terminal = self.state_payloads()
+        reused_terminal["restart"] = reused["restart"]
+        reused_terminal["terminal-07"] = provider.encode_journal_operation(non_update)
+        cases.append(reused_terminal)
+        previous_boot = self.state_payloads()
+        previous_boot["restart"] = reused["restart"]
+        previous_boot["terminal-07"] = provider.encode_journal_operation(
+            replace(terminal, boot_id="11234567-89ab-cdef-0123-456789abcdef")
+        )
+        cases.append(previous_boot)
+        missing_contribution = self.state_payloads()
+        missing_contribution["restart"] = reused["restart"]
+        missing_contribution["terminal-07"] = provider.encode_journal_operation(
+            replace(terminal, system_restart="security-system")
+        )
+        cases.append(missing_contribution)
+        older_contribution = self.state_payloads()
+        newer = replace(
+            terminal,
+            operation_id="op-ffffffffffffffffffffffffffffffff",
+            terminal_monotonic=200,
+            slot=8,
+        )
+        older_contribution["restart"] = provider.encode_journal_restart(
+            replace(
+                provider.decode_journal_restart(older_contribution["restart"]),
+                last_applied_operation_id=newer.operation_id,
+            )
+        )
+        older_contribution["terminal-07"] = provider.encode_journal_operation(
+            replace(terminal, system_restart="security-system")
+        )
+        older_contribution["terminal-08"] = provider.encode_journal_operation(newer)
+        cases.append(older_contribution)
+        stale_identity = self.state_payloads()
+        stale_identity["restart"] = provider.encode_journal_restart(
+            replace(
+                provider.decode_journal_restart(stale_identity["restart"]),
+                last_applied_operation_id=terminal.operation_id,
+            )
+        )
+        stale_identity["terminal-07"] = provider.encode_journal_operation(terminal)
+        stale_identity["terminal-08"] = provider.encode_journal_operation(newer)
+        cases.append(stale_identity)
+        for field, changes in (
+            (
+                "session",
+                {
+                    "session": "session",
+                    "session_cutoff": terminal.terminal_monotonic - 1,
+                },
+            ),
+            (
+                "application",
+                {
+                    "application": True,
+                    "application_cutoff": terminal.terminal_monotonic - 1,
+                },
+            ),
+        ):
+            stale_cutoff = self.state_payloads()
+            stale_cutoff["restart"] = provider.encode_journal_restart(
+                replace(
+                    provider.decode_journal_restart(stale_cutoff["restart"]),
+                    last_applied_operation_id=terminal.operation_id,
+                    **changes,
+                )
+            )
+            stale_cutoff["terminal-07"] = provider.encode_journal_operation(
+                replace(
+                    terminal,
+                    session_restart="session" if field == "session" else "none",
+                    application_restart=field == "application",
+                )
+            )
+            cases.append(stale_cutoff)
+        unidentified_guidance = self.state_payloads()
+        unidentified_guidance["restart"] = provider.encode_journal_restart(
+            replace(
+                provider.decode_journal_restart(unidentified_guidance["restart"]),
+                system="unknown",
+            )
+        )
+        cases.append(unidentified_guidance)
+        for index, payloads in enumerate(cases):
+            with self.subTest(index=index):
+                with self.assertRaises(provider.JournalRecordError):
+                    provider.decode_journal_state(payloads)
 
 
 class JournalFileTests(unittest.TestCase):

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -949,6 +949,38 @@ class JournalControlRecordTests(unittest.TestCase):
                 )
             )
             cases[f"{field} cutoff is stale"] = stale_cutoff
+        for field, changes in (
+            (
+                "session",
+                {
+                    "session": "session",
+                    "session_cutoff": terminal.terminal_monotonic + 1,
+                },
+            ),
+            (
+                "application",
+                {
+                    "application": True,
+                    "application_cutoff": terminal.terminal_monotonic + 1,
+                },
+            ),
+        ):
+            future_cutoff = self.state_payloads()
+            future_cutoff["restart"] = provider.encode_journal_restart(
+                replace(
+                    provider.decode_journal_restart(future_cutoff["restart"]),
+                    last_applied_operation_id=terminal.operation_id,
+                    **changes,
+                )
+            )
+            future_cutoff["terminal-07"] = provider.encode_journal_operation(
+                replace(
+                    terminal,
+                    session_restart="session" if field == "session" else "none",
+                    application_restart=field == "application",
+                )
+            )
+            cases[f"{field} cutoff is newer than the last update"] = future_cutoff
         unidentified_guidance = self.state_payloads()
         unidentified_guidance["restart"] = provider.encode_journal_restart(
             replace(
@@ -989,6 +1021,46 @@ class JournalControlRecordTests(unittest.TestCase):
             replace(terminal, slot=8, terminal_monotonic=100)
         )
         cases["active update predates retained history"] = stale_active
+
+        stale_refresh = self.state_payloads()
+        refresh = replace(
+            terminal,
+            action_id="updates-refresh",
+            kind="refresh",
+            generation=None,
+            system_restart=None,
+            session_restart=None,
+            application_restart=None,
+            boot_id=None,
+            terminal_monotonic=100,
+            slot=8,
+        )
+        stale_refresh["terminal-07"] = provider.encode_journal_operation(newer)
+        stale_refresh["cursor"] = "08"
+        stale_refresh["restart"] = provider.encode_journal_restart(
+            replace(
+                provider.decode_journal_restart(stale_refresh["restart"]),
+                last_applied_operation_id=newer.operation_id,
+            )
+        )
+        stale_refresh["active"] = provider.encode_journal_operation(refresh)
+        cases["active refresh predates retained update history"] = stale_refresh
+
+        old_boot_active = self.state_payloads()
+        old_boot_active["restart"] = provider.encode_journal_restart(
+            replace(
+                provider.decode_journal_restart(old_boot_active["restart"]),
+                last_applied_operation_id="op-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                system="unknown",
+            )
+        )
+        old_boot_active["active"] = provider.encode_journal_operation(
+            replace(
+                self.update_operation(slot=7),
+                boot_id="11234567-89ab-cdef-0123-456789abcdef",
+            )
+        )
+        cases["old-boot active update restart is not clear"] = old_boot_active
 
         old_boot_handoff = self.state_payloads()
         old_boot_terminal = replace(

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -718,6 +718,28 @@ class JournalControlRecordTests(unittest.TestCase):
         )
         self.assertEqual(provider.decode_journal_state(payloads).active, current)
 
+    def test_state_accepts_pruned_lower_scope_restart_guidance(self):
+        terminal = replace(
+            self.update_operation(slot=7),
+            finished_at="2026-02-28T01:03:04Z",
+            state="succeeded",
+            session_restart="security-session",
+            application_restart=True,
+            terminal_monotonic=123,
+        )
+        payloads = self.state_payloads()
+        payloads["terminal-07"] = provider.encode_journal_operation(terminal)
+        payloads["cursor"] = "08"
+        payloads["restart"] = provider.encode_journal_restart(
+            replace(
+                provider.decode_journal_restart(payloads["restart"]),
+                last_applied_operation_id=terminal.operation_id,
+            )
+        )
+        state = provider.decode_journal_state(payloads)
+        self.assertEqual(state.restart.session, "none")
+        self.assertFalse(state.restart.application)
+
     def test_state_rejects_missing_extra_or_wrong_typed_paths(self):
         payloads = self.state_payloads()
         invalid = []
@@ -935,6 +957,105 @@ class JournalControlRecordTests(unittest.TestCase):
             )
         )
         cases["restart guidance has no identity"] = unidentified_guidance
+        for name, payloads in cases.items():
+            with self.subTest(name=name):
+                with self.assertRaises(provider.JournalRecordError):
+                    provider.decode_journal_state(payloads)
+
+    def test_state_rejects_cross_record_recovery_conflicts(self):
+        terminal = replace(
+            self.update_operation(slot=7),
+            finished_at="2026-02-28T01:03:04Z",
+            state="succeeded",
+            terminal_monotonic=123,
+        )
+        cases = {}
+
+        newer = replace(
+            terminal,
+            operation_id="op-ffffffffffffffffffffffffffffffff",
+            terminal_monotonic=200,
+        )
+        stale_active = self.state_payloads()
+        stale_active["terminal-07"] = provider.encode_journal_operation(newer)
+        stale_active["cursor"] = "08"
+        stale_active["restart"] = provider.encode_journal_restart(
+            replace(
+                provider.decode_journal_restart(stale_active["restart"]),
+                last_applied_operation_id=newer.operation_id,
+            )
+        )
+        stale_active["active"] = provider.encode_journal_operation(
+            replace(terminal, slot=8, terminal_monotonic=100)
+        )
+        cases["active update predates retained history"] = stale_active
+
+        old_boot_handoff = self.state_payloads()
+        old_boot_terminal = replace(
+            terminal, boot_id="11234567-89ab-cdef-0123-456789abcdef"
+        )
+        old_boot_handoff["terminal-07"] = provider.encode_journal_operation(
+            old_boot_terminal
+        )
+        old_boot_handoff["cursor"] = "08"
+        old_boot_handoff["handoff"] = provider.encode_journal_handoff(
+            provider.JournalHandoff(old_boot_terminal.operation_id, 7)
+        )
+        old_boot_handoff["restart"] = provider.encode_journal_restart(
+            replace(
+                provider.decode_journal_restart(old_boot_handoff["restart"]),
+                last_applied_operation_id="op-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                system="unknown",
+            )
+        )
+        cases["old-boot handoff restart is not clear"] = old_boot_handoff
+
+        downgraded_session = self.state_payloads()
+        downgraded_session["terminal-07"] = provider.encode_journal_operation(
+            replace(terminal, session_restart="security-session")
+        )
+        downgraded_session["cursor"] = "08"
+        downgraded_session["restart"] = provider.encode_journal_restart(
+            replace(
+                provider.decode_journal_restart(downgraded_session["restart"]),
+                last_applied_operation_id=terminal.operation_id,
+                session="session",
+                session_cutoff=terminal.terminal_monotonic,
+            )
+        )
+        cases["security-session urgency is downgraded"] = downgraded_session
+
+        stale_handoff = self.state_payloads()
+        refresh = replace(
+            terminal,
+            action_id="updates-refresh",
+            kind="refresh",
+            generation=None,
+            system_restart=None,
+            session_restart=None,
+            application_restart=None,
+            boot_id=None,
+            terminal_monotonic=100,
+        )
+        later_update = replace(newer, slot=8)
+        stale_handoff["terminal-07"] = provider.encode_journal_operation(refresh)
+        stale_handoff["terminal-08"] = provider.encode_journal_operation(later_update)
+        stale_handoff["cursor"] = "08"
+        stale_handoff["handoff"] = provider.encode_journal_handoff(
+            provider.JournalHandoff(refresh.operation_id, 7)
+        )
+        stale_handoff["restart"] = provider.encode_journal_restart(
+            replace(
+                provider.decode_journal_restart(stale_handoff["restart"]),
+                last_applied_operation_id=later_update.operation_id,
+            )
+        )
+        cases["handoff is superseded by retained update"] = stale_handoff
+
+        stale_cursor = self.state_payloads()
+        stale_cursor["terminal-07"] = provider.encode_journal_operation(refresh)
+        cases["completed terminal cursor is stale"] = stale_cursor
+
         for name, payloads in cases.items():
             with self.subTest(name=name):
                 with self.assertRaises(provider.JournalRecordError):

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -742,29 +742,29 @@ class JournalControlRecordTests(unittest.TestCase):
             state="succeeded",
             terminal_monotonic=123,
         )
-        cases = []
+        cases = {}
         nonterminal = self.state_payloads()
         nonterminal["terminal-07"] = provider.encode_journal_operation(
             self.update_operation(slot=7)
         )
-        cases.append(nonterminal)
+        cases["nonterminal slot"] = nonterminal
         wrong_slot = self.state_payloads()
         wrong_slot["terminal-06"] = provider.encode_journal_operation(terminal)
-        cases.append(wrong_slot)
+        cases["wrong slot identity"] = wrong_slot
         duplicate = self.state_payloads()
         duplicate["terminal-07"] = provider.encode_journal_operation(terminal)
         duplicate["terminal-08"] = provider.encode_journal_operation(
             replace(terminal, slot=8)
         )
-        cases.append(duplicate)
+        cases["duplicate retained identity"] = duplicate
         active_duplicate = self.state_payloads()
         active_duplicate["active"] = provider.encode_journal_operation(
             self.update_operation(slot=7)
         )
         active_duplicate["terminal-07"] = provider.encode_journal_operation(terminal)
-        cases.append(active_duplicate)
-        for index, payloads in enumerate(cases):
-            with self.subTest(index=index):
+        cases["active identity duplicated in terminal"] = active_duplicate
+        for name, payloads in cases.items():
+            with self.subTest(name=name):
                 with self.assertRaises(provider.JournalRecordError):
                     provider.decode_journal_state(payloads)
 
@@ -779,19 +779,19 @@ class JournalControlRecordTests(unittest.TestCase):
             terminal,
             operation_id="op-ffffffffffffffffffffffffffffffff",
         )
-        cases = []
+        cases = {}
         missing = self.state_payloads()
         missing["handoff"] = provider.encode_journal_handoff(
             provider.JournalHandoff(terminal.operation_id, 7)
         )
-        cases.append(missing)
+        cases["handoff terminal missing"] = missing
         mismatch = self.state_payloads()
         mismatch["terminal-07"] = provider.encode_journal_operation(terminal)
         mismatch["cursor"] = "08"
         mismatch["handoff"] = provider.encode_journal_handoff(
             provider.JournalHandoff(other.operation_id, 7)
         )
-        cases.append(mismatch)
+        cases["handoff identity mismatch"] = mismatch
         active_conflict = self.state_payloads()
         active_conflict["active"] = provider.encode_journal_operation(other)
         active_conflict["terminal-07"] = provider.encode_journal_operation(terminal)
@@ -799,9 +799,9 @@ class JournalControlRecordTests(unittest.TestCase):
         active_conflict["handoff"] = provider.encode_journal_handoff(
             provider.JournalHandoff(terminal.operation_id, 7)
         )
-        cases.append(active_conflict)
-        for payloads in cases:
-            with self.subTest():
+        cases["active conflicts with handoff"] = active_conflict
+        for name, payloads in cases.items():
+            with self.subTest(name=name):
                 with self.assertRaises(provider.JournalRecordError):
                     provider.decode_journal_state(payloads)
 
@@ -812,22 +812,22 @@ class JournalControlRecordTests(unittest.TestCase):
             state="succeeded",
             terminal_monotonic=123,
         )
-        cases = []
+        cases = {}
         stale_cursor = self.state_payloads()
         stale_cursor["terminal-07"] = provider.encode_journal_operation(terminal)
         stale_cursor["handoff"] = provider.encode_journal_handoff(
             provider.JournalHandoff(terminal.operation_id, 7)
         )
-        cases.append(stale_cursor)
+        cases["handoff cursor is stale"] = stale_cursor
         missing_restart = self.state_payloads()
         missing_restart["active"] = provider.encode_journal_operation(terminal)
         missing_restart["terminal-07"] = provider.encode_journal_operation(terminal)
-        cases.append(missing_restart)
+        cases["terminal update restart commit missing"] = missing_restart
         missing_retained_restart = self.state_payloads()
         missing_retained_restart["terminal-07"] = provider.encode_journal_operation(
             terminal
         )
-        cases.append(missing_retained_restart)
+        cases["retained update restart identity missing"] = missing_retained_restart
         reused = self.state_payloads()
         reused["restart"] = provider.encode_journal_restart(
             replace(
@@ -838,7 +838,7 @@ class JournalControlRecordTests(unittest.TestCase):
         reused["active"] = provider.encode_journal_operation(
             self.update_operation(slot=8)
         )
-        cases.append(reused)
+        cases["nonterminal active reuses restart identity"] = reused
         non_update = replace(
             terminal,
             action_id="timezone-set",
@@ -854,19 +854,19 @@ class JournalControlRecordTests(unittest.TestCase):
         reused_terminal = self.state_payloads()
         reused_terminal["restart"] = reused["restart"]
         reused_terminal["terminal-07"] = provider.encode_journal_operation(non_update)
-        cases.append(reused_terminal)
+        cases["non-update terminal reuses restart identity"] = reused_terminal
         previous_boot = self.state_payloads()
         previous_boot["restart"] = reused["restart"]
         previous_boot["terminal-07"] = provider.encode_journal_operation(
             replace(terminal, boot_id="11234567-89ab-cdef-0123-456789abcdef")
         )
-        cases.append(previous_boot)
+        cases["previous-boot update reuses restart identity"] = previous_boot
         missing_contribution = self.state_payloads()
         missing_contribution["restart"] = reused["restart"]
         missing_contribution["terminal-07"] = provider.encode_journal_operation(
             replace(terminal, system_restart="security-system")
         )
-        cases.append(missing_contribution)
+        cases["system contribution missing"] = missing_contribution
         older_contribution = self.state_payloads()
         newer = replace(
             terminal,
@@ -884,7 +884,7 @@ class JournalControlRecordTests(unittest.TestCase):
             replace(terminal, system_restart="security-system")
         )
         older_contribution["terminal-08"] = provider.encode_journal_operation(newer)
-        cases.append(older_contribution)
+        cases["older system contribution missing"] = older_contribution
         stale_identity = self.state_payloads()
         stale_identity["restart"] = provider.encode_journal_restart(
             replace(
@@ -894,7 +894,7 @@ class JournalControlRecordTests(unittest.TestCase):
         )
         stale_identity["terminal-07"] = provider.encode_journal_operation(terminal)
         stale_identity["terminal-08"] = provider.encode_journal_operation(newer)
-        cases.append(stale_identity)
+        cases["last-applied identity is stale"] = stale_identity
         for field, changes in (
             (
                 "session",
@@ -926,7 +926,7 @@ class JournalControlRecordTests(unittest.TestCase):
                     application_restart=field == "application",
                 )
             )
-            cases.append(stale_cutoff)
+            cases[f"{field} cutoff is stale"] = stale_cutoff
         unidentified_guidance = self.state_payloads()
         unidentified_guidance["restart"] = provider.encode_journal_restart(
             replace(
@@ -934,9 +934,9 @@ class JournalControlRecordTests(unittest.TestCase):
                 system="unknown",
             )
         )
-        cases.append(unidentified_guidance)
-        for index, payloads in enumerate(cases):
-            with self.subTest(index=index):
+        cases["restart guidance has no identity"] = unidentified_guidance
+        for name, payloads in cases.items():
+            with self.subTest(name=name):
                 with self.assertRaises(provider.JournalRecordError):
                     provider.decode_journal_state(payloads)
 


### PR DESCRIPTION
## Summary

- decode the complete fixed 36-path journal payload set into one typed state
- enforce terminal-slot identity, retained-operation uniqueness, cursor, handoff, and crash-checkpoint consistency
- validate restart identity, ordering, system contribution strength, and lower-scope monotonic cutoffs without writing state or contacting PackageKit

This is a read-only semantic validation boundary. It does not load files, mutate the journal, recover operations, or call a backend.

## Validation

- python3 tests/test-system-management.py (85 tests)
- ruff check scripts/dwm-system-management tests/test-system-management.py
- git diff --check
- scripts/run-tests make clean all
- scripts/run-tests
- CodeRabbit uncommitted review: 0 findings
- built-in Codex review: clean