### PR TITLE
feat(system): watch and acknowledge exact journaled operations

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -76,7 +76,10 @@ active list, plus at most 64 history records for updates only. It distinguishes
 lookup failure from absence, checkpoints adopted restart signals, rejects stale
 ownership, and durably recovers terminal evidence or conservative interruption.
 Previous-boot records cannot reintroduce satisfied guidance. Public mutation
-commands remain disabled: snapshot/control integration and the root-scoped
+commands remain disabled. Exact-ID watch and acknowledgment controls now replay
+retained results without a service call or keep a verified PackageKit observer
+subscribed through completion without reissuing the action. Snapshot, cancel,
+and mutation-command integration and the root-scoped
 confirmation and operation UI must be completed before this boundary can be accepted.
 
 - [ ] Add user-initiated Fedora update discovery and status through the selected

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -136,6 +136,11 @@ Bus loss, malformed evidence, or a failed output/checkpoint ends observation
 without a terminal success claim or a `Cancel` call. A failure after stream
 output begins exits 1 with fixed interruption guidance, not the stream-free
 stale-target status 3.
+The watcher obtains logind session evidence only after transaction observation
+has captured a terminal result or exact absence, before the unlocked result is
+committed. A current live phase can update displayed authorization state without
+erasing uncertainty about earlier execution; a later authorization phase alone
+cannot prove an earlier unknown phase never changed packages.
 
 The root model calls `ack-operation` only for an exact durable handoff that it
 has received in a snapshot. It first validates either the matching originating

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -151,6 +151,11 @@ inconsistent with the validated journal state, or replaced exits 3 with only
 `ack target is unavailable` on standard error and leaves the handoff unchanged.
 Invalid command or operation-ID syntax exits 2. Acknowledgment never removes or
 rewrites the retained terminal slot and never invokes an external service.
+Journal-only control completion uses the boot evidence but does not invent a
+logind timestamp or open logind for replay/acknowledgment. Same-boot session and
+application guidance is conservatively retained until snapshot recovery obtains
+session evidence and prunes it before publishing `update-restart`. The required
+snapshot before acknowledgment is also the normal display reconciliation point.
 
 The PackageKit service is authoritative for package state. The project provider
 adds only validation, bounded record formatting, a private operation journal,

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -130,6 +130,12 @@ snapshot as the next recovery attempt.
 and `update`. Regional and delegated operations remain owned by their finite
 originating stream while active, but an exact retained terminal record for any
 valid kind can be replayed without reissuing its external action.
+After bounded initial adoption validates the exact object, the live watcher
+keeps those same subscriptions without a silence deadline or polling timer.
+Bus loss, malformed evidence, or a failed output/checkpoint ends observation
+without a terminal success claim or a `Cancel` call. A failure after stream
+output begins exits 1 with fixed interruption guidance, not the stream-free
+stale-target status 3.
 
 The root model calls `ack-operation` only for an exact durable handoff that it
 has received in a snapshot. It first validates either the matching originating

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -3591,6 +3591,12 @@ def recover_journal_active(
     if session_started is not None:
         _encode_journal_uint64(session_started, "session start")
     original = load_journal_state(journal.chain).active
+    if expected_operation_id is not None and original is None:
+        # Completion can race the watcher's initial target selection. Validate
+        # the exact retained result without following a replacement owner.
+        with lock_writable_journal(journal):
+            retained_journal_operation(journal, expected_operation_id)
+            return load_writable_journal_state(journal), None, None
     if expected_operation_id is not None and (original is None or original.operation_id != expected_operation_id):
         raise JournalAdmissionError("recovery target changed")
     if original is None:
@@ -4295,6 +4301,7 @@ class PackageKitBackend:
         subscriptions = []
         identity_verified = None
         snapshot_applied = False
+        pending_properties = {}
         watch_loop = None
         connection_closed = None
 
@@ -4347,10 +4354,13 @@ class PackageKitBackend:
             nonlocal terminal_state, terminal_time, transaction_failure, malformed, present, destroyed, checkpoint_failure
             if not live or identity_verified is False or malformed is not None or checkpoint_failure is not None or time.monotonic() >= deadline:
                 return
+            if interface != PROPERTIES_INTERFACE and signal not in {"RequireRestart", "ErrorCode", "Finished", "Destroy"}:
+                return
             if terminal_state is not None:
                 if signal == "Finished":
                     malformed = SnapshotFailure("malformed", "PackageKit recovery completion is duplicated")
                 return
+            previous = evidence(progress=True)
             try:
                 values = variant.unpack()
                 if interface == PROPERTIES_INTERFACE:
@@ -4359,11 +4369,20 @@ class PackageKitBackend:
                     changed = dict(values[1])
                     for key in values[2]:
                         changed[key] = None
+                    if not snapshot_applied:
+                        # Coalesce only three fields; never retain package or
+                        # arbitrary property payloads while identity is pending.
+                        for key in ("Status", "AllowCancel", "Percentage"):
+                            if key in changed:
+                                value = changed[key]
+                                pending_properties[key] = value if type(value) is (bool if key == "AllowCancel" else int) else None
                     properties(changed)
                 elif signal == "RequireRestart":
                     if variant.get_type_string() != "(us)":
                         raise ValueError
                     value = values[0] if values[0] in {1, 2, 3, 4, 5, 6} else 0
+                    if value in restarts:
+                        return
                     if identity_verified is True:
                         checkpoint(on_restart, value)
                         if checkpoint_failure is not None:
@@ -4395,7 +4414,8 @@ class PackageKitBackend:
             except (TypeError, ValueError, IndexError):
                 malformed = SnapshotFailure("malformed", "PackageKit recovery signal is malformed")
             finally:
-                watch_changed()
+                if malformed is not None or checkpoint_failure is not None or evidence(progress=True) != previous:
+                    watch_changed()
 
         def service_changed(_connection, _sender, _path, _interface, _signal, variant, _data):
             nonlocal malformed
@@ -4450,8 +4470,10 @@ class PackageKitBackend:
                 for value in sorted(restarts):
                     checkpoint(on_restart, value)
                 properties({"Status": None, **values})
-                present = not destroyed and status != 18
                 snapshot_applied = True
+                properties(pending_properties)
+                pending_properties.clear()
+                present = not destroyed and status != 18
                 if watch:
                     checkpoint(on_progress, evidence(progress=True))
             if checkpoint_failure is not None:

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -4283,6 +4283,7 @@ class PackageKitBackend:
         restarts = set()
         subscriptions = []
         identity_verified = None
+        snapshot_applied = False
         watch_loop = None
         connection_closed = None
 
@@ -4323,7 +4324,7 @@ class PackageKitBackend:
                         checkpoint(on_running)
             if "AllowCancel" in values:
                 allow_cancel = values["AllowCancel"] if type(values["AllowCancel"]) is bool else False
-                cancel_blocked = (cancel_blocked or not allow_cancel) if watch_loop is None else False
+                cancel_blocked = False if watch and snapshot_applied else cancel_blocked or not allow_cancel
             if "Percentage" in values:
                 value = values["Percentage"]
                 percent = value if type(value) is int and 0 <= value <= 100 else None
@@ -4436,6 +4437,7 @@ class PackageKitBackend:
                     checkpoint(on_restart, value)
                 properties(values)
                 present = not destroyed and status != 18
+                snapshot_applied = True
                 if watch:
                     checkpoint(on_progress, evidence())
             if checkpoint_failure is not None:

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -3583,6 +3583,7 @@ def recover_journal_active(
     boot_id: str, session_started: int | None = None,
     watch: bool = False, expected_operation_id: str | None = None,
     on_progress: Callable[[RecoveryEvidence], object] | None = None,
+    session_reader: Callable[[], int | None] | None = None,
 ) -> tuple[JournalState, RecoveryEvidence | None, SnapshotFailure | None]:
     """Recover one copied owner without holding a journal lock across service work."""
     if not isinstance(boot_id, str) or BOOT_ID_PATTERN.fullmatch(boot_id) is None:
@@ -3647,6 +3648,16 @@ def recover_journal_active(
             except SnapshotFailure as failure:
                 if failure.code == "malformed" or lookup_failure is None:
                     lookup_failure = failure
+    if session_reader is not None and (history_used or (evidence is not None and (
+            evidence.state is not None or not evidence.present))):
+        # Never delay attachment with an unrelated service lookup. Exact
+        # terminal/absence evidence is already captured before reading logind.
+        try:
+            session_started = session_reader()
+        except SnapshotFailure:
+            session_started = None
+        if session_started is not None:
+            _encode_journal_uint64(session_started, "session start")
     with lock_writable_journal(journal):
         current_state = load_writable_journal_state(journal)
         current = current_state.active
@@ -4287,9 +4298,12 @@ class PackageKitBackend:
         watch_loop = None
         connection_closed = None
 
-        def evidence():
+        def evidence(*, progress=False):
+            # A current display phase is not proof that earlier execution was
+            # excluded. Preserve uncertainty in terminal recovery evidence.
+            observed_status = status if progress else 3 if saw_running else 0 if uncertain_status else status
             return RecoveryEvidence(not destroyed and (present or path in listed), terminal_state, transaction_failure,
-                tuple(sorted(restarts)), 3 if saw_running else 0 if uncertain_status else status,
+                tuple(sorted(restarts)), observed_status,
                 allow_cancel and not cancel_blocked and not destroyed, percent, terminal_time)
 
         def watch_changed():
@@ -4298,7 +4312,7 @@ class PackageKitBackend:
             if terminal_state is not None or destroyed or malformed is not None or checkpoint_failure is not None:
                 watch_loop.quit()
             elif identity_verified is True:
-                checkpoint(on_progress, evidence())
+                checkpoint(on_progress, evidence(progress=True))
                 if checkpoint_failure is not None:
                     watch_loop.quit()
 
@@ -4435,11 +4449,11 @@ class PackageKitBackend:
                     checkpoint(on_running)
                 for value in sorted(restarts):
                     checkpoint(on_restart, value)
-                properties(values)
+                properties({"Status": None, **values})
                 present = not destroyed and status != 18
                 snapshot_applied = True
                 if watch:
-                    checkpoint(on_progress, evidence())
+                    checkpoint(on_progress, evidence(progress=True))
             if checkpoint_failure is not None:
                 raise checkpoint_failure
             if terminal_state is None:
@@ -5009,12 +5023,8 @@ def watch_journal_operation(
 
     progress(RecoveryEvidence(True))
     backend = backend_factory()
-    try:
-        session_started = backend.session_started()
-    except SnapshotFailure:
-        session_started = None
     state, evidence, failure = recover_journal_active(journal, backend, boot_id=boot_id,
-        session_started=session_started, watch=True, expected_operation_id=operation_id, on_progress=progress)
+        session_reader=backend.session_started, watch=True, expected_operation_id=operation_id, on_progress=progress)
     if state.active is not None:
         raise failure or SnapshotFailure("interrupted", "PackageKit observation ended without terminal evidence")
     terminal = next((item for item in state.terminals if item is not None and item.operation_id == operation_id), None)

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -3150,7 +3150,7 @@ class OperationStream:
         self.closed = False
         self.faulted = False
         self._write = write
-        self._last_progress: tuple[str, bool, str] | None = None
+        self._last_progress: tuple[str, bool, str] | None = ("unknown", False, detail)
         self._send([
             f"system-management-protocol\t{PROTOCOL_MAJOR}\t{PROTOCOL_MINOR}",
             self._operation_line("pending", "unknown", False, detail),
@@ -3202,6 +3202,22 @@ class OperationStream:
         self._last_progress = progress
         if repeated:
             self.progress_records += 1
+        return True
+
+    def progress(self, detail: str, *, percent: int | None = None, cancelable: bool = False) -> bool:
+        """Update current-state fields without inventing a lifecycle transition."""
+        if self.closed or self.faulted:
+            raise OperationProtocolError("operation stream is no longer writable")
+        if type(cancelable) is not bool or (percent is not None and (type(percent) is not int or not 0 <= percent <= 100)):
+            raise OperationProtocolError("operation progress is invalid")
+        _validate_journal_detail(detail)
+        percentage = "unknown" if percent is None else str(percent)
+        progress = (percentage, cancelable, detail)
+        if progress == self._last_progress or self.progress_records >= MAX_OPERATION_PROGRESS_RECORDS:
+            return False
+        self._send([self._operation_line(self.state, percentage, cancelable, detail)])
+        self._last_progress = progress
+        self.progress_records += 1
         return True
 
     def finish(self, operation: JournalOperation, *, detail: str | None = None) -> None:
@@ -3565,6 +3581,8 @@ def read_fedora_identity() -> dict[str, str]:
 def recover_journal_active(
     journal: JournalDescriptorSet, backend: PackageKitBackend, *,
     boot_id: str, session_started: int | None = None,
+    watch: bool = False, expected_operation_id: str | None = None,
+    on_progress: Callable[[RecoveryEvidence], object] | None = None,
 ) -> tuple[JournalState, RecoveryEvidence | None, SnapshotFailure | None]:
     """Recover one copied owner without holding a journal lock across service work."""
     if not isinstance(boot_id, str) or BOOT_ID_PATTERN.fullmatch(boot_id) is None:
@@ -3572,6 +3590,8 @@ def recover_journal_active(
     if session_started is not None:
         _encode_journal_uint64(session_started, "session start")
     original = load_journal_state(journal.chain).active
+    if expected_operation_id is not None and (original is None or original.operation_id != expected_operation_id):
+        raise JournalAdmissionError("recovery target changed")
     if original is None:
         with lock_writable_journal(journal):
             prune_journal_restart(journal, boot_id, session_started)
@@ -3589,6 +3609,8 @@ def recover_journal_active(
                 raise SnapshotFailure("conflict", "Recovery owner changed; discard the stale observation")
             if current.state in {"pending", "authorizing"}:
                 advance_journal_operation(journal, current, replace(current, state="running", detail="PackageKit execution observed during recovery"))
+        if watch and on_progress is not None:
+            on_progress(RecoveryEvidence(True, status=3))
 
     def checkpoint_restart(value):
         if original.kind != "update" or original.boot_id != boot_id:
@@ -3610,7 +3632,8 @@ def recover_journal_active(
 
     if original.state not in JOURNAL_OPERATION_TERMINAL_STATES and original.kind in {"update", "refresh"}:
         try:
-            evidence = backend.probe_operation(original, on_restart=checkpoint_restart, on_running=checkpoint_running)
+            watch_options = dict(watch=True, on_progress=on_progress) if watch else {}
+            evidence = backend.probe_operation(original, on_restart=checkpoint_restart, on_running=checkpoint_running, **watch_options)
         except SnapshotFailure as failure:
             lookup_failure = failure
         if original.kind == "update" and (evidence is None or evidence.state is None) and (
@@ -4233,8 +4256,10 @@ class PackageKitBackend:
 
     def probe_operation(self, operation: JournalOperation, *,
                         on_restart: Callable[[int], object] | None = None,
-                        on_running: Callable[[], object] | None = None) -> RecoveryEvidence:
-        """Attach only to the recorded object, then obtain a bounded active list."""
+                        on_running: Callable[[], object] | None = None,
+                        watch: bool = False,
+                        on_progress: Callable[[RecoveryEvidence], object] | None = None) -> RecoveryEvidence:
+        """Bound adoption; optionally keep its verified subscriptions until completion."""
         encode_journal_operation(operation)
         if operation.kind not in {"refresh", "update"} or operation.state in JOURNAL_OPERATION_TERMINAL_STATES:
             raise SnapshotFailure("malformed", "PackageKit recovery target is not active")
@@ -4243,6 +4268,7 @@ class PackageKitBackend:
         live = True
         present = False
         destroyed = False
+        listed = ()
         status = 0
         allow_cancel = False
         percent = None
@@ -4257,13 +4283,30 @@ class PackageKitBackend:
         restarts = set()
         subscriptions = []
         identity_verified = None
+        watch_loop = None
+        connection_closed = None
+
+        def evidence():
+            return RecoveryEvidence(not destroyed and (present or path in listed), terminal_state, transaction_failure,
+                tuple(sorted(restarts)), 3 if saw_running else 0 if uncertain_status else status,
+                allow_cancel and not cancel_blocked and not destroyed, percent, terminal_time)
+
+        def watch_changed():
+            if watch_loop is None:
+                return
+            if terminal_state is not None or destroyed or malformed is not None or checkpoint_failure is not None:
+                watch_loop.quit()
+            elif identity_verified is True:
+                checkpoint(on_progress, evidence())
+                if checkpoint_failure is not None:
+                    watch_loop.quit()
 
         def checkpoint(callback, *args):
             nonlocal checkpoint_failure
             if callback is not None and checkpoint_failure is None:
                 try:
                     callback(*args)
-                except (SnapshotFailure, JournalFileError, JournalRecordError, JournalFrameError, JournalAdmissionError) as error:
+                except Exception as error:
                     checkpoint_failure = error
 
         def properties(values):
@@ -4280,7 +4323,7 @@ class PackageKitBackend:
                         checkpoint(on_running)
             if "AllowCancel" in values:
                 allow_cancel = values["AllowCancel"] if type(values["AllowCancel"]) is bool else False
-                cancel_blocked = cancel_blocked or not allow_cancel
+                cancel_blocked = (cancel_blocked or not allow_cancel) if watch_loop is None else False
             if "Percentage" in values:
                 value = values["Percentage"]
                 percent = value if type(value) is int and 0 <= value <= 100 else None
@@ -4336,6 +4379,8 @@ class PackageKitBackend:
                     present = False
             except (TypeError, ValueError, IndexError):
                 malformed = SnapshotFailure("malformed", "PackageKit recovery signal is malformed")
+            finally:
+                watch_changed()
 
         def service_changed(_connection, _sender, _path, _interface, _signal, variant, _data):
             nonlocal malformed
@@ -4343,8 +4388,17 @@ class PackageKitBackend:
                 values = variant.unpack()
                 if values[0] == PACKAGEKIT_NAME and values[1] != values[2]:
                     malformed = SnapshotFailure("missing-provider", "PackageKit changed during recovery; retry the lookup")
+                    watch_changed()
+
+        def bus_closed(*_args):
+            nonlocal malformed
+            if live:
+                malformed = SnapshotFailure("missing-provider", "PackageKit connection closed; retry recovery")
+                watch_changed()
 
         try:
+            if watch:
+                connection_closed = self.connection.connect("closed", bus_closed)
             subscriptions.append(self.connection.signal_subscribe(PACKAGEKIT_NAME, TRANSACTION_INTERFACE, None, path, None, self.Gio.DBusSignalFlags.NONE, signal_received, None))
             subscriptions.append(self.connection.signal_subscribe(PACKAGEKIT_NAME, PROPERTIES_INTERFACE, "PropertiesChanged", path, TRANSACTION_INTERFACE, self.Gio.DBusSignalFlags.NONE, signal_received, None))
             subscriptions.append(self.connection.signal_subscribe("org.freedesktop.DBus", "org.freedesktop.DBus", "NameOwnerChanged", "/org/freedesktop/DBus", PACKAGEKIT_NAME, self.Gio.DBusSignalFlags.NONE, service_changed, None))
@@ -4382,9 +4436,10 @@ class PackageKitBackend:
                     checkpoint(on_restart, value)
                 properties(values)
                 present = not destroyed and status != 18
+                if watch:
+                    checkpoint(on_progress, evidence())
             if checkpoint_failure is not None:
                 raise checkpoint_failure
-            listed = ()
             if terminal_state is None:
                 try:
                     reply = self._recovery_call(PACKAGEKIT_PATH, PACKAGEKIT_INTERFACE, "GetTransactionList", None, deadline, "(ao)")
@@ -4397,13 +4452,27 @@ class PackageKitBackend:
                         raise
             if malformed is not None:
                 raise malformed
-            return RecoveryEvidence(not destroyed and (present or path in listed), terminal_state, transaction_failure,
-                                    tuple(sorted(restarts)), 3 if saw_running else 0 if uncertain_status else status,
-                                    allow_cancel and not cancel_blocked and not destroyed, percent, terminal_time)
+            if watch and terminal_state is None and evidence().present:
+                if identity_verified is not True:
+                    raise SnapshotFailure("interrupted", "Active PackageKit object could not be verified; retry recovery")
+                # Only attachment has a deadline. A verified live transaction
+                # has no silence watchdog, polling timer, or reinvocation.
+                deadline = float("inf")
+                watch_loop = self.GLib.MainLoop()
+                watch_changed()
+                if checkpoint_failure is None:
+                    watch_loop.run()
+                if malformed is not None:
+                    raise malformed
+                if terminal_state is None and not destroyed and checkpoint_failure is None:
+                    raise SnapshotFailure("interrupted", "PackageKit watch ended without terminal evidence")
+            return evidence()
         finally:
             live = False
             for subscription in subscriptions:
                 self.connection.signal_unsubscribe(subscription)
+            if connection_closed is not None:
+                self.connection.disconnect(connection_closed)
             if checkpoint_failure is not None:
                 raise checkpoint_failure
 
@@ -4894,12 +4963,112 @@ class PackageKitBackend:
         return SnapshotFailure("internal", "PackageKit transaction failed internally")
 
 
+def control_journal_target(journal: JournalDescriptorSet, operation_id: str, boot_id: str) -> JournalOperation:
+    """Complete interrupted terminal commits, then select only the exact control ID."""
+    with lock_writable_journal(journal):
+        state = load_writable_journal_state(journal)
+        if state.active is not None and state.active.state in JOURNAL_OPERATION_TERMINAL_STATES:
+            complete_journal_terminal(journal, boot_id=boot_id)
+            state = load_writable_journal_state(journal)
+        if state.active is None:
+            return retained_journal_operation(journal, operation_id)
+        if state.active.operation_id != operation_id or state.active.kind not in {"refresh", "update"}:
+            raise JournalAdmissionError("journal control target is unavailable")
+        return state.active
+
+
+def watch_journal_operation(
+    journal: JournalDescriptorSet, operation_id: str, write: Callable[[str], object], *,
+    boot_id: str, backend_factory: Callable[[], PackageKitBackend] = PackageKitBackend,
+) -> None:
+    """Replay a retained result or observe one exact live owner without reinvocation."""
+    original = control_journal_target(journal, operation_id, boot_id)
+    if original.state in JOURNAL_OPERATION_TERMINAL_STATES:
+        replay_terminal_operation(original, write)
+        return
+    detail = "Observing recovered PackageKit operation; package comparison is unavailable"
+    stream = OperationStream(original.operation_id, original.action_id, original.started_at, detail, write)
+
+    def progress(evidence):
+        with lock_writable_journal(journal):
+            current = load_writable_journal_state(journal).active
+            identity = ("operation_id", "action_id", "started_at", "kind", "generation", "transaction_path", "boot_id", "slot")
+            if current is None or any(getattr(current, key) != getattr(original, key) for key in identity) or current.state in JOURNAL_OPERATION_TERMINAL_STATES:
+                raise JournalAdmissionError("journal watch owner changed")
+            if current.state == "pending" and evidence.status == 31:
+                current = advance_journal_operation(journal, current, replace(current, state="authorizing", detail=detail))
+        target = current.state
+        if target in {"running", "cancel-requested"} and stream.state in {"pending", "authorizing"}:
+            stream.transition("running", detail)
+        if target != stream.state:
+            stream.transition(target, detail, percent=evidence.percent, cancelable=evidence.allow_cancel)
+        else:
+            stream.progress(detail, percent=evidence.percent, cancelable=evidence.allow_cancel)
+
+    progress(RecoveryEvidence(True))
+    backend = backend_factory()
+    try:
+        session_started = backend.session_started()
+    except SnapshotFailure:
+        session_started = None
+    state, evidence, failure = recover_journal_active(journal, backend, boot_id=boot_id,
+        session_started=session_started, watch=True, expected_operation_id=operation_id, on_progress=progress)
+    if state.active is not None:
+        raise failure or SnapshotFailure("interrupted", "PackageKit observation ended without terminal evidence")
+    terminal = next((item for item in state.terminals if item is not None and item.operation_id == operation_id), None)
+    if terminal is None:
+        raise JournalAdmissionError("journal watch result is unavailable")
+    if terminal.state == "succeeded" and stream.state in {"pending", "authorizing"}:
+        stream.transition("running", detail)
+    elif terminal.state == "permission-denied" and stream.state == "pending":
+        stream.transition("authorizing", detail)
+    elif terminal.state == "canceled" and stream.state == "running":
+        stream.transition("cancel-requested", detail)
+    stream.finish(terminal, detail=clean_text(f"{terminal.detail}; recovered package comparison is unavailable")
+                  if terminal.kind == "update" else terminal.detail)
+
+
+def operation_control(command: str, operation_id: str) -> int:
+    """Keep stale control rejection stream-free and watch failure distinct."""
+    started = False
+
+    def write(chunk):
+        nonlocal started
+        started = True
+        sys.stdout.write(chunk)
+        sys.stdout.flush()
+
+    try:
+        boot_id = read_boot_id()
+        with open_journal_directory() as chain, retain_writable_journal(chain) as journal:
+            if command == "watch-operation":
+                watch_journal_operation(journal, operation_id, write, boot_id=boot_id)
+            else:
+                control_journal_target(journal, operation_id, boot_id)
+                with lock_writable_journal(journal):
+                    acknowledge_journal_handoff(journal, operation_id)
+        return 0
+    except (SnapshotFailure, JournalFrameError, JournalRecordError, JournalAdmissionError, OSError, OperationProtocolError) as error:
+        if started:
+            if isinstance(error, BrokenPipeError):
+                # Avoid a second buffered flush at interpreter shutdown changing
+                # the exit status or writing an unraisable-exception diagnostic.
+                with open(os.devnull, "w") as sink:
+                    os.dup2(sink.fileno(), sys.stdout.fileno())
+            print("operation observation was interrupted", file=sys.stderr)
+            return 1
+        print("watch target is unavailable" if command == "watch-operation" else "ack target is unavailable", file=sys.stderr)
+        return 3
+
+
 def usage() -> int:
-    print(f"usage: {sys.argv[0]} snapshot", file=sys.stderr)
+    print(f"usage: {sys.argv[0]} snapshot | watch-operation OPERATION_ID | ack-operation OPERATION_ID", file=sys.stderr)
     return 2
 
 
 def main(argv: Sequence[str]) -> int:
+    if len(argv) == 2 and argv[0] in {"watch-operation", "ack-operation"} and JOURNAL_OPERATION_ID_PATTERN.fullmatch(argv[1]):
+        return operation_control(argv[0], argv[1])
     if list(argv) != ["snapshot"]:
         return usage()
     try:

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 import contextlib
 import errno
 import hashlib
+import io
 import importlib.util
 import importlib.machinery
 import os
 import pathlib
 import stat
+import subprocess
 import sys
 import tempfile
 import threading
@@ -131,6 +133,21 @@ class OperationStreamTests(unittest.TestCase):
         self.assertFalse(stream.transition("running", "Working", percent=0))
         self.assertTrue(stream.transition("running", "Working", percent=0, cancelable=True))
         self.assertEqual(stream.progress_records, 1)
+
+    def test_pending_and_authorizing_progress_share_the_budget_without_consuming_lifecycle(self):
+        output = []
+        stream = self.stream(output)
+        stream.progress("Pending", cancelable=True)
+        stream.transition("authorizing", "Authorization")
+        for index in range(300):
+            stream.progress("Authorization", cancelable=index % 2 == 0)
+        self.assertEqual(stream.progress_records, 252)
+        stream.transition("running", "Running")
+        stream.transition("cancel-requested", "Cancel requested")
+        stream.finish(self.terminal())
+        operation_rows = rows("".join(output).splitlines(), "operation")
+        self.assertEqual(len(operation_rows), 257)
+        self.assertEqual([row[4] for row in operation_rows[-3:]], ["running", "cancel-requested", "succeeded"])
 
     def test_replay_all_kinds_and_results_preserves_exact_terminal_and_error_owner(self):
         for action in provider.JOURNAL_OPERATION_ACTION_KINDS:
@@ -5829,6 +5846,258 @@ class RecoveryAdapterTests(unittest.TestCase):
                 before = backend.connection.call_finish.call_count
                 state["reply"](backend.connection, object(), None)
                 self.assertEqual(backend.connection.call_finish.call_count, before)
+
+
+class OperationWatchTests(unittest.TestCase):
+    """Live fixtures use the real adapter but never invoke a package action."""
+    boot_id = PackageKitExecutionTests.boot_id
+    package_id = PackageKitExecutionTests.package_id
+    journal = PackageKitExecutionTests.journal
+    begin = OperationRecoveryTests.begin
+    backend = RecoveryAdapterTests.backend
+    emit = RecoveryAdapterTests.emit
+    properties = RecoveryAdapterTests.properties
+
+    def live_backend(self, journal, events, **properties):
+        backend = self.backend(journal)
+        backend.session_started = mock.Mock(return_value=None)
+        backend._recovery_call = mock.Mock(side_effect=lambda _path, _interface, method, *_args:
+            SessionEvidenceTests.Variant("(a{sv})", (self.properties(**properties),)) if method == "GetAll"
+            else SessionEvidenceTests.Variant("(ao)", (["/1_test"],)))
+        test = self
+
+        class Loop:
+            stopped = False
+
+            def quit(self):
+                self.stopped = True
+
+            def run(self):
+                for event in events:
+                    test.assertFalse(journal._exclusive)
+                    if self.stopped:
+                        break
+                    event(backend)
+                test.assertTrue(self.stopped, "watch did not terminate from exact evidence")
+
+        backend.GLib.MainLoop = Loop
+        return backend
+
+    def progress(self, backend, **values):
+        self.emit(backend, "PropertiesChanged", "(sa{sv}as)",
+            (provider.TRANSACTION_INTERFACE, values, []), provider.PROPERTIES_INTERFACE)
+
+    def test_live_watch_keeps_subscriptions_and_commits_before_terminal_output(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            chunks = []
+            backend = self.live_backend(journal, [lambda bus: self.progress(bus, Status=3, AllowCancel=True, Percentage=42),
+                lambda bus: self.emit(bus, "RequireRestart", "(us)", (6, self.package_id)),
+                lambda bus: self.emit(bus, "Finished", "(uu)", (1, 1))], Status=31)
+
+            def write(chunk):
+                if "complete\toperation" in chunk:
+                    state = provider.load_journal_state(journal.chain)
+                    self.assertIsNone(state.active)
+                    self.assertEqual(state.handoff.operation_id, operation.operation_id)
+                chunks.append(chunk)
+
+            provider.watch_journal_operation(journal, operation.operation_id, write,
+                boot_id=self.boot_id, backend_factory=lambda: backend)
+            output = "".join(chunks)
+            for value in ("\tauthorizing\t", "\trunning\t", "\t42\tyes\t", "\tsucceeded\t", "comparison is unavailable"):
+                self.assertIn(value, output)
+            self.assertEqual(backend.connection.calls, [])
+            self.assertEqual([call.args[2] for call in backend._recovery_call.call_args_list], ["GetAll", "GetTransactionList"])
+            self.assertEqual(backend.connection.subscriptions, {})
+            self.assertIsNone(backend.connection.closed_callback)
+            self.assertEqual(provider.load_journal_state(journal.chain).restart.system, "security-system")
+
+    def test_watch_has_no_silence_deadline_after_verified_adoption(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            clock = [100]
+            def later(bus):
+                clock[0] = 100000
+                self.progress(bus, Status=3)
+                self.emit(bus, "Finished", "(uu)", (1, 1))
+            backend = self.live_backend(journal, [later])
+            with mock.patch.object(provider.time, "monotonic", side_effect=lambda: clock[0]):
+                result = backend.probe_operation(operation, watch=True)
+            self.assertEqual(result.state, "succeeded")
+            self.assertEqual(backend.connection.calls, [])
+
+    def test_watch_uses_new_live_cancelability_not_stale_initial_false(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            progress = []
+            backend = self.live_backend(journal, [lambda bus: self.progress(bus, AllowCancel=True),
+                lambda bus: self.progress(bus, AllowCancel=False),
+                lambda bus: self.emit(bus, "Finished", "(uu)", (1, 1))], AllowCancel=False)
+            backend.probe_operation(operation, watch=True, on_progress=progress.append)
+            self.assertIn(True, [item.allow_cancel for item in progress])
+            self.assertFalse(progress[-1].allow_cancel)
+
+    def test_authorizing_watch_emits_cancelability_loss_without_claiming_running(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.live_backend(journal, [lambda bus: self.progress(bus, AllowCancel=False),
+                lambda bus: self.emit(bus, "Finished", "(uu)", (3, 0))], Status=31)
+            chunks = []
+            provider.watch_journal_operation(journal, operation.operation_id, chunks.append,
+                boot_id=self.boot_id, backend_factory=lambda: backend)
+            operation_rows = rows("".join(chunks).splitlines(), "operation")
+            authorizing = [row for row in operation_rows if row[4] == "authorizing"]
+            self.assertEqual([row[6] for row in authorizing], ["yes", "no"])
+            self.assertNotIn("running", [row[4] for row in operation_rows])
+            self.assertEqual(operation_rows[-1][4], "canceled")
+
+    def test_watch_bus_loss_malformed_signal_or_output_failure_detaches_without_cancel(self):
+        for fault in ("bus", "malformed", "output"):
+            with self.subTest(fault=fault), self.journal() as journal:
+                operation = self.begin(journal)
+                def event(bus):
+                    if fault == "bus":
+                        bus.connection.closed_callback()
+                    elif fault == "malformed":
+                        self.emit(bus, "Destroy", "(s)", ("wrong",))
+                    else:
+                        self.progress(bus, Percentage=40)
+                backend = self.live_backend(journal, [event])
+                def progress(evidence):
+                    if evidence.percent == 40:
+                        raise BrokenPipeError("closed consumer")
+                with self.assertRaises((provider.SnapshotFailure, BrokenPipeError)):
+                    backend.probe_operation(operation, watch=True, on_progress=progress)
+                self.assertEqual(backend.connection.calls, [])
+                self.assertEqual(backend.connection.subscriptions, {})
+                self.assertIsNone(backend.connection.closed_callback)
+                self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
+
+    def test_destroyed_watch_recovers_conservative_interruption(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, "refresh")
+            backend = self.live_backend(journal, [lambda bus: self.emit(bus, "Destroy", "()", ())], Role=13)
+            chunks = []
+            provider.watch_journal_operation(journal, operation.operation_id, chunks.append,
+                boot_id=self.boot_id, backend_factory=lambda: backend)
+            self.assertIn("\tinterrupted\t", "".join(chunks))
+            self.assertIn("complete\toperation", "".join(chunks))
+
+    def test_terminalized_active_replays_and_acknowledges_without_backend(self):
+        for kind in ("update", "refresh", "timezone"):
+            with self.subTest(kind=kind), self.journal() as journal:
+                operation = self.begin(journal, kind)
+                terminal = replace(operation, state="failed", error_code="internal",
+                    finished_at="2026-09-05T00:01:00Z", detail="Fixture failure",
+                    terminal_monotonic=100 if kind in {"refresh", "update"} else None)
+                with provider.lock_writable_journal(journal):
+                    provider.advance_journal_operation(journal, operation, terminal)
+                chunks = []
+                backend = mock.Mock(side_effect=AssertionError("replay opened a service"))
+                provider.watch_journal_operation(journal, operation.operation_id, chunks.append,
+                    boot_id=self.boot_id, backend_factory=backend)
+                backend.assert_not_called()
+                self.assertIn("complete\toperation", "".join(chunks))
+                with provider.lock_writable_journal(journal):
+                    provider.acknowledge_journal_handoff(journal, operation.operation_id)
+                    self.assertEqual(provider.retained_journal_operation(journal, operation.operation_id), terminal)
+
+    def test_stale_id_and_active_regional_emit_no_stream(self):
+        for kind in ("refresh", "timezone"):
+            with self.subTest(kind=kind), self.journal() as journal:
+                operation = self.begin(journal, kind)
+                requested = "op-" + "0" * 32 if kind == "refresh" else operation.operation_id
+                chunks = []
+                backend = mock.Mock()
+                with self.assertRaises(provider.JournalAdmissionError):
+                    provider.watch_journal_operation(journal, requested, chunks.append,
+                        boot_id=self.boot_id, backend_factory=backend)
+                self.assertEqual(chunks, [])
+                backend.assert_not_called()
+                self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
+
+    def test_control_cli_has_fixed_syntax_and_stream_free_stale_diagnostics(self):
+        for args in ([], ["watch-operation"], ["ack-operation", "bad"], ["watch-operation", "op-" + "a" * 32, "extra"],
+                     ["updates-refresh"]):
+            with self.subTest(args=args), contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(provider.main(args), 2)
+                self.assertEqual(stdout.getvalue(), "")
+        for command, diagnostic in (("watch-operation", "watch"), ("ack-operation", "ack")):
+            with self.subTest(command=command), mock.patch.object(provider, "open_journal_directory", side_effect=provider.JournalLayoutError("Unsafe raw text")), \
+                    mock.patch.object(provider, "read_boot_id", return_value=self.boot_id), \
+                    contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(io.StringIO()) as stderr:
+                self.assertEqual(provider.main([command, "op-" + "a" * 32]), 3)
+                self.assertEqual(stdout.getvalue(), "")
+                self.assertEqual(stderr.getvalue(), f"{diagnostic} target is unavailable\n")
+
+    def test_owner_replaced_before_adoption_is_never_followed(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, "refresh")
+            backend = mock.Mock()
+            backend.session_started.return_value = None
+            following = []
+            def factory():
+                with provider.lock_writable_journal(journal):
+                    terminal = replace(operation, state="failed", error_code="internal", detail="Fixture",
+                        finished_at="2026-09-05T00:01:00Z", terminal_monotonic=100)
+                    provider.advance_journal_operation(journal, operation, terminal)
+                    provider.complete_journal_terminal(journal, boot_id=self.boot_id)
+                    provider.acknowledge_journal_handoff(journal, operation.operation_id)
+                following.append(self.begin(journal, "refresh"))
+                return backend
+            chunks = []
+            with self.assertRaises(provider.JournalAdmissionError):
+                provider.watch_journal_operation(journal, operation.operation_id, chunks.append,
+                    boot_id=self.boot_id, backend_factory=factory)
+            backend.probe_operation.assert_not_called()
+            self.assertNotIn("complete\toperation", "".join(chunks))
+            self.assertEqual(provider.load_journal_state(journal.chain).active, following[0])
+
+    def test_cli_replay_and_ack_preserve_terminal_and_use_no_service(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, "refresh")
+            terminal = replace(operation, state="failed", error_code="internal", detail="Fixture",
+                finished_at="2026-09-05T00:01:00Z", terminal_monotonic=100)
+            with provider.lock_writable_journal(journal):
+                provider.advance_journal_operation(journal, operation, terminal)
+            state_home = str(pathlib.Path(journal.chain.path).parents[1])
+            with mock.patch.dict(os.environ, {"XDG_STATE_HOME": state_home}), \
+                    mock.patch.object(provider, "read_boot_id", return_value=self.boot_id), \
+                    mock.patch.object(provider.PackageKitBackend, "__init__", side_effect=AssertionError("Unexpected service")), \
+                    contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(io.StringIO()) as stderr:
+                self.assertEqual(provider.main(["watch-operation", operation.operation_id]), 0)
+                self.assertIn("complete\toperation", stdout.getvalue())
+                stdout.seek(0)
+                stdout.truncate(0)
+                self.assertEqual(provider.main(["ack-operation", operation.operation_id]), 0)
+                self.assertEqual(stdout.getvalue(), "")
+                self.assertEqual(stderr.getvalue(), "")
+                self.assertEqual(provider.main(["ack-operation", operation.operation_id]), 3)
+                self.assertEqual(stderr.getvalue(), "ack target is unavailable\n")
+            state = provider.load_journal_state(journal.chain)
+            self.assertEqual(state.terminals[operation.slot], terminal)
+            self.assertIsNone(state.handoff)
+
+    def test_closed_cli_pipe_has_fixed_exit_and_preserves_handoff(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, "refresh")
+            terminal = replace(operation, state="failed", error_code="internal", detail="Fixture",
+                finished_at="2026-09-05T00:01:00Z", terminal_monotonic=100)
+            with provider.lock_writable_journal(journal):
+                provider.advance_journal_operation(journal, operation, terminal)
+                provider.complete_journal_terminal(journal, boot_id=self.boot_id)
+            environment = dict(os.environ, XDG_STATE_HOME=str(pathlib.Path(journal.chain.path).parents[1]))
+            reader, writer = os.pipe()
+            os.close(reader)
+            try:
+                result = subprocess.run(["/usr/bin/python3", str(PROVIDER_PATH), "watch-operation", operation.operation_id],
+                    stdout=writer, stderr=subprocess.PIPE, env=environment, timeout=10)
+            finally:
+                os.close(writer)
+            self.assertEqual(result.returncode, 1)
+            self.assertEqual(result.stderr, b"operation observation was interrupted\n")
+            self.assertEqual(provider.load_journal_state(journal.chain).handoff.operation_id, operation.operation_id)
 
 
 if __name__ == "__main__":

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -5952,6 +5952,20 @@ class OperationWatchTests(unittest.TestCase):
             self.assertNotIn("running", [row[4] for row in operation_rows])
             self.assertEqual(operation_rows[-1][4], "canceled")
 
+    def test_cancelability_change_during_active_list_is_not_latched_out(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.live_backend(journal, [lambda bus: self.emit(bus, "Finished", "(uu)", (1, 1))], AllowCancel=False)
+            def request(_path, _interface, method, *_args):
+                if method == "GetAll":
+                    return SessionEvidenceTests.Variant("(a{sv})", (self.properties(AllowCancel=False),))
+                self.progress(backend, AllowCancel=True)
+                return SessionEvidenceTests.Variant("(ao)", ([operation.transaction_path],))
+            backend._recovery_call.side_effect = request
+            progress = []
+            backend.probe_operation(operation, watch=True, on_progress=progress.append)
+            self.assertTrue(progress[-1].allow_cancel)
+
     def test_watch_bus_loss_malformed_signal_or_output_failure_detaches_without_cancel(self):
         for fault in ("bus", "malformed", "output"):
             with self.subTest(fault=fault), self.journal() as journal:
@@ -6016,6 +6030,25 @@ class OperationWatchTests(unittest.TestCase):
                 self.assertEqual(chunks, [])
                 backend.assert_not_called()
                 self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
+
+    def test_service_free_controls_retain_lower_guidance_until_snapshot_has_session_evidence(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, session_restart="security-session", application_restart=True)
+            terminal = replace(operation, state="failed", error_code="internal", detail="Fixture",
+                finished_at="2026-09-05T00:01:00Z", terminal_monotonic=100)
+            with provider.lock_writable_journal(journal):
+                provider.advance_journal_operation(journal, operation, terminal)
+            backend = mock.Mock(side_effect=AssertionError("Replay opened a service"))
+            provider.watch_journal_operation(journal, operation.operation_id, lambda _chunk: None,
+                boot_id=self.boot_id, backend_factory=backend)
+            backend.assert_not_called()
+            with provider.lock_writable_journal(journal):
+                provider.acknowledge_journal_handoff(journal, operation.operation_id)
+                state = provider.load_writable_journal_state(journal)
+                self.assertEqual((state.restart.session, state.restart.application), ("security-session", True))
+                provider.prune_journal_restart(journal, self.boot_id, 200)
+                state = provider.load_writable_journal_state(journal)
+                self.assertEqual((state.restart.session, state.restart.application), ("none", False))
 
     def test_control_cli_has_fixed_syntax_and_stream_free_stale_diagnostics(self):
         for args in ([], ["watch-operation"], ["ack-operation", "bad"], ["watch-operation", "op-" + "a" * 32, "extra"],

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -5949,6 +5949,61 @@ class OperationWatchTests(unittest.TestCase):
                 backend.session_started.assert_called_once_with()
                 self.assertIn("\tsucceeded\t", "".join(chunks))
 
+    def test_completion_during_backend_creation_replays_the_exact_retained_result(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = mock.Mock()
+            def attach():
+                with provider.lock_writable_journal(journal):
+                    running = provider.advance_journal_operation(journal, operation,
+                        replace(operation, state="running"))
+                    provider.advance_journal_operation(journal, running, replace(running,
+                        state="succeeded", finished_at="2026-09-05T01:00:00Z", terminal_monotonic=10))
+                    provider.complete_journal_terminal(journal, boot_id=self.boot_id)
+                return backend
+            chunks = []
+            provider.watch_journal_operation(journal, operation.operation_id, chunks.append,
+                boot_id=self.boot_id, backend_factory=attach)
+            backend.probe_operation.assert_not_called()
+            backend.operation_history.assert_not_called()
+            backend.session_started.assert_not_called()
+            output = "".join(chunks).splitlines()
+            self.assertEqual(rows(output, "operation")[-1][1:5],
+                [operation.operation_id, operation.action_id, "update", "succeeded"])
+            self.assertEqual(output[-1], "complete\toperation")
+            self.assertEqual(provider.load_journal_state(journal.chain).handoff.operation_id, operation.operation_id)
+
+    def test_property_deltas_during_getall_override_its_stale_snapshot(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.live_backend(journal, [lambda bus: self.emit(bus, "Finished", "(uu)", (3, 0))])
+            def request(_path, _interface, method, *_args):
+                if method == "GetAll":
+                    self.progress(backend, Status=31, AllowCancel=True, Percentage=27)
+                    return SessionEvidenceTests.Variant("(a{sv})", (self.properties(Status=1, AllowCancel=False, Percentage=0),))
+                return SessionEvidenceTests.Variant("(ao)", ([operation.transaction_path],))
+            backend._recovery_call.side_effect = request
+            chunks = []
+            provider.watch_journal_operation(journal, operation.operation_id, chunks.append,
+                boot_id=self.boot_id, backend_factory=lambda: backend)
+            self.assertIn("\tauthorizing\t27\tyes\t", "".join(chunks))
+
+    def test_unrelated_and_unchanged_signals_do_not_reload_the_journal(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            def noise(bus):
+                with mock.patch.object(provider, "load_writable_journal_state", side_effect=AssertionError("Noise reloaded journal")):
+                    for _ in range(100):
+                        self.emit(bus, "Package", "(uss)", (12, self.package_id, "Package"))
+                        self.emit(bus, "Packages", "(a(uss))", ([(12, self.package_id, "Package")],))
+                        self.progress(bus, Percentage=45, AllowCancel=True, Status=3)
+                        self.progress(bus, Speed=100)
+            backend = self.live_backend(journal, [noise, lambda bus: self.emit(bus, "Finished", "(uu)", (1, 0))])
+            chunks = []
+            provider.watch_journal_operation(journal, operation.operation_id, chunks.append,
+                boot_id=self.boot_id, backend_factory=lambda: backend)
+            self.assertEqual("".join(chunks).splitlines()[-1], "complete\toperation")
+
     def test_watch_uses_new_live_cancelability_not_stale_initial_false(self):
         with self.journal() as journal:
             operation = self.begin(journal)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -5927,6 +5927,28 @@ class OperationWatchTests(unittest.TestCase):
             self.assertEqual(result.state, "succeeded")
             self.assertEqual(backend.connection.calls, [])
 
+    def test_logind_lookup_follows_terminal_observation_and_precedes_commit(self):
+        for kind in ("refresh", "update"):
+            with self.subTest(kind=kind), self.journal() as journal:
+                operation = self.begin(journal, kind)
+                finished = []
+                def finish(bus):
+                    finished.append(True)
+                    self.emit(bus, "Finished", "(uu)", (1, 1))
+                    self.emit(bus, "Destroy", "()", ())
+                backend = self.live_backend(journal, [finish], Role=13 if kind == "refresh" else 22)
+                def session():
+                    self.assertEqual(finished, [True])
+                    self.assertFalse(journal._exclusive)
+                    self.assertIsNotNone(provider.load_journal_state(journal.chain).active)
+                    return None
+                backend.session_started.side_effect = session
+                chunks = []
+                provider.watch_journal_operation(journal, operation.operation_id, chunks.append,
+                    boot_id=self.boot_id, backend_factory=lambda: backend)
+                backend.session_started.assert_called_once_with()
+                self.assertIn("\tsucceeded\t", "".join(chunks))
+
     def test_watch_uses_new_live_cancelability_not_stale_initial_false(self):
         with self.journal() as journal:
             operation = self.begin(journal)
@@ -5951,6 +5973,24 @@ class OperationWatchTests(unittest.TestCase):
             self.assertEqual([row[6] for row in authorizing], ["yes", "no"])
             self.assertNotIn("running", [row[4] for row in operation_rows])
             self.assertEqual(operation_rows[-1][4], "canceled")
+
+    def test_live_authorization_is_displayed_without_erasing_unknown_execution(self):
+        for initial in ("invalid", "missing"):
+            with self.subTest(initial=initial), self.journal() as journal:
+                operation = self.begin(journal)
+                backend = self.live_backend(journal, [lambda bus: self.progress(bus, Status=31),
+                    lambda bus: self.emit(bus, "Finished", "(uu)", (3, 0))], Status="invalid")
+                if initial == "missing":
+                    values = self.properties()
+                    del values["Status"]
+                    backend._recovery_call.side_effect = [SessionEvidenceTests.Variant("(a{sv})", (values,)),
+                        SessionEvidenceTests.Variant("(ao)", ([operation.transaction_path],))]
+                chunks = []
+                provider.watch_journal_operation(journal, operation.operation_id, chunks.append,
+                    boot_id=self.boot_id, backend_factory=lambda: backend)
+                self.assertIn("\tauthorizing\t", "".join(chunks))
+                state = provider.load_journal_state(journal.chain)
+                self.assertEqual((state.terminals[operation.slot].state, state.restart.system), ("canceled", "unknown"))
 
     def test_cancelability_change_during_active_list_is_not_latched_out(self):
         with self.journal() as journal:


### PR DESCRIPTION
## Summary
- Add exact-ID watch-operation and ack-operation controls; invalid syntax exits 2, stale controls exit 3 without a stream, and interrupted observation after output begins exits 1.
- Complete durable terminal commit sequences before matching controls. Retained results replay without opening PackageKit, and acknowledgment clears only the exact handoff.
- Extend bounded recovery attachment into a signal-driven live observer using the same verified subscriptions, without reinvocation, an idle watchdog, polling, or Cancel.
- Preserve live property deltas during initial attachment, replay the exact retained completion that wins attachment, and ignore unrelated/unchanged signals before journal reads.
- Revalidate journal ownership around checkpoints, keep service waits outside locks, emit bounded pending/authorization progress, and preserve required lifecycle and terminal records.

## Validation
- Focused watch/control tests: 19 pass; all 253 provider tests pass.
- `scripts/run-tests make clean all` and `scripts/run-tests`: pass, including configured QML lint, nested-X11 lifecycle, staged/repeated installation and workspace cleanup.
- Closed Settings CPU 0.033%; large surfaces 0.00% in the current managed nested-X11 run.
- Local CodeRabbit review: no findings. Required post-gate local Codex review: no findings after the final 253-test suite (58 focused tests independently passed). A separate earlier whole-PR Codex review was also clean; fresh hosted reviews are required after every push.
- Fedora 44 native GLib/Gio fixture on an isolated private D-Bus: verified attachment, live progress, restart checkpoint, terminal handoff, and completion pass. No host PackageKit connection or package action was used.
- A real subprocess with a closed stdout pipe exits 1 with only the fixed interruption diagnostic and preserves the durable handoff.
- Native live host PackageKit mutation is not exercised; the successful native watch uses an isolated producer. Existing own-logind-session availability limitation remains explicit.

- Initial hosted validation on 9ef1bfa hit wallpaper-preview convergence failure in unchanged Settings code. Its same-head rerun passed in 13m53s without assertion changes; the separate local Settings Xvfb rerun also passed. Fresh exact-head checks remain required after the follow-up push.

## Scope
One operation watch/control boundary. Snapshot integration, cancel and mutation commands, root-owned UI/confirmation, regional/delegated administration, information/recovery surfaces, and combined Phase 6 qualification remain. Update mutation commands and UI remain disabled. No installed shell, host packages, settings, or login session were changed.
