### PR TITLE
Add bounded Phase 6 operation streams and terminal replay

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -56,7 +56,11 @@ lookup, and handoff acknowledgment. These are tested foundations, not an enabled
 update execution workflow. Operation owners can retain every journal file
 identity across unlocked service waits and reacquire bounded exclusive intervals
 for checkpoints; unlocked state access and stale ownership are rejected.
-PackageKit execution/recovery integration and its
+The operation formatter reserves required lifecycle records separately from its
+bounded progress budget, validates terminal/audit identity, and replays retained
+results without an external action. Observed package comparisons use bounded
+counts and mismatch samples plus an arrival-ordered digest; they are not persisted
+as an atomic completed plan. PackageKit execution/recovery integration and its
 root-scoped confirmation and operation UI remain to be completed before this
 boundary can be accepted.
 

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -15,7 +15,7 @@ import sys
 import time
 from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import Iterable, Iterator, Mapping, Protocol, Sequence
+from typing import Callable, Iterable, Iterator, Mapping, Protocol, Sequence
 
 
 PROTOCOL_MAJOR = 1
@@ -26,6 +26,8 @@ MAX_LIST_BYTES = 3 * 1024 * 1024
 READ_DEADLINE_SECONDS = 120
 REFRESH_AGE_DEADLINE_SECONDS = 10
 CANCEL_GRACE_SECONDS = 5
+MAX_OPERATION_PROGRESS_RECORDS = 252
+MAX_OPERATION_MISMATCH_SAMPLES = 128
 
 JOURNAL_MAGIC = b"DWMJNL1\0"
 JOURNAL_FRAME_MAJOR = 1
@@ -3010,6 +3012,245 @@ def snapshot_generation(update_ids: Sequence[str], plan: Sequence[PlanRow]) -> s
             digest.update(len(encoded).to_bytes(8, "big"))
             digest.update(encoded)
     return digest.hexdigest()
+
+
+class OperationProtocolError(ValueError):
+    """An operation stream would violate its closed lifecycle or field bounds."""
+
+
+class OperationStream:
+    """Emit bounded progress and one validated terminal/audit/completion bundle.
+
+    The owner supplies only durably reached lifecycle states. This formatter
+    never starts a service call or commits a journal frame. A failed output
+    write poisons the stream so callers cannot retry a possibly partial record.
+    """
+
+    def __init__(
+        self, operation_id: str, action_id: str, started_at: str, detail: str,
+        write: Callable[[str], object],
+    ) -> None:
+        if (
+            not isinstance(operation_id, str)
+            or JOURNAL_OPERATION_ID_PATTERN.fullmatch(operation_id) is None
+            or not isinstance(action_id, str)
+            or action_id not in JOURNAL_OPERATION_ACTION_KINDS
+            or not callable(write)
+        ):
+            raise OperationProtocolError("operation stream identity is invalid")
+        _validate_journal_timestamp(started_at, "operation start")
+        _validate_journal_detail(detail)
+        self.operation_id = operation_id
+        self.action_id = action_id
+        self.kind = JOURNAL_OPERATION_ACTION_KINDS[action_id]
+        self.started_at = started_at
+        self.state = "pending"
+        self.progress_records = 0
+        self.closed = False
+        self.faulted = False
+        self._write = write
+        self._last_progress: tuple[str, bool, str] | None = None
+        self._send([
+            f"system-management-protocol\t{PROTOCOL_MAJOR}\t{PROTOCOL_MINOR}",
+            self._operation_line("pending", "unknown", False, detail),
+        ])
+
+    def _send(self, lines: Sequence[str]) -> None:
+        if self.closed or self.faulted:
+            raise OperationProtocolError("operation stream is no longer writable")
+        try:
+            self._write("\n".join(lines) + "\n")
+        except BaseException:
+            self.faulted = True
+            raise
+
+    def _operation_line(
+        self, state: str, percent: str, cancelable: bool, detail: str,
+    ) -> str:
+        return "\t".join((
+            "operation", self.operation_id, self.action_id, self.kind, state,
+            percent, "yes" if cancelable else "no", detail,
+        ))
+
+    def transition(
+        self, state: str, detail: str, *, percent: int | None = None,
+        cancelable: bool = False,
+    ) -> bool:
+        """Emit a reached state; coalesce and cap only repeated progress rows."""
+        if self.closed or self.faulted:
+            raise OperationProtocolError("operation stream is no longer writable")
+        if (
+            not isinstance(state, str)
+            or state not in JOURNAL_TRANSITIONS[self.state]
+            or state in JOURNAL_OPERATION_TERMINAL_STATES
+            or type(cancelable) is not bool
+            or (percent is not None and (type(percent) is not int or not 0 <= percent <= 100))
+        ):
+            raise OperationProtocolError("operation progress or transition is invalid")
+        _validate_journal_detail(detail)
+        percentage = "unknown" if percent is None else str(percent)
+        progress = (percentage, cancelable, detail)
+        repeated = state == self.state
+        if repeated and (
+            progress == self._last_progress
+            or self.progress_records >= MAX_OPERATION_PROGRESS_RECORDS
+        ):
+            return False
+        self._send([self._operation_line(state, percentage, cancelable, detail)])
+        self.state = state
+        self._last_progress = progress
+        if repeated:
+            self.progress_records += 1
+        return True
+
+    def finish(self, operation: JournalOperation, *, detail: str | None = None) -> None:
+        """Publish only an exact terminal record after the owner's durable handoff."""
+        if self.closed or self.faulted:
+            raise OperationProtocolError("operation stream is no longer writable")
+        encode_journal_operation(operation)
+        if (
+            operation.operation_id != self.operation_id
+            or operation.action_id != self.action_id
+            or operation.kind != self.kind
+            or operation.started_at != self.started_at
+            or operation.state not in JOURNAL_OPERATION_TERMINAL_STATES
+            or operation.state not in JOURNAL_TRANSITIONS[self.state]
+        ):
+            raise OperationProtocolError("operation terminal identity or transition is invalid")
+        terminal_detail = operation.detail if detail is None else detail
+        _validate_journal_detail(terminal_detail)
+        lines = []
+        if operation.error_code is not None:
+            owner = (
+                "updates" if self.kind in {"refresh", "update"}
+                else "regional" if self.kind in {"timezone", "ntp", "locale"}
+                else {"accounts-open": "accounts", "password-open": "accounts",
+                      "printers-open": "printers", "sources-open": "sources"}[self.action_id]
+            )
+            lines.append(f"error\t{owner}\t{operation.error_code}\t{terminal_detail}")
+        lines.extend([
+            self._operation_line(operation.state, "unknown", False, terminal_detail),
+            "\t".join(("audit", self.operation_id, self.action_id, self.kind,
+                       operation.state, self.started_at, operation.finished_at, terminal_detail)),
+            "complete\toperation",
+        ])
+        self._send(lines)
+        self.state = operation.state
+        self.closed = True
+
+
+def replay_terminal_operation(
+    operation: JournalOperation, write: Callable[[str], object],
+) -> None:
+    """Replay exact retained evidence without opening a service or relaunching a tool."""
+    encode_journal_operation(operation)
+    if operation.state not in JOURNAL_OPERATION_TERMINAL_STATES:
+        raise OperationProtocolError("operation replay requires a terminal record")
+    stream = OperationStream(
+        operation.operation_id, operation.action_id, operation.started_at,
+        "Replaying retained result; observed package comparison is unavailable"
+        if operation.kind == "update" else "Replaying retained operation result",
+        write,
+    )
+    if operation.state == "permission-denied":
+        stream.transition("authorizing", "Replaying the retained authorization result")
+    elif operation.state == "succeeded":
+        stream.transition("running", "Replaying the retained completion result")
+    stream.finish(operation)
+
+
+class ObservedUpdateSummary:
+    """Bounded, nonpersistent comparison of actual PackageKit signals to a preview.
+
+    Preview membership is bounded by the discovery contract. Unexpected package
+    IDs never enter an unbounded set: only 128 distinct samples are retained.
+    Counts and the digest describe signal observations, not an atomic frozen plan.
+    """
+
+    actions = ("install", "update", "remove", "obsolete", "unknown")
+
+    def __init__(self, preview: Sequence[PlanRow]) -> None:
+        if len(preview) > MAX_LIST_RECORDS:
+            raise SnapshotFailure("malformed", "Observed comparison preview is oversized")
+        self._preview: dict[str, str] = {}
+        self._inbound: set[tuple[str, str]] = set()
+        for row in preview:
+            if (
+                not isinstance(row, PlanRow)
+                or row.action not in self.actions[:-1]
+                or not isinstance(row.package_id, str)
+                or row.package_id in self._preview
+            ):
+                raise SnapshotFailure("malformed", "Observed comparison preview is invalid")
+            name, architecture = self._package_key(row.package_id)
+            self._preview[row.package_id] = row.action
+            if row.action == "update":
+                self._inbound.add((name, architecture))
+        enforce_list_budget(preview)
+        self.counts = dict.fromkeys(self.actions, 0)
+        self.samples: list[tuple[str, str]] = []
+        self._matched: set[str] = set()
+        self._different = False
+        self._unknown = False
+        self._digest = hashlib.sha256(b"dwm-titus-update-observed-v1")
+
+    @staticmethod
+    def _package_key(package_id: str) -> tuple[str, str]:
+        if not isinstance(package_id, str):
+            raise SnapshotFailure("malformed", "Observed package identity is invalid")
+        try:
+            package_id.encode("utf-8")
+        except UnicodeEncodeError as error:
+            raise SnapshotFailure("malformed", "Observed package identity is invalid") from error
+        canonical_identity(package_id)
+        parts = package_id.split(";")
+        if len(parts) != 4 or not all(parts[:3]) or "\0" in package_id:
+            raise SnapshotFailure("malformed", "Observed package identity is invalid")
+        return parts[0], parts[2]
+
+    def observe(self, info: int, package_id: str) -> bool:
+        """Digest one accepted action in arrival order, excluding phase-only signals."""
+        if type(info) is not int or not 0 <= info <= G_MAXUINT:
+            raise SnapshotFailure("malformed", "Observed package classification is invalid")
+        key = self._package_key(package_id)
+        if info == 10 or (info == 14 and key in self._inbound):
+            return False
+        action = {11: "update", 12: "install", 13: "remove", 15: "obsolete"}.get(info)
+        if info == 14 and self._preview.get(package_id) == "obsolete":
+            action = "obsolete"
+        if action is None:
+            action = "unknown"
+            self._unknown = True
+        if self.counts[action] == JOURNAL_SEQUENCE_MAX:
+            self._unknown = True
+        else:
+            self.counts[action] += 1
+        for field in (action, package_id):
+            encoded = field.encode("utf-8")
+            self._digest.update(len(encoded).to_bytes(8, "big"))
+            self._digest.update(encoded)
+        if self._preview.get(package_id) == action:
+            self._matched.add(package_id)
+        else:
+            self._different = True
+            sample = (action, package_id)
+            if len(self.samples) < MAX_OPERATION_MISMATCH_SAMPLES and sample not in self.samples:
+                self.samples.append(sample)
+        return True
+
+    def comparison(self, *, final: bool = False) -> str:
+        """Keep incomplete or unclassified evidence explicitly unknown."""
+        if self._unknown:
+            return "unknown"
+        if self._different or (final and len(self._matched) != len(self._preview)):
+            return "yes"
+        return "no" if final else "unknown"
+
+    def detail(self, *, final: bool = False) -> str:
+        """Return a fixed-size aggregate suitable for one operation detail field."""
+        counts = " ".join(f"{action}={self.counts[action]}" for action in self.actions)
+        return (f"Observed signals: {counts}; sha256={self._digest.hexdigest()}; "
+                f"different={self.comparison(final=final)}; mismatch-samples={len(self.samples)}")
 
 
 def build_snapshot(backend: UpdateBackend) -> list[str]:

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -80,6 +80,243 @@ def rows(lines, kind):
     return [line.split("\t") for line in lines if line.startswith(f"{kind}\t")]
 
 
+class OperationStreamTests(unittest.TestCase):
+    operation_id = "op-" + "1" * 32
+    started = "2026-09-05T01:00:00Z"
+    finished = "2026-09-05T00:00:00Z"  # A wall-clock rollback is valid.
+
+    def terminal(self, action="updates-refresh", state="succeeded", error=None):
+        kind = provider.JOURNAL_OPERATION_ACTION_KINDS[action]
+        return provider.JournalOperation(
+            self.operation_id, action, self.started, self.finished, kind, state,
+            error, "Durable result", "a" * 64 if kind == "update" else None,
+            "/18_adcbcaed" if kind in {"refresh", "update"} else None,
+            "none" if kind == "update" else None,
+            "none" if kind == "update" else None,
+            False if kind == "update" else None,
+            "01234567-89ab-cdef-0123-456789abcdef" if kind == "update" else None,
+            123 if kind in {"refresh", "update"} else None, 0,
+        )
+
+    def stream(self, output, action="updates-refresh"):
+        return provider.OperationStream(self.operation_id, action, self.started, "Starting", output.append)
+
+    def test_progress_cap_reserves_every_lifecycle_and_terminal_record(self):
+        output = []
+        stream = self.stream(output)
+        stream.transition("authorizing", "Authorization")
+        stream.transition("running", "Running")
+        for index in range(400):
+            emitted = stream.transition("running", str(index), percent=index % 101, cancelable=True)
+            self.assertEqual(emitted, index < 252)
+        self.assertTrue(stream.transition("cancel-requested", "Cancellation requested", cancelable=False))
+        self.assertFalse(stream.transition("cancel-requested", "Still waiting", percent=100))
+        stream.finish(self.terminal())  # Success may race cancellation.
+        lines = "".join(output).splitlines()
+        operations = rows(lines, "operation")
+        self.assertEqual(len(operations), 257)
+        self.assertEqual([row[4] for row in operations[:3]], ["pending", "authorizing", "running"])
+        self.assertEqual([row[4] for row in operations[-2:]], ["cancel-requested", "succeeded"])
+        self.assertEqual(operations[-1][6], "no")
+        self.assertEqual(rows(lines, "audit")[0][1:7], [self.operation_id, "updates-refresh", "refresh", "succeeded", self.started, self.finished])
+        self.assertEqual(lines[-1], "complete\toperation")
+        self.assertLess(len("".join(output).encode()), 8 * 1024 * 1024)
+        self.assertEqual(stream.progress_records, 252)
+
+    def test_repeated_progress_is_coalesced_but_changed_cancelability_is_visible(self):
+        output = []
+        stream = self.stream(output)
+        stream.transition("running", "Working", percent=0)
+        self.assertFalse(stream.transition("running", "Working", percent=0))
+        self.assertTrue(stream.transition("running", "Working", percent=0, cancelable=True))
+        self.assertEqual(stream.progress_records, 1)
+
+    def test_replay_all_kinds_and_results_preserves_exact_terminal_and_error_owner(self):
+        for action in provider.JOURNAL_OPERATION_ACTION_KINDS:
+            for state in sorted(provider.JOURNAL_OPERATION_TERMINAL_STATES):
+                with self.subTest(action=action, state=state):
+                    error = "internal" if state == "failed" else None
+                    record = self.terminal(action, state, error)
+                    output = []
+                    provider.replay_terminal_operation(record, output.append)
+                    lines = "".join(output).splitlines()
+                    states = [row[4] for row in rows(lines, "operation")]
+                    implied = ["running"] if state == "succeeded" else ["authorizing"] if state == "permission-denied" else []
+                    self.assertEqual(states, ["pending", *implied, state])
+                    self.assertEqual(rows(lines, "operation")[-1][7], record.detail)
+                    self.assertEqual(rows(lines, "audit")[0][-1], record.detail)
+                    self.assertEqual(len(rows(lines, "audit")), 1)
+                    self.assertEqual(len(rows(lines, "complete")), 1)
+                    if error:
+                        owner = "updates" if record.kind in {"refresh", "update"} else "regional" if record.kind != "delegate" else "accounts" if action in {"accounts-open", "password-open"} else action.split("-")[0]
+                        self.assertEqual(rows(lines, "error"), [["error", owner, error, record.detail]])
+                        self.assertEqual(lines[-4].split("\t")[0], "error")
+                    else:
+                        self.assertEqual(rows(lines, "error"), [])
+                    if record.kind == "update":
+                        self.assertIn("comparison is unavailable", rows(lines, "operation")[0][-1])
+
+    def test_invalid_transitions_fields_and_terminal_identity_emit_nothing(self):
+        output = []
+        stream = self.stream(output)
+        before = tuple(output)
+        for state, options in (
+            ("pending", {}), ("cancel-requested", {}), ("succeeded", {}),
+            ("running", {"percent": 101}), ("running", {"percent": True}),
+            ("running", {"percent": "50"}), ("running", {"cancelable": 1}),
+        ):
+            with self.subTest(state=state, options=options), self.assertRaises(ValueError):
+                stream.transition(state, "Invalid", **options)
+            self.assertEqual(tuple(output), before)
+        for detail in ("bad\tvalue", "bad\nvalue", "bad\0value", "x" * 513, "\ud800"):
+            with self.subTest(detail=repr(detail)), self.assertRaises(ValueError):
+                stream.transition("running", detail)
+            self.assertEqual(tuple(output), before)
+        for record in (
+            self.terminal(),  # Success before running is invalid.
+            self.terminal(state="failed"),  # Failed requires an error.
+            replace(self.terminal(state="failed", error="internal"), operation_id="op-" + "2" * 32),
+            replace(self.terminal(state="failed", error="internal"), started_at=self.finished),
+        ):
+            with self.assertRaises(ValueError):
+                stream.finish(record)
+            self.assertEqual(tuple(output), before)
+
+    def test_terminal_error_and_completion_are_final_and_output_failure_is_not_retried(self):
+        output = []
+        stream = self.stream(output)
+        stream.finish(self.terminal(state="failed", error="conflict"))
+        before = tuple(output)
+        with self.assertRaises(ValueError):
+            stream.finish(self.terminal(state="failed", error="conflict"))
+        with self.assertRaises(ValueError):
+            stream.transition("running", "Late")
+        self.assertEqual(tuple(output), before)
+        output = []
+        stream = self.stream(output)
+        broken_pipe = BrokenPipeError("closed consumer")
+        writer = mock.Mock(side_effect=broken_pipe)
+        stream._write = writer
+        with self.assertRaises(BrokenPipeError) as caught:
+            stream.finish(self.terminal(state="interrupted", error="timeout"))
+        self.assertIs(caught.exception, broken_pipe)
+        self.assertTrue(stream.faulted)
+        with self.assertRaises(ValueError):
+            stream.finish(self.terminal(state="interrupted", error="timeout"))
+        writer.assert_called_once()
+
+    def test_live_terminal_summary_is_not_written_into_retained_record(self):
+        record = self.terminal()
+        output = []
+        stream = self.stream(output)
+        stream.transition("running", "Running")
+        stream.finish(record, detail="Live observed summary")
+        self.assertEqual(record.detail, "Durable result")
+        replay = []
+        provider.replay_terminal_operation(record, replay.append)
+        self.assertNotIn("Live observed summary", "".join(replay))
+
+    def test_invalid_construction_or_nonterminal_replay_has_no_output(self):
+        for operation_id, action, started in (
+            ("bad", "updates-refresh", self.started),
+            (self.operation_id, "updates-cancel", self.started),
+            (self.operation_id, "health-open", self.started),
+            (self.operation_id, "updates-refresh", "2026-02-30T00:00:00Z"),
+        ):
+            output = []
+            with self.assertRaises(ValueError):
+                provider.OperationStream(operation_id, action, started, "Starting", output.append)
+            self.assertEqual(output, [])
+        output = []
+        pending = replace(self.terminal(), state="pending", finished_at=None, terminal_monotonic=None)
+        with self.assertRaises(ValueError):
+            provider.replay_terminal_operation(pending, output.append)
+        self.assertEqual(output, [])
+
+
+class ObservedUpdateTests(unittest.TestCase):
+    def preview(self, action="update", package_id="pkg;2;x86_64;updates"):
+        return provider.PlanRow(package_id, action, "pkg", "2", "Preview")
+
+    def test_normalized_digest_matches_fixed_bytes_and_ignores_download_and_old_cleanup(self):
+        preview = [self.preview(), self.preview("install", "dep;1;x86_64;updates"),
+                   self.preview("obsolete", "old;1;noarch;installed")]
+        observed = provider.ObservedUpdateSummary(preview)
+        self.assertFalse(observed.observe(10, "pkg;2;x86_64;updates"))
+        self.assertFalse(observed.observe(14, "pkg;1;x86_64;installed"))
+        accepted = [(11, "update", "pkg;2;x86_64;updates"),
+                    (12, "install", "dep;1;x86_64;updates"),
+                    (14, "obsolete", "old;1;noarch;installed")]
+        expected = hashlib.sha256(b"dwm-titus-update-observed-v1")
+        for info, action, package_id in accepted:
+            self.assertTrue(observed.observe(info, package_id))
+            for field in (action, package_id):
+                encoded = field.encode()
+                expected.update(len(encoded).to_bytes(8, "big") + encoded)
+        self.assertEqual(observed._digest.hexdigest(), expected.hexdigest())
+        self.assertEqual(observed.counts, {"install": 1, "update": 1, "remove": 0, "obsolete": 1, "unknown": 0})
+        self.assertEqual(observed.comparison(), "unknown")
+        self.assertEqual(observed.comparison(final=True), "no")
+        self.assertEqual(observed.samples, [])
+
+    def test_cleanup_uses_architecture_and_exact_obsolete_identity(self):
+        observed = provider.ObservedUpdateSummary([self.preview()])
+        self.assertTrue(observed.observe(14, "pkg;1;i686;installed"))
+        self.assertEqual(observed.counts["unknown"], 1)
+        self.assertEqual(observed.comparison(final=True), "unknown")
+
+    def test_repeated_expected_signals_are_digested_without_unbounded_identity_storage(self):
+        observed = provider.ObservedUpdateSummary([self.preview()])
+        observed.observe(11, "pkg;2;x86_64;updates")
+        digest = observed._digest.hexdigest()
+        observed.observe(11, "pkg;2;x86_64;updates")
+        self.assertNotEqual(observed._digest.hexdigest(), digest)
+        self.assertEqual(observed.counts["update"], 2)
+        self.assertEqual(len(observed._matched), 1)
+        self.assertEqual(observed.comparison(final=True), "no")
+
+    def test_missing_extra_and_unknown_actions_never_report_equal(self):
+        observed = provider.ObservedUpdateSummary([self.preview()])
+        self.assertEqual(observed.comparison(final=True), "yes")
+        observed.observe(11, "pkg;2;x86_64;updates")
+        self.assertEqual(observed.comparison(final=True), "no")
+        observed.observe(13, "other;1;x86_64;installed")
+        self.assertEqual(observed.comparison(), "yes")
+        observed.observe(99, "unknown;1;x86_64;installed")
+        self.assertEqual(observed.comparison(final=True), "unknown")
+
+    def test_samples_and_summary_size_remain_bounded_and_duplicate_samples_coalesce(self):
+        observed = provider.ObservedUpdateSummary([])
+        for index in range(4096):
+            observed.observe(12, f"extra-{index};1;x86_64;updates")
+        observed.observe(12, "extra-0;1;x86_64;updates")
+        self.assertEqual(len(observed.samples), 128)
+        self.assertEqual(observed.counts["install"], 4097)
+        self.assertEqual(len(observed._matched), 0)
+        self.assertEqual(observed.comparison(final=True), "yes")
+        observed.counts = dict.fromkeys(observed.actions, provider.JOURNAL_SEQUENCE_MAX)
+        observed.observe(12, "extra-0;1;x86_64;updates")
+        self.assertEqual(observed.counts["install"], provider.JOURNAL_SEQUENCE_MAX)
+        self.assertEqual(observed.comparison(final=True), "unknown")
+        self.assertLessEqual(len(observed.detail(final=True).encode()), 512)
+
+    def test_invalid_input_cannot_change_counts_or_digest(self):
+        observed = provider.ObservedUpdateSummary([])
+        before = observed.detail(final=True)
+        for info, package_id in ((True, "pkg;1;x86_64;repo"), (-1, "pkg;1;x86_64;repo"),
+                                 (12, "malformed"), (12, "pkg;1;;repo"),
+                                 (12, "pkg;1;x86_64;bad\nrepo"), (12, "\ud800;1;x86_64;repo"),
+                                 (12, "x" * 513), (12, "pkg;1;x86_64;bad\0repo")):
+            with self.subTest(info=info, package_id=repr(package_id)), self.assertRaises(provider.SnapshotFailure):
+                observed.observe(info, package_id)
+            self.assertEqual(observed.detail(final=True), before)
+        for preview in ([self.preview(), self.preview()], [self.preview("reinstall")],
+                        [self.preview("downgrade")], [replace(self.preview(), package_id=[])],
+                        [None], [self.preview()] * 4097):
+            with self.assertRaises(provider.SnapshotFailure):
+                provider.ObservedUpdateSummary(preview)
+
+
 class SnapshotTests(unittest.TestCase):
     def test_complete_read_only_snapshot(self):
         backend = FixtureBackend(


### PR DESCRIPTION
## Summary
- Add an operation formatter with closed lifecycle transitions, exact terminal/audit identity, a separate 252-record progress cap, coalescing, and fail-closed output handling.
- Replay every retained operation kind with its minimum implied lifecycle and exact terminal evidence, without opening a service or relaunching a tool.
- Compare actual PackageKit observations to the preview using bounded action counts, an arrival-ordered SHA-256 digest, and at most 128 distinct mismatch samples. Downloads and matching old-version cleanup are excluded; unexplained actions remain unknown.
- Keep live observed summaries out of retained journal records, and document remaining integration in TASKS.md.

This is the operation runtime boundary for Phase 6. It does not yet enable update commands or change QML; PackageKit execution/recovery and its root-scoped confirmation UI remain subsequent work.

## Validation
- `scripts/run-tests make check-system-management`: PASS, 158 tests.
- `scripts/run-tests make clean all`: PASS.
- `scripts/run-tests`: PASS, including nested-X11 Settings, system-management lifecycle, staged installation, repeated-install preservation, and release validation.
- Post-suite built-in Codex review: no actionable defects.
- Independent CodeRabbit local review: zero findings.
- `git diff --check`: PASS.

Fedora 44 x86_64. Closed Settings CPU 0.067%; closed large surfaces 0.00%. No live package mutation or desktop installation was performed by this boundary. Its pure formatter and comparison tests do not claim PackageKit execution coverage.