### PR TITLE
Phase 6: complete durable journal lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ versions from `config.mk`.
 
 ### Changed
 
+- Preserve a pending Input discovery refresh when a preview finishes during an
+  earlier read, so kept accessibility settings do not remain stale in Settings.
+
 - Accept Fedora PackageKit's actual root-level transaction object IDs in the
   operation journal. The previous namespaced-path assumption rejected real
   transactions; update execution remains disabled pending its integration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ versions from `config.mk`.
 
 ### Changed
 
+- Accept Fedora PackageKit's actual root-level transaction object IDs in the
+  operation journal. The previous namespaced-path assumption rejected real
+  transactions; update execution remains disabled pending its integration.
+
 - Show the Phase 6 Fedora update snapshot in a dedicated read-only System
   Settings pane with provider state, update and plan details, diagnostics,
   restart guidance, recovery ownership, and existing administration boundaries.

--- a/TASKS.md
+++ b/TASKS.md
@@ -49,6 +49,14 @@ Acceptance:
 
 ### UPDATE-001: Fedora Updates
 
+Progress: Read-only PackageKit discovery and its Settings pane are implemented.
+The journal now supports durable pending admission, identity-checked lifecycle
+transitions, restart pruning, recoverable terminal commits, exact retained-result
+lookup, and handoff acknowledgment. These are tested foundations, not an enabled
+update execution workflow. PackageKit execution/recovery integration and its
+root-scoped confirmation and operation UI remain to be completed before this
+boundary can be accepted.
+
 - [ ] Add user-initiated Fedora update discovery and status through the selected
   stable package-management interface.
 - [ ] Add confirmed update execution with transparent progress and logs, strict

--- a/config/quickshell/settings/SettingsModel.qml
+++ b/config/quickshell/settings/SettingsModel.qml
@@ -43,6 +43,7 @@ Scope {
     property var inputUnsupported: []
     property string inputState: "idle"
     property string inputMessage: ""
+    property bool inputRefreshPending: false
     property string previewKind: ""
     property string previewToken: ""
     property int previewSeconds: 0
@@ -511,7 +512,12 @@ Scope {
     }
 
     function refreshInput() {
-        if (!root.visible || inputDiscoverProcess.running) return;
+        if (!root.visible) return;
+        if (inputDiscoverProcess.running) {
+            root.inputRefreshPending = true;
+            return;
+        }
+        root.inputRefreshPending = false;
         root.inputState = "loading";
         inputDiscoverProcess.running = true;
     }
@@ -654,6 +660,7 @@ Scope {
         root.capabilityRefreshPending = false;
         root.displayRefreshPending = false;
         displayDiscoverProcess.running = false;
+        root.inputRefreshPending = false;
         inputDiscoverProcess.running = false;
         displayWatchProcess.running = false;
         inputWatchProcess.running = false;
@@ -745,6 +752,15 @@ Scope {
         running: false
         stdout: StdioCollector { onStreamFinished: root.parseInput(this.text) }
         stderr: StdioCollector { onStreamFinished: { const error = this.text.trim(); if (error) { root.inputState = "failure"; root.inputMessage = error; } } }
+        onRunningChanged: {
+            if (!running && root.inputRefreshPending && root.visible) {
+                root.inputRefreshPending = false;
+                Qt.callLater(function() {
+                    if (root.visible && !inputDiscoverProcess.running)
+                        root.refreshInput();
+                });
+            }
+        }
     }
 
     Process {

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -13,7 +13,7 @@ import stat
 import struct
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from typing import Iterable, Iterator, Mapping, Protocol, Sequence
 
@@ -53,7 +53,9 @@ JOURNAL_TIMESTAMP_PATTERN = re.compile(
     r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"
 )
 JOURNAL_PACKAGEKIT_PATH_PATTERN = re.compile(
-    r"/org/freedesktop/PackageKit/transactions/[A-Za-z0-9_]+"
+    # PackageKit CreateTransaction returns a root-level ID (e.g. /18_adcbcaed),
+    # not a child of the manager's /org/freedesktop/PackageKit object.
+    r"/[0-9]{1,20}_[A-Za-z0-9_]{1,64}"
 )
 JOURNAL_RESTART_SYSTEM_STRENGTH = {
     "none": 0,
@@ -125,8 +127,9 @@ JOURNAL_CONTROL_ADMISSION_COMMITS = {
     # pending, three later nonterminal states, six strictly stronger restart
     # contributions, the terminal result, and the final empty active payload.
     "active": JOURNAL_ACTIVE_ADMISSION_COMMITS,
-    # Snapshots may independently prune session and application buckets while
-    # an update runs; terminalization then commits the new contribution.
+    # Each existing session/application bucket can be pruned at most once by
+    # snapshots OR terminalization (no-op pruning writes nothing). One further
+    # commit applies the new terminal contribution: at most three in total.
     "restart": 3,
     "handoff": 2,
     JOURNAL_CURSOR_NAME: 1,
@@ -2453,6 +2456,269 @@ def prepare_journal_admission(journal: JournalDescriptorSet) -> JournalAdmission
         if frames[f"terminal-{slot:02d}"].sequence < JOURNAL_SEQUENCE_MAX - 1:
             return JournalAdmission(state, slot, generate_journal_operation_id(state))
     raise JournalAdmissionError("journal has no reusable terminal slot")
+
+
+JOURNAL_TRANSITIONS = {
+    "pending": frozenset(
+        ("authorizing", "running", "canceled", "failed", "interrupted")
+    ),
+    "authorizing": frozenset(
+        ("running", "permission-denied", "canceled", "failed", "interrupted")
+    ),
+    "running": frozenset(
+        ("running", "cancel-requested", "succeeded", "failed", "interrupted")
+    ),
+    "cancel-requested": frozenset(
+        ("cancel-requested", "canceled", "succeeded", "failed", "interrupted")
+    ),
+}
+
+
+def begin_journal_operation(
+    journal: JournalDescriptorSet,
+    action_id: str,
+    started_at: str,
+    detail: str,
+    *,
+    transaction_path: str | None = None,
+    generation: str | None = None,
+    boot_id: str | None = None,
+) -> JournalOperation:
+    """Reserve and durably publish pending before the caller can mutate anything.
+
+    The caller holds open_writable_journal only for this local critical section,
+    never while creating a service transaction or waiting for its result.
+    """
+    admission = prepare_journal_admission(journal)
+    kind = JOURNAL_OPERATION_ACTION_KINDS.get(action_id)
+    operation = JournalOperation(
+        admission.operation_id,
+        action_id,
+        started_at,
+        None,
+        kind,
+        "pending",
+        None,
+        detail,
+        generation,
+        transaction_path,
+        "none" if kind == "update" else None,
+        "none" if kind == "update" else None,
+        False if kind == "update" else None,
+        boot_id if kind != "refresh" else None,
+        None,
+        admission.slot,
+    )
+    payload = encode_journal_operation(operation)
+    # Refresh terminal timestamps also use this boot's monotonic clock. Reject
+    # stale boot evidence for both PackageKit kinds before comparing history.
+    if kind in ("refresh", "update") and boot_id != admission.state.restart.boot_id:
+        raise JournalAdmissionError("journal boot boundary needs recovery")
+    commit_writable_journal_path(journal, "active", payload)
+    return operation
+
+
+def advance_journal_operation(
+    journal: JournalDescriptorSet,
+    expected: JournalOperation,
+    following: JournalOperation,
+) -> JournalOperation:
+    """Commit one legal state/contribution change, rejecting stale observations."""
+    encode_journal_operation(expected)
+    payload = encode_journal_operation(following)
+    state = load_writable_journal_state(journal)
+    current = state.active
+    if current != expected:
+        raise JournalAdmissionError("journal active operation changed")
+    if following == expected:
+        return current
+    immutable = (
+        "operation_id",
+        "action_id",
+        "started_at",
+        "kind",
+        "generation",
+        "transaction_path",
+        "boot_id",
+        "slot",
+    )
+    if any(
+        getattr(expected, field) != getattr(following, field) for field in immutable
+    ):
+        raise JournalAdmissionError("journal operation identity changed")
+    # RequireRestart can strengthen a tuple before running or during authorization.
+    same_state = following.state == expected.state
+    if expected.state in JOURNAL_OPERATION_TERMINAL_STATES or (
+        not same_state and following.state not in JOURNAL_TRANSITIONS[expected.state]
+    ):
+        raise JournalAdmissionError("journal operation transition is invalid")
+    if expected.kind == "update" and (
+        JOURNAL_RESTART_SYSTEM_STRENGTH[following.system_restart]
+        < JOURNAL_RESTART_SYSTEM_STRENGTH[expected.system_restart]
+        or JOURNAL_RESTART_SESSION_STRENGTH[following.session_restart]
+        < JOURNAL_RESTART_SESSION_STRENGTH[expected.session_restart]
+        or (expected.application_restart and not following.application_restart)
+    ):
+        raise JournalAdmissionError("journal restart contribution weakened")
+    # Progress/detail-only changes are in-memory; reserve frame headroom for
+    # actual lifecycle and strictly stronger restart contributions only.
+    if same_state and (
+        expected.system_restart,
+        expected.session_restart,
+        expected.application_restart,
+    ) == (
+        following.system_restart,
+        following.session_restart,
+        following.application_restart,
+    ):
+        raise JournalAdmissionError("journal operation has no durable change")
+    # A valid individual record can still contradict retained history (for
+    # example, a stale monotonic cutoff). Reject it before poisoning active.
+    prospective = {
+        "active": payload,
+        "restart": encode_journal_restart(state.restart),
+        "cursor": encode_journal_cursor(state.cursor),
+        "handoff": encode_journal_handoff(state.handoff),
+        **{
+            f"terminal-{slot:02d}": (
+                "" if operation is None else encode_journal_operation(operation)
+            )
+            for slot, operation in enumerate(state.terminals)
+        },
+    }
+    decode_journal_state(prospective)
+    commit_writable_journal_path(journal, "active", payload)
+    return following
+
+
+def prune_journal_restart(
+    journal: JournalDescriptorSet,
+    boot_id: str,
+    session_started: int | None,
+) -> JournalRestart:
+    """Apply already-obtained boot/logind evidence; no service calls under lock."""
+    if not isinstance(boot_id, str) or BOOT_ID_PATTERN.fullmatch(boot_id) is None:
+        raise JournalRecordError("journal restart boot identity is invalid")
+    if session_started is not None:
+        _encode_journal_uint64(session_started, "session start")
+    restart = load_writable_journal_state(journal).restart
+    if restart.boot_id != boot_id:
+        pruned = JournalRestart(boot_id, None, "none", "none", 0, False, 0)
+    else:
+        pruned = restart
+        if session_started is not None:
+            if session_started > restart.session_cutoff:
+                pruned = replace(pruned, session="none", session_cutoff=0)
+            if session_started > restart.application_cutoff:
+                pruned = replace(pruned, application=False, application_cutoff=0)
+    if pruned != restart:
+        commit_writable_journal_path(journal, "restart", encode_journal_restart(pruned))
+    return pruned
+
+
+def complete_journal_terminal(
+    journal: JournalDescriptorSet,
+    *,
+    boot_id: str | None = None,
+    session_started: int | None = None,
+) -> JournalOperation | None:
+    """Idempotently finish a durable terminal checkpoint through its handoff.
+
+    Callers checkpoint the final result with advance_journal_operation first.
+    Every return implies all required commits were synced and identity-checked;
+    any failure leaves the last durable checkpoint for bounded recovery.
+    """
+    state = load_writable_journal_state(journal)
+    operation = state.active
+    if operation is None:
+        return None
+    if operation.state not in JOURNAL_OPERATION_TERMINAL_STATES:
+        raise JournalAdmissionError("journal operation is not terminal")
+    if operation.kind == "update":
+        restart = prune_journal_restart(journal, boot_id, session_started)
+        if (
+            operation.boot_id == boot_id
+            and restart.last_applied_operation_id != operation.operation_id
+        ):
+            restart = replace(
+                restart,
+                last_applied_operation_id=operation.operation_id,
+                system=max(
+                    restart.system,
+                    operation.system_restart,
+                    key=JOURNAL_RESTART_SYSTEM_STRENGTH.__getitem__,
+                ),
+                session=max(
+                    restart.session,
+                    operation.session_restart,
+                    key=JOURNAL_RESTART_SESSION_STRENGTH.__getitem__,
+                ),
+                session_cutoff=(
+                    operation.terminal_monotonic
+                    if operation.session_restart != "none"
+                    else restart.session_cutoff
+                ),
+                application=restart.application or operation.application_restart,
+                application_cutoff=(
+                    operation.terminal_monotonic
+                    if operation.application_restart
+                    else restart.application_cutoff
+                ),
+            )
+            # A recovered checkpoint can predate the current login. Its original
+            # cutoff is authoritative; never reintroduce already satisfied work.
+            if session_started is not None:
+                if session_started > restart.session_cutoff:
+                    restart = replace(restart, session="none", session_cutoff=0)
+                if session_started > restart.application_cutoff:
+                    restart = replace(restart, application=False, application_cutoff=0)
+            commit_writable_journal_path(
+                journal, "restart", encode_journal_restart(restart)
+            )
+    payload = encode_journal_operation(operation)
+    name = f"terminal-{operation.slot:02d}"
+    if state.terminals[operation.slot] != operation:
+        commit_writable_journal_path(journal, name, payload)
+    cursor = (operation.slot + 1) % JOURNAL_TERMINAL_COUNT
+    if state.cursor != cursor:
+        commit_writable_journal_path(journal, "cursor", encode_journal_cursor(cursor))
+    handoff = JournalHandoff(operation.operation_id, operation.slot)
+    if state.handoff != handoff:
+        commit_writable_journal_path(
+            journal, "handoff", encode_journal_handoff(handoff)
+        )
+    commit_writable_journal_path(journal, "active", "")
+    load_writable_journal_state(journal)
+    return operation
+
+
+def retained_journal_operation(
+    journal: JournalDescriptorSet, operation_id: str
+) -> JournalOperation:
+    """Find exactly the requested retained terminal, independent of ring age."""
+    if (
+        not isinstance(operation_id, str)
+        or JOURNAL_OPERATION_ID_PATTERN.fullmatch(operation_id) is None
+    ):
+        raise JournalRecordError("journal operation ID is invalid")
+    state = load_writable_journal_state(journal)
+    if state.active is not None:
+        raise JournalAdmissionError("journal active operation needs recovery")
+    for operation in state.terminals:
+        if operation is not None and operation.operation_id == operation_id:
+            return operation
+    raise JournalAdmissionError("journal terminal operation is unavailable")
+
+
+def acknowledge_journal_handoff(
+    journal: JournalDescriptorSet, operation_id: str
+) -> None:
+    """Clear only an exact validated handoff, retaining its audit evidence."""
+    operation = retained_journal_operation(journal, operation_id)
+    state = load_writable_journal_state(journal)
+    if state.handoff != JournalHandoff(operation_id, operation.slot):
+        raise JournalAdmissionError("journal handoff is unavailable")
+    commit_writable_journal_path(journal, "handoff", "")
 
 
 @dataclass(frozen=True)

--- a/tests/test-quickshell-settings-xvfb.sh
+++ b/tests/test-quickshell-settings-xvfb.sh
@@ -382,6 +382,30 @@ cp "$repo/scripts/dwm-settings-provider" "$repo/scripts/dwm-system-health" \
 	"$repo/scripts/theme-apply.sh" \
 	"$repo/scripts/dwm-terminal" "$repo/scripts/dwm-lock" "$data_home/dwm-titus/scripts/"
 
+input_discovery_fixture=$config_home/dwm-titus/input-discovery-fixture
+mv "$data_home/dwm-titus/scripts/dwm-settings-input" \
+	"$data_home/dwm-titus/scripts/dwm-settings-input.real"
+cat >"$data_home/dwm-titus/scripts/dwm-settings-input" <<'SH'
+#!/bin/sh
+set -eu
+fixture=$XDG_CONFIG_HOME/dwm-titus/input-discovery-fixture
+if [ "${1:-}" = discover ] && [ -f "$fixture.hold" ]; then
+	rm -f "$fixture.hold"
+	"$(dirname -- "$0")/dwm-settings-input.real" "$@" >"$fixture.snapshot"
+	: >"$fixture.captured"
+	attempt=0
+	while [ ! -f "$fixture.release" ] && [ "$attempt" -lt 1000 ]; do
+		attempt=$((attempt + 1))
+		sleep 0.01
+	done
+	[ -f "$fixture.release" ] || exit 1
+	cat "$fixture.snapshot"
+	exit 0
+fi
+exec "$(dirname -- "$0")/dwm-settings-input.real" "$@"
+SH
+chmod +x "$data_home/dwm-titus/scripts/dwm-settings-input"
+
 appearance_failure_fixture=$work/appearance-snapshot-failure
 mv "$data_home/dwm-titus/scripts/dwm-settings-appearance" \
 	"$data_home/dwm-titus/scripts/dwm-settings-appearance.real"
@@ -1014,6 +1038,16 @@ done
 [ "$sticky_value" = "$sticky_baseline" ]
 [ "$sticky_live" = "$sticky_baseline" ]
 
+# Hold a pre-change discovery result across Keep. The model must queue the
+# resulting refresh instead of letting this stale snapshot win permanently.
+: >"$input_discovery_fixture.hold"
+settings_ipc_retry select input >/dev/null
+i=0
+while [ ! -f "$input_discovery_fixture.captured" ] && [ "$i" -lt 100 ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+[ -f "$input_discovery_fixture.captured" ]
 settings_ipc_retry inputAccessibilityPreview sticky-keys "$sticky_preview" >/dev/null
 i=0
 while [ "$i" -lt 100 ]; do
@@ -1035,6 +1069,15 @@ while [ "$i" -lt 100 ]; do
 done
 grep -Fqx "$sticky_record" \
 	"$config_home/dwm-titus/input-settings.conf"
+i=0
+while [ "$i" -lt 100 ]; do
+	preview_state=$(settings_ipc_retry inputPreviewState)
+	[ -z "$preview_state" ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ -z "$preview_state" ]
+: >"$input_discovery_fixture.release"
 i=0
 while [ "$i" -lt 100 ]; do
 	preview_state=$(settings_ipc_retry inputPreviewState)
@@ -2175,6 +2218,12 @@ while [ "$i" -lt 600 ]; do
 done
 if [ "$wallpaper_preview" != active ]; then
 	printf 'External wallpaper preview did not become active: %s\n' "$wallpaper_preview" >&2
+	printf 'Wallpaper watcher: %s; status busy: %s\n' \
+		"$(settings_ipc_retry appearanceInventoryWatchState)" \
+		"$(settings_ipc_retry appearanceWallpaperStatusBusy)" >&2
+	DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
+		XDG_RUNTIME_DIR=$runtime DWM_APPEARANCE_WALLPAPER_DIR=$home/Pictures/backgrounds \
+		"$data_home/dwm-titus/scripts/dwm-settings-wallpaper" status --read-only >&2 || true
 	exit 1
 fi
 wallpaper_remaining_before=$(settings_ipc_retry appearanceWallpaperPreviewRemaining)

--- a/tests/test-settings.sh
+++ b/tests/test-settings.sh
@@ -707,6 +707,12 @@ grep -Fq 'readonly property bool displayHasPendingChanges:' \
 	"$repo/config/quickshell/settings/SettingsModel.qml"
 grep -Fq 'property bool displayRefreshPending: false' \
 	"$repo/config/quickshell/settings/SettingsModel.qml"
+grep -Fq 'property bool inputRefreshPending: false' \
+	"$repo/config/quickshell/settings/SettingsModel.qml"
+grep -Fq 'root.inputRefreshPending = true;' \
+	"$repo/config/quickshell/settings/SettingsModel.qml"
+grep -Fq 'if (!running && root.inputRefreshPending && root.visible) {' \
+	"$repo/config/quickshell/settings/SettingsModel.qml"
 grep -Fq 'root.displayRefreshPending = true;' \
 	"$repo/config/quickshell/settings/SettingsModel.qml"
 grep -Fq 'if (!running && root.displayRefreshPending && root.visible) {' \

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -487,7 +487,7 @@ class JournalControlRecordTests(unittest.TestCase):
             None,
             "Installing updates",
             "a" * 64,
-            "/org/freedesktop/PackageKit/transactions/1_deadbeef",
+            "/1_deadbeef",
             "none",
             "none",
             False,
@@ -2906,17 +2906,374 @@ class JournalWritableCommitTests(unittest.TestCase):
                             "_commit_journal_file_unlocked",
                             side_effect=fail_after_replacement,
                         ):
-                            provider.commit_writable_journal_path(
-                                journal, "active", ""
-                            )
+                            provider.commit_writable_journal_path(journal, "active", "")
 
                 self.assertIs(caught.exception, commit_error)
                 self.assertIsInstance(
                     caught.exception.__cause__, provider.JournalLayoutError
                 )
-                self.assertIn("active identity is unsafe", str(caught.exception.__cause__))
+                self.assertIn(
+                    "active identity is unsafe", str(caught.exception.__cause__)
+                )
             finally:
                 chain.close()
+
+
+class JournalLifecycleTests(unittest.TestCase):
+    boot_id = "01234567-89ab-cdef-0123-456789abcdef"
+    started = "2026-09-04T18:00:00Z"
+    finished = "2026-09-04T18:01:00Z"
+
+    def test_fedora_transaction_paths_are_root_level_bounded_ids(self):
+        for path in ("/18_adcbcaed", "/45_dafeca"):
+            self.assertIsNotNone(provider.JOURNAL_PACKAGEKIT_PATH_PATTERN.fullmatch(path))
+        for path in (
+            "/org/freedesktop/PackageKit/transactions/18_adcbcaed",
+            "/org/freedesktop/PackageKit", "/", "/18_adcbcaed/child",
+            "/18_", "/18_" + "a" * 65, "/" + "1" * 21 + "_abcd",
+            "/18_abcd\n", "/18_ab-cd",
+        ):
+            self.assertIsNone(provider.JOURNAL_PACKAGEKIT_PATH_PATTERN.fullmatch(path))
+
+    @contextlib.contextmanager
+    def journal(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "state" / "dwm-titus" / "system-management"
+            with provider.open_journal_directory_chain(str(path)) as chain:
+                provider.initialize_journal_layout(
+                    chain.directory_descriptor, self.boot_id
+                )
+                with provider.open_writable_journal(chain) as journal:
+                    yield journal
+
+    def begin(self, journal, action="updates-refresh"):
+        args = {}
+        if action in ("updates-refresh", "updates-install-all"):
+            args["transaction_path"] = "/1_test"
+            args["boot_id"] = self.boot_id
+        if action == "updates-install-all":
+            args.update(generation="a" * 64, boot_id=self.boot_id)
+        return provider.begin_journal_operation(
+            journal, action, self.started, "Starting operation", **args
+        )
+
+    def finish(self, journal, operation, **contributions):
+        running = replace(operation, state="running", **contributions)
+        provider.advance_journal_operation(journal, operation, running)
+        terminal = replace(
+            running,
+            state="succeeded",
+            finished_at=self.finished,
+            terminal_monotonic=100 if running.kind in ("refresh", "update") else None,
+        )
+        provider.advance_journal_operation(journal, running, terminal)
+        return terminal
+
+    def image(self, journal, name):
+        return os.pread(journal.descriptor(name), provider.JOURNAL_FILE_SIZE, 0)
+
+    def test_pending_is_durable_and_blocks_overlap(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            self.assertEqual(
+                provider.load_writable_journal_state(journal).active, operation
+            )
+            self.assertEqual(operation.state, "pending")
+            before = self.image(journal, "active")
+            with self.assertRaises(provider.JournalAdmissionError):
+                self.begin(journal)
+            self.assertEqual(self.image(journal, "active"), before)
+
+    def test_invalid_admission_arguments_never_commit(self):
+        with self.journal() as journal:
+            with mock.patch.object(provider, "commit_writable_journal_path") as commit:
+                for action, args in (
+                    ("unknown", {}),
+                    ("updates-refresh", {"transaction_path": "/arbitrary"}),
+                    ("timezone-set", {"generation": "a" * 64}),
+                    (
+                        "updates-install-all",
+                        {
+                            "generation": "a" * 64,
+                            "transaction_path": "/1_test",
+                            "boot_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                        },
+                    ),
+                ):
+                    with self.subTest(action=action):
+                        with self.assertRaises(
+                            (
+                                provider.JournalRecordError,
+                                provider.JournalAdmissionError,
+                            )
+                        ):
+                            provider.begin_journal_operation(
+                                journal, action, self.started, "Starting", **args
+                            )
+                commit.assert_not_called()
+
+    def test_rejects_stale_identity_illegal_transition_and_progress_writes(self):
+        with self.journal() as journal:
+            pending = self.begin(journal)
+            running = replace(pending, state="running")
+            provider.advance_journal_operation(journal, pending, running)
+            for expected, following in (
+                (pending, running),
+                (
+                    running,
+                    replace(
+                        running,
+                        transaction_path="/2_other",
+                    ),
+                ),
+                (running, replace(running, state="authorizing")),
+                (running, replace(running, detail="Progress only")),
+            ):
+                with self.subTest(following=following):
+                    before = self.image(journal, "active")
+                    with self.assertRaises(provider.JournalAdmissionError):
+                        provider.advance_journal_operation(journal, expected, following)
+                    self.assertEqual(self.image(journal, "active"), before)
+
+    def test_restart_contributions_only_strengthen(self):
+        with self.journal() as journal:
+            pending = self.begin(journal, "updates-install-all")
+            stronger = replace(
+                pending, session_restart="security-session", application_restart=True
+            )
+            provider.advance_journal_operation(journal, pending, stronger)
+            with self.assertRaises(provider.JournalAdmissionError):
+                provider.advance_journal_operation(journal, stronger, pending)
+
+    def test_every_kind_retains_exact_terminal_until_acknowledged(self):
+        for action in provider.JOURNAL_OPERATION_ACTION_KINDS:
+            with self.subTest(action=action), self.journal() as journal:
+                terminal = self.finish(journal, self.begin(journal, action))
+                restart_before = self.image(journal, "restart")
+                provider.complete_journal_terminal(journal, boot_id=self.boot_id)
+                state = provider.load_writable_journal_state(journal)
+                self.assertIsNone(state.active)
+                self.assertEqual(
+                    state.handoff, provider.JournalHandoff(terminal.operation_id, 0)
+                )
+                self.assertEqual(state.cursor, 1)
+                self.assertEqual(
+                    provider.retained_journal_operation(journal, terminal.operation_id),
+                    terminal,
+                )
+                with self.assertRaises(provider.JournalAdmissionError):
+                    self.begin(journal)
+                with self.assertRaises(provider.JournalAdmissionError):
+                    provider.acknowledge_journal_handoff(journal, "op-" + "f" * 32)
+                provider.acknowledge_journal_handoff(journal, terminal.operation_id)
+                self.assertIsNone(provider.load_writable_journal_state(journal).handoff)
+                self.assertEqual(
+                    provider.retained_journal_operation(journal, terminal.operation_id),
+                    terminal,
+                )
+                if terminal.kind != "update":
+                    self.assertEqual(self.image(journal, "restart"), restart_before)
+
+    def test_terminalization_recovers_before_and_after_every_commit(self):
+        for action in (
+            "updates-refresh",
+            "updates-install-all",
+            "timezone-set",
+            "accounts-open",
+        ):
+            names = ["terminal-00", "cursor", "handoff", "active"]
+            if action == "updates-install-all":
+                names.insert(0, "restart")
+            for target in names:
+                for after in (False, True):
+                    with (
+                        self.subTest(action=action, target=target, after=after),
+                        self.journal() as journal,
+                    ):
+                        contributions = {}
+                        if action == "updates-install-all":
+                            contributions = dict(
+                                system_restart="system",
+                                session_restart="security-session",
+                                application_restart=True,
+                            )
+                        terminal = self.finish(
+                            journal, self.begin(journal, action), **contributions
+                        )
+                        real_commit = provider.commit_writable_journal_path
+
+                        def crash(journal, name, payload):
+                            if name == target and not after:
+                                raise provider.JournalCommitError(
+                                    "injected before commit"
+                                )
+                            result = real_commit(journal, name, payload)
+                            if name == target:
+                                raise provider.JournalCommitError(
+                                    "injected after commit"
+                                )
+                            return result
+
+                        with mock.patch.object(
+                            provider, "commit_writable_journal_path", side_effect=crash
+                        ):
+                            with self.assertRaises(provider.JournalCommitError):
+                                provider.complete_journal_terminal(
+                                    journal, boot_id=self.boot_id
+                                )
+                        provider.load_writable_journal_state(journal)
+                        provider.complete_journal_terminal(
+                            journal, boot_id=self.boot_id
+                        )
+                        state = provider.load_writable_journal_state(journal)
+                        self.assertIsNone(state.active)
+                        self.assertEqual(state.terminals[0], terminal)
+                        self.assertEqual(state.cursor, 1)
+                        self.assertEqual(
+                            state.handoff.operation_id, terminal.operation_id
+                        )
+                        if action == "updates-install-all":
+                            self.assertEqual(state.restart.system, "system")
+                            self.assertEqual(state.restart.session, "security-session")
+                            self.assertEqual(state.restart.application_cutoff, 100)
+
+    def test_boot_and_login_boundaries_never_reapply_satisfied_contributions(self):
+        for new_boot, login in (
+            (self.boot_id, 101),
+            ("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", None),
+        ):
+            with self.subTest(boot=new_boot), self.journal() as journal:
+                terminal = self.finish(
+                    journal,
+                    self.begin(journal, "updates-install-all"),
+                    system_restart="system",
+                    session_restart="security-session",
+                    application_restart=True,
+                )
+                provider.complete_journal_terminal(
+                    journal, boot_id=new_boot, session_started=login
+                )
+                state = provider.load_writable_journal_state(journal)
+                self.assertEqual(state.restart.session, "none")
+                self.assertFalse(state.restart.application)
+                self.assertEqual(
+                    state.restart.system,
+                    "system" if new_boot == self.boot_id else "none",
+                )
+                self.assertEqual(state.terminals[0], terminal)
+
+    def test_ring_wrap_replays_older_exact_identity_not_newest_slot(self):
+        with self.journal() as journal:
+            terminals = []
+            for _ in range(34):
+                terminal = self.finish(journal, self.begin(journal))
+                provider.complete_journal_terminal(journal)
+                provider.acknowledge_journal_handoff(journal, terminal.operation_id)
+                terminals.append(terminal)
+            self.assertEqual(
+                provider.retained_journal_operation(journal, terminals[2].operation_id),
+                terminals[2],
+            )
+            with self.assertRaises(provider.JournalAdmissionError):
+                provider.retained_journal_operation(journal, terminals[0].operation_id)
+            self.assertEqual(provider.load_writable_journal_state(journal).cursor, 2)
+
+    def test_pending_and_ack_commit_errors_preserve_durable_authority(self):
+        for target in ("active", "handoff"):
+            for after in (False, True):
+                with self.subTest(target=target, after=after), self.journal() as journal:
+                    operation = None
+                    if target == "handoff":
+                        operation = self.finish(journal, self.begin(journal))
+                        provider.complete_journal_terminal(journal)
+                    real_commit = provider.commit_writable_journal_path
+
+                    def fail(journal, name, payload):
+                        self.assertEqual(name, target)
+                        if after:
+                            real_commit(journal, name, payload)
+                        raise provider.JournalCommitError("indeterminate commit")
+
+                    with mock.patch.object(provider, "commit_writable_journal_path", side_effect=fail):
+                        with self.assertRaises(provider.JournalCommitError):
+                            if target == "active":
+                                self.begin(journal)
+                            else:
+                                provider.acknowledge_journal_handoff(journal, operation.operation_id)
+                    state = provider.load_writable_journal_state(journal)
+                    if target == "active":
+                        self.assertEqual(state.active is not None, after)
+                    else:
+                        self.assertEqual(state.handoff is None, after)
+                        self.assertEqual(state.terminals[0], operation)
+
+    def test_stale_terminal_timestamp_is_rejected_before_checkpoint(self):
+        with self.journal() as journal:
+            terminal = self.finish(journal, self.begin(journal, "updates-install-all"))
+            provider.complete_journal_terminal(journal, boot_id=self.boot_id)
+            provider.acknowledge_journal_handoff(journal, terminal.operation_id)
+            pending = self.begin(journal)
+            interrupted = replace(
+                pending, state="interrupted", finished_at=self.finished,
+                terminal_monotonic=99,
+            )
+            before = self.image(journal, "active")
+            with self.assertRaises(provider.JournalRecordError):
+                provider.advance_journal_operation(journal, pending, interrupted)
+            self.assertEqual(self.image(journal, "active"), before)
+
+    def test_refresh_requires_boot_reconciliation_without_storing_a_boot_field(self):
+        with self.journal() as journal:
+            terminal = self.finish(journal, self.begin(journal, "updates-install-all"))
+            provider.complete_journal_terminal(journal, boot_id=self.boot_id)
+            provider.acknowledge_journal_handoff(journal, terminal.operation_id)
+            new_boot = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+            with self.assertRaises(provider.JournalAdmissionError):
+                provider.begin_journal_operation(
+                    journal, "updates-refresh", self.started, "Starting",
+                    transaction_path="/18_adcbcaed", boot_id=new_boot,
+                )
+            provider.prune_journal_restart(journal, new_boot, None)
+            pending = provider.begin_journal_operation(
+                journal, "updates-refresh", self.started, "Starting",
+                transaction_path="/18_adcbcaed", boot_id=new_boot,
+            )
+            self.assertIsNone(pending.boot_id)
+            interrupted = replace(
+                pending, state="interrupted", finished_at=self.finished,
+                terminal_monotonic=1,
+            )
+            provider.advance_journal_operation(journal, pending, interrupted)
+            before = self.image(journal, "restart")
+            provider.complete_journal_terminal(journal)
+            self.assertEqual(self.image(journal, "restart"), before)
+
+    def test_terminal_pruning_shares_the_three_commit_restart_budget(self):
+        for prune_before_terminal in (False, True):
+            with self.subTest(prune_before_terminal=prune_before_terminal), self.journal() as journal:
+                for cutoff, contributions in (
+                    (100, {"session_restart": "session"}),
+                    (200, {"application_restart": True}),
+                ):
+                    pending = self.begin(journal, "updates-install-all")
+                    running = replace(pending, state="running", **contributions)
+                    provider.advance_journal_operation(journal, pending, running)
+                    terminal = replace(running, state="succeeded", finished_at=self.finished, terminal_monotonic=cutoff)
+                    provider.advance_journal_operation(journal, running, terminal)
+                    provider.complete_journal_terminal(journal, boot_id=self.boot_id)
+                    provider.acknowledge_journal_handoff(journal, terminal.operation_id)
+                pending = self.begin(journal, "updates-install-all")
+                real_commit = provider.commit_writable_journal_path
+                with mock.patch.object(provider, "commit_writable_journal_path", wraps=real_commit) as commits:
+                    provider.prune_journal_restart(journal, self.boot_id, 150)
+                    if prune_before_terminal:
+                        provider.prune_journal_restart(journal, self.boot_id, 250)
+                    running = replace(pending, state="running")
+                    provider.advance_journal_operation(journal, pending, running)
+                    terminal = replace(running, state="succeeded", finished_at=self.finished, terminal_monotonic=300)
+                    provider.advance_journal_operation(journal, running, terminal)
+                    provider.complete_journal_terminal(journal, boot_id=self.boot_id, session_started=250)
+                self.assertEqual(sum(call.args[1] == "restart" for call in commits.call_args_list), 3)
 
 
 class JournalAdmissionTests(unittest.TestCase):
@@ -2941,7 +3298,7 @@ class JournalAdmissionTests(unittest.TestCase):
             None,
             "Refreshing update metadata",
             None,
-            "/org/freedesktop/PackageKit/transactions/1_deadbeef",
+            "/1_deadbeef",
             None,
             None,
             None,


### PR DESCRIPTION
## Scope
Complete the journal lifecycle as one independently testable Phase 6 boundary: durable pending admission, validated transitions, restart pruning, crash-recoverable terminal commits, retained-result lookup, and exact handoff acknowledgment. Update execution remains disabled until the PackageKit and root-model integration lands.

Also correct the existing PackageKit transaction-path validator. Fedora 44 PackageKit 1.3.6 returned /18_adcbcaed from CreateTransaction, matching its installed D-Bus XML, not the previously assumed namespaced path. No refresh or package mutation was started by that probe.

## Validation
- scripts/run-tests make clean all: passed.
- scripts/run-tests: passed, including nested X11, QML lint, shell gates, package checks, staged installation, repeated-install preservation, and release checks.
- Final affected gates: scripts/run-tests make check-system-management check-quickshell-system-management: passed; 136 provider tests and nested-X11 lifecycle coverage.
- Settings closed CPU: 0.067%; large surfaces: 0.00%.
- git diff --check: passed.
- Local Codex review with the existing desktop-bundled /usr/lib/chatgpt/resources/codex: no actionable findings. The older PATH CLI cannot run the configured model; no global settings were changed.
- Independent CodeRabbit review: clean after fixing boot reconciliation for refresh. A regression test verifies that snapshot and terminal pruning share the existing three-write restart budget.

## Recovery coverage
Faults before and after terminalization commits, indeterminate pending and acknowledgment writes, exact history replay after ring wrap, overlap rejection, stale identity and timestamps, boot/login pruning, and unchanged restart frames for non-update terminalization.

## Limits and next boundary
This is preparatory provider code, not phase completion. Real update execution, recovery observation, confirmations, regional/delegated administration, information/security surfaces, combined qualification, and live-install synchronization remain tracked in TASKS.md. No visible UI changes in this PR.