### PR TITLE
Generate collision-safe journal operation IDs

### DIFF
--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -120,6 +120,7 @@ JOURNAL_DATA_NAMES = (
 )
 JOURNAL_NAMES = (*JOURNAL_DATA_NAMES, JOURNAL_CURSOR_NAME)
 JOURNAL_ACTIVE_ADMISSION_COMMITS = 12
+JOURNAL_OPERATION_ID_ATTEMPTS = 4
 JOURNAL_CONTROL_ADMISSION_COMMITS = {
     # pending, three later nonterminal states, six strictly stronger restart
     # contributions, the terminal result, and the final empty active payload.
@@ -272,6 +273,7 @@ class JournalAdmission:
 
     state: JournalState
     slot: int
+    operation_id: str
 
 
 @dataclass
@@ -2369,6 +2371,55 @@ def load_writable_journal_state(journal: JournalDescriptorSet) -> JournalState:
     return state
 
 
+def generate_journal_operation_id(state: JournalState) -> str:
+    """Generate a unique journal operation ID from the kernel CSPRNG."""
+    if (
+        not isinstance(state, JournalState)
+        or not isinstance(state.restart, JournalRestart)
+        or not isinstance(state.terminals, tuple)
+        or len(state.terminals) != JOURNAL_TERMINAL_COUNT
+        or any(
+            operation is not None and not isinstance(operation, JournalOperation)
+            for operation in state.terminals
+        )
+        or (state.active is not None and not isinstance(state.active, JournalOperation))
+    ):
+        raise JournalAdmissionError("journal operation ID state is invalid")
+    operations = tuple(
+        operation for operation in state.terminals if operation is not None
+    ) + ((state.active,) if state.active is not None else ())
+    operation_ids = tuple(operation.operation_id for operation in operations)
+    restart_operation_id = state.restart.last_applied_operation_id
+    if any(
+        not isinstance(operation_id, str)
+        or JOURNAL_OPERATION_ID_PATTERN.fullmatch(operation_id) is None
+        for operation_id in operation_ids
+    ) or (
+        restart_operation_id is not None
+        and (
+            not isinstance(restart_operation_id, str)
+            or JOURNAL_OPERATION_ID_PATTERN.fullmatch(restart_operation_id) is None
+        )
+    ):
+        raise JournalAdmissionError("journal operation ID state is invalid")
+    retained_ids = set(operation_ids)
+    if restart_operation_id is not None:
+        retained_ids.add(restart_operation_id)
+    for _attempt in range(JOURNAL_OPERATION_ID_ATTEMPTS):
+        try:
+            random_bytes = os.urandom(16)
+        except OSError as error:
+            raise JournalAdmissionError(
+                "journal operation ID generation failed"
+            ) from error
+        if not isinstance(random_bytes, bytes) or len(random_bytes) != 16:
+            raise JournalAdmissionError("journal operation ID generation failed")
+        operation_id = f"op-{random_bytes.hex()}"
+        if operation_id not in retained_ids:
+            return operation_id
+    raise JournalAdmissionError("journal operation ID collision limit reached")
+
+
 def prepare_journal_admission(journal: JournalDescriptorSet) -> JournalAdmission:
     """Select a reusable ring slot when no operation or handoff blocks admission."""
     state, frames = _load_writable_journal_state(journal)
@@ -2380,7 +2431,7 @@ def prepare_journal_admission(journal: JournalDescriptorSet) -> JournalAdmission
     for offset in range(JOURNAL_TERMINAL_COUNT):
         slot = (state.cursor + offset) % JOURNAL_TERMINAL_COUNT
         if frames[f"terminal-{slot:02d}"].sequence < JOURNAL_SEQUENCE_MAX - 1:
-            return JournalAdmission(state, slot)
+            return JournalAdmission(state, slot, generate_journal_operation_id(state))
     raise JournalAdmissionError("journal has no reusable terminal slot")
 
 

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -2758,10 +2758,10 @@ class JournalAdmissionTests(unittest.TestCase):
         provider.initialize_journal_layout(chain.directory_descriptor, self.boot_id)
         return journal, chain
 
-    def operation(self, *, state="running", slot=0):
+    def operation(self, *, operation_id=None, state="running", slot=0):
         terminal = state in provider.JOURNAL_OPERATION_TERMINAL_STATES
         return provider.JournalOperation(
-            self.operation_id,
+            operation_id or self.operation_id,
             "updates-refresh",
             "2026-09-04T18:00:00Z",
             "2026-09-04T18:01:00Z" if terminal else None,
@@ -2793,9 +2793,14 @@ class JournalAdmissionTests(unittest.TestCase):
                     provider._commit_journal_file_unlocked(
                         journal.descriptor("cursor"), "31"
                     )
-                    admission = provider.prepare_journal_admission(journal)
+                    with mock.patch.object(
+                        provider.os, "urandom", return_value=b"\xab" * 16
+                    ) as urandom:
+                        admission = provider.prepare_journal_admission(journal)
 
                     self.assertEqual(admission.slot, 31)
+                    self.assertEqual(admission.operation_id, f"op-{'ab' * 16}")
+                    urandom.assert_called_once_with(16)
                     self.assertEqual(admission.state.cursor, 31)
                     self.assertIsNone(admission.state.active)
                     self.assertIsNone(admission.state.handoff)
@@ -2804,6 +2809,139 @@ class JournalAdmissionTests(unittest.TestCase):
                         journal.descriptor("terminal-31"),
                         journal.descriptor(f"terminal-{admission.slot:02d}"),
                     )
+            finally:
+                chain.close()
+
+    def test_retries_a_retained_terminal_collision(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _journal_path, chain = self.open_initialized_chain(directory)
+            terminal = self.operation(
+                operation_id=f"op-{'11' * 16}", state="succeeded", slot=0
+            )
+            try:
+                with provider.open_writable_journal(chain) as journal:
+                    provider._commit_journal_file_unlocked(
+                        journal.descriptor("terminal-00"),
+                        provider.encode_journal_operation(terminal),
+                    )
+                    provider._commit_journal_file_unlocked(
+                        journal.descriptor("cursor"), "01"
+                    )
+                    with mock.patch.object(
+                        provider.os,
+                        "urandom",
+                        side_effect=(b"\x11" * 16, b"\x22" * 16),
+                    ) as urandom:
+                        admission = provider.prepare_journal_admission(journal)
+
+                    self.assertEqual(admission.slot, 1)
+                    self.assertEqual(admission.operation_id, f"op-{'22' * 16}")
+                    self.assertEqual(urandom.call_count, 2)
+            finally:
+                chain.close()
+
+    def test_rejects_restart_only_collision_after_four_attempts(self):
+        restart_operation_id = f"op-{'ff' * 16}"
+        with tempfile.TemporaryDirectory() as directory:
+            _journal_path, chain = self.open_initialized_chain(directory)
+            try:
+                with provider.open_writable_journal(chain) as journal:
+                    for slot in range(provider.JOURNAL_TERMINAL_COUNT):
+                        terminal = self.operation(
+                            operation_id=f"op-{slot + 1:032x}",
+                            state="succeeded",
+                            slot=slot,
+                        )
+                        provider._commit_journal_file_unlocked(
+                            journal.descriptor(f"terminal-{slot:02d}"),
+                            provider.encode_journal_operation(terminal),
+                        )
+                    provider._commit_journal_file_unlocked(
+                        journal.descriptor("restart"),
+                        provider.encode_journal_restart(
+                            provider.JournalRestart(
+                                self.boot_id,
+                                restart_operation_id,
+                                "none",
+                                "none",
+                                0,
+                                False,
+                                0,
+                            )
+                        ),
+                    )
+                    with mock.patch.object(
+                        provider.os, "urandom", return_value=b"\xff" * 16
+                    ) as urandom:
+                        with self.assertRaisesRegex(
+                            provider.JournalAdmissionError,
+                            "collision limit reached",
+                        ):
+                            provider.prepare_journal_admission(journal)
+
+                    self.assertEqual(
+                        urandom.call_count, provider.JOURNAL_OPERATION_ID_ATTEMPTS
+                    )
+            finally:
+                chain.close()
+
+    def test_rng_failure_blocks_admission(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _journal_path, chain = self.open_initialized_chain(directory)
+            try:
+                with provider.open_writable_journal(chain) as journal:
+                    with mock.patch.object(
+                        provider.os, "urandom", side_effect=OSError("unavailable")
+                    ) as urandom:
+                        with self.assertRaisesRegex(
+                            provider.JournalAdmissionError,
+                            "generation failed",
+                        ):
+                            provider.prepare_journal_admission(journal)
+
+                    urandom.assert_called_once_with(16)
+            finally:
+                chain.close()
+
+    def test_rejects_malformed_nested_state_before_randomness(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _journal_path, chain = self.open_initialized_chain(directory)
+            try:
+                with provider.open_writable_journal(chain) as journal:
+                    admission = provider.prepare_journal_admission(journal)
+                    terminal = self.operation(state="succeeded", slot=0)
+                    cases = {
+                        "restart record": replace(admission.state, restart=None),
+                        "restart ID": replace(
+                            admission.state,
+                            restart=replace(
+                                admission.state.restart,
+                                last_applied_operation_id=17,
+                            ),
+                        ),
+                        "active ID": replace(
+                            admission.state,
+                            active=replace(self.operation(), operation_id=[]),
+                        ),
+                        "terminal ID": replace(
+                            admission.state,
+                            terminals=(
+                                replace(terminal, operation_id="op-bad"),
+                                *admission.state.terminals[1:],
+                            ),
+                        ),
+                    }
+                    for name, malformed in cases.items():
+                        with self.subTest(name=name), mock.patch.object(
+                            provider.os, "urandom"
+                        ) as urandom:
+                            with self.assertRaisesRegex(
+                                provider.JournalAdmissionError,
+                                "state is invalid",
+                            ):
+                                provider.generate_journal_operation_id(malformed)
+
+                            urandom.assert_not_called()
             finally:
                 chain.close()
 


### PR DESCRIPTION
## Summary
- generate canonical journal operation IDs from 128 bits of kernel CSPRNG output
- validate active, terminal, and restart identities before collision checks
- reject collisions with active, retained terminal, and restart last-applied identities
- fail closed after four collisions, malformed retained state, or an entropy-source failure
- return the reserved ID with the validated admission result without committing journal state or starting external mutation

## Validation
- `python3 tests/test-system-management.py JournalAdmissionTests` (13 tests)
- `python3 tests/test-system-management.py` (118 tests)
- `ruff check scripts/dwm-system-management tests/test-system-management.py`
- `git diff --check`
- `coderabbit review --agent --uncommitted` (0 findings after fixes)
- `codex review --base main` (clean)
- `make check-quickshell-settings-xvfb` (passed while isolating one transient full-suite failure)
- `scripts/run-tests` (clean final rerun)
