### PR TITLE
feat(system): add journaled PackageKit execution owner

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -60,9 +60,16 @@ The operation formatter reserves required lifecycle records separately from its
 bounded progress budget, validates terminal/audit identity, and replays retained
 results without an external action. Observed package comparisons use bounded
 counts and mismatch samples plus an arrival-ordered digest; they are not persisted
-as an atomic completed plan. PackageKit execution/recovery integration and its
-root-scoped confirmation and operation UI remain to be completed before this
-boundary can be accepted.
+as an atomic completed plan. The internal PackageKit execution owner now gates
+mutations on the installed security floor and running daemon version (with exact
+running-executable identity required for the same-version Fedora backport), dispatches
+only a durably admitted exact transaction, checkpoints restart signals, and
+observes through terminal evidence even after a lost method reply. Persistence
+failure suppresses terminal success and permits only narrowly bound cancellation.
+Fake-bus coverage exercises these paths without changing host packages. Public
+mutation commands remain disabled: fresh-plan confirmation, recovery integration,
+and the root-scoped operation UI must be completed before this boundary can be
+accepted.
 
 - [ ] Add user-initiated Fedora update discovery and status through the selected
   stable package-management interface.

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -9,12 +9,13 @@ import fcntl
 import hashlib
 import os
 import re
+import shlex
 import stat
 import struct
 import sys
 import time
 from dataclasses import dataclass, replace
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Callable, Iterable, Iterator, Mapping, Protocol, Sequence
 
 
@@ -3413,6 +3414,293 @@ def build_snapshot(backend: UpdateBackend) -> list[str]:
     return lines
 
 
+def packagekit_security_floor(
+    version: str, release: str, fedora_release: str,
+    daemon_version: tuple[int, int, int], compare: Callable,
+) -> bool:
+    """Use RPM ordering, including Fedora 44's explicitly patched backport."""
+    if (
+        not isinstance(version, str) or not isinstance(release, str)
+        or len(version) > 128 or len(release) > 128
+        or re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:[~^][0-9A-Za-z.+_-]+)?", version) is None
+        or re.fullmatch(r"[0-9A-Za-z.+_~^-]+", release) is None
+        or not isinstance(daemon_version, tuple) or len(daemon_version) != 3
+        or any(type(value) is not int or not 0 <= value <= G_MAXUINT for value in daemon_version)
+    ):
+        return False
+    numeric = re.match(r"([0-9]+)\.([0-9]+)\.([0-9]+)", version)
+    if tuple(int(value) for value in numeric.groups()) != daemon_version:
+        return False
+    candidate = ("0", version, release)
+    return compare(candidate, ("0", "1.3.5", "0")) >= 0 or (
+        fedora_release == "44" and version == "1.3.4"
+        and re.fullmatch(r"[0-9]+(?:\.[0-9]+)*\.fc44(?:\.[0-9]+)*", release) is not None
+        and compare(candidate, ("0", "1.3.4", "3.fc44")) >= 0
+    )
+
+
+def read_fedora_identity() -> dict[str, str]:
+    """Read only the fixed platform identity keys; never evaluate shell content."""
+    try:
+        with open("/etc/os-release", "rb") as source:
+            data = source.read(65537)
+        if len(data) > 65536:
+            raise ValueError
+        identity = {}
+        for line in data.decode("utf-8").splitlines():
+            key = line.partition("=")[0]
+            if key not in {"ID", "VERSION_ID"}:
+                continue
+            fields = shlex.split(line, comments=True)
+            if len(fields) != 1 or key in identity or "=" not in fields[0]:
+                raise ValueError
+            identity[key] = fields[0].partition("=")[2]
+        if identity.get("ID") != "fedora":
+            raise SnapshotFailure("unsupported", "System changes are supported only on Fedora", "unsupported")
+        return identity
+    except (OSError, UnicodeError, ValueError) as error:
+        raise SnapshotFailure("unsupported", "Fedora platform identity is unavailable", "unsupported") from error
+
+
+class PackageKitMutation:
+    """Own one exact journaled transaction; callbacks never hold a service-wait lock."""
+
+    def __init__(
+        self, journal: JournalDescriptorSet, operation: JournalOperation,
+        write: Callable[[str], object], preview: Sequence[PlanRow],
+        boot_id: str, session_started: int | None,
+    ) -> None:
+        self.journal = journal
+        self.operation = operation
+        self.boot_id = boot_id
+        self.session_started = session_started
+        self.stream = OperationStream(operation.operation_id, operation.action_id,
+                                      operation.started_at, operation.detail, write)
+        self.observed = ObservedUpdateSummary(preview) if operation.kind == "update" else None
+        self.sent = False
+        self.allow_cancel = False
+        self.percent: int | None = None
+        self.last_status = 0
+        self.progress_warning = ""
+        self.failure: SnapshotFailure | None = None
+        self.persistence_error: Exception | None = None
+        self.output_error: Exception | None = None
+        self.terminal: JournalOperation | None = None
+
+    def _current(self) -> JournalOperation:
+        current = load_writable_journal_state(self.journal).active
+        identity = ("operation_id", "action_id", "kind", "started_at", "generation",
+                    "transaction_path", "boot_id", "slot")
+        if current is None or any(getattr(current, key) != getattr(self.operation, key) for key in identity):
+            raise JournalAdmissionError("PackageKit operation ownership changed")
+        if current.state in JOURNAL_OPERATION_TERMINAL_STATES:
+            raise JournalAdmissionError("PackageKit operation was terminalized by another observer")
+        return current
+
+    def _output(self, callback: Callable[[], object]) -> None:
+        if self.output_error is None:
+            try:
+                callback()
+            except Exception as error:
+                if not self.stream.faulted:
+                    raise
+                self.output_error = error
+
+    def _sync_stream(self) -> None:
+        target = self.operation.state
+        if self.output_error is not None or target == self.stream.state:
+            return
+        if target == "authorizing":
+            self._output(lambda: self.stream.transition("authorizing", self.operation.detail))
+        else:
+            if self.stream.state in {"pending", "authorizing"}:
+                self._output(lambda: self.stream.transition("running", "PackageKit is processing the transaction"))
+            if target == "cancel-requested" and self.stream.state != target:
+                self._output(lambda: self.stream.transition("cancel-requested", "PackageKit cancellation requested"))
+
+    def _checkpoint(self, state: str | None = None, **changes: object) -> None:
+        if self.persistence_error is not None:
+            return
+        try:
+            with lock_writable_journal(self.journal):
+                current = self._current()
+                target = state or current.state
+                if target in {"authorizing", "running"} and current.state == "cancel-requested":
+                    target = current.state
+                if target == "authorizing" and current.state == "running":
+                    target = current.state
+                for key, strength in (("system_restart", JOURNAL_RESTART_SYSTEM_STRENGTH),
+                                      ("session_restart", JOURNAL_RESTART_SESSION_STRENGTH)):
+                    if key in changes:
+                        changes[key] = max(getattr(current, key), changes[key], key=strength.__getitem__)
+                if target != current.state and "detail" not in changes:
+                    changes["detail"] = "PackageKit cancellation requested" if target == "cancel-requested" else "PackageKit is processing the transaction"
+                following = replace(current, state=target, **changes)
+                self.operation = advance_journal_operation(self.journal, current, following)
+            self._sync_stream()
+        except (JournalFileError, JournalRecordError, JournalFrameError, JournalAdmissionError) as error:
+            self.persistence_error = error
+
+    def before_send(self) -> None:
+        self._checkpoint("authorizing", detail="PackageKit authorization is pending")
+        if self.persistence_error is not None:
+            raise self.persistence_error
+        if self.output_error is not None:
+            raise self.output_error
+        self.journal.validate()
+        self.sent = True
+
+    def after_send(self) -> None:
+        try:
+            self.journal.validate()
+        except JournalFileError as error:
+            self.persistence_error = error
+
+    def _detail(self) -> str:
+        detail = self.observed.detail() if self.observed is not None else "PackageKit metadata refresh is running"
+        return clean_text(f"{detail}; {self.progress_warning}" if self.progress_warning else detail)
+
+    def _progress(self) -> None:
+        if self.persistence_error is None and self.operation.state in {"running", "cancel-requested"}:
+            self._output(lambda: self.stream.transition(self.operation.state, self._detail(),
+                                                       percent=self.percent, cancelable=self.allow_cancel))
+
+    def on_properties(self, properties: Mapping[str, object]) -> None:
+        old_progress = (self.percent, self.allow_cancel, self.progress_warning)
+        if "AllowCancel" in properties:
+            value = properties["AllowCancel"]
+            self.allow_cancel = value if type(value) is bool else False
+            if type(value) is not bool:
+                self.progress_warning = "PackageKit cancellation state is malformed"
+        if "Percentage" in properties:
+            value = properties["Percentage"]
+            self.percent = value if type(value) is int and 0 <= value <= 100 else None
+            if type(value) is not int or not 0 <= value <= 101:
+                self.progress_warning = "PackageKit percentage is malformed; progress is unknown"
+        if "Status" in properties:
+            status = properties["Status"]
+            if type(status) is int and 0 <= status <= 36:
+                self.last_status = status
+                if status not in {0, 1, 2, 18, 31} and self.operation.state not in {"running", "cancel-requested"}:
+                    self._checkpoint("running")
+            else:
+                self.progress_warning = "PackageKit phase is unknown"
+        if old_progress != (self.percent, self.allow_cancel, self.progress_warning):
+            # A cooperating cancel control may have checkpointed while the
+            # transaction was running. Reconcile its exact identity once here.
+            self._checkpoint()
+            self._progress()
+
+    def on_package(self, info: int, package_id: str) -> None:
+        if self.observed is None or self.persistence_error is not None:
+            return
+        previous = (self.observed.comparison(), len(self.observed.samples))
+        try:
+            self.observed.observe(info, package_id)
+        except SnapshotFailure as error:
+            self.failure = self.failure or error
+            return
+        if self.operation.state not in {"running", "cancel-requested"}:
+            self._checkpoint("running")
+        if previous != (self.observed.comparison(), len(self.observed.samples)):
+            self._progress()
+
+    def on_restart(self, value: int) -> None:
+        if self.operation.kind != "update" or self.persistence_error is not None:
+            return
+        changes = {}
+        if value == 2:
+            changes["application_restart"] = True
+        elif value in {3, 5}:
+            requested = "security-session" if value == 5 else "session"
+            changes["session_restart"] = max(self.operation.session_restart, requested,
+                key=JOURNAL_RESTART_SESSION_STRENGTH.__getitem__)
+        elif value != 1:
+            requested = {4: "system", 6: "security-system"}.get(value, "unknown")
+            changes["system_restart"] = max(self.operation.system_restart, requested,
+                key=JOURNAL_RESTART_SYSTEM_STRENGTH.__getitem__)
+        if changes and any(getattr(self.operation, key) != value for key, value in changes.items()):
+            self._checkpoint(**changes)
+
+    def finish(self, state: str, failure: SnapshotFailure | None = None) -> None:
+        cutoff = time.monotonic_ns() // 1000
+        finished_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        if self.persistence_error is not None or self.terminal is not None:
+            return
+        try:
+            with lock_writable_journal(self.journal):
+                self.operation = self._current()
+            self._sync_stream()
+            if state == "succeeded":
+                self._checkpoint("running")
+            elif state == "permission-denied" and self.operation.state in {"running", "cancel-requested"}:
+                state = "failed"
+            elif state == "canceled" and self.operation.state == "running":
+                self._checkpoint("cancel-requested")
+            if self.persistence_error is not None:
+                return
+            with lock_writable_journal(self.journal):
+                current = self._current()
+                contribution = current.system_restart
+                pre_running = current.state in {"pending", "authorizing"}
+                excluded = state == "permission-denied" or (state == "canceled" and pre_running and self.last_status == 31)
+                if current.kind == "update" and self.sent and not excluded and state != "succeeded" and contribution == "none":
+                    contribution = "unknown"
+                terminal = replace(current, state=state, finished_at=finished_at,
+                                   error_code=None if failure is None else failure.code,
+                                   detail="PackageKit transaction completed" if failure is None else failure.detail,
+                                   system_restart=contribution, terminal_monotonic=cutoff)
+                advance_journal_operation(self.journal, current, terminal)
+                complete_journal_terminal(self.journal, boot_id=self.boot_id,
+                                          session_started=self.session_started)
+            self.terminal = terminal
+            detail = terminal.detail
+            if self.observed is not None:
+                detail = clean_text(f"{self.observed.detail(final=True)}; {detail}")
+            self._output(lambda: self.stream.finish(terminal, detail=detail))
+        except (JournalFileError, JournalRecordError, JournalFrameError, JournalAdmissionError) as error:
+            self.persistence_error = error
+
+
+def run_packagekit_mutation(
+    journal: JournalDescriptorSet, backend: PackageKitBackend, action_id: str,
+    write: Callable[[str], object], *, boot_id: str, session_started: int | None = None,
+    generation: str | None = None, package_ids: Sequence[str] = (), preview: Sequence[PlanRow] = (),
+) -> JournalOperation:
+    """Run an already revalidated confirmed plan; no public command enables this yet."""
+    if action_id not in {"updates-refresh", "updates-install-all"}:
+        raise SnapshotFailure("unsupported", "Unsupported PackageKit mutation", "unsupported")
+    if action_id == "updates-install-all":
+        ObservedUpdateSummary(preview)
+        if (
+            not isinstance(generation, str) or JOURNAL_GENERATION_PATTERN.fullmatch(generation) is None
+            or not package_ids or len(package_ids) > MAX_LIST_RECORDS
+            or any(not isinstance(package_id, str) for package_id in package_ids)
+            or len(set(package_ids)) != len(package_ids)
+            or not set(package_ids).issubset({row.package_id for row in preview if row.action == "update"})
+        ):
+            raise SnapshotFailure("malformed", "Confirmed PackageKit update inputs are invalid")
+    elif generation is not None or package_ids or preview:
+        raise SnapshotFailure("malformed", "Metadata refresh cannot select packages")
+    backend.require_mutation_safe()
+    path = backend.create_mutation()
+    if not isinstance(path, str) or JOURNAL_PACKAGEKIT_PATH_PATTERN.fullmatch(path) is None:
+        raise SnapshotFailure("malformed", "PackageKit returned an invalid operation path")
+    with lock_writable_journal(journal):
+        operation = begin_journal_operation(journal, action_id,
+            datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"), "Starting PackageKit operation",
+            transaction_path=path, generation=generation, boot_id=boot_id)
+    owner = PackageKitMutation(journal, operation, write, preview, boot_id, session_started)
+    backend.execute_mutation(owner, package_ids)
+    if owner.persistence_error is not None:
+        raise owner.persistence_error
+    if owner.output_error is not None:
+        raise owner.output_error
+    if owner.terminal is None:
+        raise SnapshotFailure("interrupted", "PackageKit observation ended without a durable terminal result")
+    return owner.terminal
+
+
 class PackageKitBackend:
     """Small direct D-Bus client with transaction-wide monotonic deadlines."""
 
@@ -3439,6 +3727,7 @@ class PackageKitBackend:
                 "simulate;only-trusted"
             )
         )
+        self.flags_only_trusted = PackageKitGlib.transaction_flag_bitfield_from_string("only-trusted")
         try:
             self.connection = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
         except GLib.Error as error:
@@ -3489,7 +3778,7 @@ class PackageKitBackend:
         if "notauthorized" in lowered or "accessdenied" in lowered:
             return SnapshotFailure(
                 "permission-denied",
-                "PackageKit denied the read-only request",
+                "PackageKit denied the request",
                 "restricted",
             )
         if "unknownmethod" in lowered:
@@ -3521,6 +3810,223 @@ class PackageKitBackend:
                 "malformed", "PackageKit returned a malformed refresh age"
             )
         return values[0]
+
+    def require_mutation_safe(self) -> None:
+        """Keep discovery readable while rejecting unknown or vulnerable mutation owners."""
+        identity = read_fedora_identity()
+        try:
+            import rpm
+        except ImportError as error:
+            raise SnapshotFailure("missing-provider", "System RPM bindings are unavailable", "unavailable") from error
+        try:
+            headers = []
+            for header in rpm.TransactionSet().dbMatch("name", "PackageKit"):
+                headers.append(header)
+                if len(headers) > 1:
+                    break
+            if len(headers) != 1 or headers[0]["epoch"] not in (None, 0):
+                raise ValueError
+            values = self._call(PACKAGEKIT_PATH, PROPERTIES_INTERFACE, "GetAll",
+                self.GLib.Variant("(s)", (PACKAGEKIT_INTERFACE,)), time.monotonic() + 10).unpack()
+            if len(values) != 1 or not isinstance(values[0], dict):
+                raise ValueError
+            properties = values[0]
+            version = tuple(properties.get(key) for key in ("VersionMajor", "VersionMinor", "VersionMicro"))
+            if not packagekit_security_floor(headers[0]["version"], headers[0]["release"],
+                                            identity.get("VERSION_ID", ""), version, rpm.labelCompare):
+                raise ValueError
+            if version == (1, 3, 4):
+                self._require_running_backport_identity()
+        except (OSError, ValueError, TypeError, KeyError, rpm.error) as error:
+            raise SnapshotFailure("unsupported", "PackageKit requires 1.3.5 or Fedora 44 security backport 1.3.4-3.fc44", "unsupported") from error
+
+    def _require_running_backport_identity(self) -> None:
+        """A release-only security fix needs more than the daemon's semantic version."""
+        deadline = time.monotonic() + 10
+
+        def bus_identity(method: str, argument: str) -> object:
+            values = self.connection.call_sync(
+                "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                method, self.GLib.Variant("(s)", (argument,)), None,
+                self.Gio.DBusCallFlags.NONE, self._timeout_ms(deadline), None).unpack()
+            if len(values) != 1:
+                raise ValueError
+            return values[0]
+
+        try:
+            owner = bus_identity("GetNameOwner", PACKAGEKIT_NAME)
+            if not isinstance(owner, str) or re.fullmatch(r":[0-9]+\.[0-9]+", owner) is None:
+                raise ValueError
+            pid = bus_identity("GetConnectionUnixProcessID", owner)
+            if type(pid) is not int or not 0 < pid <= 2_147_483_647:
+                raise ValueError
+            installed = os.stat("/usr/libexec/packagekitd", follow_symlinks=False)
+            running = os.stat(f"/proc/{pid}/exe")
+            if any(not stat.S_ISREG(item.st_mode) or item.st_uid != 0 or item.st_mode & 0o022
+                   for item in (installed, running)):
+                raise ValueError
+            if (installed.st_dev, installed.st_ino) != (running.st_dev, running.st_ino):
+                raise ValueError
+            if bus_identity("GetNameOwner", PACKAGEKIT_NAME) != owner:
+                raise ValueError
+        except (OSError, ValueError, TypeError, self.GLib.Error, SnapshotFailure) as error:
+            # Some Fedora procfs policies deny this read to session clients.
+            # Do not elevate or guess that a same-version daemon was restarted.
+            raise SnapshotFailure("unsupported", "Cannot verify the running PackageKit security backport; PackageKit 1.3.5 or newer is required when executable identity is unreadable", "unsupported") from error
+
+    def create_mutation(self) -> str:
+        """Create and configure an empty transaction, without invoking package work."""
+        deadline = time.monotonic() + 10
+        result = self._call(PACKAGEKIT_PATH, PACKAGEKIT_INTERFACE, "CreateTransaction", None, deadline).unpack()
+        if len(result) != 1 or not isinstance(result[0], str) or JOURNAL_PACKAGEKIT_PATH_PATTERN.fullmatch(result[0]) is None:
+            raise SnapshotFailure("malformed", "PackageKit returned an invalid operation path")
+        path = result[0]
+        self._call(path, TRANSACTION_INTERFACE, "SetHints",
+                   self.GLib.Variant("(as)", (["background=false", "interactive=true"],)), deadline)
+        return path
+
+    def execute_mutation(self, owner: PackageKitMutation, package_ids: Sequence[str]) -> None:
+        """Observe the exact object through Finished; a missing reply is not a result."""
+        path = owner.operation.transaction_path
+        method = "RefreshCache" if owner.operation.kind == "refresh" else "UpdatePackages"
+        parameters = self.GLib.Variant("(b)", (True,)) if method == "RefreshCache" else self.GLib.Variant("(tas)", (self.flags_only_trusted, list(package_ids)))
+        loop = self.GLib.MainLoop()
+        request = self.Gio.Cancellable()
+        active = True
+        cancel_sent = False
+        call_failure: SnapshotFailure | None = None
+        subscriptions = []
+
+        def stop(state: str, failure: SnapshotFailure | None = None) -> None:
+            nonlocal active
+            if not active:
+                return
+            active = False
+            try:
+                owner.finish(state, failure)
+            finally:
+                loop.quit()
+
+        def cancel_faulted() -> None:
+            nonlocal cancel_sent
+            if not active or cancel_sent or not owner.allow_cancel or not (owner.persistence_error or owner.failure):
+                return
+            deadline = time.monotonic() + CANCEL_GRACE_SECONDS
+            try:
+                reply = self._call(path, PROPERTIES_INTERFACE, "Get",
+                    self.GLib.Variant("(ss)", (TRANSACTION_INTERFACE, "AllowCancel")), deadline).unpack()
+                allowed = len(reply) == 1 and type(reply[0]) is bool and reply[0]
+                owner.allow_cancel = bool(allowed)
+                if allowed:
+                    cancel_sent = True
+                    if owner.persistence_error is None:
+                        if owner.operation.state == "running":
+                            owner._checkpoint("cancel-requested")
+                        owner.journal.validate()
+                    try:
+                        self._call(path, TRANSACTION_INTERFACE, "Cancel", None, deadline)
+                    finally:
+                        owner.after_send()
+            except (SnapshotFailure, JournalFileError):
+                pass
+
+        def signal_received(_connection, _sender, _path, interface, signal, values, _data):
+            if not active:
+                return
+            try:
+                unpacked = values.unpack()
+                if interface == PROPERTIES_INTERFACE:
+                    if len(unpacked) != 3 or unpacked[0] != TRANSACTION_INTERFACE or not isinstance(unpacked[1], dict):
+                        raise ValueError
+                    properties = dict(unpacked[1])
+                    if not isinstance(unpacked[2], (list, tuple)):
+                        raise ValueError
+                    # Never retain an invalidated cancellation permission.
+                    for key in unpacked[2]:
+                        if key in {"Status", "Percentage", "AllowCancel"}:
+                            properties[key] = None
+                    owner.on_properties(properties)
+                elif signal in {"Package", "Packages"}:
+                    packages = [unpacked] if signal == "Package" else unpacked[0] if len(unpacked) == 1 else None
+                    if not isinstance(packages, (list, tuple)):
+                        raise ValueError
+                    for item in packages:
+                        if len(item) != 3:
+                            raise ValueError
+                        owner.on_package(item[0], item[1])
+                elif signal == "RequireRestart":
+                    if len(unpacked) != 2 or type(unpacked[0]) is not int:
+                        raise ValueError
+                    owner.on_restart(unpacked[0])
+                elif signal == "ErrorCode":
+                    if len(unpacked) != 2 or type(unpacked[0]) is not int:
+                        raise ValueError
+                    owner.failure = owner.failure or self._transaction_failure(unpacked[0], "")
+                elif signal == "Finished":
+                    if len(unpacked) != 2 or type(unpacked[0]) is not int:
+                        raise ValueError
+                    failure = owner.failure
+                    if failure is not None:
+                        state = "permission-denied" if failure.code == "permission-denied" else "canceled" if failure.code == "canceled" else "failed"
+                        stop(state, failure)
+                    elif unpacked[0] == EXIT_SUCCESS:
+                        stop("succeeded")
+                    elif unpacked[0] == 3:
+                        stop("canceled", SnapshotFailure("canceled", "PackageKit canceled the transaction"))
+                    else:
+                        stop("failed", SnapshotFailure("internal", "PackageKit transaction did not succeed"))
+                elif signal == "Destroy":
+                    stop("interrupted", call_failure or SnapshotFailure("interrupted", "PackageKit object disappeared without a terminal result; refresh status before retrying"))
+                cancel_faulted()
+            except (TypeError, ValueError, IndexError):
+                owner.failure = SnapshotFailure("malformed", "PackageKit sent malformed transaction evidence")
+                if signal == "Finished":
+                    stop("interrupted", owner.failure)
+                else:
+                    cancel_faulted()
+
+        def owner_changed(_connection, _sender, _path, _interface, _signal, values, _data):
+            unpacked = values.unpack()
+            if len(unpacked) == 3 and unpacked[0] == PACKAGEKIT_NAME and unpacked[1] != unpacked[2]:
+                stop("interrupted", SnapshotFailure("missing-provider", "PackageKit service changed; transaction outcome is unknown"))
+
+        def method_finished(connection, result, _data):
+            nonlocal call_failure
+            try:
+                connection.call_finish(result)
+            except self.GLib.Error as error:
+                if active:
+                    call_failure = self._dbus_failure(error)
+                    if call_failure.code == "permission-denied":
+                        stop("permission-denied", call_failure)
+                    else:
+                        owner.progress_warning = "PackageKit method reply failed; still observing the exact transaction"
+                        owner._progress()
+
+        closed_handler = self.connection.connect("closed", lambda *_args: stop("interrupted", SnapshotFailure("missing-provider", "System bus connection closed; transaction outcome is unknown")))
+        try:
+            subscriptions.append(self.connection.signal_subscribe(PACKAGEKIT_NAME, TRANSACTION_INTERFACE, None, path, None, self.Gio.DBusSignalFlags.NONE, signal_received, None))
+            subscriptions.append(self.connection.signal_subscribe(PACKAGEKIT_NAME, PROPERTIES_INTERFACE, "PropertiesChanged", path, TRANSACTION_INTERFACE, self.Gio.DBusSignalFlags.NONE, signal_received, None))
+            subscriptions.append(self.connection.signal_subscribe("org.freedesktop.DBus", "org.freedesktop.DBus", "NameOwnerChanged", "/org/freedesktop/DBus", PACKAGEKIT_NAME, self.Gio.DBusSignalFlags.NONE, owner_changed, None))
+            owner.before_send()
+            try:
+                self.connection.call(PACKAGEKIT_NAME, path, TRANSACTION_INTERFACE, method, parameters,
+                    self.GLib.VariantType.new("()"), self.Gio.DBusCallFlags.ALLOW_INTERACTIVE_AUTHORIZATION,
+                    60000, request, method_finished, None)
+            finally:
+                owner.after_send()
+            cancel_faulted()
+            if active:
+                # Silence is not terminal evidence: authorization or a package
+                # script can remain quiet while the exact backend is still live.
+                # An idle watchdog must not clear admission by terminalizing it.
+                loop.run()
+        finally:
+            active = False
+            request.cancel()
+            for subscription in subscriptions:
+                self.connection.signal_unsubscribe(subscription)
+            self.connection.disconnect(closed_handler)
 
     def updates(self) -> TransactionResult:
         return self._transaction(

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -3451,7 +3451,7 @@ def read_fedora_identity() -> dict[str, str]:
             key = line.partition("=")[0]
             if key not in {"ID", "VERSION_ID"}:
                 continue
-            fields = shlex.split(line, comments=True)
+            fields = shlex.split(line, comments=False)
             if len(fields) != 1 or key in identity or "=" not in fields[0]:
                 raise ValueError
             identity[key] = fields[0].partition("=")[2]
@@ -3584,6 +3584,7 @@ class PackageKitMutation:
                 if status not in {0, 1, 2, 18, 31} and self.operation.state not in {"running", "cancel-requested"}:
                     self._checkpoint("running")
             else:
+                self.last_status = 0
                 self.progress_warning = "PackageKit phase is unknown"
         if old_progress != (self.percent, self.allow_cancel, self.progress_warning):
             # A cooperating cancel control may have checkpointed while the
@@ -3622,7 +3623,8 @@ class PackageKitMutation:
         if changes and any(getattr(self.operation, key) != value for key, value in changes.items()):
             self._checkpoint(**changes)
 
-    def finish(self, state: str, failure: SnapshotFailure | None = None) -> None:
+    def finish(self, state: str, failure: SnapshotFailure | None = None,
+               *, invocation_rejected: bool = False) -> None:
         cutoff = time.monotonic_ns() // 1000
         finished_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         if self.persistence_error is not None or self.terminal is not None:
@@ -3643,7 +3645,8 @@ class PackageKitMutation:
                 current = self._current()
                 contribution = current.system_restart
                 pre_running = current.state in {"pending", "authorizing"}
-                excluded = state == "permission-denied" or (state == "canceled" and pre_running and self.last_status == 31)
+                excluded = state == "permission-denied" or (pre_running and (
+                    invocation_rejected or (state == "canceled" and self.last_status == 31)))
                 if current.kind == "update" and self.sent and not excluded and state != "succeeded" and contribution == "none":
                     contribution = "unknown"
                 terminal = replace(current, state=state, finished_at=finished_at,
@@ -3787,6 +3790,8 @@ class PackageKitBackend:
                 "PackageKit does not support the required method",
                 "unsupported",
             )
+        if "invalidargs" in lowered:
+            return SnapshotFailure("malformed", "PackageKit rejected the method arguments")
         if "timedout" in lowered or "timeout" in lowered:
             return SnapshotFailure(
                 "timeout", "PackageKit request timed out", "unavailable"
@@ -3897,13 +3902,14 @@ class PackageKitBackend:
         call_failure: SnapshotFailure | None = None
         subscriptions = []
 
-        def stop(state: str, failure: SnapshotFailure | None = None) -> None:
+        def stop(state: str, failure: SnapshotFailure | None = None,
+                 *, invocation_rejected: bool = False) -> None:
             nonlocal active
             if not active:
                 return
             active = False
             try:
-                owner.finish(state, failure)
+                owner.finish(state, failure, invocation_rejected=invocation_rejected)
             finally:
                 loop.quit()
 
@@ -3999,6 +4005,13 @@ class PackageKitBackend:
                     call_failure = self._dbus_failure(error)
                     if call_failure.code == "permission-denied":
                         stop("permission-denied", call_failure)
+                    elif self.Gio.dbus_error_get_remote_error(error) in {
+                        "org.freedesktop.DBus.Error.UnknownMethod",
+                        "org.freedesktop.DBus.Error.InvalidArgs",
+                        "org.freedesktop.DBus.Error.UnknownInterface",
+                        "org.freedesktop.DBus.Error.UnknownObject",
+                    }:
+                        stop("failed", call_failure, invocation_rejected=True)
                     else:
                         owner.progress_warning = "PackageKit method reply failed; still observing the exact transaction"
                         owner._progress()

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import threading
 import time
+import types
 import unittest
 from dataclasses import replace
 from unittest import mock
@@ -4509,6 +4510,416 @@ class SnapshotValidationTests(unittest.TestCase):
 
         self.assertEqual(rows(output, "update"), [])
         self.assertEqual(rows(output, "error")[0][2], "malformed")
+
+
+class PackageKitSafetyTests(unittest.TestCase):
+    def test_backport_gate_is_required_before_mutation_is_enabled(self):
+        for micro in (4, 6):
+            with self.subTest(micro=micro):
+                backend = provider.PackageKitBackend.__new__(provider.PackageKitBackend)
+                backend.GLib = types.SimpleNamespace(Variant=lambda signature, values: values)
+                backend._call = mock.Mock(return_value=types.SimpleNamespace(unpack=lambda: (
+                    {"VersionMajor": 1, "VersionMinor": 3, "VersionMicro": micro},)))
+                backend._require_running_backport_identity = mock.Mock(
+                    side_effect=provider.SnapshotFailure("unsupported", "Old running executable", "unsupported"))
+                rpm = types.SimpleNamespace(error=RuntimeError, labelCompare=lambda left, right: 0,
+                    TransactionSet=lambda: types.SimpleNamespace(dbMatch=lambda *args: [
+                        {"epoch": None, "version": f"1.3.{micro}", "release": "3.fc44"}]))
+                with mock.patch.dict(sys.modules, {"rpm": rpm}), mock.patch.object(
+                    provider, "read_fedora_identity", return_value={"ID": "fedora", "VERSION_ID": "44"}):
+                    if micro == 4:
+                        with self.assertRaises(provider.SnapshotFailure):
+                            backend.require_mutation_safe()
+                        backend._require_running_backport_identity.assert_called_once_with()
+                    else:
+                        backend.require_mutation_safe()
+                        backend._require_running_backport_identity.assert_not_called()
+
+    def test_backport_requires_running_executable_identity_and_stable_bus_owner(self):
+        regular = stat.S_IFREG | 0o755
+        installed = types.SimpleNamespace(st_mode=regular, st_uid=0, st_dev=1, st_ino=2)
+        for running, final_owner, accepted in (
+            (installed, ":1.8", True),
+            (types.SimpleNamespace(st_mode=regular, st_uid=0, st_dev=1, st_ino=1), ":1.8", False),
+            (types.SimpleNamespace(st_mode=regular, st_uid=1000, st_dev=1, st_ino=2), ":1.8", False),
+            (PermissionError("procfs denied"), ":1.8", False),
+            (installed, ":1.9", False),
+        ):
+            with self.subTest(running=running, final_owner=final_owner):
+                backend = provider.PackageKitBackend.__new__(provider.PackageKitBackend)
+                backend.GLib = types.SimpleNamespace(Variant=lambda signature, values: values, Error=RuntimeError)
+                backend.Gio = types.SimpleNamespace(DBusCallFlags=types.SimpleNamespace(NONE=0))
+                replies = [types.SimpleNamespace(unpack=lambda: (":1.8",)),
+                           types.SimpleNamespace(unpack=lambda: (123,)),
+                           types.SimpleNamespace(unpack=lambda: (final_owner,))]
+                backend.connection = mock.Mock()
+                backend.connection.call_sync.side_effect = replies
+                with mock.patch.object(provider.os, "stat", side_effect=[installed, running]) as read:
+                    if accepted:
+                        backend._require_running_backport_identity()
+                    else:
+                        with self.assertRaises(provider.SnapshotFailure) as raised:
+                            backend._require_running_backport_identity()
+                        self.assertEqual(raised.exception.status, "unsupported")
+                self.assertEqual(read.call_args_list, [mock.call("/usr/libexec/packagekitd", follow_symlinks=False),
+                                                      mock.call("/proc/123/exe")])
+                self.assertEqual(backend.connection.call_sync.call_args_list[1].args[4], (":1.8",))
+
+    def test_unknown_action_reports_unsupported_without_touching_backend(self):
+        backend = mock.Mock()
+        with self.assertRaises(provider.SnapshotFailure) as raised:
+            provider.run_packagekit_mutation(None, backend, "arbitrary", lambda value: None,
+                                            boot_id="01234567-89ab-cdef-0123-456789abcdef")
+        self.assertEqual((raised.exception.code, raised.exception.status), ("unsupported", "unsupported"))
+        self.assertEqual(backend.mock_calls, [])
+
+    def test_security_floor_uses_rpm_order_and_checks_running_daemon(self):
+        compare = mock.Mock(return_value=0)
+        self.assertTrue(provider.packagekit_security_floor("1.3.5", "1.fc44", "44", (1, 3, 5), compare))
+        compare.assert_called_once_with(("0", "1.3.5", "1.fc44"), ("0", "1.3.5", "0"))
+        compare = mock.Mock(side_effect=[-1, 0])
+        self.assertTrue(provider.packagekit_security_floor("1.3.4", "3.fc44", "44", (1, 3, 4), compare))
+        self.assertEqual(compare.call_args.args[1], ("0", "1.3.4", "3.fc44"))
+        for version, release, fedora, daemon in (
+            ("1.3.4", "2.fc44", "44", (1, 3, 4)),
+            ("1.3.4", "3.fc44", "43", (1, 3, 4)),
+            ("1.3.4", "3.fc43", "44", (1, 3, 4)),
+            ("1.3.4", "3.fc44.custom", "44", (1, 3, 4)),
+            ("1.3.6", "1.fc44", "44", (1, 3, 4)),
+            ("1.3.6", "1.fc44", "44", (True, 3, 6)),
+            ("1.3.6", "1.fc44", "44", None),
+            ("1.3.6;bad", "1.fc44", "44", (1, 3, 6)),
+        ):
+            with self.subTest(version=version, release=release, fedora=fedora, daemon=daemon):
+                self.assertFalse(provider.packagekit_security_floor(version, release, fedora, daemon,
+                                                                    mock.Mock(return_value=-1)))
+
+    def test_platform_identity_is_fixed_bounded_and_never_evaluated(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data=b'ID=fedora\nVERSION_ID="44"\nNAME="ignored"\n')) as source:
+            self.assertEqual(provider.read_fedora_identity(), {"ID": "fedora", "VERSION_ID": "44"})
+            source.assert_called_once_with("/etc/os-release", "rb")
+            source().read.assert_called_once_with(65537)
+        for data in (b"ID=ubuntu\nID_LIKE=fedora", b"ID=fedora\nID=fedora", b"ID=$(false)",
+                     b"ID='fedora", b"\xff", b"x" * 65537):
+            with self.subTest(data=data[:20]), mock.patch("builtins.open", mock.mock_open(read_data=data)):
+                with self.assertRaises(provider.SnapshotFailure):
+                    provider.read_fedora_identity()
+
+
+class PackageKitExecutionTests(unittest.TestCase):
+    boot_id = "01234567-89ab-cdef-0123-456789abcdef"
+    package_id = "example;2;x86_64;updates"
+
+    @contextlib.contextmanager
+    def journal(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "state" / "dwm-titus" / "system-management"
+            with provider.open_journal_directory_chain(str(path)) as chain:
+                provider.initialize_journal_layout(chain.directory_descriptor, self.boot_id)
+                with provider.retain_writable_journal(chain) as journal:
+                    yield journal
+
+    def backend(self, journal, events):
+        """Drive the real adapter with a deterministic, host-independent bus."""
+        test = self
+
+        class Variant:
+            def __init__(self, signature, values):
+                self.signature, self.values = signature, values
+
+            def unpack(self):
+                return self.values
+
+        class BusError(Exception):
+            pass
+
+        class Loop:
+            stopped = False
+
+            def quit(self):
+                self.stopped = True
+
+            def run(self):
+                for event in events:
+                    if self.stopped:
+                        break
+                    test.assertFalse(journal._exclusive)
+                    event(connection)
+                test.assertTrue(self.stopped, "adapter did not reach a terminal observation")
+
+        class Connection:
+            def __init__(self):
+                self.subscriptions = {}
+                self.calls = []
+                self.cancel_allowed = True
+                self.closed_callback = None
+
+            def connect(self, signal, callback):
+                test.assertEqual(signal, "closed")
+                self.closed_callback = callback
+                return 19
+
+            def disconnect(self, handle):
+                test.assertEqual(handle, 19)
+                self.closed_callback = None
+
+            def signal_subscribe(self, *args):
+                key = len(self.subscriptions) + 1
+                self.subscriptions[key] = args
+                return key
+
+            def signal_unsubscribe(self, key):
+                del self.subscriptions[key]
+
+            def call(self, *args):
+                test.assertFalse(journal._exclusive)
+                with provider.lock_writable_journal(journal):
+                    active = provider.load_writable_journal_state(journal).active
+                test.assertEqual(active.state, "authorizing")
+                test.assertEqual(active.transaction_path, args[1])
+                test.assertEqual(len(self.subscriptions), 3)
+                self.calls.append(args)
+                self.reply_callback = args[-2]
+
+            def call_finish(self, result):
+                if isinstance(result, Exception):
+                    raise result
+                return Variant("()", ())
+
+            def call_sync(self, *args):
+                test.assertFalse(journal._exclusive)
+                self.calls.append(args)
+                test.assertEqual(args[1], "/1_test")
+                if args[3] == "Get":
+                    return Variant("(v)", (self.cancel_allowed,))
+                test.assertEqual(args[3], "Cancel")
+                return Variant("()", ())
+
+            def emit(self, signal, values, *, properties=False):
+                interface = provider.PROPERTIES_INTERFACE if properties else provider.TRANSACTION_INTERFACE
+                for args in tuple(self.subscriptions.values()):
+                    if args[1] == interface:
+                        test.assertEqual(args[0], provider.PACKAGEKIT_NAME)
+                        test.assertEqual(args[3], "/1_test")
+                        args[-2](self, provider.PACKAGEKIT_NAME, "/1_test", interface,
+                                 signal, Variant("", values), None)
+
+            def progress(self, **properties):
+                self.emit("PropertiesChanged", (provider.TRANSACTION_INTERFACE, properties, []), properties=True)
+
+            def reply_error(self, message):
+                self.reply_callback(self, BusError(message), None)
+
+        connection = Connection()
+        backend = provider.PackageKitBackend.__new__(provider.PackageKitBackend)
+        backend.connection = connection
+        backend.flags_only_trusted = 2
+        backend.GLib = types.SimpleNamespace(Variant=Variant, MainLoop=Loop, Error=BusError,
+                                            VariantType=types.SimpleNamespace(new=lambda value: value))
+        backend.Gio = types.SimpleNamespace(
+            Cancellable=lambda: types.SimpleNamespace(cancel=lambda: None),
+            DBusSignalFlags=types.SimpleNamespace(NONE=0),
+            DBusCallFlags=types.SimpleNamespace(NONE=0, ALLOW_INTERACTIVE_AUTHORIZATION=1))
+        backend.require_mutation_safe = mock.Mock()
+        backend.create_mutation = mock.Mock(return_value="/1_test")
+        return backend
+
+    def run_operation(self, journal, backend, chunks, update=False, write=None):
+        args = {}
+        if update:
+            args = dict(generation="a" * 64, package_ids=[self.package_id],
+                        preview=[provider.PlanRow(self.package_id, "update", "example", "2", "Example")])
+        return provider.run_packagekit_mutation(
+            journal, backend, "updates-install-all" if update else "updates-refresh",
+            write or chunks.append, boot_id=self.boot_id, **args)
+
+    def test_refresh_dispatch_and_durable_handoff_precede_terminal_output(self):
+        with self.journal() as journal:
+            chunks = []
+            backend = self.backend(journal, [lambda bus: bus.progress(Status=3, Percentage=42, AllowCancel=True),
+                                            lambda bus: bus.emit("Finished", (1, 10))])
+
+            def write(chunk):
+                if "complete\toperation" in chunk:
+                    with provider.lock_writable_journal(journal):
+                        state = provider.load_writable_journal_state(journal)
+                    self.assertIsNone(state.active)
+                    self.assertIsNotNone(state.handoff)
+                    self.assertEqual(state.terminals[0].state, "succeeded")
+                chunks.append(chunk)
+
+            terminal = self.run_operation(journal, backend, chunks, write=write)
+            self.assertEqual(terminal.state, "succeeded")
+            self.assertEqual(backend.connection.calls[0][3], "RefreshCache")
+            self.assertEqual(backend.connection.calls[0][4].unpack(), (True,))
+            self.assertEqual(backend.connection.subscriptions, {})
+            self.assertIsNone(backend.connection.closed_callback)
+            self.assertIn("\t42\tyes\t", "".join(chunks))
+
+    def test_update_uses_exact_ids_and_accumulates_restart_contributions(self):
+        with self.journal() as journal:
+            chunks = []
+            backend = self.backend(journal, [lambda bus: bus.emit("Package", (11, self.package_id, "Example")),
+                lambda bus: bus.emit("RequireRestart", (3, self.package_id)),
+                lambda bus: bus.emit("RequireRestart", (6, self.package_id)),
+                lambda bus: bus.emit("RequireRestart", (2, self.package_id)),
+                lambda bus: bus.emit("Finished", (1, 10))])
+            terminal = self.run_operation(journal, backend, chunks, update=True)
+            self.assertEqual(backend.connection.calls[0][3], "UpdatePackages")
+            self.assertEqual(backend.connection.calls[0][4].unpack(), (2, [self.package_id]))
+            self.assertEqual((terminal.system_restart, terminal.session_restart, terminal.application_restart),
+                             ("security-system", "session", True))
+            self.assertIn("different=no", "".join(chunks))
+
+    def test_lost_method_reply_keeps_observing_until_finished(self):
+        with self.journal() as journal:
+            chunks = []
+            backend = self.backend(journal, [lambda bus: bus.reply_error("TimedOut"),
+                lambda bus: bus.progress(Status=3), lambda bus: bus.emit("Finished", (1, 1))])
+            self.assertEqual(self.run_operation(journal, backend, chunks, update=True).state, "succeeded")
+
+    def test_denial_before_running_does_not_add_restart_uncertainty(self):
+        with self.journal() as journal:
+            chunks = []
+            backend = self.backend(journal, [lambda bus: bus.reply_error("AccessDenied")])
+            terminal = self.run_operation(journal, backend, chunks, update=True)
+            self.assertEqual((terminal.state, terminal.system_restart), ("permission-denied", "none"))
+            self.assertIn("error\tupdates\tpermission-denied", "".join(chunks))
+
+    def test_lost_object_or_bus_after_send_is_interrupted_unknown(self):
+        for event in (lambda bus: bus.emit("Destroy", ()), lambda bus: bus.closed_callback()):
+            with self.subTest(event=event), self.journal() as journal:
+                backend = self.backend(journal, [event])
+                terminal = self.run_operation(journal, backend, [], update=True)
+                self.assertEqual((terminal.state, terminal.system_restart), ("interrupted", "unknown"))
+
+    def test_error_cancels_only_with_fresh_allow_cancel_and_never_after_finished(self):
+        for allowed in (True, False):
+            with self.subTest(allowed=allowed), self.journal() as journal:
+                chunks = []
+                backend = self.backend(journal, [lambda bus: bus.progress(Status=3, AllowCancel=True),
+                    lambda bus: bus.emit("ErrorCode", (13, "Untrusted raw text")),
+                    lambda bus: bus.emit("Finished", (2, 10))])
+                backend.connection.cancel_allowed = allowed
+                terminal = self.run_operation(journal, backend, chunks, update=True)
+                self.assertEqual(terminal.state, "failed")
+                methods = [call[3] for call in backend.connection.calls]
+                self.assertEqual(methods.count("Cancel"), int(allowed))
+                self.assertEqual(methods.count("Get"), 1)
+                self.assertNotIn("Untrusted raw text", "".join(chunks))
+
+    def test_canceled_while_running_has_legal_transition_and_uncertainty(self):
+        with self.journal() as journal:
+            chunks = []
+            backend = self.backend(journal, [lambda bus: bus.progress(Status=3),
+                                            lambda bus: bus.emit("Finished", (3, 0))])
+            terminal = self.run_operation(journal, backend, chunks, update=True)
+            self.assertEqual((terminal.state, terminal.system_restart), ("canceled", "unknown"))
+            self.assertIn("\tcancel-requested\t", "".join(chunks))
+
+    def test_malformed_percentage_is_unknown_and_invalidated_cancel_is_not_reused(self):
+        with self.journal() as journal:
+            chunks = []
+            backend = self.backend(journal, [lambda bus: bus.progress(Status=3, Percentage=True, AllowCancel=True),
+                lambda bus: bus.emit("PropertiesChanged", (provider.TRANSACTION_INTERFACE, {}, ["AllowCancel"]), properties=True),
+                lambda bus: bus.emit("ErrorCode", (13, "")), lambda bus: bus.emit("Finished", (2, 1))])
+            self.run_operation(journal, backend, chunks)
+            self.assertIn("percentage is malformed", "".join(chunks))
+            self.assertEqual([call[3] for call in backend.connection.calls], ["RefreshCache"])
+
+    def test_persistence_failure_keeps_observer_but_suppresses_terminal(self):
+        with self.journal() as journal:
+            chunks = []
+            observed = []
+
+            def damage(bus):
+                os.fchmod(journal.descriptor("terminal-31"), 0o644)
+                bus.progress(Status=3, AllowCancel=True)
+
+            def finish(bus):
+                observed.append(True)
+                bus.emit("Finished", (1, 0))
+
+            backend = self.backend(journal, [damage, finish])
+            with self.assertRaises(provider.JournalFileError):
+                self.run_operation(journal, backend, chunks, update=True)
+            self.assertEqual(observed, [True])
+            self.assertNotIn("complete\toperation", "".join(chunks))
+            self.assertIn("Cancel", [call[3] for call in backend.connection.calls])
+            os.fchmod(journal.descriptor("terminal-31"), 0o600)
+
+    def test_output_failure_after_send_does_not_abandon_durable_result(self):
+        with self.journal() as journal:
+            backend = self.backend(journal, [lambda bus: bus.progress(Status=3),
+                                            lambda bus: bus.emit("Finished", (1, 0))])
+            def write(chunk):
+                if "\trunning\t" in chunk:
+                    raise BrokenPipeError("closed consumer")
+            with self.assertRaises(BrokenPipeError):
+                self.run_operation(journal, backend, [], write=write)
+            with provider.lock_writable_journal(journal):
+                state = provider.load_writable_journal_state(journal)
+            self.assertIsNone(state.active)
+            self.assertEqual(state.terminals[0].state, "succeeded")
+
+    def test_overlap_and_invalid_inputs_never_dispatch(self):
+        with self.journal() as journal:
+            backend = self.backend(journal, [lambda bus: bus.emit("Finished", (1, 0))])
+            self.run_operation(journal, backend, [])
+            before = len(backend.connection.calls)
+            with self.assertRaises(provider.JournalAdmissionError):
+                self.run_operation(journal, backend, [])
+            self.assertEqual(len(backend.connection.calls), before)
+            with self.assertRaises(provider.SnapshotFailure):
+                provider.run_packagekit_mutation(journal, backend, "updates-install-all", lambda value: None,
+                                                boot_id=self.boot_id, generation="a" * 64)
+            self.assertEqual(len(backend.connection.calls), before)
+
+    def test_security_rejection_never_creates_or_journals_a_transaction(self):
+        with self.journal() as journal:
+            backend = self.backend(journal, [])
+            backend.require_mutation_safe.side_effect = provider.SnapshotFailure("unsupported", "Unsafe build")
+            with self.assertRaises(provider.SnapshotFailure):
+                self.run_operation(journal, backend, [])
+            backend.create_mutation.assert_not_called()
+            with provider.lock_writable_journal(journal):
+                self.assertIsNone(provider.load_writable_journal_state(journal).active)
+
+    def test_output_failure_before_dispatch_preserves_recoverable_active_record(self):
+        with self.journal() as journal:
+            backend = self.backend(journal, [])
+            def write(chunk):
+                if "\tauthorizing\t" in chunk:
+                    raise BrokenPipeError("closed consumer")
+            with self.assertRaises(BrokenPipeError):
+                self.run_operation(journal, backend, [], write=write)
+            self.assertEqual(backend.connection.calls, [])
+            self.assertEqual(backend.connection.subscriptions, {})
+            with provider.lock_writable_journal(journal):
+                self.assertEqual(provider.load_writable_journal_state(journal).active.state, "authorizing")
+
+    def test_external_cancellation_checkpoint_is_reconciled_without_regression(self):
+        with self.journal() as journal:
+            def cancel(bus):
+                with provider.lock_writable_journal(journal):
+                    current = provider.load_writable_journal_state(journal).active
+                    provider.advance_journal_operation(journal, current,
+                        replace(current, state="cancel-requested", detail="Canceled by a second control"))
+                bus.progress(Status=3, Percentage=55)
+            chunks = []
+            backend = self.backend(journal, [lambda bus: bus.progress(Status=3), cancel,
+                                            lambda bus: bus.emit("Finished", (3, 0))])
+            self.assertEqual(self.run_operation(journal, backend, chunks).state, "canceled")
+            output = "".join(chunks)
+            self.assertIn("\tcancel-requested\t55\t", output)
+            self.assertNotIn("\trunning\t55\t", output)
+
+    def test_malformed_finished_is_interrupted_not_success(self):
+        with self.journal() as journal:
+            backend = self.backend(journal, [lambda bus: bus.emit("Finished", (True, 0))])
+            terminal = self.run_operation(journal, backend, [], update=True)
+            self.assertEqual((terminal.state, terminal.error_code, terminal.system_restart),
+                             ("interrupted", "malformed", "unknown"))
 
 
 if __name__ == "__main__":

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -4542,6 +4542,8 @@ class PackageKitSafetyTests(unittest.TestCase):
             (installed, ":1.8", True),
             (types.SimpleNamespace(st_mode=regular, st_uid=0, st_dev=1, st_ino=1), ":1.8", False),
             (types.SimpleNamespace(st_mode=regular, st_uid=1000, st_dev=1, st_ino=2), ":1.8", False),
+            (types.SimpleNamespace(st_mode=stat.S_IFREG | 0o775, st_uid=0, st_dev=1, st_ino=2), ":1.8", False),
+            (types.SimpleNamespace(st_mode=stat.S_IFREG | 0o757, st_uid=0, st_dev=1, st_ino=2), ":1.8", False),
             (PermissionError("procfs denied"), ":1.8", False),
             (installed, ":1.9", False),
         ):
@@ -4600,6 +4602,7 @@ class PackageKitSafetyTests(unittest.TestCase):
             source.assert_called_once_with("/etc/os-release", "rb")
             source().read.assert_called_once_with(65537)
         for data in (b"ID=ubuntu\nID_LIKE=fedora", b"ID=fedora\nID=fedora", b"ID=$(false)",
+                     b"ID=fedora#variant", b'ID="fedora"#variant', b"ID=fedora #inline",
                      b"ID='fedora", b"\xff", b"x" * 65537):
             with self.subTest(data=data[:20]), mock.patch("builtins.open", mock.mock_open(read_data=data)):
                 with self.assertRaises(provider.SnapshotFailure):
@@ -4718,6 +4721,7 @@ class PackageKitExecutionTests(unittest.TestCase):
                                             VariantType=types.SimpleNamespace(new=lambda value: value))
         backend.Gio = types.SimpleNamespace(
             Cancellable=lambda: types.SimpleNamespace(cancel=lambda: None),
+            dbus_error_get_remote_error=lambda error: "org.freedesktop.DBus.Error." + str(error),
             DBusSignalFlags=types.SimpleNamespace(NONE=0),
             DBusCallFlags=types.SimpleNamespace(NONE=0, ALLOW_INTERACTIVE_AUTHORIZATION=1))
         backend.require_mutation_safe = mock.Mock()
@@ -4785,6 +4789,35 @@ class PackageKitExecutionTests(unittest.TestCase):
             terminal = self.run_operation(journal, backend, chunks, update=True)
             self.assertEqual((terminal.state, terminal.system_restart), ("permission-denied", "none"))
             self.assertIn("error\tupdates\tpermission-denied", "".join(chunks))
+
+    def test_definitive_method_rejection_does_not_wait_for_terminal_signals(self):
+        for error in ("UnknownMethod", "InvalidArgs", "UnknownInterface", "UnknownObject"):
+            with self.subTest(error=error), self.journal() as journal:
+                backend = self.backend(journal, [lambda bus: bus.reply_error(error)])
+                chunks = []
+                terminal = self.run_operation(journal, backend, chunks, update=True)
+                self.assertEqual((terminal.state, terminal.system_restart), ("failed", "none"))
+                self.assertIn("complete\toperation", "".join(chunks))
+
+    def test_definitive_rejection_does_not_clear_observed_execution_uncertainty(self):
+        with self.journal() as journal:
+            backend = self.backend(journal, [lambda bus: bus.progress(Status=3),
+                                            lambda bus: bus.reply_error("InvalidArgs")])
+            terminal = self.run_operation(journal, backend, [], update=True)
+            self.assertEqual((terminal.state, terminal.system_restart), ("failed", "unknown"))
+
+    def test_invalidated_or_malformed_status_cannot_prove_prerunning_cancellation(self):
+        for invalidate in (True, False):
+            with self.subTest(invalidate=invalidate), self.journal() as journal:
+                def invalidate_status(bus):
+                    if invalidate:
+                        bus.emit("PropertiesChanged", (provider.TRANSACTION_INTERFACE, {}, ["Status"]), properties=True)
+                    else:
+                        bus.progress(Status="bad")
+                backend = self.backend(journal, [lambda bus: bus.progress(Status=31), invalidate_status,
+                                                lambda bus: bus.emit("Finished", (3, 0))])
+                terminal = self.run_operation(journal, backend, [], update=True)
+                self.assertEqual((terminal.state, terminal.system_restart), ("canceled", "unknown"))
 
     def test_lost_object_or_bus_after_send_is_interrupted_unknown(self):
         for event in (lambda bus: bus.emit("Destroy", ()), lambda bus: bus.closed_callback()):


### PR DESCRIPTION
## Scope

Add the internal PackageKit execution owner as one Phase 6 review boundary. Public mutation commands remain disabled until fresh-plan confirmation, recovery, and the root-scoped Settings operation UI are integrated.

- Admit and sync pending state before exact-object dispatch; keep all journal identities retained and all service waits outside exclusive locks.
- Use fixed RefreshCache(force=true) or UpdatePackages(ONLY_TRUSTED, exact IDs), consume typed progress and restart signals, and commit terminal/handoff state before terminal output.
- Continue observation after a lost method reply or broken output consumer. Persistence faults suppress terminal success and allow only narrowly bound, freshly authorized cancellation.
- Gate mutations on Fedora, RPM security floor, and running daemon version. Same-version Fedora backports additionally require a stable bus owner and exact root-owned executable identity; unreadable procfs proof fails closed without elevation.
- Add deterministic fake-bus tests for denial, cancellation, overlap, malformed evidence, ownership races, lost replies, output failure, restart contributions, and persistence failure.

## Validation

- PASS: scripts/run-tests make check-system-management (181 tests in final full suite).
- PASS: scripts/run-tests make clean all.
- PASS: scripts/run-tests, rerun after the security-gate correction, including configured QML lint, Fedora package map, staged install, repeated install preservation, and release archive validation.
- PASS: nested-X11 Settings lifecycle, 0.033% closed CPU; large surfaces, 0.00% closed CPU.
- PASS: final post-suite built-in Codex review and final independent CodeRabbit CLI review, both no actionable findings.
- Fedora 44 / PackageKit 1.3.6: live read-only safety gate passed; created one empty transaction and validated fixed hints. No RefreshCache or UpdatePackages mutation was invoked.

## Review decisions and limits

The local Codex finding about an old daemon surviving a same-version security-backport upgrade was fixed with executable identity verification and regression coverage. An inactivity watchdog suggestion was rejected: silence does not prove the backend stopped, and terminalizing a still-live transaction would incorrectly clear admission. The next CodeRabbit review was clean.

The hosted code-review follow-up also rejects identity suffixes without comment reinterpretation, clears invalidated authorization evidence, and terminalizes exact definitive method rejections while retaining observation for ambiguous replies. Regression coverage includes both group- and world-writable executables.

This is tested execution infrastructure, not acceptance of UPDATE-001 or Phase 6. Real package changes, user confirmation, cancellation controls, restart/recovery snapshots, and Settings operation lifetime require the remaining integration boundaries. Existing QML tooling warnings are unchanged; no applicable local gates were skipped.