### PR TITLE
fix(system): revalidate confirmed update plans

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -66,10 +66,13 @@ running-executable identity required for the same-version Fedora backport), disp
 only a durably admitted exact transaction, checkpoints restart signals, and
 observes through terminal evidence even after a lost method reply. Persistence
 failure suppresses terminal success and permits only narrowly bound cancellation.
-Fake-bus coverage exercises these paths without changing host packages. Public
-mutation commands remain disabled: fresh-plan confirmation, recovery integration,
-and the root-scoped operation UI must be completed before this boundary can be
-accepted.
+Fake-bus coverage exercises these paths without changing host packages. Execution
+now repeats bounded inventory and simulation reads and compares the confirmed
+generation before creating its mutable transaction. Callers cannot supply their
+own package IDs or preview to bypass that check. Fixed, bounded kernel boot and
+typed logind session evidence readers are available for recovery integration.
+Public mutation commands remain disabled: recovery integration and the root-scoped
+confirmation and operation UI must be completed before this boundary can be accepted.
 
 - [ ] Add user-initiated Fedora update discovery and status through the selected
   stable package-management interface.

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -3015,6 +3015,35 @@ def snapshot_generation(update_ids: Sequence[str], plan: Sequence[PlanRow]) -> s
     return digest.hexdigest()
 
 
+def confirmed_update_plan(backend: UpdateBackend, generation: str) -> tuple[tuple[str, ...], tuple[PlanRow, ...]]:
+    """Revalidate a confirmation using fresh bounded read-only transactions."""
+    if not isinstance(generation, str) or JOURNAL_GENERATION_PATTERN.fullmatch(generation) is None:
+        raise SnapshotFailure("malformed", "Confirmed update generation is invalid")
+    updates = normalize_updates(backend.updates().packages)
+    package_ids = tuple(row.package_id for row in updates if row.installability == "installable")
+    preview = tuple(normalize_plan(backend.simulate(package_ids).packages, package_ids)) if package_ids else ()
+    if any(row.action in {"reinstall", "downgrade"} for row in preview):
+        raise SnapshotFailure("unsupported", "PackageKit preview requires unsupported reinstall or downgrade flags", "unsupported")
+    if snapshot_generation(package_ids, preview) != generation:
+        raise SnapshotFailure("conflict", "The update plan changed; refresh the preview and confirm again")
+    if not package_ids:
+        raise SnapshotFailure("conflict", "There are no installable updates; refresh the preview")
+    return package_ids, preview
+
+
+def read_boot_id() -> str:
+    """Read only the bounded kernel boot identity, never a caller-selected path."""
+    try:
+        with open("/proc/sys/kernel/random/boot_id", "rb") as source:
+            data = source.read(37)
+        value = data.removesuffix(b"\n").decode("ascii")
+    except (OSError, UnicodeError) as error:
+        raise SnapshotFailure("internal", "Kernel boot identity is unavailable", "unavailable") from error
+    if BOOT_ID_PATTERN.fullmatch(value) is None:
+        raise SnapshotFailure("malformed", "Kernel boot identity is malformed")
+    return value
+
+
 class OperationProtocolError(ValueError):
     """An operation stream would violate its closed lifecycle or field bounds."""
 
@@ -3668,24 +3697,22 @@ class PackageKitMutation:
 def run_packagekit_mutation(
     journal: JournalDescriptorSet, backend: PackageKitBackend, action_id: str,
     write: Callable[[str], object], *, boot_id: str, session_started: int | None = None,
-    generation: str | None = None, package_ids: Sequence[str] = (), preview: Sequence[PlanRow] = (),
+    generation: str | None = None,
 ) -> JournalOperation:
-    """Run an already revalidated confirmed plan; no public command enables this yet."""
+    """Revalidate and run a confirmed request; public commands remain disabled."""
     if action_id not in {"updates-refresh", "updates-install-all"}:
         raise SnapshotFailure("unsupported", "Unsupported PackageKit mutation", "unsupported")
     if action_id == "updates-install-all":
-        ObservedUpdateSummary(preview)
-        if (
-            not isinstance(generation, str) or JOURNAL_GENERATION_PATTERN.fullmatch(generation) is None
-            or not package_ids or len(package_ids) > MAX_LIST_RECORDS
-            or any(not isinstance(package_id, str) for package_id in package_ids)
-            or len(set(package_ids)) != len(package_ids)
-            or not set(package_ids).issubset({row.package_id for row in preview if row.action == "update"})
-        ):
-            raise SnapshotFailure("malformed", "Confirmed PackageKit update inputs are invalid")
-    elif generation is not None or package_ids or preview:
+        if not isinstance(generation, str) or JOURNAL_GENERATION_PATTERN.fullmatch(generation) is None:
+            raise SnapshotFailure("malformed", "Confirmed update generation is invalid")
+    elif generation is not None:
         raise SnapshotFailure("malformed", "Metadata refresh cannot select packages")
+    # Reject existing owners before service work, then repeat admission under
+    # the lock after the unlocked preflight to close concurrent-start races.
+    with lock_writable_journal(journal):
+        prepare_journal_admission(journal)
     backend.require_mutation_safe()
+    package_ids, preview = confirmed_update_plan(backend, generation) if action_id == "updates-install-all" else ((), ())
     path = backend.create_mutation()
     if not isinstance(path, str) or JOURNAL_PACKAGEKIT_PATH_PATTERN.fullmatch(path) is None:
         raise SnapshotFailure("malformed", "PackageKit returned an invalid operation path")
@@ -3799,6 +3826,54 @@ class PackageKitBackend:
         return SnapshotFailure(
             "internal", "PackageKit D-Bus request failed", "unavailable"
         )
+
+    def session_started(self) -> int:
+        """Read this process's logind session timestamp under one fixed deadline."""
+        deadline = time.monotonic() + 10
+
+        def call(path: str, interface: str, method: str, parameters: object, signature: str) -> object:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise SnapshotFailure("timeout", "Current logind session read timed out; restart guidance is retained", "unavailable")
+            try:
+                reply = self.connection.call_sync(
+                    "org.freedesktop.login1", path, interface, method, parameters,
+                    self.GLib.VariantType.new(signature), self.Gio.DBusCallFlags.NONE,
+                    max(1, min(int(remaining * 1000), 10000)), None)
+            except self.GLib.Error as error:
+                name = self.Gio.dbus_error_get_remote_error(error)
+                if time.monotonic() >= deadline or name in {"org.freedesktop.DBus.Error.Timeout", "org.freedesktop.DBus.Error.TimedOut", "org.freedesktop.DBus.Error.NoReply"}:
+                    raise SnapshotFailure("timeout", "Current logind session read timed out; restart guidance is retained", "unavailable") from error
+                if name == "org.freedesktop.DBus.Error.AccessDenied":
+                    raise SnapshotFailure("permission-denied", "Current logind session read was denied; restart guidance is retained", "restricted") from error
+                code = {
+                    "org.freedesktop.DBus.Error.ServiceUnknown": "missing-provider",
+                    "org.freedesktop.DBus.Error.NameHasNoOwner": "missing-provider",
+                    "org.freedesktop.DBus.Error.UnknownObject": "missing-provider",
+                    "org.freedesktop.login1.NoSessionForPID": "missing-provider",
+                    "org.freedesktop.DBus.Error.InvalidArgs": "malformed",
+                }.get(name, "internal")
+                raise SnapshotFailure(code, "Current logind session is unavailable; restart guidance is retained", "unavailable") from error
+            if time.monotonic() >= deadline:
+                raise SnapshotFailure("timeout", "Current logind session read timed out; restart guidance is retained", "unavailable")
+            if reply.get_type_string() != signature:
+                raise SnapshotFailure("malformed", "Current logind session reply is malformed")
+            return reply
+
+        reply = call("/org/freedesktop/login1", "org.freedesktop.login1.Manager", "GetSessionByPID",
+                     self.GLib.Variant("(u)", (os.getpid(),)), "(o)")
+        path = reply.unpack()[0]
+        if not isinstance(path, str) or len(path) > 256 or re.fullmatch(r"/org/freedesktop/login1/session/[A-Za-z0-9_]+", path) is None:
+            raise SnapshotFailure("malformed", "Current logind session path is malformed")
+        reply = call(path, PROPERTIES_INTERFACE, "Get",
+                     self.GLib.Variant("(ss)", ("org.freedesktop.login1.Session", "TimestampMonotonic")), "(v)")
+        value = reply.get_child_value(0).get_variant()
+        if value.get_type_string() != "t":
+            raise SnapshotFailure("malformed", "Current logind session timestamp is not unsigned 64-bit")
+        timestamp = value.unpack()
+        if type(timestamp) is not int or not 0 <= timestamp <= JOURNAL_SEQUENCE_MAX:
+            raise SnapshotFailure("malformed", "Current logind session timestamp is malformed")
+        return timestamp
 
     def last_refresh_age(self) -> int:
         deadline = time.monotonic() + REFRESH_AGE_DEADLINE_SECONDS

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -4726,13 +4726,15 @@ class PackageKitExecutionTests(unittest.TestCase):
             DBusCallFlags=types.SimpleNamespace(NONE=0, ALLOW_INTERACTIVE_AUTHORIZATION=1))
         backend.require_mutation_safe = mock.Mock()
         backend.create_mutation = mock.Mock(return_value="/1_test")
+        backend.updates = mock.Mock(return_value=provider.TransactionResult((provider.Package(5, self.package_id, "Example"),)))
+        backend.simulate = mock.Mock(return_value=provider.TransactionResult((provider.Package(11, self.package_id, "Example"),)))
         return backend
 
     def run_operation(self, journal, backend, chunks, update=False, write=None):
         args = {}
         if update:
-            args = dict(generation="a" * 64, package_ids=[self.package_id],
-                        preview=[provider.PlanRow(self.package_id, "update", "example", "2", "Example")])
+            args = dict(generation=provider.snapshot_generation([self.package_id],
+                        [provider.PlanRow(self.package_id, "update", "example", "2", "Example")]))
         return provider.run_packagekit_mutation(
             journal, backend, "updates-install-all" if update else "updates-refresh",
             write or chunks.append, boot_id=self.boot_id, **args)
@@ -4905,7 +4907,7 @@ class PackageKitExecutionTests(unittest.TestCase):
             self.assertEqual(len(backend.connection.calls), before)
             with self.assertRaises(provider.SnapshotFailure):
                 provider.run_packagekit_mutation(journal, backend, "updates-install-all", lambda value: None,
-                                                boot_id=self.boot_id, generation="a" * 64)
+                                                boot_id=self.boot_id, generation="invalid")
             self.assertEqual(len(backend.connection.calls), before)
 
     def test_security_rejection_never_creates_or_journals_a_transaction(self):
@@ -4917,6 +4919,93 @@ class PackageKitExecutionTests(unittest.TestCase):
             backend.create_mutation.assert_not_called()
             with provider.lock_writable_journal(journal):
                 self.assertIsNone(provider.load_writable_journal_state(journal).active)
+
+    def test_changed_plan_rejects_before_mutable_transaction_or_journal_write(self):
+        with self.journal() as journal:
+            backend = self.backend(journal, [])
+            backend.simulate.return_value = provider.TransactionResult((provider.Package(11, self.package_id, "Changed preview"),))
+            with self.assertRaises(provider.SnapshotFailure) as raised:
+                self.run_operation(journal, backend, [], update=True)
+            self.assertEqual(raised.exception.code, "conflict")
+            backend.create_mutation.assert_not_called()
+            with provider.lock_writable_journal(journal):
+                state = provider.load_writable_journal_state(journal)
+                self.assertIsNone(state.active)
+                self.assertIsNone(state.handoff)
+
+    def test_preflight_waits_are_unlocked_and_competing_admission_is_rechecked(self):
+        with self.journal() as journal:
+            backend = self.backend(journal, [])
+            def competing_owner(package_ids):
+                with provider.lock_writable_journal(journal):
+                    provider.begin_journal_operation(journal, "updates-refresh", "2026-09-05T00:00:00Z",
+                                                     "Competing owner", transaction_path="/2_other")
+                return provider.TransactionResult((provider.Package(11, self.package_id, "Example"),))
+            backend.simulate.side_effect = competing_owner
+            with self.assertRaises(provider.JournalAdmissionError):
+                self.run_operation(journal, backend, [], update=True)
+            self.assertEqual(backend.connection.calls, [])
+
+    def test_fresh_complete_plan_matches_snapshot_generation(self):
+        backend = FixtureBackend(updates=(provider.Package(5, self.package_id, "Example"),
+                                         provider.Package(9, "blocked;1;x86_64;updates", "Blocked")),
+                                 plan=(provider.Package(12, "dependency;1;x86_64;updates", "Dependency"),
+                                       provider.Package(11, self.package_id, "Example")))
+        generation = rows(provider.build_snapshot(backend), "snapshot-generation")[0][1]
+        package_ids, preview = provider.confirmed_update_plan(backend, generation)
+        self.assertEqual(package_ids, (self.package_id,))
+        self.assertEqual({row.action for row in preview}, {"install", "update"})
+
+    def test_invalid_generation_never_reads_backend(self):
+        for generation in (None, "", "A" * 64, "a" * 65, "a" * 63):
+            with self.subTest(generation=generation):
+                backend = mock.Mock()
+                with self.assertRaises(provider.SnapshotFailure) as raised:
+                    provider.confirmed_update_plan(backend, generation)
+                self.assertEqual(raised.exception.code, "malformed")
+                self.assertEqual(backend.mock_calls, [])
+
+    def test_empty_set_never_simulates_even_when_generation_matches(self):
+        backend = mock.Mock()
+        backend.updates.return_value = provider.TransactionResult(())
+        with self.assertRaises(provider.SnapshotFailure) as raised:
+            provider.confirmed_update_plan(backend, provider.snapshot_generation((), ()))
+        self.assertEqual(raised.exception.code, "conflict")
+        backend.simulate.assert_not_called()
+
+    def test_failed_or_unsupported_plan_never_becomes_confirmed(self):
+        for result, code in (
+            (provider.SnapshotFailure("permission-denied", "Denied"), "permission-denied"),
+            (provider.TransactionResult(()), "malformed"),
+            (provider.TransactionResult((provider.Package(11, self.package_id, "Example"),) * 2), "malformed"),
+            (provider.TransactionResult((provider.Package(11, self.package_id, "Example"),
+                                          provider.Package(20, "dependency;1;x86_64;updates", "Downgrade"))), "unsupported"),
+        ):
+            with self.subTest(code=code):
+                backend = mock.Mock()
+                backend.updates.return_value = provider.TransactionResult((provider.Package(5, self.package_id, "Example"),))
+                if isinstance(result, Exception):
+                    backend.simulate.side_effect = result
+                else:
+                    backend.simulate.return_value = result
+                with self.assertRaises(provider.SnapshotFailure) as raised:
+                    provider.confirmed_update_plan(backend, "a" * 64)
+                self.assertEqual(raised.exception.code, code)
+
+    def test_boot_identity_is_fixed_bounded_and_strict(self):
+        value = "01234567-89ab-cdef-0123-456789abcdef"
+        for data in (value.encode(), (value + "\n").encode()):
+            with mock.patch("builtins.open", mock.mock_open(read_data=data)) as source:
+                self.assertEqual(provider.read_boot_id(), value)
+                source.assert_called_once_with("/proc/sys/kernel/random/boot_id", "rb")
+                source().read.assert_called_once_with(37)
+        for data in (b"", value.upper().encode(), b" " + value.encode(), value.encode() + b"x", b"\xff"):
+            with self.subTest(data=data), mock.patch("builtins.open", mock.mock_open(read_data=data)):
+                with self.assertRaises(provider.SnapshotFailure):
+                    provider.read_boot_id()
+        with mock.patch("builtins.open", side_effect=PermissionError):
+            with self.assertRaises(provider.SnapshotFailure):
+                provider.read_boot_id()
 
     def test_output_failure_before_dispatch_preserves_recoverable_active_record(self):
         with self.journal() as journal:
@@ -4953,6 +5042,92 @@ class PackageKitExecutionTests(unittest.TestCase):
             terminal = self.run_operation(journal, backend, [], update=True)
             self.assertEqual((terminal.state, terminal.error_code, terminal.system_restart),
                              ("interrupted", "malformed", "unknown"))
+
+
+class SessionEvidenceTests(unittest.TestCase):
+    class Variant:
+        def __init__(self, signature, value):
+            self.signature, self.value = signature, value
+
+        def get_type_string(self):
+            return self.signature
+
+        def unpack(self):
+            return self.value
+
+        def get_child_value(self, index):
+            return self.value[index]
+
+        def get_variant(self):
+            return self.value
+
+    def backend(self, path="/org/freedesktop/login1/session/_31", timestamp=None):
+        backend = provider.PackageKitBackend.__new__(provider.PackageKitBackend)
+        backend.GLib = types.SimpleNamespace(Variant=self.Variant, Error=RuntimeError,
+                                            VariantType=types.SimpleNamespace(new=lambda value: value))
+        backend.Gio = types.SimpleNamespace(DBusCallFlags=types.SimpleNamespace(NONE=0),
+            dbus_error_get_remote_error=lambda error: "org.freedesktop.DBus.Error." + str(error))
+        backend.connection = mock.Mock()
+        backend.connection.call_sync.side_effect = [self.Variant("(o)", (path,)),
+            self.Variant("(v)", (self.Variant("v", timestamp or self.Variant("t", 123)),))]
+        return backend
+
+    def test_fixed_own_session_and_typed_timestamp_share_deadline(self):
+        backend = self.backend()
+        with mock.patch.object(provider.time, "monotonic", side_effect=[100, 101, 102, 103, 104]), \
+                mock.patch.object(provider.os, "getpid", return_value=456):
+            self.assertEqual(backend.session_started(), 123)
+        first, second = backend.connection.call_sync.call_args_list
+        self.assertEqual(first.args[:4], ("org.freedesktop.login1", "/org/freedesktop/login1",
+                                          "org.freedesktop.login1.Manager", "GetSessionByPID"))
+        self.assertEqual(first.args[4].unpack(), (456,))
+        self.assertEqual(second.args[:4], ("org.freedesktop.login1", "/org/freedesktop/login1/session/_31",
+                                           provider.PROPERTIES_INTERFACE, "Get"))
+        self.assertEqual(second.args[4].unpack(), ("org.freedesktop.login1.Session", "TimestampMonotonic"))
+        self.assertEqual((first.args[5], second.args[5]), ("(o)", "(v)"))
+        self.assertEqual((first.args[7], second.args[7]), (9000, 7000))
+
+    def test_malformed_session_path_never_reads_property(self):
+        for path in ("/other", "/org/freedesktop/login1/session/", "/org/freedesktop/login1/session/" + "x" * 257):
+            with self.subTest(path=path):
+                backend = self.backend(path=path)
+                with self.assertRaises(provider.SnapshotFailure) as raised:
+                    backend.session_started()
+                self.assertEqual(raised.exception.code, "malformed")
+                self.assertEqual(backend.connection.call_sync.call_count, 1)
+
+    def test_signed_boolean_or_out_of_range_timestamp_is_not_recovery_evidence(self):
+        for signature, value in (("x", 123), ("b", True), ("t", True), ("t", -1), ("t", 1 << 64)):
+            with self.subTest(signature=signature, value=value):
+                with self.assertRaises(provider.SnapshotFailure) as raised:
+                    self.backend(timestamp=self.Variant(signature, value)).session_started()
+                self.assertEqual(raised.exception.code, "malformed")
+
+    def test_missing_service_or_expired_deadline_does_not_guess_clear(self):
+        backend = self.backend()
+        backend.connection.call_sync.side_effect = RuntimeError("ServiceUnknown")
+        with self.assertRaises(provider.SnapshotFailure) as raised:
+            backend.session_started()
+        self.assertEqual(raised.exception.status, "unavailable")
+        self.assertEqual(raised.exception.code, "missing-provider")
+        backend = self.backend()
+        with mock.patch.object(provider.time, "monotonic", side_effect=[100, 101, 110]):
+            with self.assertRaises(provider.SnapshotFailure) as raised:
+                backend.session_started()
+        self.assertEqual(raised.exception.code, "timeout")
+        self.assertEqual(backend.connection.call_sync.call_count, 1)
+
+
+    def test_denied_and_timeout_replies_keep_distinct_failure_codes(self):
+        for message, code in (("AccessDenied", "permission-denied"), ("NoReply", "timeout"),
+                              ("TimedOut", "timeout"), ("Timeout", "timeout"),
+                              ("InvalidArgs", "malformed"), ("Unrecognized", "internal")):
+            with self.subTest(message=message):
+                backend = self.backend()
+                backend.connection.call_sync.side_effect = RuntimeError(message)
+                with self.assertRaises(provider.SnapshotFailure) as raised:
+                    backend.session_started()
+                self.assertEqual(raised.exception.code, code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Re-read the bounded PackageKit inventory and SIMULATE|ONLY_TRUSTED dependency plan before every confirmed update, and compare its canonical generation before creating a mutable transaction.
- Derive exact package IDs and the observed-comparison preview from that fresh result; callers can no longer inject either. Reject stale, empty, malformed, denied, or unsupported plans without dispatch or a journaled mutation.
- Check journal admission before service work and repeat it after unlocked preflight to reject competing owners.
- Add fixed bounded kernel boot-ID and typed logind session timestamp readers for upcoming recovery integration.

## Validation
- Focused execution/session tests and all 193 provider tests passed.
- Clean build and full managed repository suite passed, including configured QML lint, shell gates, nested-X11 lifecycle checks, and staged installation checks.
- Closed Settings CPU: 0.067%; large surfaces: 0.00%.
- Post-suite local Codex review: clean; it independently reran all 193 provider tests.
- Independent local CodeRabbit review: clean.
- Fedora 44 native kernel boot-ID read and native GLib uint64 unwrapping passed.

## Limits and follow-up
- Public mutation commands remain disabled until recovery and root-scoped confirmation/operation UI integration is complete.
- No real RefreshCache or UpdatePackages mutation was invoked.
- This agent process has no logind session (NoSessionForPID). The live reader correctly retains guidance as unavailable; successful live own-session evidence is not claimed.
- Existing unrelated QML type warnings remain unchanged.
