### PR TITLE
Prepare safe journal operation admission

### DIFF
--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -119,6 +119,17 @@ JOURNAL_DATA_NAMES = (
     *(f"terminal-{index:02d}" for index in range(JOURNAL_TERMINAL_COUNT)),
 )
 JOURNAL_NAMES = (*JOURNAL_DATA_NAMES, JOURNAL_CURSOR_NAME)
+JOURNAL_ACTIVE_ADMISSION_COMMITS = 12
+JOURNAL_CONTROL_ADMISSION_COMMITS = {
+    # pending, three later nonterminal states, six strictly stronger restart
+    # contributions, the terminal result, and the final empty active payload.
+    "active": JOURNAL_ACTIVE_ADMISSION_COMMITS,
+    # Snapshots may independently prune session and application buckets while
+    # an update runs; terminalization then commits the new contribution.
+    "restart": 3,
+    "handoff": 2,
+    JOURNAL_CURSOR_NAME: 1,
+}
 BOOT_ID_PATTERN = re.compile(
     r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 )
@@ -199,6 +210,10 @@ class JournalLayoutError(JournalFileError):
     """The fixed journal path set could not be opened or initialized safely."""
 
 
+class JournalAdmissionError(RuntimeError):
+    """A valid journal state cannot admit another operation."""
+
+
 @dataclass(frozen=True)
 class JournalFrame:
     sequence: int
@@ -249,6 +264,14 @@ class JournalState:
     active: JournalOperation | None
     handoff: JournalHandoff | None
     terminals: tuple[JournalOperation | None, ...]
+
+
+@dataclass(frozen=True)
+class JournalAdmission:
+    """Validated journal state and its next reusable terminal slot."""
+
+    state: JournalState
+    slot: int
 
 
 @dataclass
@@ -2317,6 +2340,48 @@ def open_writable_journal(
                 raise JournalLayoutError(
                     "writable journal descriptor close failed"
                 ) from first_error
+
+
+def _load_writable_journal_state(
+    journal: JournalDescriptorSet,
+) -> tuple[JournalState, dict[str, JournalFrame]]:
+    if not isinstance(journal, JournalDescriptorSet) or not journal.writable:
+        raise JournalLayoutError("writable journal descriptor set is invalid")
+    journal.validate()
+    payloads: dict[str, str] = {}
+    frames: dict[str, JournalFrame] = {}
+    for name in JOURNAL_NAMES:
+        descriptor = journal.descriptor(name)
+        try:
+            _index, frame = _read_journal_file_unlocked(descriptor)
+        except (JournalFileError, JournalFrameError) as error:
+            raise JournalLayoutError(f"journal path {name} is malformed") from error
+        payloads[name] = frame.payload
+        frames[name] = frame
+    state = decode_journal_state(payloads)
+    journal.validate()
+    return state, frames
+
+
+def load_writable_journal_state(journal: JournalDescriptorSet) -> JournalState:
+    """Decode the complete state through an exclusively locked descriptor set."""
+    state, _frames = _load_writable_journal_state(journal)
+    return state
+
+
+def prepare_journal_admission(journal: JournalDescriptorSet) -> JournalAdmission:
+    """Select a reusable ring slot when no operation or handoff blocks admission."""
+    state, frames = _load_writable_journal_state(journal)
+    if state.active is not None or state.handoff is not None:
+        raise JournalAdmissionError("journal operation admission is blocked")
+    for name, required_commits in JOURNAL_CONTROL_ADMISSION_COMMITS.items():
+        if frames[name].sequence >= JOURNAL_SEQUENCE_MAX - required_commits:
+            raise JournalAdmissionError("journal control path has no commit headroom")
+    for offset in range(JOURNAL_TERMINAL_COUNT):
+        slot = (state.cursor + offset) % JOURNAL_TERMINAL_COUNT
+        if frames[f"terminal-{slot:02d}"].sequence < JOURNAL_SEQUENCE_MAX - 1:
+            return JournalAdmission(state, slot)
+    raise JournalAdmissionError("journal has no reusable terminal slot")
 
 
 @dataclass(frozen=True)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -2748,6 +2748,260 @@ class JournalWritableOpenTests(unittest.TestCase):
                 chain.close()
 
 
+class JournalAdmissionTests(unittest.TestCase):
+    boot_id = "01234567-89ab-cdef-0123-456789abcdef"
+    operation_id = "op-0123456789abcdef0123456789abcdef"
+
+    def open_initialized_chain(self, directory):
+        journal = pathlib.Path(directory) / "state" / "dwm-titus" / "system-management"
+        chain = provider.open_journal_directory_chain(str(journal))
+        provider.initialize_journal_layout(chain.directory_descriptor, self.boot_id)
+        return journal, chain
+
+    def operation(self, *, state="running", slot=0):
+        terminal = state in provider.JOURNAL_OPERATION_TERMINAL_STATES
+        return provider.JournalOperation(
+            self.operation_id,
+            "updates-refresh",
+            "2026-09-04T18:00:00Z",
+            "2026-09-04T18:01:00Z" if terminal else None,
+            "refresh",
+            state,
+            None,
+            "Refreshing update metadata",
+            None,
+            "/org/freedesktop/PackageKit/transactions/1_deadbeef",
+            None,
+            None,
+            None,
+            None,
+            1 if terminal else None,
+            slot,
+        )
+
+    def set_sequence(self, journal, name, sequence, payload):
+        image = provider.encode_journal_frame(sequence, payload)
+        descriptor = journal.descriptor(name)
+        os.pwrite(descriptor, image + bytes(provider.JOURNAL_FRAME_SIZE), 0)
+        os.fsync(descriptor)
+
+    def test_loads_complete_state_and_selects_the_cursor_slot(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _journal_path, chain = self.open_initialized_chain(directory)
+            try:
+                with provider.open_writable_journal(chain) as journal:
+                    provider._commit_journal_file_unlocked(
+                        journal.descriptor("cursor"), "31"
+                    )
+                    admission = provider.prepare_journal_admission(journal)
+
+                    self.assertEqual(admission.slot, 31)
+                    self.assertEqual(admission.state.cursor, 31)
+                    self.assertIsNone(admission.state.active)
+                    self.assertIsNone(admission.state.handoff)
+                    self.assertEqual(len(admission.state.terminals), 32)
+                    self.assertEqual(
+                        journal.descriptor("terminal-31"),
+                        journal.descriptor(f"terminal-{admission.slot:02d}"),
+                    )
+            finally:
+                chain.close()
+
+    def test_scans_from_cursor_for_the_first_slot_with_commit_headroom(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _journal_path, chain = self.open_initialized_chain(directory)
+            try:
+                with provider.open_writable_journal(chain) as journal:
+                    provider._commit_journal_file_unlocked(
+                        journal.descriptor("cursor"), "31"
+                    )
+                    self.set_sequence(
+                        journal,
+                        "terminal-31",
+                        provider.JOURNAL_SEQUENCE_MAX - 1,
+                        "",
+                    )
+                    self.set_sequence(
+                        journal,
+                        "terminal-00",
+                        provider.JOURNAL_SEQUENCE_MAX - 1,
+                        "",
+                    )
+
+                    admission = provider.prepare_journal_admission(journal)
+
+                    self.assertEqual(admission.state.cursor, 31)
+                    self.assertEqual(admission.slot, 1)
+            finally:
+                chain.close()
+
+    def test_rejects_admission_when_every_terminal_slot_lacks_headroom(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _journal_path, chain = self.open_initialized_chain(directory)
+            try:
+                with provider.open_writable_journal(chain) as journal:
+                    for slot in range(provider.JOURNAL_TERMINAL_COUNT):
+                        self.set_sequence(
+                            journal,
+                            f"terminal-{slot:02d}",
+                            provider.JOURNAL_SEQUENCE_MAX - 1,
+                            "",
+                        )
+
+                    with self.assertRaisesRegex(
+                        provider.JournalAdmissionError,
+                        "no reusable terminal slot",
+                    ):
+                        provider.prepare_journal_admission(journal)
+            finally:
+                chain.close()
+
+    def test_rejects_each_control_path_without_commit_headroom(self):
+        payloads = provider._initial_journal_payloads(self.boot_id)
+        for name, required_commits in (
+            provider.JOURNAL_CONTROL_ADMISSION_COMMITS.items()
+        ):
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                _journal_path, chain = self.open_initialized_chain(directory)
+                try:
+                    with provider.open_writable_journal(chain) as journal:
+                        self.set_sequence(
+                            journal,
+                            name,
+                            provider.JOURNAL_SEQUENCE_MAX - required_commits,
+                            payloads[name],
+                        )
+
+                        with self.assertRaisesRegex(
+                            provider.JournalAdmissionError,
+                            "control path has no commit headroom",
+                        ):
+                            provider.prepare_journal_admission(journal)
+                finally:
+                    chain.close()
+
+    def test_accepts_control_paths_with_the_exact_required_headroom(self):
+        payloads = provider._initial_journal_payloads(self.boot_id)
+        for name, required_commits in (
+            provider.JOURNAL_CONTROL_ADMISSION_COMMITS.items()
+        ):
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                _journal_path, chain = self.open_initialized_chain(directory)
+                try:
+                    with provider.open_writable_journal(chain) as journal:
+                        self.set_sequence(
+                            journal,
+                            name,
+                            provider.JOURNAL_SEQUENCE_MAX - required_commits - 1,
+                            payloads[name],
+                        )
+
+                        admission = provider.prepare_journal_admission(journal)
+
+                        self.assertEqual(admission.slot, 0)
+                finally:
+                    chain.close()
+
+    def test_nonterminal_active_operation_blocks_admission_without_writes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _journal_path, chain = self.open_initialized_chain(directory)
+            try:
+                with provider.open_writable_journal(chain) as journal:
+                    provider._commit_journal_file_unlocked(
+                        journal.descriptor("active"),
+                        provider.encode_journal_operation(self.operation()),
+                    )
+                    active_before = os.pread(
+                        journal.descriptor("active"), provider.JOURNAL_FILE_SIZE, 0
+                    )
+                    with self.assertRaisesRegex(
+                        provider.JournalAdmissionError, "admission is blocked"
+                    ):
+                        provider.prepare_journal_admission(journal)
+                    self.assertEqual(
+                        os.pread(
+                            journal.descriptor("active"),
+                            provider.JOURNAL_FILE_SIZE,
+                            0,
+                        ),
+                        active_before,
+                    )
+            finally:
+                chain.close()
+
+    def test_valid_terminal_handoff_blocks_admission(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _journal_path, chain = self.open_initialized_chain(directory)
+            terminal = self.operation(state="succeeded", slot=7)
+            try:
+                with provider.open_writable_journal(chain) as journal:
+                    provider._commit_journal_file_unlocked(
+                        journal.descriptor("terminal-07"),
+                        provider.encode_journal_operation(terminal),
+                    )
+                    provider._commit_journal_file_unlocked(
+                        journal.descriptor("cursor"), "08"
+                    )
+                    provider._commit_journal_file_unlocked(
+                        journal.descriptor("handoff"),
+                        provider.encode_journal_handoff(
+                            provider.JournalHandoff(self.operation_id, 7)
+                        ),
+                    )
+
+                    with self.assertRaisesRegex(
+                        provider.JournalAdmissionError, "admission is blocked"
+                    ):
+                        provider.prepare_journal_admission(journal)
+            finally:
+                chain.close()
+
+    def test_malformed_fixed_path_names_the_path_and_blocks_admission(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _journal_path, chain = self.open_initialized_chain(directory)
+            try:
+                with provider.open_writable_journal(chain) as journal:
+                    descriptor = journal.descriptor("terminal-12")
+                    os.pwrite(descriptor, bytes(provider.JOURNAL_FILE_SIZE), 0)
+                    os.fsync(descriptor)
+
+                    with self.assertRaisesRegex(
+                        provider.JournalLayoutError, "terminal-12 is malformed"
+                    ):
+                        provider.prepare_journal_admission(journal)
+            finally:
+                chain.close()
+
+    def test_replaced_path_is_rejected_after_complete_decode(self):
+        with tempfile.TemporaryDirectory() as directory:
+            journal_path, chain = self.open_initialized_chain(directory)
+            active = journal_path / "active"
+            detached = journal_path / "active-detached"
+            image = active.read_bytes()
+            original_decode = provider.decode_journal_state
+
+            def replace_active(payloads):
+                state = original_decode(payloads)
+                active.rename(detached)
+                active.write_bytes(image)
+                os.chmod(active, 0o600)
+                return state
+
+            try:
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "active identity is unsafe"
+                ):
+                    with provider.open_writable_journal(chain) as journal:
+                        with mock.patch.object(
+                            provider,
+                            "decode_journal_state",
+                            side_effect=replace_active,
+                        ):
+                            provider.prepare_journal_admission(journal)
+            finally:
+                chain.close()
+
+
 class JournalDirectoryChainTests(unittest.TestCase):
     def test_xdg_state_path_and_home_fallback_are_canonical(self):
         self.assertEqual(


### PR DESCRIPTION
## Summary
- decode the complete journal state through retained writable descriptors under the exclusive lock
- block admission while a validated active operation or terminal handoff remains
- reserve full control-path commit headroom and scan from the cursor for the first reusable terminal slot
- perform no journal commit or external mutation during admission

## Validation
- `python3 tests/test-system-management.py` (114 tests)
- `python3 tests/test-system-management.py JournalAdmissionTests` (9 tests)
- `ruff check scripts/dwm-system-management tests/test-system-management.py`
- `git diff --check`
- `coderabbit review --agent --uncommitted` (0 findings)
- `codex review --base main` (clean)
- `scripts/run-tests`
