### PR TITLE
feat(system): recover exact PackageKit operation evidence

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -71,7 +71,12 @@ now repeats bounded inventory and simulation reads and compares the confirmed
 generation before creating its mutable transaction. Callers cannot supply their
 own package IDs or preview to bypass that check. Fixed, bounded kernel boot and
 typed logind session evidence readers are available for recovery integration.
-Public mutation commands remain disabled: recovery integration and the root-scoped
+The internal recovery coordinator now uses exact-object adoption and a bounded
+active list, plus at most 64 history records for updates only. It distinguishes
+lookup failure from absence, checkpoints adopted restart signals, rejects stale
+ownership, and durably recovers terminal evidence or conservative interruption.
+Previous-boot records cannot reintroduce satisfied guidance. Public mutation
+commands remain disabled: snapshot/control integration and the root-scoped
 confirmation and operation UI must be completed before this boundary can be accepted.
 
 - [ ] Add user-initiated Fedora update discovery and status through the selected

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -1230,7 +1230,11 @@ path, or elevation mechanism.
   For a nonterminal record, recovery validates and copies the bounded record
   under a shared journal lock, releases that lock, and only then attempts to
   adopt the exact recorded transaction object and consume its current or
-  replayed result before checking the active PackageKit transaction list. One
+  replayed result before checking the active PackageKit transaction list. Signals
+  received during the initial object-property read remain bounded in memory:
+  no running or restart checkpoint is written until the role and invoking UID
+  are validated. An absent or mismatched object cannot contribute those signals
+  to the journal. One
   independent ten-second monotonic aggregate deadline covers attachment to the
   recorded object, its required property reads and replayed signals, and the
   manager `GetTransactionList` call. An exact validated `Finished` result skips

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -1233,7 +1233,11 @@ path, or elevation mechanism.
   replayed result before checking the active PackageKit transaction list. One
   independent ten-second monotonic aggregate deadline covers attachment to the
   recorded object, its required property reads and replayed signals, and the
-  manager `GetTransactionList` call. The active-list reply accepts at most 256
+  manager `GetTransactionList` call. An exact validated `Finished` result skips
+  the secondary active-list lookup. If it arrives while that lookup is already
+  in flight, a failed or malformed list reply cannot discard the captured result;
+  malformed transaction evidence or a journal checkpoint failure still prevents
+  terminal recovery. Without terminal evidence, the active-list reply accepts at most 256
   unique valid PackageKit transaction object paths and 64 KiB of their complete
   encoded UTF-8 values. Expiry cancels unfinished local D-Bus requests, detaches
   every recovery observer without calling `Cancel` on the recorded transaction,
@@ -1282,7 +1286,10 @@ path, or elevation mechanism.
   commit. A partial replay containing only application, session, or `none`
   signals also cannot exclude a missed system-restart requirement: unless
   execution is proven excluded, an otherwise `none` system contribution becomes
-  `unknown`. Specific observed system or security-system guidance is retained.
+  `unknown`. Specific system or security-system guidance is retained on that
+  partial-replay path. The no-replayed-signal and history paths still use their
+  explicitly required uncertainty replacement, even when `active` previously
+  recorded specific system guidance.
   A valid durable
   terminal record written from `Finished` recovers its persisted tuple. A
   missing, malformed, or kind-incompatible contribution field in the active or

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -1307,7 +1307,11 @@ path, or elevation mechanism.
   because history cannot
   replay a `RequireRestart` signal that may have been missed before persistence.
   It never substitutes or preserves `none` on that path. An exact history match
-  with `succeeded=false` is still `interrupted`, because history cannot
+  with `succeeded=false` is usable only after a successful bounded lookup proves
+  exact absence: PackageKit inserts that row at its ready state, before
+  execution finishes. A still-active transaction or a lookup timeout retains
+  ownership despite this unsuccessful history row. With confirmed absence the
+  result is `interrupted`, because history cannot
   distinguish cancellation from another failure or reconstruct the required
   typed error row. It uses the same conservative system `unknown` contribution
   while retaining validated session and application evidence regardless of the

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -1279,7 +1279,11 @@ path, or elevation mechanism.
   cannot be excluded sets the system contribution to `unknown` while retaining
   the validated session and application contributions already in `active`; a
   restart signal may have occurred after the last successful active-frame
-  commit. A valid durable
+  commit. A partial replay containing only application, session, or `none`
+  signals also cannot exclude a missed system-restart requirement: unless
+  execution is proven excluded, an otherwise `none` system contribution becomes
+  `unknown`. Specific observed system or security-system guidance is retained.
+  A valid durable
   terminal record written from `Finished` recovers its persisted tuple. A
   missing, malformed, or kind-incompatible contribution field in the active or
   terminal record is a `malformed` recovery error that preserves the record and

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -4243,6 +4243,15 @@ class PackageKitBackend:
         checkpoint_failure = None
         restarts = set()
         subscriptions = []
+        identity_verified = None
+
+        def checkpoint(callback, *args):
+            nonlocal checkpoint_failure
+            if callback is not None and checkpoint_failure is None:
+                try:
+                    callback(*args)
+                except (SnapshotFailure, JournalFileError, JournalRecordError, JournalFrameError, JournalAdmissionError) as error:
+                    checkpoint_failure = error
 
         def properties(values):
             nonlocal status, allow_cancel, percent, saw_running, uncertain_status, cancel_blocked, checkpoint_failure
@@ -4254,11 +4263,8 @@ class PackageKitBackend:
                 uncertain_status = uncertain_status or status == 0
                 if not saw_running and status not in {0, 1, 2, 18, 31}:
                     saw_running = True
-                    if on_running is not None:
-                        try:
-                            on_running()
-                        except (SnapshotFailure, JournalFileError, JournalRecordError, JournalFrameError, JournalAdmissionError) as error:
-                            checkpoint_failure = error
+                    if identity_verified is True:
+                        checkpoint(on_running)
             if "AllowCancel" in values:
                 allow_cancel = values["AllowCancel"] if type(values["AllowCancel"]) is bool else False
                 cancel_blocked = cancel_blocked or not allow_cancel
@@ -4268,7 +4274,7 @@ class PackageKitBackend:
 
         def signal_received(_connection, _sender, _path, interface, signal, variant, _data):
             nonlocal terminal_state, terminal_time, transaction_failure, malformed, present, checkpoint_failure
-            if not live or checkpoint_failure is not None or time.monotonic() >= deadline:
+            if not live or identity_verified is False or malformed is not None or checkpoint_failure is not None or time.monotonic() >= deadline:
                 return
             if terminal_state is not None:
                 if signal == "Finished":
@@ -4287,11 +4293,9 @@ class PackageKitBackend:
                     if variant.get_type_string() != "(us)":
                         raise ValueError
                     value = values[0] if values[0] in {1, 2, 3, 4, 5, 6} else 0
-                    if on_restart is not None:
-                        try:
-                            on_restart(value)
-                        except (SnapshotFailure, JournalFileError, JournalRecordError, JournalFrameError, JournalAdmissionError) as error:
-                            checkpoint_failure = error
+                    if identity_verified is True:
+                        checkpoint(on_restart, value)
+                        if checkpoint_failure is not None:
                             return
                     restarts.add(value)
                 elif signal == "ErrorCode":
@@ -4336,6 +4340,13 @@ class PackageKitBackend:
                 if not isinstance(cause, self.GLib.Error) or self.Gio.dbus_error_get_remote_error(cause) not in {
                         "org.freedesktop.DBus.Error.UnknownObject", "org.freedesktop.DBus.Error.UnknownMethod"}:
                     raise
+                # No object identity was established. Discard buffered signals
+                # and ignore later ones; only the bounded list/history may help.
+                identity_verified = False
+                restarts.clear()
+                saw_running = False
+                status, allow_cancel, percent = 0, False, None
+                terminal_state, terminal_time, transaction_failure = None, None, None
             else:
                 values = reply.unpack()[0]
                 role, uid = values.get("Role"), values.get("Uid")
@@ -4343,6 +4354,15 @@ class PackageKitBackend:
                 allowed_roles = {expected_role, 0} if operation.state in {"pending", "authorizing"} else {expected_role}
                 if type(role) is not int or role not in allowed_roles or type(uid) is not int or uid != os.getuid():
                     raise SnapshotFailure("malformed", "PackageKit active object does not match the recorded operation")
+                if malformed is not None:
+                    raise malformed
+                # Before this point callbacks collect only a fixed-size status
+                # tuple and at most seven restart enums, never journal writes.
+                identity_verified = True
+                if saw_running:
+                    checkpoint(on_running)
+                for value in sorted(restarts):
+                    checkpoint(on_restart, value)
                 properties(values)
                 present = status != 18
             if checkpoint_failure is not None:

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -4347,8 +4347,17 @@ class PackageKitBackend:
                 present = status != 18
             if checkpoint_failure is not None:
                 raise checkpoint_failure
-            reply = self._recovery_call(PACKAGEKIT_PATH, PACKAGEKIT_INTERFACE, "GetTransactionList", None, deadline, "(ao)")
-            listed = validate_transaction_list(reply.unpack()[0])
+            listed = ()
+            if terminal_state is None:
+                try:
+                    reply = self._recovery_call(PACKAGEKIT_PATH, PACKAGEKIT_INTERFACE, "GetTransactionList", None, deadline, "(ao)")
+                    if terminal_state is None:
+                        listed = validate_transaction_list(reply.unpack()[0])
+                except SnapshotFailure:
+                    # Finished may arrive while the secondary request is in
+                    # flight. Its exact result does not depend on that lookup.
+                    if terminal_state is None:
+                        raise
             if malformed is not None:
                 raise malformed
             return RecoveryEvidence(present or path in listed, terminal_state, transaction_failure,

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -3617,7 +3617,10 @@ def recover_journal_active(
                 lookup_failure is None or lookup_failure.code == "timeout"):
             try:
                 history_match = match_update_history(backend.operation_history(), original.transaction_path, os.getuid())
-                history_used = history_match is not None
+                # PackageKit inserts history at READY with succeeded=false.
+                # That row alone cannot distinguish a live job from failure.
+                history_used = history_match is True or (
+                    history_match is False and evidence is not None and not evidence.present)
             except SnapshotFailure as failure:
                 if failure.code == "malformed" or lookup_failure is None:
                     lookup_failure = failure
@@ -4239,6 +4242,7 @@ class PackageKitBackend:
         deadline = time.monotonic() + 10
         live = True
         present = False
+        destroyed = False
         status = 0
         allow_cancel = False
         percent = None
@@ -4282,7 +4286,7 @@ class PackageKitBackend:
                 percent = value if type(value) is int and 0 <= value <= 100 else None
 
         def signal_received(_connection, _sender, _path, interface, signal, variant, _data):
-            nonlocal terminal_state, terminal_time, transaction_failure, malformed, present, checkpoint_failure
+            nonlocal terminal_state, terminal_time, transaction_failure, malformed, present, destroyed, checkpoint_failure
             if not live or identity_verified is False or malformed is not None or checkpoint_failure is not None or time.monotonic() >= deadline:
                 return
             if terminal_state is not None:
@@ -4326,6 +4330,9 @@ class PackageKitBackend:
                         terminal_state = "failed"
                         transaction_failure = SnapshotFailure("internal", "PackageKit transaction did not succeed")
                 elif signal == "Destroy":
+                    if variant.get_type_string() != "()":
+                        raise ValueError
+                    destroyed = True
                     present = False
             except (TypeError, ValueError, IndexError):
                 malformed = SnapshotFailure("malformed", "PackageKit recovery signal is malformed")
@@ -4353,6 +4360,7 @@ class PackageKitBackend:
                 # and ignore later ones; only the bounded list/history may help.
                 identity_verified = False
                 restarts.clear()
+                destroyed = False
                 saw_running = False
                 status, allow_cancel, percent = 0, False, None
                 terminal_state, terminal_time, transaction_failure = None, None, None
@@ -4373,7 +4381,7 @@ class PackageKitBackend:
                 for value in sorted(restarts):
                     checkpoint(on_restart, value)
                 properties(values)
-                present = status != 18
+                present = not destroyed and status != 18
             if checkpoint_failure is not None:
                 raise checkpoint_failure
             listed = ()
@@ -4389,9 +4397,9 @@ class PackageKitBackend:
                         raise
             if malformed is not None:
                 raise malformed
-            return RecoveryEvidence(present or path in listed, terminal_state, transaction_failure,
+            return RecoveryEvidence(not destroyed and (present or path in listed), terminal_state, transaction_failure,
                                     tuple(sorted(restarts)), 3 if saw_running else 0 if uncertain_status else status,
-                                    allow_cancel and not cancel_blocked, percent, terminal_time)
+                                    allow_cancel and not cancel_blocked and not destroyed, percent, terminal_time)
         finally:
             live = False
             for subscription in subscriptions:

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -2587,6 +2587,8 @@ def advance_journal_operation(
     journal: JournalDescriptorSet,
     expected: JournalOperation,
     following: JournalOperation,
+    *,
+    recovery_boot_id: str | None = None,
 ) -> JournalOperation:
     """Commit one legal state/contribution change, rejecting stale observations."""
     encode_journal_operation(expected)
@@ -2617,7 +2619,20 @@ def advance_journal_operation(
         not same_state and following.state not in JOURNAL_TRANSITIONS[expected.state]
     ):
         raise JournalAdmissionError("journal operation transition is invalid")
-    if expected.kind == "update" and (
+    recovery_replacement = False
+    if recovery_boot_id is not None:
+        if (not isinstance(recovery_boot_id, str) or BOOT_ID_PATTERN.fullmatch(recovery_boot_id) is None
+                or expected.kind != "update" or following.state not in JOURNAL_OPERATION_TERMINAL_STATES):
+            raise JournalAdmissionError("journal recovery boundary is invalid")
+        recovery_replacement = (
+            recovery_boot_id != expected.boot_id
+            and (following.system_restart, following.session_restart, following.application_restart) == ("none", "none", False)
+        ) or (
+            recovery_boot_id == expected.boot_id and following.system_restart == "unknown"
+            and following.session_restart == expected.session_restart
+            and following.application_restart == expected.application_restart
+        )
+    if expected.kind == "update" and not recovery_replacement and (
         JOURNAL_RESTART_SYSTEM_STRENGTH[following.system_restart]
         < JOURNAL_RESTART_SYSTEM_STRENGTH[expected.system_restart]
         or JOURNAL_RESTART_SESSION_STRENGTH[following.session_restart]
@@ -2797,6 +2812,62 @@ class Package:
 class TransactionResult:
     packages: tuple[Package, ...]
     restart_types: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
+class RecoveryEvidence:
+    """Finite exact-object evidence; absence is distinct from a failed lookup."""
+    present: bool
+    state: str | None = None
+    failure: SnapshotFailure | None = None
+    restart_types: tuple[int, ...] = ()
+    status: int = 0
+    allow_cancel: bool = False
+    percent: int | None = None
+    terminal_monotonic: int | None = None
+
+
+def validate_transaction_list(values: object) -> tuple[str, ...]:
+    if not isinstance(values, (list, tuple)) or len(values) > 256:
+        raise SnapshotFailure("malformed", "PackageKit active transaction list is malformed")
+    seen = set()
+    size = 0
+    for path in values:
+        if not isinstance(path, str) or JOURNAL_PACKAGEKIT_PATH_PATTERN.fullmatch(path) is None or path in seen:
+            raise SnapshotFailure("malformed", "PackageKit active transaction identity is malformed")
+        seen.add(path)
+        size += len(path.encode("utf-8"))
+        if size > 65536:
+            raise SnapshotFailure("malformed", "PackageKit active transaction list exceeds its byte budget")
+    return tuple(values)
+
+
+def validate_history_record(values: object) -> tuple[str, bool, int, int]:
+    """Discard package data and command lines; retain only exact typed identity."""
+    if not isinstance(values, (list, tuple)) or len(values) != 8:
+        raise SnapshotFailure("malformed", "PackageKit history record is malformed")
+    path, timespec, succeeded, role, duration, data, uid, command = values
+    if (
+        not isinstance(path, str) or JOURNAL_PACKAGEKIT_PATH_PATTERN.fullmatch(path) is None
+        or type(succeeded) is not bool
+        or any(type(value) is not int or not 0 <= value <= G_MAXUINT for value in (role, duration, uid))
+        or any(not isinstance(value, str) for value in (timespec, data, command))
+        or len(timespec) > 128
+    ):
+        raise SnapshotFailure("malformed", "PackageKit history identity is malformed")
+    return path, succeeded, role, uid
+
+
+def match_update_history(records: Sequence[tuple[str, bool, int, int]], path: str, uid: int) -> bool | None:
+    """A wrong owner or duplicate exact match is ambiguity, never negative history."""
+    if len(records) > 64:
+        raise SnapshotFailure("malformed", "PackageKit history exceeds its record budget")
+    matches = [record for record in records if record[0] == path]
+    if not matches:
+        return None
+    if len(matches) != 1 or matches[0][2:] != (22, uid):
+        raise SnapshotFailure("malformed", "PackageKit history does not uniquely identify this update")
+    return matches[0][1]
 
 
 @dataclass(frozen=True)
@@ -3491,6 +3562,138 @@ def read_fedora_identity() -> dict[str, str]:
         raise SnapshotFailure("unsupported", "Fedora platform identity is unavailable", "unsupported") from error
 
 
+def recover_journal_active(
+    journal: JournalDescriptorSet, backend: PackageKitBackend, *,
+    boot_id: str, session_started: int | None = None,
+) -> tuple[JournalState, RecoveryEvidence | None, SnapshotFailure | None]:
+    """Recover one copied owner without holding a journal lock across service work."""
+    if not isinstance(boot_id, str) or BOOT_ID_PATTERN.fullmatch(boot_id) is None:
+        raise JournalRecordError("recovery boot identity is invalid")
+    if session_started is not None:
+        _encode_journal_uint64(session_started, "session start")
+    original = load_journal_state(journal.chain).active
+    if original is None:
+        with lock_writable_journal(journal):
+            prune_journal_restart(journal, boot_id, session_started)
+            return load_writable_journal_state(journal), None, None
+    evidence = None
+    lookup_failure = None
+    history_match = None
+    history_used = False
+    identity = ("operation_id", "action_id", "started_at", "kind", "generation", "transaction_path", "boot_id", "slot")
+
+    def checkpoint_running():
+        with lock_writable_journal(journal):
+            current = load_writable_journal_state(journal).active
+            if current is None or any(getattr(current, field) != getattr(original, field) for field in identity) or current.state in JOURNAL_OPERATION_TERMINAL_STATES:
+                raise SnapshotFailure("conflict", "Recovery owner changed; discard the stale observation")
+            if current.state in {"pending", "authorizing"}:
+                advance_journal_operation(journal, current, replace(current, state="running", detail="PackageKit execution observed during recovery"))
+
+    def checkpoint_restart(value):
+        if original.kind != "update" or original.boot_id != boot_id:
+            return
+        with lock_writable_journal(journal):
+            current = load_writable_journal_state(journal).active
+            if current is None or any(getattr(current, field) != getattr(original, field) for field in identity) or current.state in JOURNAL_OPERATION_TERMINAL_STATES:
+                raise SnapshotFailure("conflict", "Recovery owner changed; discard the stale observation")
+            changes = {}
+            if value == 2:
+                changes["application_restart"] = True
+            elif value in {3, 5}:
+                changes["session_restart"] = max(current.session_restart, "security-session" if value == 5 else "session", key=JOURNAL_RESTART_SESSION_STRENGTH.__getitem__)
+            elif value != 1:
+                changes["system_restart"] = max(current.system_restart, {4: "system", 6: "security-system"}.get(value, "unknown"), key=JOURNAL_RESTART_SYSTEM_STRENGTH.__getitem__)
+            following = replace(current, **changes)
+            if following != current:
+                advance_journal_operation(journal, current, following)
+
+    if original.state not in JOURNAL_OPERATION_TERMINAL_STATES and original.kind in {"update", "refresh"}:
+        try:
+            evidence = backend.probe_operation(original, on_restart=checkpoint_restart, on_running=checkpoint_running)
+        except SnapshotFailure as failure:
+            lookup_failure = failure
+        if original.kind == "update" and (evidence is None or evidence.state is None) and (
+                lookup_failure is None or lookup_failure.code == "timeout"):
+            try:
+                history_match = match_update_history(backend.operation_history(), original.transaction_path, os.getuid())
+                history_used = history_match is not None
+            except SnapshotFailure as failure:
+                if failure.code == "malformed" or lookup_failure is None:
+                    lookup_failure = failure
+    with lock_writable_journal(journal):
+        current_state = load_writable_journal_state(journal)
+        current = current_state.active
+        if current is None or any(getattr(current, field) != getattr(original, field) for field in identity):
+            return current_state, None, None
+        # Boot/session satisfaction is independent of the recovered operation.
+        # Apply it before comparing a new boot's monotonic terminal cutoff.
+        prune_journal_restart(journal, boot_id, session_started)
+        current_state = load_writable_journal_state(journal)
+        if current.state in JOURNAL_OPERATION_TERMINAL_STATES:
+            complete_journal_terminal(journal, boot_id=boot_id, session_started=session_started)
+            return load_writable_journal_state(journal), None, None
+        if lookup_failure is not None and (lookup_failure.code == "malformed" or (
+                not history_used and (evidence is None or evidence.present))):
+            return current_state, evidence, lookup_failure
+        if evidence is not None and evidence.status == 3 and current.state in {"pending", "authorizing"}:
+            current = advance_journal_operation(journal, current, replace(current, state="running", detail="PackageKit execution observed during recovery"))
+            current_state = load_writable_journal_state(journal)
+        if evidence is not None and evidence.state is None and evidence.present and not history_used:
+            prune_journal_restart(journal, boot_id, session_started)
+            return load_writable_journal_state(journal), evidence, lookup_failure
+        state = evidence.state if evidence is not None and evidence.state is not None else "succeeded" if history_match is True else "interrupted"
+        failure = evidence.failure if evidence is not None and evidence.state is not None else None
+        if state == "interrupted":
+            failure = SnapshotFailure("interrupted", "Operation observation was interrupted; the platform outcome is unknown. Refresh status and inspect diagnostics before retrying")
+        pre_running = current.state in {"pending", "authorizing"}
+        if state == "permission-denied" and not pre_running:
+            state = "failed"
+        if state == "succeeded" and pre_running:
+            current = advance_journal_operation(journal, current, replace(current, state="running", detail="Recovered PackageKit completion"))
+        elif state == "permission-denied" and current.state == "pending":
+            current = advance_journal_operation(journal, current, replace(current, state="authorizing", detail="Recovered PackageKit authorization result"))
+        elif state == "canceled" and current.state == "running":
+            current = advance_journal_operation(journal, current, replace(current, state="cancel-requested", detail="Recovered PackageKit cancellation"))
+        changes = {}
+        recovery_boot = None
+        if current.kind == "update":
+            system, session, application = current.system_restart, current.session_restart, current.application_restart
+            if current.boot_id != boot_id:
+                system, session, application = "none", "none", False
+                recovery_boot = boot_id
+            else:
+                observed = evidence.restart_types if evidence is not None and evidence.state is not None else ()
+                for value in observed:
+                    if value == 2:
+                        application = True
+                    elif value in {3, 5}:
+                        session = max(session, "security-session" if value == 5 else "session", key=JOURNAL_RESTART_SESSION_STRENGTH.__getitem__)
+                    elif value != 1:
+                        system = max(system, {4: "system", 6: "security-system"}.get(value, "unknown"), key=JOURNAL_RESTART_SYSTEM_STRENGTH.__getitem__)
+                excluded = pre_running and evidence is not None and evidence.status == 31 and state in {"permission-denied", "canceled"}
+                if history_used or (not observed and not excluded):
+                    # History or incomplete adoption cannot reconstruct missed
+                    # signals. This is uncertainty replacement, not satisfaction.
+                    system = "unknown"
+                    recovery_boot = boot_id
+                elif not excluded and system == "none":
+                    # A partial replay containing only lower-scope (or NONE)
+                    # signals cannot exclude an earlier missed reboot signal.
+                    system = "unknown"
+            changes = dict(system_restart=system, session_restart=session, application_restart=application)
+        cutoff = evidence.terminal_monotonic if evidence is not None and evidence.state is not None else None
+        terminal = replace(current, state=state,
+            finished_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            terminal_monotonic=(cutoff if cutoff is not None else time.monotonic_ns() // 1000) if current.kind in {"update", "refresh"} else None,
+            error_code=None if failure is None else failure.code,
+            detail="Recovered PackageKit completion; missed restart evidence remains unknown" if failure is None else failure.detail,
+            **changes)
+        advance_journal_operation(journal, current, terminal, recovery_boot_id=recovery_boot)
+        complete_journal_terminal(journal, boot_id=boot_id, session_started=session_started)
+        return load_writable_journal_state(journal), None, lookup_failure
+
+
 class PackageKitMutation:
     """Own one exact journaled transaction; callbacks never hold a service-wait lock."""
 
@@ -3838,7 +4041,7 @@ class PackageKitBackend:
             try:
                 reply = self.connection.call_sync(
                     "org.freedesktop.login1", path, interface, method, parameters,
-                    self.GLib.VariantType.new(signature), self.Gio.DBusCallFlags.NONE,
+                    None, self.Gio.DBusCallFlags.NONE,
                     max(1, min(int(remaining * 1000), 10000)), None)
             except self.GLib.Error as error:
                 name = self.Gio.dbus_error_get_remote_error(error)
@@ -3964,6 +4167,281 @@ class PackageKitBackend:
         self._call(path, TRANSACTION_INTERFACE, "SetHints",
                    self.GLib.Variant("(as)", (["background=false", "interactive=true"],)), deadline)
         return path
+
+    def _recovery_call(self, path: str, interface: str, method: str,
+                       parameters: object, deadline: float, signature: str) -> object:
+        """Dispatch signals in order during a bounded request; validate its reply locally.
+
+        Local signature validation keeps a wrong reply type classified as
+        malformed instead of a GIO-generated transport or argument error.
+        """
+        wait_ms = self._timeout_ms(deadline)
+        loop = self.GLib.MainLoop()
+        request = self.Gio.Cancellable()
+        live = True
+        reply = None
+        failure = None
+        source = 0
+
+        def completed(connection, result, _data):
+            nonlocal reply, failure
+            if not live:
+                return
+            try:
+                reply = connection.call_finish(result)
+            except self.GLib.Error as error:
+                failure = error
+            loop.quit()
+
+        def expired():
+            nonlocal source
+            source = 0
+            loop.quit()
+            return self.GLib.SOURCE_REMOVE
+
+        try:
+            source = self.GLib.timeout_add(wait_ms, expired)
+            self.connection.call(PACKAGEKIT_NAME, path, interface, method, parameters,
+                None, self.Gio.DBusCallFlags.NONE,
+                wait_ms, request, completed, None)
+            if reply is None and failure is None and source:
+                loop.run()
+        finally:
+            live = False
+            request.cancel()
+            if source:
+                self.GLib.source_remove(source)
+        if time.monotonic() >= deadline or (reply is None and failure is None):
+            raise SnapshotFailure("timeout", "PackageKit recovery lookup timed out")
+        if failure is not None:
+            raise self._dbus_failure(failure) from failure
+        if reply.get_type_string() != signature:
+            raise SnapshotFailure("malformed", "PackageKit recovery reply is malformed")
+        return reply
+
+    def probe_operation(self, operation: JournalOperation, *,
+                        on_restart: Callable[[int], object] | None = None,
+                        on_running: Callable[[], object] | None = None) -> RecoveryEvidence:
+        """Attach only to the recorded object, then obtain a bounded active list."""
+        encode_journal_operation(operation)
+        if operation.kind not in {"refresh", "update"} or operation.state in JOURNAL_OPERATION_TERMINAL_STATES:
+            raise SnapshotFailure("malformed", "PackageKit recovery target is not active")
+        path = operation.transaction_path
+        deadline = time.monotonic() + 10
+        live = True
+        present = False
+        status = 0
+        allow_cancel = False
+        percent = None
+        saw_running = False
+        uncertain_status = False
+        cancel_blocked = False
+        terminal_state = None
+        terminal_time = None
+        transaction_failure = None
+        malformed = None
+        checkpoint_failure = None
+        restarts = set()
+        subscriptions = []
+
+        def properties(values):
+            nonlocal status, allow_cancel, percent, saw_running, uncertain_status, cancel_blocked, checkpoint_failure
+            if not isinstance(values, dict):
+                raise ValueError
+            if "Status" in values:
+                value = values["Status"]
+                status = value if type(value) is int and 0 <= value <= 36 else 0
+                uncertain_status = uncertain_status or status == 0
+                if not saw_running and status not in {0, 1, 2, 18, 31}:
+                    saw_running = True
+                    if on_running is not None:
+                        try:
+                            on_running()
+                        except (SnapshotFailure, JournalFileError, JournalRecordError, JournalFrameError, JournalAdmissionError) as error:
+                            checkpoint_failure = error
+            if "AllowCancel" in values:
+                allow_cancel = values["AllowCancel"] if type(values["AllowCancel"]) is bool else False
+                cancel_blocked = cancel_blocked or not allow_cancel
+            if "Percentage" in values:
+                value = values["Percentage"]
+                percent = value if type(value) is int and 0 <= value <= 100 else None
+
+        def signal_received(_connection, _sender, _path, interface, signal, variant, _data):
+            nonlocal terminal_state, terminal_time, transaction_failure, malformed, present, checkpoint_failure
+            if not live or checkpoint_failure is not None or time.monotonic() >= deadline:
+                return
+            if terminal_state is not None:
+                if signal == "Finished":
+                    malformed = SnapshotFailure("malformed", "PackageKit recovery completion is duplicated")
+                return
+            try:
+                values = variant.unpack()
+                if interface == PROPERTIES_INTERFACE:
+                    if variant.get_type_string() != "(sa{sv}as)" or values[0] != TRANSACTION_INTERFACE:
+                        raise ValueError
+                    changed = dict(values[1])
+                    for key in values[2]:
+                        changed[key] = None
+                    properties(changed)
+                elif signal == "RequireRestart":
+                    if variant.get_type_string() != "(us)":
+                        raise ValueError
+                    value = values[0] if values[0] in {1, 2, 3, 4, 5, 6} else 0
+                    if on_restart is not None:
+                        try:
+                            on_restart(value)
+                        except (SnapshotFailure, JournalFileError, JournalRecordError, JournalFrameError, JournalAdmissionError) as error:
+                            checkpoint_failure = error
+                            return
+                    restarts.add(value)
+                elif signal == "ErrorCode":
+                    if variant.get_type_string() != "(us)":
+                        raise ValueError
+                    transaction_failure = transaction_failure or self._transaction_failure(values[0], "")
+                elif signal == "Finished":
+                    if variant.get_type_string() != "(uu)" or terminal_state is not None:
+                        raise ValueError
+                    terminal_time = time.monotonic_ns() // 1000
+                    if transaction_failure is not None:
+                        terminal_state = {"permission-denied": "permission-denied", "canceled": "canceled"}.get(transaction_failure.code, "failed")
+                    elif values[0] == EXIT_SUCCESS:
+                        terminal_state = "succeeded"
+                    elif values[0] == 3:
+                        terminal_state = "canceled"
+                        transaction_failure = SnapshotFailure("canceled", "PackageKit canceled the transaction")
+                    else:
+                        terminal_state = "failed"
+                        transaction_failure = SnapshotFailure("internal", "PackageKit transaction did not succeed")
+                elif signal == "Destroy":
+                    present = False
+            except (TypeError, ValueError, IndexError):
+                malformed = SnapshotFailure("malformed", "PackageKit recovery signal is malformed")
+
+        def service_changed(_connection, _sender, _path, _interface, _signal, variant, _data):
+            nonlocal malformed
+            if live and variant.get_type_string() == "(sss)":
+                values = variant.unpack()
+                if values[0] == PACKAGEKIT_NAME and values[1] != values[2]:
+                    malformed = SnapshotFailure("missing-provider", "PackageKit changed during recovery; retry the lookup")
+
+        try:
+            subscriptions.append(self.connection.signal_subscribe(PACKAGEKIT_NAME, TRANSACTION_INTERFACE, None, path, None, self.Gio.DBusSignalFlags.NONE, signal_received, None))
+            subscriptions.append(self.connection.signal_subscribe(PACKAGEKIT_NAME, PROPERTIES_INTERFACE, "PropertiesChanged", path, TRANSACTION_INTERFACE, self.Gio.DBusSignalFlags.NONE, signal_received, None))
+            subscriptions.append(self.connection.signal_subscribe("org.freedesktop.DBus", "org.freedesktop.DBus", "NameOwnerChanged", "/org/freedesktop/DBus", PACKAGEKIT_NAME, self.Gio.DBusSignalFlags.NONE, service_changed, None))
+            try:
+                reply = self._recovery_call(path, PROPERTIES_INTERFACE, "GetAll",
+                    self.GLib.Variant("(s)", (TRANSACTION_INTERFACE,)), deadline, "(a{sv})")
+            except SnapshotFailure as failure:
+                cause = failure.__cause__
+                if not isinstance(cause, self.GLib.Error) or self.Gio.dbus_error_get_remote_error(cause) not in {
+                        "org.freedesktop.DBus.Error.UnknownObject", "org.freedesktop.DBus.Error.UnknownMethod"}:
+                    raise
+            else:
+                values = reply.unpack()[0]
+                role, uid = values.get("Role"), values.get("Uid")
+                expected_role = 13 if operation.kind == "refresh" else 22
+                allowed_roles = {expected_role, 0} if operation.state in {"pending", "authorizing"} else {expected_role}
+                if type(role) is not int or role not in allowed_roles or type(uid) is not int or uid != os.getuid():
+                    raise SnapshotFailure("malformed", "PackageKit active object does not match the recorded operation")
+                properties(values)
+                present = status != 18
+            if checkpoint_failure is not None:
+                raise checkpoint_failure
+            reply = self._recovery_call(PACKAGEKIT_PATH, PACKAGEKIT_INTERFACE, "GetTransactionList", None, deadline, "(ao)")
+            listed = validate_transaction_list(reply.unpack()[0])
+            if malformed is not None:
+                raise malformed
+            return RecoveryEvidence(present or path in listed, terminal_state, transaction_failure,
+                                    tuple(sorted(restarts)), 3 if saw_running else 0 if uncertain_status else status,
+                                    allow_cancel and not cancel_blocked, percent, terminal_time)
+        finally:
+            live = False
+            for subscription in subscriptions:
+                self.connection.signal_unsubscribe(subscription)
+            if checkpoint_failure is not None:
+                raise checkpoint_failure
+
+    def operation_history(self) -> tuple[tuple[str, bool, int, int], ...]:
+        """Collect no more than 64 old transactions under an independent deadline."""
+        deadline = time.monotonic() + 10
+        reply = self._recovery_call(PACKAGEKIT_PATH, PACKAGEKIT_INTERFACE, "CreateTransaction", None, deadline, "(o)")
+        path = reply.unpack()[0]
+        if not isinstance(path, str) or JOURNAL_PACKAGEKIT_PATH_PATTERN.fullmatch(path) is None:
+            raise SnapshotFailure("malformed", "PackageKit returned an invalid history transaction")
+        loop = self.GLib.MainLoop()
+        records = []
+        finished = None
+        failure = None
+        live = True
+        discarding = False
+        source = 0
+
+        def signal_received(_connection, _sender, _path, _interface, signal, variant, _data):
+            nonlocal finished, failure
+            if not live:
+                return
+            if discarding:
+                # Grace consumes only stop-observing evidence, never a late
+                # history result that could turn expiry into success.
+                if signal == "Finished" and variant.get_type_string() == "(uu)":
+                    finished = variant.unpack()[0]
+                    loop.quit()
+                return
+            if time.monotonic() >= deadline:
+                return
+            if finished is not None:
+                if signal == "Finished":
+                    failure = SnapshotFailure("malformed", "PackageKit history completion is duplicated")
+                return
+            try:
+                if signal == "Transaction":
+                    if variant.get_type_string() != "(osbuusus)" or len(records) >= 64:
+                        raise SnapshotFailure("malformed", "PackageKit history exceeds its typed record budget")
+                    records.append(validate_history_record(variant.unpack()))
+                elif signal == "ErrorCode":
+                    if variant.get_type_string() != "(us)":
+                        raise SnapshotFailure("malformed", "PackageKit history error is malformed")
+                    failure = failure or self._transaction_failure(variant.unpack()[0], "")
+                elif signal == "Finished":
+                    if variant.get_type_string() != "(uu)" or finished is not None:
+                        raise SnapshotFailure("malformed", "PackageKit history completion is malformed")
+                    finished = variant.unpack()[0]
+                    loop.quit()
+            except SnapshotFailure as error:
+                failure = error
+                loop.quit()
+
+        def expired():
+            nonlocal source
+            source = 0
+            loop.quit()
+            return self.GLib.SOURCE_REMOVE
+
+        subscription = self.connection.signal_subscribe(PACKAGEKIT_NAME, TRANSACTION_INTERFACE, None, path, None, self.Gio.DBusSignalFlags.NONE, signal_received, None)
+        try:
+            try:
+                self._recovery_call(path, TRANSACTION_INTERFACE, "GetOldTransactions",
+                    self.GLib.Variant("(u)", (64,)), deadline, "()")
+                if finished is None and failure is None:
+                    source = self.GLib.timeout_add(self._timeout_ms(deadline), expired)
+                    loop.run()
+                if finished is None and failure is None:
+                    raise SnapshotFailure("timeout", "PackageKit recovery history timed out")
+                if failure is not None:
+                    raise failure
+                if finished != EXIT_SUCCESS:
+                    raise SnapshotFailure("internal", "PackageKit recovery history did not succeed")
+                return tuple(records)
+            except SnapshotFailure:
+                if finished is None:
+                    discarding = True
+                    self._cancel_with_grace(path, loop, lambda: finished is not None)
+                raise
+        finally:
+            live = False
+            if source:
+                self.GLib.source_remove(source)
+            self.connection.signal_unsubscribe(subscription)
 
     def execute_mutation(self, owner: PackageKitMutation, package_ids: Sequence[str]) -> None:
         """Observe the exact object through Finished; a missing reply is not a result."""

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -4002,27 +4002,36 @@ class PackageKitBackend:
             raise self._dbus_failure(error) from error
 
     def _dbus_failure(self, error: Exception) -> SnapshotFailure:
-        message = str(error)
-        lowered = message.lower()
-        if "serviceunknown" in lowered or "namehasnoowner" in lowered:
+        name = self.Gio.dbus_error_get_remote_error(error)
+        if name in {"org.freedesktop.DBus.Error.ServiceUnknown",
+                    "org.freedesktop.DBus.Error.NameHasNoOwner",
+                    "org.freedesktop.DBus.Error.UnknownObject"}:
             return SnapshotFailure(
                 "missing-provider", "PackageKit service is unavailable", "unavailable"
             )
-        if "notauthorized" in lowered or "accessdenied" in lowered:
+        if name in {"org.freedesktop.DBus.Error.AccessDenied",
+                    "org.freedesktop.DBus.Error.AuthFailed",
+                    "org.freedesktop.PackageKit.Transaction.RefusedByPolicy"}:
             return SnapshotFailure(
                 "permission-denied",
                 "PackageKit denied the request",
                 "restricted",
             )
-        if "unknownmethod" in lowered:
+        if name in {"org.freedesktop.DBus.Error.UnknownMethod",
+                    "org.freedesktop.DBus.Error.UnknownInterface"}:
             return SnapshotFailure(
                 "unsupported",
                 "PackageKit does not support the required method",
                 "unsupported",
             )
-        if "invalidargs" in lowered:
+        if name in {"org.freedesktop.DBus.Error.InvalidArgs",
+                    "org.freedesktop.DBus.Error.InvalidSignature"}:
             return SnapshotFailure("malformed", "PackageKit rejected the method arguments")
-        if "timedout" in lowered or "timeout" in lowered:
+        if name in {"org.freedesktop.DBus.Error.Timeout",
+                    "org.freedesktop.DBus.Error.TimedOut",
+                    "org.freedesktop.DBus.Error.NoReply"} or (
+                name is None and callable(getattr(error, "matches", None))
+                and error.matches(self.Gio.io_error_quark(), self.Gio.IOErrorEnum.TIMED_OUT)):
             return SnapshotFailure(
                 "timeout", "PackageKit request timed out", "unavailable"
             )

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -4939,7 +4939,7 @@ class PackageKitExecutionTests(unittest.TestCase):
             def competing_owner(package_ids):
                 with provider.lock_writable_journal(journal):
                     provider.begin_journal_operation(journal, "updates-refresh", "2026-09-05T00:00:00Z",
-                                                     "Competing owner", transaction_path="/2_other")
+                                                     "Competing owner", transaction_path="/2_other", boot_id=self.boot_id)
                 return provider.TransactionResult((provider.Package(11, self.package_id, "Example"),))
             backend.simulate.side_effect = competing_owner
             with self.assertRaises(provider.JournalAdmissionError):
@@ -5084,7 +5084,7 @@ class SessionEvidenceTests(unittest.TestCase):
         self.assertEqual(second.args[:4], ("org.freedesktop.login1", "/org/freedesktop/login1/session/_31",
                                            provider.PROPERTIES_INTERFACE, "Get"))
         self.assertEqual(second.args[4].unpack(), ("org.freedesktop.login1.Session", "TimestampMonotonic"))
-        self.assertEqual((first.args[5], second.args[5]), ("(o)", "(v)"))
+        self.assertEqual((first.args[5], second.args[5]), (None, None))
         self.assertEqual((first.args[7], second.args[7]), (9000, 7000))
 
     def test_malformed_session_path_never_reads_property(self):
@@ -5102,6 +5102,13 @@ class SessionEvidenceTests(unittest.TestCase):
                 with self.assertRaises(provider.SnapshotFailure) as raised:
                     self.backend(timestamp=self.Variant(signature, value)).session_started()
                 self.assertEqual(raised.exception.code, "malformed")
+
+    def test_wrong_outer_reply_type_is_a_malformed_result(self):
+        backend = self.backend()
+        backend.connection.call_sync.side_effect = [self.Variant("(s)", ("/org/freedesktop/login1/session/_31",))]
+        with self.assertRaises(provider.SnapshotFailure) as raised:
+            backend.session_started()
+        self.assertEqual(raised.exception.code, "malformed")
 
     def test_missing_service_or_expired_deadline_does_not_guess_clear(self):
         backend = self.backend()
@@ -5128,6 +5135,502 @@ class SessionEvidenceTests(unittest.TestCase):
                 with self.assertRaises(provider.SnapshotFailure) as raised:
                     backend.session_started()
                 self.assertEqual(raised.exception.code, code)
+
+
+class OperationRecoveryTests(unittest.TestCase):
+    boot_id = PackageKitExecutionTests.boot_id
+    journal = PackageKitExecutionTests.journal
+
+    def begin(self, journal, kind="update", **changes):
+        with provider.lock_writable_journal(journal):
+            args = dict(transaction_path="/1_test", boot_id=self.boot_id) if kind in {"update", "refresh"} else {}
+            if kind == "update":
+                args.update(generation="a" * 64, boot_id=self.boot_id)
+            operation = provider.begin_journal_operation(journal,
+                {"update": "updates-install-all", "refresh": "updates-refresh", "timezone": "timezone-set"}[kind],
+                "2026-09-05T00:00:00Z", "Recovery fixture", **args)
+            if changes:
+                operation = provider.advance_journal_operation(journal, operation, replace(operation, **changes))
+            return operation
+
+    def backend(self, evidence=None, history=()):
+        backend = mock.Mock()
+        backend.probe_operation.return_value = evidence or provider.RecoveryEvidence(False)
+        backend.operation_history.return_value = history
+        return backend
+
+    def recover(self, journal, backend, **kwargs):
+        return provider.recover_journal_active(journal, backend, boot_id=kwargs.pop("boot_id", self.boot_id), **kwargs)
+
+    def test_exact_history_success_failure_and_absence_have_distinct_results(self):
+        for result, expected in ((True, "succeeded"), (False, "interrupted"), (None, "interrupted")):
+            with self.subTest(result=result), self.journal() as journal:
+                operation = self.begin(journal)
+                history = () if result is None else ((operation.transaction_path, result, 22, os.getuid()),)
+                state, evidence, failure = self.recover(journal, self.backend(history=history))
+                self.assertIsNone(state.active)
+                self.assertIsNone(evidence)
+                self.assertIsNone(failure)
+                terminal = state.terminals[operation.slot]
+                self.assertEqual((terminal.state, terminal.system_restart), (expected, "unknown"))
+                self.assertEqual(state.handoff.operation_id, operation.operation_id)
+                self.assertEqual(state.restart.system, "unknown")
+
+    def test_active_transaction_remains_owned_and_is_never_retried(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, state="running")
+            observation = provider.RecoveryEvidence(True, status=3, allow_cancel=True, percent=45)
+            backend = self.backend(observation)
+            state, evidence, failure = self.recover(journal, backend)
+            self.assertEqual(state.active, operation)
+            self.assertEqual(evidence, observation)
+            self.assertIsNone(failure)
+            self.assertEqual([call[0] for call in backend.mock_calls], ["probe_operation", "operation_history"])
+
+    def test_timeout_is_not_absence_but_exact_history_can_supply_a_result(self):
+        for history_success in (False, True):
+            with self.subTest(history_success=history_success), self.journal() as journal:
+                operation = self.begin(journal)
+                history = ((operation.transaction_path, True, 22, os.getuid()),) if history_success else ()
+                backend = self.backend(history=history)
+                backend.probe_operation.side_effect = provider.SnapshotFailure("timeout", "Expired")
+                state, _, failure = self.recover(journal, backend)
+                self.assertEqual(failure.code, "timeout")
+                if history_success:
+                    self.assertIsNone(state.active)
+                    self.assertEqual(state.terminals[operation.slot].state, "succeeded")
+                else:
+                    self.assertEqual(state.active, operation)
+                    self.assertIsNone(state.handoff)
+
+    def test_history_timeout_after_exact_absence_is_conservative_interruption(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.backend()
+            backend.operation_history.side_effect = provider.SnapshotFailure("timeout", "Expired history")
+            state, _, failure = self.recover(journal, backend)
+            self.assertEqual(failure.code, "timeout")
+            self.assertEqual(state.terminals[operation.slot].state, "interrupted")
+
+    def test_malformed_probe_or_history_preserves_nonterminal_record(self):
+        for source in ("probe_operation", "operation_history"):
+            with self.subTest(source=source), self.journal() as journal:
+                operation = self.begin(journal)
+                backend = self.backend()
+                getattr(backend, source).side_effect = provider.SnapshotFailure("malformed", "Malformed evidence")
+                state, _, failure = self.recover(journal, backend)
+                self.assertEqual(state.active, operation)
+                self.assertEqual(failure.code, "malformed")
+                if source == "probe_operation":
+                    backend.operation_history.assert_not_called()
+
+    def test_refresh_and_regional_interruption_never_query_history(self):
+        for kind in ("refresh", "timezone"):
+            with self.subTest(kind=kind), self.journal() as journal:
+                operation = self.begin(journal, kind)
+                backend = self.backend()
+                state, _, _ = self.recover(journal, backend)
+                self.assertEqual(state.terminals[operation.slot].state, "interrupted")
+                backend.operation_history.assert_not_called()
+                if kind == "timezone":
+                    backend.probe_operation.assert_not_called()
+
+    def test_durable_terminal_recovery_opens_no_service(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, state="failed", finished_at="2026-09-05T00:01:00Z",
+                                   terminal_monotonic=100, error_code="package")
+            backend = self.backend()
+            state, _, _ = self.recover(journal, backend)
+            self.assertEqual(state.terminals[operation.slot], operation)
+            self.assertEqual(backend.mock_calls, [])
+
+    def test_restart_checkpoint_precedes_adopted_finished(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.backend()
+            def probe(_operation, *, on_restart, on_running):
+                on_restart(5)
+                on_restart(6)
+                with provider.lock_writable_journal(journal):
+                    active = provider.load_writable_journal_state(journal).active
+                    self.assertEqual((active.system_restart, active.session_restart), ("security-system", "security-session"))
+                    self.assertEqual(active.state, "pending")
+                return provider.RecoveryEvidence(False, "succeeded", restart_types=(5, 6), terminal_monotonic=100)
+            backend.probe_operation.side_effect = probe
+            state, _, _ = self.recover(journal, backend)
+            terminal = state.terminals[operation.slot]
+            self.assertEqual((terminal.system_restart, terminal.session_restart, terminal.terminal_monotonic),
+                             ("security-system", "security-session", 100))
+            backend.operation_history.assert_not_called()
+
+    def test_persistence_failure_never_consumes_a_later_success(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.backend()
+            def probe(_operation, *, on_restart, on_running):
+                with mock.patch.object(provider, "commit_writable_journal_path", side_effect=provider.JournalFileError("Fault")):
+                    on_restart(6)
+                self.fail("A persistence failure must stop recovered success")
+            backend.probe_operation.side_effect = probe
+            with self.assertRaises(provider.JournalFileError):
+                self.recover(journal, backend)
+            with provider.lock_writable_journal(journal):
+                state = provider.load_writable_journal_state(journal)
+            self.assertEqual(state.active, operation)
+            self.assertIsNone(state.handoff)
+
+    def test_partial_restart_adoption_cannot_prove_no_reboot(self):
+        for signals, session, application in (((1,), "none", False),
+                ((2,), "none", True), ((3,), "session", False),
+                ((5, 2), "security-session", True)):
+            with self.subTest(signals=signals), self.journal() as journal:
+                operation = self.begin(journal, state="running")
+                backend = self.backend(provider.RecoveryEvidence(False, "succeeded",
+                    restart_types=signals, status=3, terminal_monotonic=100))
+                state, _, _ = self.recover(journal, backend)
+                terminal = state.terminals[operation.slot]
+                self.assertEqual((terminal.system_restart, terminal.session_restart,
+                                  terminal.application_restart), ("unknown", session, application))
+                self.assertEqual((state.restart.system, state.restart.session,
+                                  state.restart.application), ("unknown", session, application))
+
+    def test_stale_probe_never_terminalizes_replacement_owner(self):
+        with self.journal() as journal:
+            self.begin(journal, "refresh")
+            replacement = None
+            backend = self.backend()
+            def probe(operation, **_kwargs):
+                nonlocal replacement
+                with provider.lock_writable_journal(journal):
+                    terminal = replace(operation, state="interrupted", finished_at="2026-09-05T00:01:00Z", terminal_monotonic=100)
+                    provider.advance_journal_operation(journal, operation, terminal)
+                    provider.complete_journal_terminal(journal)
+                    provider.acknowledge_journal_handoff(journal, operation.operation_id)
+                    replacement = provider.begin_journal_operation(journal, "updates-refresh", "2026-09-05T00:02:00Z", "New owner", transaction_path="/2_new", boot_id=self.boot_id)
+                return provider.RecoveryEvidence(False, "succeeded", terminal_monotonic=200)
+            backend.probe_operation.side_effect = probe
+            state, evidence, failure = self.recover(journal, backend)
+            self.assertEqual(state.active, replacement)
+            self.assertIsNone(evidence)
+            self.assertIsNone(failure)
+
+    def test_history_uncertainty_retains_lower_scopes_and_boot_change_clears_all(self):
+        for new_boot in (self.boot_id, "11111111-2222-3333-4444-555555555555"):
+            with self.subTest(boot=new_boot), self.journal() as journal:
+                operation = self.begin(journal, system_restart="security-system", session_restart="security-session", application_restart=True)
+                backend = self.backend(history=((operation.transaction_path, True, 22, os.getuid()),))
+                state, _, _ = self.recover(journal, backend, boot_id=new_boot)
+                terminal = state.terminals[operation.slot]
+                expected = ("unknown", "security-session", True) if new_boot == self.boot_id else ("none", "none", False)
+                self.assertEqual((terminal.system_restart, terminal.session_restart, terminal.application_restart), expected)
+                self.assertEqual((state.restart.system, state.restart.session, state.restart.application), expected)
+
+    def test_adoption_denial_or_proven_authorization_cancel_is_all_clear(self):
+        for result in ("permission-denied", "canceled"):
+            with self.subTest(result=result), self.journal() as journal:
+                operation = self.begin(journal)
+                backend = self.backend(provider.RecoveryEvidence(False, result, provider.SnapshotFailure(result, "Stopped"), status=31, terminal_monotonic=100))
+                state, _, _ = self.recover(journal, backend)
+                self.assertEqual((state.terminals[operation.slot].state, state.restart.system), (result, "none"))
+
+    def test_new_boot_prunes_old_cutoffs_before_recovered_terminal_commit(self):
+        with self.journal() as journal:
+            first = self.begin(journal, state="running", system_restart="system")
+            with provider.lock_writable_journal(journal):
+                provider.advance_journal_operation(journal, first, replace(first, state="succeeded",
+                    finished_at="2026-09-05T00:01:00Z", terminal_monotonic=1000000))
+                provider.complete_journal_terminal(journal, boot_id=self.boot_id)
+                provider.acknowledge_journal_handoff(journal, first.operation_id)
+            operation = self.begin(journal)
+            backend = self.backend(history=((operation.transaction_path, True, 22, os.getuid()),))
+            with mock.patch.object(provider.time, "monotonic_ns", return_value=200000):
+                state, _, _ = self.recover(journal, backend, boot_id="11111111-2222-3333-4444-555555555555")
+            self.assertEqual(state.terminals[operation.slot].terminal_monotonic, 200)
+            self.assertEqual(state.restart.system, "none")
+            self.assertEqual(state.terminals[first.slot].terminal_monotonic, 1000000)
+
+    def test_denial_with_running_or_unknown_adopted_status_retains_uncertainty(self):
+        for status, expected in ((0, "permission-denied"), (3, "failed")):
+            with self.subTest(status=status), self.journal() as journal:
+                operation = self.begin(journal)
+                backend = self.backend(provider.RecoveryEvidence(False, "permission-denied",
+                    provider.SnapshotFailure("permission-denied", "Denied"), status=status, terminal_monotonic=100))
+                state, _, _ = self.recover(journal, backend)
+                self.assertEqual((state.terminals[operation.slot].state, state.restart.system), (expected, "unknown"))
+
+    def test_observed_running_is_durable_before_a_later_recovery_attempt(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.backend()
+            def probe(_operation, *, on_restart, on_running):
+                on_running()
+                with provider.lock_writable_journal(journal):
+                    self.assertEqual(provider.load_writable_journal_state(journal).active.state, "running")
+                return provider.RecoveryEvidence(True, status=3)
+            backend.probe_operation.side_effect = probe
+            state, _, _ = self.recover(journal, backend)
+            self.assertEqual(state.active.state, "running")
+            backend = self.backend(provider.RecoveryEvidence(False, "canceled", status=31, terminal_monotonic=100))
+            state, _, _ = self.recover(journal, backend)
+            self.assertEqual((state.terminals[operation.slot].state, state.restart.system), ("canceled", "unknown"))
+
+    def test_recovery_override_cannot_weaken_arbitrary_contributions(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, system_restart="system", session_restart="session", application_restart=True)
+            for changes in ({"system_restart": "none"}, {"system_restart": "unknown", "session_restart": "none"},
+                            {"system_restart": "unknown", "application_restart": False}):
+                with self.subTest(changes=changes), provider.lock_writable_journal(journal):
+                    terminal = replace(operation, state="failed", error_code="internal",
+                        finished_at="2026-09-05T00:01:00Z", terminal_monotonic=100, **changes)
+                    with self.assertRaises(provider.JournalAdmissionError):
+                        provider.advance_journal_operation(journal, operation, terminal, recovery_boot_id=self.boot_id)
+                    self.assertEqual(provider.load_writable_journal_state(journal).active, operation)
+
+    def test_active_list_and_history_identity_bounds(self):
+        self.assertEqual(provider.validate_transaction_list(["/1_test"]), ("/1_test",))
+        for values in (["/1_test"] * 2, [f"/{index}_test" for index in range(257)], ["/wrong/path"], None, "x"):
+            with self.subTest(values=str(values)[:40]), self.assertRaises(provider.SnapshotFailure):
+                provider.validate_transaction_list(values)
+        row = ("/1_test", "2026-09-05T00:00:00Z", True, 22, 10, "ignored package data", os.getuid(), "ignored command")
+        self.assertEqual(provider.validate_history_record(row), ("/1_test", True, 22, os.getuid()))
+        for index, value in ((0, "/wrong"), (2, 1), (3, True), (4, -1), (6, 1 << 32)):
+            malformed = list(row)
+            malformed[index] = value
+            with self.subTest(index=index), self.assertRaises(provider.SnapshotFailure):
+                provider.validate_history_record(malformed)
+        exact = ("/1_test", True, 22, os.getuid())
+        for records in ((exact, exact), (("/1_test", True, 13, os.getuid()),), (("/1_test", True, 22, os.getuid() + 1),)):
+            with self.subTest(records=records), self.assertRaises(provider.SnapshotFailure):
+                provider.match_update_history(records, "/1_test", os.getuid())
+
+
+class RecoveryAdapterTests(unittest.TestCase):
+    boot_id = PackageKitExecutionTests.boot_id
+    package_id = PackageKitExecutionTests.package_id
+    journal = PackageKitExecutionTests.journal
+    begin = OperationRecoveryTests.begin
+
+    def backend(self, journal):
+        backend = PackageKitExecutionTests.backend(self, journal, [])
+        backend.GLib.Variant = SessionEvidenceTests.Variant
+        return backend
+
+    def emit(self, backend, signal, signature, values, interface=None):
+        interface = interface or provider.TRANSACTION_INTERFACE
+        for args in tuple(backend.connection.subscriptions.values()):
+            if args[1] == interface:
+                args[-2](backend.connection, args[0], args[3], interface, signal,
+                         SessionEvidenceTests.Variant(signature, values), None)
+
+    def properties(self, **changes):
+        return {"Role": 22, "Uid": os.getuid(), "Status": 3, "AllowCancel": True, "Percentage": 45, **changes}
+
+    def test_probe_uses_exact_object_and_shared_deadline_without_cancellation(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.backend(journal)
+            backend._recovery_call = mock.Mock(side_effect=[SessionEvidenceTests.Variant("(a{sv})", (self.properties(),)),
+                                                          SessionEvidenceTests.Variant("(ao)", ([operation.transaction_path],))])
+            result = backend.probe_operation(operation)
+            first, second = backend._recovery_call.call_args_list
+            self.assertEqual(first.args[:3], (operation.transaction_path, provider.PROPERTIES_INTERFACE, "GetAll"))
+            self.assertEqual(second.args[:3], (provider.PACKAGEKIT_PATH, provider.PACKAGEKIT_INTERFACE, "GetTransactionList"))
+            self.assertEqual(first.args[4], second.args[4])
+            self.assertEqual((result.present, result.status, result.allow_cancel, result.percent), (True, 3, True, 45))
+            self.assertEqual(backend.connection.calls, [])
+            self.assertEqual(backend.connection.subscriptions, {})
+
+    def test_exact_unknown_object_and_empty_list_prove_absence(self):
+        for error in ("UnknownObject", "UnknownMethod"):
+            for listed in ([], ["/1_test"]):
+                with self.subTest(error=error, listed=listed), self.journal() as journal:
+                    operation = self.begin(journal)
+                    backend = self.backend(journal)
+                    failure = provider.SnapshotFailure("missing-provider", "Absent object")
+                    failure.__cause__ = backend.GLib.Error(error)
+                    backend._recovery_call = mock.Mock(side_effect=[failure, SessionEvidenceTests.Variant("(ao)", (listed,))])
+                    self.assertEqual(backend.probe_operation(operation).present, bool(listed))
+
+    def test_adapter_checkpoints_running_before_consuming_finished(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.backend(journal)
+            checkpointed = []
+            def request(_path, _interface, method, *_args):
+                if method == "GetAll":
+                    return SessionEvidenceTests.Variant("(a{sv})", (self.properties(),))
+                self.assertEqual(checkpointed, ["running"])
+                self.emit(backend, "Finished", "(uu)", (1, 1))
+                return SessionEvidenceTests.Variant("(ao)", ([],))
+            backend._recovery_call = mock.Mock(side_effect=request)
+            self.assertEqual(backend.probe_operation(operation, on_running=lambda: checkpointed.append("running")).state, "succeeded")
+
+    def test_malformed_list_or_owner_never_becomes_absence(self):
+        for properties, listed in ((self.properties(Uid=os.getuid() + 1), []),
+                                   (self.properties(Role=13), []),
+                                   (self.properties(), ["/1_test", "/1_test"])):
+            with self.subTest(properties=properties, listed=listed), self.journal() as journal:
+                operation = self.begin(journal)
+                backend = self.backend(journal)
+                backend._recovery_call = mock.Mock(side_effect=[SessionEvidenceTests.Variant("(a{sv})", (properties,)),
+                                                              SessionEvidenceTests.Variant("(ao)", (listed,))])
+                with self.assertRaises(provider.SnapshotFailure) as raised:
+                    backend.probe_operation(operation)
+                self.assertEqual(raised.exception.code, "malformed")
+                self.assertEqual(backend.connection.subscriptions, {})
+
+    def test_probe_checkpoints_restart_before_finished_and_discards_late_signal(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.backend(journal)
+            checkpointed = []
+            saved = []
+            def request(_path, _interface, method, *_args):
+                if method == "GetAll":
+                    return SessionEvidenceTests.Variant("(a{sv})", (self.properties(),))
+                saved.extend(backend.connection.subscriptions.values())
+                self.emit(backend, "RequireRestart", "(us)", (6, self.package_id))
+                self.assertEqual(checkpointed, [6])
+                self.emit(backend, "Finished", "(uu)", (1, 1))
+                return SessionEvidenceTests.Variant("(ao)", ([],))
+            backend._recovery_call = mock.Mock(side_effect=request)
+            result = backend.probe_operation(operation, on_restart=checkpointed.append)
+            self.assertEqual((result.state, result.restart_types), ("succeeded", (6,)))
+            self.assertIsInstance(result.terminal_monotonic, int)
+            args = saved[0]
+            args[-2](backend.connection, args[0], args[3], args[1], "RequireRestart", SessionEvidenceTests.Variant("(us)", (4, self.package_id)), None)
+            self.assertEqual(checkpointed, [6])
+
+    def test_checkpoint_fault_suppresses_later_finished(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.backend(journal)
+            def request(*_args):
+                self.emit(backend, "RequireRestart", "(us)", (6, self.package_id))
+                self.emit(backend, "Finished", "(uu)", (1, 1))
+                return SessionEvidenceTests.Variant("(a{sv})", (self.properties(),))
+            backend._recovery_call = mock.Mock(side_effect=request)
+            fault = provider.JournalFileError("Persistence fault")
+            with self.assertRaises(provider.JournalFileError) as raised:
+                backend.probe_operation(operation, on_restart=mock.Mock(side_effect=fault))
+            self.assertIs(raised.exception, fault)
+            self.assertEqual(backend.connection.subscriptions, {})
+
+    def test_invalidated_status_and_cancel_permission_are_not_reused(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.backend(journal)
+            def request(_path, _interface, method, *_args):
+                if method == "GetAll":
+                    return SessionEvidenceTests.Variant("(a{sv})", (self.properties(Status=31),))
+                self.emit(backend, "PropertiesChanged", "(sa{sv}as)", (provider.TRANSACTION_INTERFACE, {}, ["Status", "AllowCancel"]), provider.PROPERTIES_INTERFACE)
+                self.emit(backend, "Finished", "(uu)", (3, 1))
+                return SessionEvidenceTests.Variant("(ao)", ([],))
+            backend._recovery_call = mock.Mock(side_effect=request)
+            result = backend.probe_operation(operation)
+            self.assertEqual((result.state, result.status, result.allow_cancel), ("canceled", 0, False))
+
+    def test_probe_timeout_detaches_without_canceling_recorded_transaction(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.backend(journal)
+            backend._recovery_call = mock.Mock(side_effect=provider.SnapshotFailure("timeout", "Expired"))
+            with self.assertRaises(provider.SnapshotFailure):
+                backend.probe_operation(operation)
+            self.assertEqual(backend.connection.subscriptions, {})
+            self.assertEqual(backend.connection.calls, [])
+
+    def test_service_owner_change_invalidates_bounded_probe(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.backend(journal)
+            def request(_path, _interface, method, *_args):
+                if method == "GetAll":
+                    return SessionEvidenceTests.Variant("(a{sv})", (self.properties(),))
+                self.emit(backend, "NameOwnerChanged", "(sss)", (provider.PACKAGEKIT_NAME, ":1.2", ":1.3"), "org.freedesktop.DBus")
+                return SessionEvidenceTests.Variant("(ao)", ([],))
+            backend._recovery_call = mock.Mock(side_effect=request)
+            with self.assertRaises(provider.SnapshotFailure) as raised:
+                backend.probe_operation(operation)
+            self.assertEqual(raised.exception.code, "missing-provider")
+            self.assertEqual(backend.connection.subscriptions, {})
+
+    def test_history_timeout_grace_does_not_accept_late_success(self):
+        with self.journal() as journal:
+            backend = self.backend(journal)
+            backend._recovery_call = mock.Mock(side_effect=[SessionEvidenceTests.Variant("(o)", ("/2_history",)),
+                provider.SnapshotFailure("timeout", "Expired")])
+            def grace(path, _loop, finished):
+                self.assertEqual(path, "/2_history")
+                self.emit(backend, "Transaction", "(osbuusus)", ("/1_test", "2026-09-05T00:00:00Z", True, 22, 1, "ignored", os.getuid(), "ignored"))
+                self.emit(backend, "Finished", "(uu)", (1, 1))
+                self.assertTrue(finished())
+            backend._cancel_with_grace = mock.Mock(side_effect=grace)
+            with self.assertRaises(provider.SnapshotFailure) as raised:
+                backend.operation_history()
+            self.assertEqual(raised.exception.code, "timeout")
+            self.assertEqual(backend.connection.subscriptions, {})
+
+    def test_history_uses_fixed_limit_discards_payload_and_rejects_overflow(self):
+        for count in (1, 65):
+            with self.subTest(count=count), self.journal() as journal:
+                backend = self.backend(journal)
+                backend._cancel_with_grace = mock.Mock()
+                def request(_path, _interface, method, parameters, *_args):
+                    if method == "CreateTransaction":
+                        return SessionEvidenceTests.Variant("(o)", ("/2_history",))
+                    self.assertEqual(method, "GetOldTransactions")
+                    self.assertEqual(parameters.unpack(), (64,))
+                    for index in range(count):
+                        self.emit(backend, "Transaction", "(osbuusus)", (f"/{index}_old", "2026-09-05T00:00:00Z", True, 22, 1, "ignored", os.getuid(), "ignored"))
+                    if count == 1:
+                        self.emit(backend, "Finished", "(uu)", (1, 1))
+                    return SessionEvidenceTests.Variant("()", ())
+                backend._recovery_call = mock.Mock(side_effect=request)
+                if count == 1:
+                    self.assertEqual(backend.operation_history(), (("/0_old", True, 22, os.getuid()),))
+                    backend._cancel_with_grace.assert_not_called()
+                else:
+                    with self.assertRaises(provider.SnapshotFailure) as raised:
+                        backend.operation_history()
+                    self.assertEqual(raised.exception.code, "malformed")
+                    self.assertEqual(backend._cancel_with_grace.call_args.args[0], "/2_history")
+                self.assertEqual(backend.connection.subscriptions, {})
+
+    def test_local_recovery_request_deadline_cancels_and_ignores_late_reply(self):
+        for expired, signature in ((False, "(ao)"), (True, "(ao)"), (False, "(as)")):
+            with self.subTest(expired=expired, signature=signature):
+                backend = provider.PackageKitBackend.__new__(provider.PackageKitBackend)
+                state = {}
+                class Loop:
+                    def run(self):
+                        if expired:
+                            state["timer"]()
+                        else:
+                            state["reply"](backend.connection, object(), None)
+                    def quit(self):
+                        pass
+                def timer(_delay, callback):
+                    state["timer"] = callback
+                    return 1
+                backend.GLib = types.SimpleNamespace(MainLoop=Loop, Error=RuntimeError, SOURCE_REMOVE=False,
+                    VariantType=types.SimpleNamespace(new=lambda value: value), timeout_add=timer, source_remove=mock.Mock())
+                cancellation = mock.Mock()
+                backend.Gio = types.SimpleNamespace(Cancellable=lambda: cancellation, DBusCallFlags=types.SimpleNamespace(NONE=0))
+                backend.connection = mock.Mock()
+                backend.connection.call.side_effect = lambda *args: state.update(reply=args[-2])
+                backend.connection.call_finish.return_value = SessionEvidenceTests.Variant(signature, ([],))
+                with mock.patch.object(provider.time, "monotonic", return_value=100):
+                    if expired or signature != "(ao)":
+                        with self.assertRaises(provider.SnapshotFailure) as raised:
+                            backend._recovery_call(provider.PACKAGEKIT_PATH, provider.PACKAGEKIT_INTERFACE, "GetTransactionList", None, 110, "(ao)")
+                        self.assertEqual(raised.exception.code, "timeout" if expired else "malformed")
+                    else:
+                        self.assertEqual(backend._recovery_call(provider.PACKAGEKIT_PATH, provider.PACKAGEKIT_INTERFACE, "GetTransactionList", None, 110, "(ao)").unpack(), ([],))
+                cancellation.cancel.assert_called_once_with()
+                before = backend.connection.call_finish.call_count
+                state["reply"](backend.connection, object(), None)
+                self.assertEqual(backend.connection.call_finish.call_count, before)
 
 
 if __name__ == "__main__":

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -5333,6 +5333,16 @@ class OperationRecoveryTests(unittest.TestCase):
                 state, _, _ = self.recover(journal, backend)
                 self.assertEqual((state.terminals[operation.slot].state, state.restart.system), (result, "none"))
 
+    def test_no_replay_replaces_system_evidence_but_partial_replay_merges_it(self):
+        for signals, expected in (((), "unknown"), ((2,), "security-system")):
+            with self.subTest(signals=signals), self.journal() as journal:
+                operation = self.begin(journal, state="running", system_restart="security-system")
+                backend = self.backend(provider.RecoveryEvidence(False, "succeeded",
+                    restart_types=signals, status=3, terminal_monotonic=100))
+                state, _, _ = self.recover(journal, backend)
+                self.assertEqual(state.terminals[operation.slot].system_restart, expected)
+                self.assertEqual(state.restart.system, expected)
+
     def test_new_boot_prunes_old_cutoffs_before_recovered_terminal_commit(self):
         with self.journal() as journal:
             first = self.begin(journal, state="running", system_restart="system")
@@ -5478,6 +5488,45 @@ class RecoveryAdapterTests(unittest.TestCase):
                     backend.probe_operation(operation)
                 self.assertEqual(raised.exception.code, "malformed")
                 self.assertEqual(backend.connection.subscriptions, {})
+
+    def test_terminal_evidence_does_not_depend_on_secondary_list(self):
+        for kind in ("refresh", "update"):
+            for result, expected in ((1, "succeeded"), (2, "failed")):
+                for stage in ("before-list", "timeout", "malformed", "invalid-list"):
+                    with self.subTest(kind=kind, result=result, stage=stage), self.journal() as journal:
+                        operation = self.begin(journal, kind)
+                        backend = self.backend(journal)
+                        def request(_path, _interface, method, *_args):
+                            if method == "GetAll":
+                                if stage == "before-list":
+                                    self.emit(backend, "Finished", "(uu)", (result, 1))
+                                return SessionEvidenceTests.Variant("(a{sv})", (self.properties(Role=13 if kind == "refresh" else 22),))
+                            self.assertNotEqual(stage, "before-list")
+                            self.emit(backend, "Finished", "(uu)", (result, 1))
+                            if stage == "invalid-list":
+                                return SessionEvidenceTests.Variant("(ao)", (["/1_duplicate", "/1_duplicate"],))
+                            raise provider.SnapshotFailure(stage, "Secondary lookup failed")
+                        backend._recovery_call = mock.Mock(side_effect=request)
+                        evidence = backend.probe_operation(operation)
+                        self.assertEqual(evidence.state, expected)
+                        self.assertIsInstance(evidence.terminal_monotonic, int)
+                        self.assertEqual(backend._recovery_call.call_count, 1 if stage == "before-list" else 2)
+                        self.assertEqual(backend.connection.subscriptions, {})
+
+    def test_terminal_evidence_does_not_override_wrong_owner_or_duplicate_finish(self):
+        for fault in ("owner", "duplicate"):
+            with self.subTest(fault=fault), self.journal() as journal:
+                operation = self.begin(journal)
+                backend = self.backend(journal)
+                def request(*_args):
+                    self.emit(backend, "Finished", "(uu)", (1, 1))
+                    if fault == "duplicate":
+                        self.emit(backend, "Finished", "(uu)", (1, 1))
+                    return SessionEvidenceTests.Variant("(a{sv})", (self.properties(Uid=os.getuid() + (fault == "owner")),))
+                backend._recovery_call = mock.Mock(side_effect=request)
+                with self.assertRaises(provider.SnapshotFailure) as raised:
+                    backend.probe_operation(operation)
+                self.assertEqual(raised.exception.code, "malformed")
 
     def test_probe_checkpoints_restart_before_finished_and_discards_late_signal(self):
         with self.journal() as journal:

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -5634,6 +5634,46 @@ class RecoveryAdapterTests(unittest.TestCase):
             self.assertEqual(backend.connection.subscriptions, {})
             self.assertEqual(backend.connection.calls, [])
 
+    def test_native_error_names_are_independent_of_message_text(self):
+        with self.journal() as journal:
+            backend = self.backend(journal)
+            cases = (("NoReply", "timeout"), ("Timeout", "timeout"), ("TimedOut", "timeout"),
+                     ("ServiceUnknown", "missing-provider"), ("NameHasNoOwner", "missing-provider"),
+                     ("UnknownObject", "missing-provider"), ("AccessDenied", "permission-denied"),
+                     ("AuthFailed", "permission-denied"), ("UnknownMethod", "unsupported"),
+                     ("UnknownInterface", "unsupported"), ("InvalidArgs", "malformed"),
+                     ("InvalidSignature", "malformed"), ("Failed", "internal"))
+            for name, expected in cases:
+                with self.subTest(name=name):
+                    backend.Gio.dbus_error_get_remote_error = mock.Mock(return_value="org.freedesktop.DBus.Error." + name)
+                    self.assertEqual(backend._dbus_failure(backend.GLib.Error("Opaque remote message")).code, expected)
+            backend.Gio.dbus_error_get_remote_error = mock.Mock(return_value="org.example.Unlisted")
+            self.assertEqual(backend._dbus_failure(backend.GLib.Error("NoReply Timeout AccessDenied")).code, "internal")
+            backend.Gio.dbus_error_get_remote_error = mock.Mock(return_value="org.freedesktop.PackageKit.Transaction.RefusedByPolicy")
+            self.assertEqual(backend._dbus_failure(backend.GLib.Error("Opaque policy denial")).code, "permission-denied")
+            backend.Gio.dbus_error_get_remote_error = mock.Mock(return_value=None)
+            backend.Gio.io_error_quark = lambda: 42
+            backend.Gio.IOErrorEnum = types.SimpleNamespace(TIMED_OUT=24)
+            local = mock.Mock(matches=lambda domain, code: (domain, code) == (42, 24))
+            self.assertEqual(backend._dbus_failure(local).code, "timeout")
+
+    def test_no_reply_before_deadline_can_use_exact_update_history(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.backend(journal)
+            backend.Gio.dbus_error_get_remote_error = mock.Mock(return_value="org.freedesktop.DBus.Error.NoReply")
+            backend.operation_history = mock.Mock(return_value=((operation.transaction_path, True, 22, os.getuid()),))
+            def request(*_args):
+                error = backend.GLib.Error("Opaque connection loss")
+                raise backend._dbus_failure(error) from error
+            backend._recovery_call = mock.Mock(side_effect=request)
+            state, evidence, failure = provider.recover_journal_active(journal, backend, boot_id=self.boot_id)
+            self.assertIsNone(state.active)
+            self.assertIsNone(evidence)
+            self.assertEqual((state.terminals[operation.slot].state, state.restart.system), ("succeeded", "unknown"))
+            self.assertEqual(failure.code, "timeout")
+            backend.operation_history.assert_called_once_with()
+
     def test_service_owner_change_invalidates_bounded_probe(self):
         with self.journal() as journal:
             operation = self.begin(journal)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -5203,6 +5203,25 @@ class OperationRecoveryTests(unittest.TestCase):
                     self.assertEqual(state.active, operation)
                     self.assertIsNone(state.handoff)
 
+    def test_unsuccessful_history_requires_confirmed_absence(self):
+        for lookup in ("present", "timeout"):
+            with self.subTest(lookup=lookup), self.journal() as journal:
+                operation = self.begin(journal, state="running")
+                observation = provider.RecoveryEvidence(True, status=3)
+                backend = self.backend(observation,
+                    ((operation.transaction_path, False, 22, os.getuid()),))
+                if lookup == "timeout":
+                    backend.probe_operation.side_effect = provider.SnapshotFailure("timeout", "Expired")
+                state, evidence, failure = self.recover(journal, backend)
+                self.assertEqual(state.active, operation)
+                self.assertIsNone(state.handoff)
+                self.assertTrue(all(terminal is None for terminal in state.terminals))
+                self.assertEqual(evidence, observation if lookup == "present" else None)
+                self.assertEqual(failure.code if failure else None, "timeout" if lookup == "timeout" else None)
+                with provider.lock_writable_journal(journal):
+                    with self.assertRaises(provider.JournalAdmissionError):
+                        provider.prepare_journal_admission(journal)
+
     def test_history_timeout_after_exact_absence_is_conservative_interruption(self):
         with self.journal() as journal:
             operation = self.begin(journal)
@@ -5474,6 +5493,48 @@ class RecoveryAdapterTests(unittest.TestCase):
                 return SessionEvidenceTests.Variant("(ao)", ([],))
             backend._recovery_call = mock.Mock(side_effect=request)
             self.assertEqual(backend.probe_operation(operation, on_running=lambda: checkpointed.append("running")).state, "succeeded")
+
+    def test_destroy_cannot_be_overwritten_by_an_inflight_snapshot(self):
+        for stage in ("GetAll", "GetTransactionList"):
+            for listed in ([], ["/1_test"]):
+                with self.subTest(stage=stage, listed=listed), self.journal() as journal:
+                    operation = self.begin(journal, "refresh")
+                    backend = self.backend(journal)
+                    def request(_path, _interface, method, *_args):
+                        if method == stage:
+                            self.emit(backend, "Destroy", "()", ())
+                        if method == "GetAll":
+                            return SessionEvidenceTests.Variant("(a{sv})", (self.properties(Role=13),))
+                        return SessionEvidenceTests.Variant("(ao)", (listed,))
+                    backend._recovery_call = mock.Mock(side_effect=request)
+                    evidence = backend.probe_operation(operation)
+                    self.assertFalse(evidence.present)
+                    self.assertFalse(evidence.allow_cancel)
+                    state, _, _ = provider.recover_journal_active(journal, backend, boot_id=self.boot_id)
+                    self.assertEqual(state.terminals[operation.slot].state, "interrupted")
+
+    def test_destroy_requires_valid_signature_and_verified_identity(self):
+        for fault in ("signature", "identity"):
+            with self.subTest(fault=fault), self.journal() as journal:
+                operation = self.begin(journal)
+                backend = self.backend(journal)
+                def request(_path, _interface, method, *_args):
+                    if method == "GetAll":
+                        self.emit(backend, "Destroy", "(s)" if fault == "signature" else "()",
+                            ("invalid",) if fault == "signature" else ())
+                        if fault == "identity":
+                            failure = provider.SnapshotFailure("missing-provider", "No object identity")
+                            failure.__cause__ = backend.GLib.Error("UnknownObject")
+                            raise failure
+                        return SessionEvidenceTests.Variant("(a{sv})", (self.properties(),))
+                    return SessionEvidenceTests.Variant("(ao)", ([operation.transaction_path],))
+                backend._recovery_call = mock.Mock(side_effect=request)
+                if fault == "signature":
+                    with self.assertRaises(provider.SnapshotFailure) as raised:
+                        backend.probe_operation(operation)
+                    self.assertEqual(raised.exception.code, "malformed")
+                else:
+                    self.assertTrue(backend.probe_operation(operation).present)
 
     def test_malformed_list_or_owner_never_becomes_absence(self):
         for properties, listed in ((self.properties(Uid=os.getuid() + 1), []),

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -5528,6 +5528,51 @@ class RecoveryAdapterTests(unittest.TestCase):
                     backend.probe_operation(operation)
                 self.assertEqual(raised.exception.code, "malformed")
 
+    def test_unverified_object_cannot_checkpoint_buffered_signals(self):
+        for fault in ("uid", "role", "absent", "service", "signal", "valid"):
+            with self.subTest(fault=fault), self.journal() as journal:
+                operation = self.begin(journal)
+                backend = self.backend(journal)
+                checkpoints = []
+                def request(_path, _interface, method, *_args):
+                    if method == "GetAll":
+                        if fault == "service":
+                            self.emit(backend, "NameOwnerChanged", "(sss)",
+                                (provider.PACKAGEKIT_NAME, ":1.2", ":1.3"), "org.freedesktop.DBus")
+                        elif fault == "signal":
+                            self.emit(backend, "RequireRestart", "(s)", ("invalid",))
+                        self.emit(backend, "PropertiesChanged", "(sa{sv}as)",
+                            (provider.TRANSACTION_INTERFACE, {"Status": 3}, []), provider.PROPERTIES_INTERFACE)
+                        self.emit(backend, "RequireRestart", "(us)", (6, self.package_id))
+                        self.emit(backend, "Finished", "(uu)", (1, 1))
+                        self.assertEqual(checkpoints, [])
+                        if fault == "absent":
+                            failure = provider.SnapshotFailure("missing-provider", "Absent object")
+                            failure.__cause__ = backend.GLib.Error("UnknownObject")
+                            raise failure
+                        return SessionEvidenceTests.Variant("(a{sv})", (self.properties(
+                            Uid=os.getuid() + (fault == "uid"), Role=13 if fault == "role" else 22),))
+                    self.emit(backend, "RequireRestart", "(us)", (4, self.package_id))
+                    self.emit(backend, "Finished", "(uu)", (1, 1))
+                    return SessionEvidenceTests.Variant("(ao)", ([],))
+                backend._recovery_call = mock.Mock(side_effect=request)
+                def probe():
+                    return backend.probe_operation(operation,
+                        on_running=lambda: checkpoints.append("running"),
+                        on_restart=lambda value: checkpoints.append(value))
+                if fault in {"uid", "role", "service", "signal"}:
+                    with self.assertRaises(provider.SnapshotFailure) as raised:
+                        probe()
+                    self.assertEqual(raised.exception.code, "missing-provider" if fault == "service" else "malformed")
+                else:
+                    evidence = probe()
+                    self.assertEqual(evidence.state, "succeeded" if fault == "valid" else None)
+                    self.assertEqual(evidence.restart_types, (6,) if fault == "valid" else ())
+                    if fault == "absent":
+                        self.assertEqual((evidence.status, evidence.allow_cancel, evidence.percent), (0, False, None))
+                self.assertEqual(checkpoints, ["running", 6] if fault == "valid" else [])
+                self.assertEqual(backend.connection.subscriptions, {})
+
     def test_probe_checkpoints_restart_before_finished_and_discards_late_signal(self):
         with self.journal() as journal:
             operation = self.begin(journal)
@@ -5593,15 +5638,18 @@ class RecoveryAdapterTests(unittest.TestCase):
         with self.journal() as journal:
             operation = self.begin(journal)
             backend = self.backend(journal)
+            checkpoint = mock.Mock()
             def request(_path, _interface, method, *_args):
                 if method == "GetAll":
                     return SessionEvidenceTests.Variant("(a{sv})", (self.properties(),))
                 self.emit(backend, "NameOwnerChanged", "(sss)", (provider.PACKAGEKIT_NAME, ":1.2", ":1.3"), "org.freedesktop.DBus")
+                self.emit(backend, "RequireRestart", "(us)", (6, self.package_id))
                 return SessionEvidenceTests.Variant("(ao)", ([],))
             backend._recovery_call = mock.Mock(side_effect=request)
             with self.assertRaises(provider.SnapshotFailure) as raised:
-                backend.probe_operation(operation)
+                backend.probe_operation(operation, on_restart=checkpoint)
             self.assertEqual(raised.exception.code, "missing-provider")
+            checkpoint.assert_not_called()
             self.assertEqual(backend.connection.subscriptions, {})
 
     def test_history_timeout_grace_does_not_accept_late_success(self):


### PR DESCRIPTION
## Summary
- Add internal exact-transaction recovery with a shared ten-second adoption/active-list deadline and a separately bounded 64-record PackageKit history lookup for updates only.
- Buffer bounded adoption signals until role/UID validation; reject invalid identity and daemon-change evidence before it can checkpoint the journal.
- Keep service waits outside journal locks; persist adopted running/restart evidence, reject changed owners, and complete durable terminal handoffs without retrying external actions.
- Preserve restart uncertainty after missed or partially replayed signals, retain lower-scope evidence, and prevent previous-boot results from reintroducing satisfied guidance.
- Preserve captured exact terminal evidence when the secondary active-list lookup fails, with refresh/update success/failure race fixtures.
- Classify D-Bus failures by native error names and local GIO timeout identity, including NoReply history fallback and PackageKit policy denial; opaque/localized message text does not choose behavior.
- Preserve verified Destroy evidence over stale snapshots, and require confirmed absence before unsuccessful history can release ownership; PackageKit creates unsuccessful history rows before execution finishes.
- Validate native reply types locally and distinguish absent objects from failed lookups. Public mutation commands and operation UI remain disabled for the next review boundary.

## Validation
- `scripts/run-tests /usr/bin/python3 tests/test-system-management.py`: 233 tests pass.
- `scripts/run-tests make clean all` and `scripts/run-tests`: pass, including staged/repeated installation, configured QML lint, nested-X11 lifecycle and closed CPU (Settings 0.067%; large surfaces 0.00%).
- Local Codex review: clean after the full 233-test post-fix suite. Final whole-PR review also found no actionable defects and independently passed 70 focused managed tests.
- `coderabbit review --agent -t uncommitted`: clean for the final Destroy/history fixes.
- Fedora 44 x86_64, PackageKit 1.3.6: read-only native active-list and bounded history probes, exact empty-transaction adoption, confirmed absent-object recovery, and wrong-signature rejection passed. No RefreshCache or real UpdatePackages call was made.
- Native GLib error-object qualification passed for remote NoReply, PackageKit RefusedByPolicy, and local GIO timeout, without making a remote mutation.
- The current agent process has no logind session (NoSessionForPID). Missing session evidence retains restart guidance; successful real-session timestamp evidence is not claimed.

## Scope and remaining Phase 6 work
This is one provider recovery boundary, not Phase 6 completion. Snapshot/control integration, root-scoped operation ownership and confirmation, regional/delegated entry points, information/recovery surfaces, and combined qualification remain in TASKS.md. No host packages, system settings, installed shell, or login session were changed.

