### PR TITLE
Validate retained journal commits

### DIFF
--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -2371,6 +2371,26 @@ def load_writable_journal_state(journal: JournalDescriptorSet) -> JournalState:
     return state
 
 
+def commit_writable_journal_path(
+    journal: JournalDescriptorSet, name: str, payload: str
+) -> tuple[int, JournalFrame]:
+    """Commit one retained path between complete journal identity checks."""
+    if not isinstance(journal, JournalDescriptorSet) or not journal.writable:
+        raise JournalLayoutError("writable journal descriptor set is invalid")
+    journal.validate()
+    descriptor = journal.descriptor(name)
+    try:
+        result = _commit_journal_file_unlocked(descriptor, payload)
+    except JournalCommitError as commit_error:
+        try:
+            journal.validate()
+        except JournalLayoutError as validation_error:
+            raise commit_error from validation_error
+        raise
+    journal.validate()
+    return result
+
+
 def generate_journal_operation_id(state: JournalState) -> str:
     """Generate a unique journal operation ID from the kernel CSPRNG."""
     if (

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -2748,6 +2748,177 @@ class JournalWritableOpenTests(unittest.TestCase):
                 chain.close()
 
 
+class JournalWritableCommitTests(unittest.TestCase):
+    boot_id = "01234567-89ab-cdef-0123-456789abcdef"
+
+    def open_initialized_chain(self, directory):
+        journal = pathlib.Path(directory) / "state" / "dwm-titus" / "system-management"
+        chain = provider.open_journal_directory_chain(str(journal))
+        provider.initialize_journal_layout(chain.directory_descriptor, self.boot_id)
+        return journal, chain
+
+    def test_commits_retained_path_between_complete_validations(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _journal_path, chain = self.open_initialized_chain(directory)
+            try:
+                with provider.open_writable_journal(chain) as journal:
+                    index, frame = provider.commit_writable_journal_path(
+                        journal, "active", ""
+                    )
+
+                    self.assertEqual(index, 1)
+                    self.assertEqual(frame, provider.JournalFrame(2, ""))
+                    self.assertEqual(
+                        provider._read_journal_file_unlocked(
+                            journal.descriptor("active")
+                        ),
+                        (index, frame),
+                    )
+            finally:
+                chain.close()
+
+    def test_replaced_target_is_rejected_before_commit(self):
+        with tempfile.TemporaryDirectory() as directory:
+            journal_path, chain = self.open_initialized_chain(directory)
+            active = journal_path / "active"
+            detached = journal_path / "active-detached"
+            image = active.read_bytes()
+            try:
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "active identity is unsafe"
+                ):
+                    with provider.open_writable_journal(chain) as journal:
+                        active.rename(detached)
+                        active.write_bytes(image)
+                        os.chmod(active, 0o600)
+                        provider.commit_writable_journal_path(journal, "active", "")
+
+                self.assertEqual(
+                    provider.select_journal_frame(detached.read_bytes())[1].sequence,
+                    1,
+                )
+                self.assertEqual(
+                    provider.select_journal_frame(active.read_bytes())[1].sequence,
+                    1,
+                )
+            finally:
+                chain.close()
+
+    def test_replaced_target_is_rejected_after_descriptor_commit(self):
+        with tempfile.TemporaryDirectory() as directory:
+            journal_path, chain = self.open_initialized_chain(directory)
+            active = journal_path / "active"
+            detached = journal_path / "active-detached"
+            image = active.read_bytes()
+            original_commit = provider._commit_journal_file_unlocked
+
+            def replace_after_commit(descriptor, payload):
+                result = original_commit(descriptor, payload)
+                active.rename(detached)
+                active.write_bytes(image)
+                os.chmod(active, 0o600)
+                return result
+
+            try:
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "active identity is unsafe"
+                ):
+                    with provider.open_writable_journal(chain) as journal:
+                        with mock.patch.object(
+                            provider,
+                            "_commit_journal_file_unlocked",
+                            side_effect=replace_after_commit,
+                        ):
+                            provider.commit_writable_journal_path(
+                                journal, "active", ""
+                            )
+
+                self.assertEqual(
+                    provider.select_journal_frame(detached.read_bytes())[1].sequence,
+                    2,
+                )
+                self.assertEqual(
+                    provider.select_journal_frame(active.read_bytes())[1].sequence,
+                    1,
+                )
+            finally:
+                chain.close()
+
+    def test_unrelated_replaced_path_is_rejected_after_commit(self):
+        with tempfile.TemporaryDirectory() as directory:
+            journal_path, chain = self.open_initialized_chain(directory)
+            terminal = journal_path / "terminal-12"
+            detached = journal_path / "terminal-12-detached"
+            terminal_image = terminal.read_bytes()
+            original_commit = provider._commit_journal_file_unlocked
+
+            def replace_after_commit(descriptor, payload):
+                result = original_commit(descriptor, payload)
+                terminal.rename(detached)
+                terminal.write_bytes(terminal_image)
+                os.chmod(terminal, 0o600)
+                return result
+
+            try:
+                with self.assertRaisesRegex(
+                    provider.JournalLayoutError, "terminal-12 identity is unsafe"
+                ):
+                    with provider.open_writable_journal(chain) as journal:
+                        with mock.patch.object(
+                            provider,
+                            "_commit_journal_file_unlocked",
+                            side_effect=replace_after_commit,
+                        ):
+                            provider.commit_writable_journal_path(
+                                journal, "active", ""
+                            )
+
+                self.assertEqual(
+                    provider.select_journal_frame(
+                        (journal_path / "active").read_bytes()
+                    )[1].sequence,
+                    2,
+                )
+            finally:
+                chain.close()
+
+    def test_indeterminate_commit_revalidates_and_preserves_primary_error(self):
+        with tempfile.TemporaryDirectory() as directory:
+            journal_path, chain = self.open_initialized_chain(directory)
+            active = journal_path / "active"
+            detached = journal_path / "active-detached"
+            image = active.read_bytes()
+            commit_error = provider.JournalCommitError(
+                "injected indeterminate commit"
+            )
+
+            def fail_after_replacement(_descriptor, _payload):
+                active.rename(detached)
+                active.write_bytes(image)
+                os.chmod(active, 0o600)
+                raise commit_error
+
+            try:
+                with self.assertRaises(provider.JournalCommitError) as caught:
+                    with provider.open_writable_journal(chain) as journal:
+                        with mock.patch.object(
+                            provider,
+                            "_commit_journal_file_unlocked",
+                            side_effect=fail_after_replacement,
+                        ):
+                            provider.commit_writable_journal_path(
+                                journal, "active", ""
+                            )
+
+                self.assertIs(caught.exception, commit_error)
+                self.assertIsInstance(
+                    caught.exception.__cause__, provider.JournalLayoutError
+                )
+                self.assertIn("active identity is unsafe", str(caught.exception.__cause__))
+            finally:
+                chain.close()
+
+
 class JournalAdmissionTests(unittest.TestCase):
     boot_id = "01234567-89ab-cdef-0123-456789abcdef"
     operation_id = "op-0123456789abcdef0123456789abcdef"


### PR DESCRIPTION
## Summary
- commit retained journal descriptors only after validating the complete fixed journal
- repeat complete path and ancestor identity validation immediately after a successful write
- revalidate after indeterminate writes while preserving the original commit error and chaining any integrity failure
- prove pre-write, post-write, unrelated-path, and indeterminate-error replacement races fail closed

## Validation
- `python3 tests/test-system-management.py JournalWritableCommitTests` (5 tests)
- `python3 tests/test-system-management.py` (123 tests)
- `ruff check scripts/dwm-system-management tests/test-system-management.py`
- `git diff --check`
- `coderabbit review --agent --uncommitted` (0 findings after one fix)
- `codex review --base main` (clean)
- `scripts/run-tests`
