### PR TITLE
Retain Phase 6 journal ownership across service waits

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -53,7 +53,10 @@ Progress: Read-only PackageKit discovery and its Settings pane are implemented.
 The journal now supports durable pending admission, identity-checked lifecycle
 transitions, restart pruning, recoverable terminal commits, exact retained-result
 lookup, and handoff acknowledgment. These are tested foundations, not an enabled
-update execution workflow. PackageKit execution/recovery integration and its
+update execution workflow. Operation owners can retain every journal file
+identity across unlocked service waits and reacquire bounded exclusive intervals
+for checkpoints; unlocked state access and stale ownership are rejected.
+PackageKit execution/recovery integration and its
 root-scoped confirmation and operation UI remain to be completed before this
 boundary can be accepted.
 

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -318,12 +318,13 @@ class JournalDirectoryChain:
 
 @dataclass
 class JournalDescriptorSet:
-    """Fixed journal file descriptors retained under one directory lock."""
+    """Fixed journal file identities retained across bounded lock intervals."""
 
     chain: JournalDirectoryChain
     _descriptors: dict[str, int]
     writable: bool
     closed: bool = False
+    _exclusive: bool = False
 
     def descriptor(self, name: str) -> int:
         if self.closed:
@@ -2299,59 +2300,107 @@ def load_journal_state(chain: JournalDirectoryChain) -> JournalState:
 
 
 @contextlib.contextmanager
+def _retain_journal_files_unlocked(
+    chain: JournalDirectoryChain,
+) -> Iterator[JournalDescriptorSet]:
+    """Open under the caller's lock; retain every file until context exit."""
+    chain.validate()
+    directory_descriptor = chain.directory_descriptor
+    journal = JournalDescriptorSet(chain, {}, writable=True)
+    completed = False
+    try:
+        for name in JOURNAL_NAMES:
+            try:
+                descriptor = os.open(
+                    name,
+                    os.O_RDWR | os.O_NONBLOCK | os.O_NOFOLLOW | os.O_CLOEXEC,
+                    dir_fd=directory_descriptor,
+                )
+            except OSError as error:
+                raise JournalLayoutError(
+                    f"journal path {name} writable open failed"
+                ) from error
+            journal._descriptors[name] = descriptor
+            _validate_journal_path_identity(
+                directory_descriptor, name, descriptor, JOURNAL_FILE_SIZE,
+            )
+
+        journal.validate()
+        yield journal
+        journal.validate()
+        completed = True
+    finally:
+        journal.closed = True
+        first_error = _close_descriptors(
+            reversed(tuple(journal._descriptors.values()))
+        )
+        if first_error is not None and completed:
+            raise JournalLayoutError(
+                "writable journal descriptor close failed"
+            ) from first_error
+
+
+@contextlib.contextmanager
+def retain_writable_journal(
+    chain: JournalDirectoryChain,
+) -> Iterator[JournalDescriptorSet]:
+    """Retain exact files without holding a lock during external service work.
+
+    Callers use lock_writable_journal for every state read and checkpoint,
+    and validate the retained identities immediately before external mutations.
+    """
+    with contextlib.ExitStack() as retained:
+        with _journal_lock(chain.directory_descriptor, exclusive=True):
+            journal = retained.enter_context(_retain_journal_files_unlocked(chain))
+        yield journal
+
+
+@contextlib.contextmanager
+def lock_writable_journal(
+    journal: JournalDescriptorSet,
+) -> Iterator[JournalDescriptorSet]:
+    """Revalidate retained identities around one bounded exclusive interval."""
+    if not isinstance(journal, JournalDescriptorSet) or not journal.writable:
+        raise JournalLayoutError("writable journal descriptor set is invalid")
+    if journal._exclusive:
+        raise JournalLockError("journal exclusive interval is already active")
+    journal.validate()
+    with _journal_lock(journal.chain.directory_descriptor, exclusive=True):
+        journal.validate()
+        journal._exclusive = True
+        try:
+            yield journal
+            journal.validate()
+        finally:
+            journal._exclusive = False
+
+
+@contextlib.contextmanager
 def open_writable_journal(
     chain: JournalDirectoryChain,
 ) -> Iterator[JournalDescriptorSet]:
     """Retain the complete writable journal under one exclusive lock."""
     chain.validate()
-    directory_descriptor = chain.directory_descriptor
-    with _journal_lock(directory_descriptor, exclusive=True):
-        journal = JournalDescriptorSet(chain, {}, writable=True)
-        completed = False
-        try:
-            chain.validate()
-            for name in JOURNAL_NAMES:
-                try:
-                    descriptor = os.open(
-                        name,
-                        os.O_RDWR
-                        | os.O_NONBLOCK
-                        | os.O_NOFOLLOW
-                        | os.O_CLOEXEC,
-                        dir_fd=directory_descriptor,
-                    )
-                except OSError as error:
-                    raise JournalLayoutError(
-                        f"journal path {name} writable open failed"
-                    ) from error
-                journal._descriptors[name] = descriptor
-                _validate_journal_path_identity(
-                    directory_descriptor,
-                    name,
-                    descriptor,
-                    JOURNAL_FILE_SIZE,
-                )
+    with _journal_lock(chain.directory_descriptor, exclusive=True):
+        with _retain_journal_files_unlocked(chain) as journal:
+            journal._exclusive = True
+            try:
+                yield journal
+            finally:
+                journal._exclusive = False
 
-            journal.validate()
-            yield journal
-            journal.validate()
-            completed = True
-        finally:
-            journal.closed = True
-            first_error = _close_descriptors(
-                reversed(tuple(journal._descriptors.values()))
-            )
-            if first_error is not None and completed:
-                raise JournalLayoutError(
-                    "writable journal descriptor close failed"
-                ) from first_error
+
+def _require_exclusive_journal(journal: JournalDescriptorSet) -> None:
+    if not isinstance(journal, JournalDescriptorSet) or not journal.writable:
+        raise JournalLayoutError("writable journal descriptor set is invalid")
+    if not journal._exclusive:
+        raise JournalLockError("journal state access requires an exclusive interval")
 
 
 def _load_writable_journal_state(
     journal: JournalDescriptorSet,
 ) -> tuple[JournalState, dict[str, JournalFrame]]:
-    if not isinstance(journal, JournalDescriptorSet) or not journal.writable:
-        raise JournalLayoutError("writable journal descriptor set is invalid")
+    _require_exclusive_journal(journal)
     journal.validate()
     payloads: dict[str, str] = {}
     frames: dict[str, JournalFrame] = {}
@@ -2378,8 +2427,7 @@ def commit_writable_journal_path(
     journal: JournalDescriptorSet, name: str, payload: str
 ) -> tuple[int, JournalFrame]:
     """Commit one retained path between complete journal identity checks."""
-    if not isinstance(journal, JournalDescriptorSet) or not journal.writable:
-        raise JournalLayoutError("writable journal descriptor set is invalid")
+    _require_exclusive_journal(journal)
     journal.validate()
     descriptor = journal.descriptor(name)
     try:

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -2326,7 +2326,14 @@ def _retain_journal_files_unlocked(
             )
 
         journal.validate()
-        yield journal
+        try:
+            yield journal
+        except BaseException as body_error:
+            try:
+                journal.validate()
+            except JournalLayoutError as validation_error:
+                raise body_error from validation_error
+            raise
         journal.validate()
         completed = True
     finally:
@@ -2369,7 +2376,14 @@ def lock_writable_journal(
         journal.validate()
         journal._exclusive = True
         try:
-            yield journal
+            try:
+                yield journal
+            except BaseException as body_error:
+                try:
+                    journal.validate()
+                except JournalLayoutError as validation_error:
+                    raise body_error from validation_error
+                raise
             journal.validate()
         finally:
             journal._exclusive = False

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -2919,6 +2919,125 @@ class JournalWritableCommitTests(unittest.TestCase):
                 chain.close()
 
 
+class JournalRetainedSessionTests(unittest.TestCase):
+    boot_id = "01234567-89ab-cdef-0123-456789abcdef"
+
+    @contextlib.contextmanager
+    def session(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "state" / "dwm-titus" / "system-management"
+            with provider.open_journal_directory_chain(str(path)) as chain:
+                provider.initialize_journal_layout(chain.directory_descriptor, self.boot_id)
+                with provider.retain_writable_journal(chain) as journal:
+                    yield path, chain, journal
+
+    def begin(self, journal):
+        return provider.begin_journal_operation(
+            journal, "updates-refresh", "2026-09-04T18:00:00Z", "Starting refresh",
+            transaction_path="/1_test", boot_id=self.boot_id,
+        )
+
+    def test_service_interval_releases_lock_but_retains_all_file_identities(self):
+        with self.session() as (_path, chain, journal):
+            identities = {
+                name: (journal.descriptor(name), os.fstat(journal.descriptor(name)).st_ino)
+                for name in provider.JOURNAL_NAMES
+            }
+            with provider._journal_lock(chain.directory_descriptor, exclusive=True):
+                pass
+            with provider.lock_writable_journal(journal):
+                operation = self.begin(journal)
+                with mock.patch.object(provider, "JOURNAL_LOCK_DEADLINE_SECONDS", 0.01):
+                    with self.assertRaises(provider.JournalLockError):
+                        with provider._journal_lock(chain.directory_descriptor, exclusive=True):
+                            self.fail("checkpoint lock did not exclude another writer")
+            with provider._journal_lock(chain.directory_descriptor, exclusive=True):
+                pass
+            with provider.lock_writable_journal(journal):
+                self.assertEqual(provider.load_writable_journal_state(journal).active, operation)
+                for name, (descriptor, inode) in identities.items():
+                    self.assertEqual(journal.descriptor(name), descriptor)
+                    self.assertEqual(os.fstat(descriptor).st_ino, inode)
+        self.assertTrue(journal.closed)
+        for descriptor, _inode in identities.values():
+            with self.assertRaises(OSError):
+                os.fstat(descriptor)
+
+    def test_unlocked_state_reads_and_commits_are_rejected(self):
+        with self.session() as (path, _chain, journal):
+            before = (path / "active").read_bytes()
+            with self.assertRaisesRegex(provider.JournalLockError, "exclusive interval"):
+                provider.load_writable_journal_state(journal)
+            with self.assertRaisesRegex(provider.JournalLockError, "exclusive interval"):
+                provider.commit_writable_journal_path(journal, "active", "active\tempty")
+            with self.assertRaisesRegex(provider.JournalLockError, "exclusive interval"):
+                self.begin(journal)
+            self.assertEqual((path / "active").read_bytes(), before)
+
+    def test_reacquisition_observes_concurrent_checkpoint_and_rejects_stale_owner(self):
+        with self.session() as (_path, chain, journal):
+            with provider.lock_writable_journal(journal):
+                pending = self.begin(journal)
+            running = replace(pending, state="running")
+            with provider.open_writable_journal(chain) as observer:
+                provider.advance_journal_operation(observer, pending, running)
+            with provider.lock_writable_journal(journal):
+                self.assertEqual(provider.load_writable_journal_state(journal).active, running)
+                with self.assertRaises(provider.JournalAdmissionError):
+                    provider.advance_journal_operation(journal, pending, running)
+
+    def test_replaced_file_during_service_wait_is_rejected_before_checkpoint(self):
+        descriptors = ()
+        with self.assertRaisesRegex(provider.JournalLayoutError, "active identity"):
+            with self.session() as (path, _chain, journal):
+                descriptors = tuple(journal.descriptor(name) for name in provider.JOURNAL_NAMES)
+                active = path / "active"
+                before = active.read_bytes()
+                active.rename(path / "detached-active")
+                active.write_bytes(before)
+                active.chmod(0o600)
+                with provider.lock_writable_journal(journal):
+                    self.fail("replacement was accepted")
+        for descriptor in descriptors:
+            with self.assertRaises(OSError):
+                os.fstat(descriptor)
+
+    def test_replaced_directory_during_service_wait_is_rejected(self):
+        with self.assertRaises(provider.JournalLayoutError):
+            with self.session() as (path, _chain, journal):
+                path.rename(path.with_name("detached-journal"))
+                path.mkdir(mode=0o700)
+                with provider.lock_writable_journal(journal):
+                    self.fail("directory replacement was accepted")
+
+    def test_nested_interval_and_body_error_release_lock(self):
+        with self.session() as (_path, chain, journal):
+            with self.assertRaisesRegex(RuntimeError, "service error"):
+                with provider.lock_writable_journal(journal):
+                    with self.assertRaisesRegex(provider.JournalLockError, "already active"):
+                        with provider.lock_writable_journal(journal):
+                            self.fail("nested interval was accepted")
+                    raise RuntimeError("service error")
+            self.assertFalse(journal._exclusive)
+            with provider._journal_lock(chain.directory_descriptor, exclusive=True):
+                pass
+            with provider.lock_writable_journal(journal):
+                self.assertIsNone(provider.load_writable_journal_state(journal).active)
+
+    def test_contended_reacquisition_remains_bounded_and_can_be_retried(self):
+        with self.session() as (_path, chain, journal):
+            with provider._journal_lock(chain.directory_descriptor, exclusive=True):
+                started = time.monotonic()
+                with mock.patch.object(provider, "JOURNAL_LOCK_DEADLINE_SECONDS", 0.01):
+                    with self.assertRaises(provider.JournalLockError):
+                        with provider.lock_writable_journal(journal):
+                            self.fail("contended interval was entered")
+                self.assertLess(time.monotonic() - started, 1)
+            self.assertFalse(journal._exclusive)
+            with provider.lock_writable_journal(journal):
+                self.assertIsNone(provider.load_writable_journal_state(journal).active)
+
+
 class JournalLifecycleTests(unittest.TestCase):
     boot_id = "01234567-89ab-cdef-0123-456789abcdef"
     started = "2026-09-04T18:00:00Z"

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -3024,6 +3024,45 @@ class JournalRetainedSessionTests(unittest.TestCase):
             with provider.lock_writable_journal(journal):
                 self.assertIsNone(provider.load_writable_journal_state(journal).active)
 
+    def test_service_error_reports_replacement_and_closes_every_descriptor(self):
+        service_error = RuntimeError("service call failed after send")
+        with self.assertRaises(RuntimeError) as caught:
+            with self.session() as (path, _chain, journal):
+                descriptors = tuple(journal.descriptor(name) for name in provider.JOURNAL_NAMES)
+                active = path / "active"
+                image = active.read_bytes()
+                active.rename(path / "detached-active")
+                active.write_bytes(image)
+                active.chmod(0o600)
+                raise service_error
+        self.assertIs(caught.exception, service_error)
+        self.assertIsInstance(caught.exception.__cause__, provider.JournalLayoutError)
+        self.assertIn("active identity", str(caught.exception.__cause__))
+        self.assertTrue(journal.closed)
+        for descriptor in descriptors:
+            with self.assertRaises(OSError):
+                os.fstat(descriptor)
+
+    def test_interval_error_revalidates_before_unlock_even_when_caught_by_owner(self):
+        with self.session() as (_path, _chain, journal):
+            checkpoint_error = RuntimeError("checkpoint failed")
+            identity_error = provider.JournalLayoutError("injected identity loss")
+            with self.assertRaises(RuntimeError) as caught:
+                with provider.lock_writable_journal(journal):
+                    original_validate = journal.validate
+                    # Keep validation fault active during context unwinding, but
+                    # restore it before the retained-session context is closed.
+                    journal.validate = mock.Mock(side_effect=identity_error)
+                    raise checkpoint_error
+            validation = journal.validate
+            journal.validate = original_validate
+            self.assertIs(caught.exception, checkpoint_error)
+            self.assertIs(caught.exception.__cause__, identity_error)
+            validation.assert_called_once_with()
+            self.assertFalse(journal._exclusive)
+            with provider.lock_writable_journal(journal):
+                self.assertIsNone(provider.load_writable_journal_state(journal).active)
+
     def test_contended_reacquisition_remains_bounded_and_can_be_retried(self):
         with self.session() as (_path, chain, journal):
             with provider._journal_lock(chain.directory_descriptor, exclusive=True):


### PR DESCRIPTION
## Summary
- Separate retained journal file identities from bounded exclusive lock intervals.
- Require an active exclusive interval for lifecycle reads and checkpoints, reject nested intervals, and revalidate identities before and after reacquisition.
- Preserve the existing single-lock API and document the remaining update execution integration in TASKS.md.

This is a small Phase 6 update foundation, not an enabled update execution workflow. No CLI, QML, package mutation, or privilege boundary changes.

## Validation
- `scripts/run-tests make check-system-management`: PASS, 143 tests.
- `scripts/run-tests`: PASS, including Fedora package map, nested-X11 Settings and large surfaces, staged installation, repeated-install preservation, and release validation.
- `scripts/run-tests make clean all`: PASS when rerun serially after the suite. An earlier accidental concurrent build failed because the suite cleaned shared build artifacts; it is not counted as passing coverage.
- Built-in Codex uncommitted review after the full suite: no actionable defects.
- Independent CodeRabbit local review: zero findings.
- `git diff --check`: PASS.

Fedora 44 x86_64; Settings closed-idle CPU 0.033%. The existing UI and helper installation are unchanged by this boundary. PackageKit mutation and recovery runtime qualification remains in the subsequent Phase 6 workflow, not claimed here.