### PR TITLE
feat(system): reconcile durable recovery in finite snapshots

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -78,9 +78,15 @@ ownership, and durably recovers terminal evidence or conservative interruption.
 Previous-boot records cannot reintroduce satisfied guidance. Public mutation
 commands remain disabled. Exact-ID watch and acknowledgment controls now replay
 retained results without a service call or keep a verified PackageKit observer
-subscribed through completion without reissuing the action. Snapshot, cancel,
-and mutation-command integration and the root-scoped
+subscribed through completion without reissuing the action. Finite snapshots now
+integrate validated journal recovery, boot/session restart pruning, exact active
+identities, and terminal handoffs without hiding readable package discovery.
+Cancel and mutation-command integration and the root-scoped
 confirmation and operation UI must be completed before this boundary can be accepted.
+Native Fedora 44 discovery exposed a separate preview validation gap: PackageKit
+represented all 23 requested IDs, but marked five as `install` rather than
+`update`. The current validator rejects those rows. Qualify and correct that
+mapping in its own review boundary before enabling confirmed execution.
 
 - [ ] Add user-initiated Fedora update discovery and status through the selected
   stable package-management interface.

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -548,6 +548,10 @@ ShellRoot {
             return systemManagementModel.updates.length;
         }
 
+        function systemManagementRestartState(): string {
+            return systemManagementModel.updateRestart.status + ":" + systemManagementModel.updateRestart.value;
+        }
+
         function systemManagementPackageChangeCount(): int {
             return systemManagementModel.packageChanges.length;
         }

--- a/config/quickshell/systemmanagement/SystemManagementModel.qml
+++ b/config/quickshell/systemmanagement/SystemManagementModel.qml
@@ -119,6 +119,17 @@ Scope {
         return "";
     }
 
+    function operationActionKind(actionId) {
+        const updateKind = root.updateActionKind(actionId);
+        if (updateKind.length > 0) return updateKind;
+        if (actionId === "timezone-set") return "timezone";
+        if (actionId === "ntp-set") return "ntp";
+        if (actionId === "locale-set") return "locale";
+        if (actionId === "accounts-open" || actionId === "password-open"
+                || actionId === "printers-open" || actionId === "sources-open") return "delegate";
+        return "";
+    }
+
     function clearState(detail) {
         root.snapshotState = "failure";
         root.message = detail;
@@ -254,7 +265,7 @@ Scope {
                         && Number(fields[3]) <= 4294967294 : fields[3] === "unknown";
                 } else {
                     valueValid = root.validRestart(fields[3])
-                        && (available || fields[3] === "unknown");
+                        && (available || fields[2] === "partial" || fields[3] === "unknown");
                 }
                 if (!valueValid) {
                     updatesInvalid = true;
@@ -381,8 +392,8 @@ Scope {
                     break;
                 }
                 if (!root.fieldsFit(fields, 4) || !root.validOperationId(fields[1])
-                        || root.updateActionKind(fields[2]).length === 0
-                        || root.updateActionKind(fields[2]) !== fields[3]) {
+                        || root.operationActionKind(fields[2]).length === 0
+                        || root.operationActionKind(fields[2]) !== fields[3]) {
                     fatal = "System management provider returned an invalid terminal handoff";
                     break;
                 }

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -130,6 +130,14 @@ snapshot as the next recovery attempt.
 and `update`. Regional and delegated operations remain owned by their finite
 originating stream while active, but an exact retained terminal record for any
 valid kind can be replayed without reissuing its external action.
+Finite snapshots now initialize or validate the fixed journal, recover its
+bounded state, and apply restart satisfaction before publishing active or
+handoff identities. Journal or logind failure preserves readable update
+discovery and reports recovery errors; known restart guidance remains visible
+with `partial` status. This incremental build still leaves mutation and cancel
+commands unavailable, so snapshot active rows advertise `cancelable=no` until
+the exact-ID cancel control is integrated. Live watch streams continue to report
+the exact PackageKit cancelability observation.
 After bounded initial adoption validates the exact object, the live watcher
 keeps those same subscriptions without a silence deadline or polling timer.
 Bus loss, malformed evidence, or a failed output/checkpoint ends observation

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -3370,6 +3370,121 @@ class ObservedUpdateSummary:
                 f"different={self.comparison(final=final)}; mismatch-samples={len(self.samples)}")
 
 
+@dataclass(frozen=True)
+class RecoverySnapshot:
+    """Finite validated journal projection; no open descriptors escape it."""
+
+    state: JournalState | None = None
+    evidence: RecoveryEvidence | None = None
+    prior_restart: JournalRestart | None = None
+    failures: tuple[SnapshotFailure, ...] = ()
+
+
+def read_recovery_snapshot(backend: PackageKitBackend) -> RecoverySnapshot:
+    """Recover and prune before display, without holding locks over service calls."""
+    prior_restart = None
+    failures = []
+    session_read = False
+    session_started = None
+
+    def read_session():
+        nonlocal session_read, session_started
+        if not session_read:
+            session_read = True
+            try:
+                session_started = backend.session_started()
+                _encode_journal_uint64(session_started, "session start")
+            except (SnapshotFailure, JournalRecordError) as error:
+                session_started = None
+                failures.append(error if isinstance(error, SnapshotFailure) else
+                    SnapshotFailure("malformed", "Session start evidence is malformed; restart guidance is retained"))
+        return session_started
+
+    try:
+        boot_id = read_boot_id()
+        with open_journal_directory() as chain:
+            try:
+                initialize_journal_layout(chain.directory_descriptor, boot_id)
+            except OSError:
+                # A read-only filesystem can still supply trustworthy prior
+                # guidance even though initialization/pruning is unavailable.
+                try:
+                    prior_restart = load_journal_state(chain).restart
+                except (OSError, JournalFrameError, JournalRecordError):
+                    pass
+                raise
+            prior_restart = load_journal_state(chain).restart
+            with retain_writable_journal(chain) as journal:
+                state, evidence, failure = recover_journal_active(journal, backend,
+                    boot_id=boot_id, session_reader=read_session)
+                if failure is not None:
+                    failures.append(failure)
+                # The finite PackageKit attachment comes first. The same
+                # cached logind result also prunes journal-only recovery paths.
+                read_session()
+                with lock_writable_journal(journal):
+                    prune_journal_restart(journal, boot_id, session_started)
+                    current = load_writable_journal_state(journal)
+                    if current.active is not None and current.active.state in JOURNAL_OPERATION_TERMINAL_STATES:
+                        complete_journal_terminal(journal, boot_id=boot_id, session_started=session_started)
+                        current = load_writable_journal_state(journal)
+                    if current.active != state.active:
+                        evidence = None
+                    if current.active is not None and current.active.kind not in {"update", "refresh"}:
+                        raise JournalAdmissionError("Another regional or delegated owner appeared during recovery")
+                    return RecoverySnapshot(current, evidence, prior_restart, tuple(failures))
+    except (SnapshotFailure, JournalFrameError, JournalRecordError, JournalAdmissionError, OSError) as error:
+        if isinstance(error, SnapshotFailure):
+            failure = error
+        elif isinstance(error, (JournalLockError, JournalAdmissionError)):
+            failure = SnapshotFailure("conflict", "Journal recovery could not obtain stable ownership; refresh status before retrying")
+        elif isinstance(error, JournalCommitError) or not isinstance(error, (JournalFrameError, JournalRecordError, JournalFileError)):
+            failure = SnapshotFailure("internal", "Journal storage is unavailable; check free space, mount writability, and permissions before refreshing. Prior guidance is retained")
+        else:
+            failure = SnapshotFailure("malformed", f"Journal recovery failed: {error}. Keep the journal intact; reboot before moving a legacy journal aside, then refresh and inspect diagnostics")
+        return RecoverySnapshot(prior_restart=prior_restart, failures=tuple(failures + [failure]))
+
+
+def build_managed_snapshot(backend: PackageKitBackend) -> list[str]:
+    """Combine readable discovery with independently validated durable recovery."""
+    recovery = read_recovery_snapshot(backend)
+    lines = build_snapshot(backend)
+    state = recovery.state
+    restart = state.restart if state is not None else recovery.prior_restart
+    value = "unknown"
+    if restart is not None and restart.system != "unknown":
+        value = aggregate_restart((
+            {"none": 1, "system": 4, "security-system": 6}[restart.system],
+            {"none": 1, "session": 3, "security-session": 5}[restart.session],
+            2 if restart.application else 1,
+        ))
+    partial = bool(recovery.failures) or state is None
+    if state is None and value == "none":
+        value = "unknown"
+    detail = "Durable journal restart guidance; session and reboot satisfaction applied"
+    if partial:
+        detail = "Known restart guidance is retained; recovery evidence is incomplete. Refresh status and inspect recovery errors"
+    for index, line in enumerate(lines):
+        if line.startswith("provider\trecovery\t"):
+            lines[index] = "\t".join(("provider", "recovery", "partial" if partial else "available",
+                "user-session", "dwm-system-management", detail if partial else "Durable journal recovery completed"))
+        elif line.startswith("state\tupdate-restart\t"):
+            lines[index] = "\t".join(("state", "update-restart", "partial" if partial else "available", value, detail))
+    lines.pop()  # Restore the single final completion after recovery records.
+    if state is not None and state.active is not None:
+        operation = state.active
+        percent = recovery.evidence.percent if recovery.evidence is not None else None
+        lines.append("\t".join(("active-operation", operation.operation_id, operation.action_id,
+            operation.kind, operation.state, "unknown" if percent is None else str(percent), "no",
+            "Exact journaled operation remains active; use watch-operation. Cancellation controls are not enabled in this build")))
+    elif state is not None and state.handoff is not None:
+        operation = state.terminals[state.handoff.slot]
+        lines.append("\t".join(("terminal-handoff", operation.operation_id, operation.action_id, operation.kind)))
+    lines.extend(f"error\trecovery\t{failure.code}\t{failure.detail}" for failure in recovery.failures)
+    lines.append("complete\tsnapshot")
+    return lines
+
+
 def build_snapshot(backend: UpdateBackend) -> list[str]:
     errors: list[tuple[str, str]] = []
     last_refresh_status = "unavailable"
@@ -5107,7 +5222,6 @@ def main(argv: Sequence[str]) -> int:
         return usage()
     try:
         backend = PackageKitBackend()
-        lines = build_snapshot(backend)
     except SnapshotFailure as failure:
         # Backend construction can fail before a usable source exists. Reuse the
         # normal snapshot shape so consumers still receive every mandatory ID.
@@ -5124,7 +5238,17 @@ def main(argv: Sequence[str]) -> int:
             def simulate(self, _package_ids: Sequence[str]) -> TransactionResult:
                 raise self.failure
 
-        lines = build_snapshot(FailedBackend(failure))
+            def session_started(self) -> int:
+                raise self.failure
+
+            def probe_operation(self, _operation, **_kwargs):
+                raise self.failure
+
+            def operation_history(self):
+                raise self.failure
+
+        backend = FailedBackend(failure)
+    lines = build_managed_snapshot(backend)
     print("\n".join(lines))
     return 0
 

--- a/tests/test-quickshell-system-management-xvfb.sh
+++ b/tests/test-quickshell-system-management-xvfb.sh
@@ -107,6 +107,15 @@ case $mode in
 valid)
 	snapshot
 	;;
+partial-restart)
+	snapshot | sed 's/state\tupdate-restart\tavailable\tsystem/state\tupdate-restart\tpartial\tsecurity-session/'
+	;;
+regional-handoff)
+	snapshot | sed '/^complete\t/i\terminal-handoff\top-11111111111111111111111111111111\ttimezone-set\ttimezone'
+	;;
+invalid-handoff)
+	snapshot | sed '/^complete\t/i\terminal-handoff\top-11111111111111111111111111111111\ttimezone-set\tdelegate'
+	;;
 bad-plan)
 	snapshot | sed \
 		-e 's/action\tupdates-install-all\tunavailable/action\tupdates-install-all\tavailable/' \
@@ -283,6 +292,22 @@ printf 'future-record\n' >"$fixture/mode"
 ipc refresh >/dev/null
 wait_state ready
 [ "$(ipc systemManagementUpdateCount)" -eq 1 ]
+
+printf 'partial-restart\n' >"$fixture/mode"
+ipc refresh >/dev/null
+wait_state ready
+[ "$(ipc systemManagementUpdateCount)" -eq 1 ]
+[ "$(ipc systemManagementRestartState)" = partial:security-session ]
+
+printf 'regional-handoff\n' >"$fixture/mode"
+ipc refresh >/dev/null
+wait_state ready
+[ "$(ipc systemManagementUpdateCount)" -eq 1 ]
+
+printf 'invalid-handoff\n' >"$fixture/mode"
+ipc refresh >/dev/null
+wait_state failure
+[ "$(ipc systemManagementUpdateCount)" -eq 0 ]
 
 printf 'unexpected-update\n' >"$fixture/mode"
 ipc refresh >/dev/null

--- a/tests/test-quickshell-system-management.sh
+++ b/tests/test-quickshell-system-management.sh
@@ -66,7 +66,8 @@ grep -Fq 'property var recoveryProvider: root.recoveryFallback(' "$model"
 grep -Fq '"providerClass": "user-session"' "$model"
 grep -Fq "Number(states[\"\$update-summary\"].value) !== parsedUpdates.length" "$model"
 grep -Fq 'parsedActive !== null || parsedHandoff !== null' "$model"
-[ "$(grep -Fc 'root.updateActionKind(fields[2]).length === 0' "$model")" -eq 2 ]
+[ "$(grep -Fc 'root.updateActionKind(fields[2]).length === 0' "$model")" -eq 1 ]
+grep -Fq 'root.operationActionKind(fields[2]).length === 0' "$model"
 grep -Fq 'responseGeneration !== root.requestGeneration || !root.settingsVisible' "$model"
 grep -Fq 'if (snapshotProcess.running)' "$model"
 grep -Fq 'root.snapshotPending = true;' "$model"

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -6228,5 +6228,208 @@ class OperationWatchTests(unittest.TestCase):
             self.assertEqual(provider.load_journal_state(journal.chain).handoff.operation_id, operation.operation_id)
 
 
+class RecoverySnapshotTests(unittest.TestCase):
+    boot_id = PackageKitExecutionTests.boot_id
+    journal = PackageKitExecutionTests.journal
+    begin = OperationRecoveryTests.begin
+
+    def backend(self, **kwargs):
+        backend = FixtureBackend(**kwargs)
+        backend.session_started = mock.Mock(return_value=0)
+        backend.probe_operation = mock.Mock(return_value=provider.RecoveryEvidence(False))
+        backend.operation_history = mock.Mock(return_value=())
+        return backend
+
+    def snapshot(self, journal, backend, *, boot_id=None):
+        state_home = str(pathlib.Path(journal.chain.path).parents[1])
+        with mock.patch.dict(os.environ, {"XDG_STATE_HOME": state_home}), \
+                mock.patch.object(provider, "read_boot_id", return_value=boot_id or self.boot_id):
+            return provider.build_managed_snapshot(backend)
+
+    def restart(self, journal, **changes):
+        cutoffs = sorted({changes[key] for key in ("session_cutoff", "application_cutoff") if key in changes}) or [100]
+        for index, cutoff in enumerate(cutoffs):
+            operation = self.begin(journal, state="running",
+                system_restart=changes.get("system", "none") if index == 0 else "none",
+                session_restart=changes.get("session", "none") if cutoff == changes.get("session_cutoff") else "none",
+                application_restart=changes.get("application", False) if cutoff == changes.get("application_cutoff") else False)
+            with provider.lock_writable_journal(journal):
+                provider.advance_journal_operation(journal, operation, replace(operation,
+                    state="succeeded", finished_at="2026-09-05T01:00:00Z", terminal_monotonic=cutoff))
+                provider.complete_journal_terminal(journal, boot_id=self.boot_id)
+                provider.acknowledge_journal_handoff(journal, operation.operation_id)
+
+    def restart_row(self, output):
+        return next(row for row in rows(output, "state") if row[1] == "update-restart")
+
+    def test_cli_initializes_only_its_fixed_journal_and_keeps_actions_disabled(self):
+        with tempfile.TemporaryDirectory() as directory, \
+                mock.patch.dict(os.environ, {"XDG_STATE_HOME": directory}), \
+                mock.patch.object(provider, "read_boot_id", return_value=self.boot_id), \
+                mock.patch.object(provider, "PackageKitBackend", return_value=self.backend()), \
+                contextlib.redirect_stdout(io.StringIO()) as stdout:
+            self.assertEqual(provider.main(["snapshot"]), 0)
+            output = stdout.getvalue().splitlines()
+            self.assertEqual(output[-1], "complete\tsnapshot")
+            self.assertEqual(self.restart_row(output)[2:4], ["available", "none"])
+            self.assertEqual([row[2] for row in rows(output, "action")], ["unavailable"] * 3)
+            path = pathlib.Path(directory) / "dwm-titus" / "system-management"
+            self.assertEqual({item.name for item in path.iterdir()}, set(provider.JOURNAL_NAMES))
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o700)
+
+    def test_durable_restart_overrides_discovery_and_survives_missing_packagekit(self):
+        for unavailable in (False, True):
+            with self.subTest(unavailable=unavailable), self.journal() as journal:
+                self.restart(journal, system="system", session="security-session", session_cutoff=100)
+                backend = self.backend(restart_types=(1,), updates_failure=
+                    provider.SnapshotFailure("missing-provider", "PackageKit is absent", "unavailable") if unavailable else None)
+                output = self.snapshot(journal, backend)
+                self.assertEqual(self.restart_row(output)[2:4], ["available", "security-system"])
+                self.assertEqual(output[-1], "complete\tsnapshot")
+
+    def test_new_session_prunes_independent_cutoffs_before_display(self):
+        with self.journal() as journal:
+            self.restart(journal, session="security-session", session_cutoff=100, application=True, application_cutoff=300)
+            backend = self.backend()
+            backend.session_started.return_value = 200
+            output = self.snapshot(journal, backend)
+            self.assertEqual(self.restart_row(output)[2:4], ["available", "application"])
+            state = provider.load_journal_state(journal.chain)
+            self.assertEqual((state.restart.session, state.restart.application), ("none", True))
+
+    def test_missing_session_evidence_retains_known_guidance_as_partial(self):
+        with self.journal() as journal:
+            self.restart(journal, session="security-session", session_cutoff=100)
+            backend = self.backend()
+            backend.session_started.side_effect = provider.SnapshotFailure("timeout", "Logind timed out")
+            output = self.snapshot(journal, backend)
+            self.assertEqual(self.restart_row(output)[2:4], ["partial", "security-session"])
+            self.assertIn(["error", "recovery", "timeout", "Logind timed out"], rows(output, "error"))
+            self.assertEqual(provider.load_journal_state(journal.chain).restart.session, "security-session")
+
+    def test_new_boot_clears_all_guidance_durably(self):
+        with self.journal() as journal:
+            self.restart(journal, system="unknown", session="session", session_cutoff=100, application=True, application_cutoff=100)
+            new_boot = "abcdef01-2345-6789-abcd-ef0123456789"
+            output = self.snapshot(journal, self.backend(), boot_id=new_boot)
+            self.assertEqual(self.restart_row(output)[2:4], ["available", "none"])
+            self.assertEqual(provider.load_journal_state(journal.chain).restart.boot_id, new_boot)
+
+    def test_logind_failure_does_not_reintroduce_guidance_satisfied_by_reboot(self):
+        with self.journal() as journal:
+            self.restart(journal, system="unknown", session="session", session_cutoff=100)
+            backend = self.backend()
+            backend.session_started.side_effect = provider.SnapshotFailure("missing-provider", "Logind missing")
+            output = self.snapshot(journal, backend, boot_id="abcdef01-2345-6789-abcd-ef0123456789")
+            self.assertEqual(self.restart_row(output)[2:4], ["partial", "none"])
+
+    def test_read_only_journal_failure_preserves_validated_prior_guidance(self):
+        with self.journal() as journal:
+            self.restart(journal, system="security-system")
+            with mock.patch.object(provider, "initialize_journal_layout", side_effect=OSError(errno.EROFS, "Read-only fixture")):
+                output = self.snapshot(journal, self.backend())
+            self.assertEqual(self.restart_row(output)[2:4], ["partial", "security-system"])
+
+    def test_active_lookup_precedes_logind_and_emits_exact_finite_identity(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, "refresh")
+            backend = self.backend()
+            def probe(record, **_kwargs):
+                self.assertEqual(record, operation)
+                self.assertFalse(journal._exclusive)
+                backend.session_started.assert_not_called()
+                return provider.RecoveryEvidence(True, percent=27, allow_cancel=True)
+            backend.probe_operation.side_effect = probe
+            output = self.snapshot(journal, backend)
+            self.assertEqual(rows(output, "active-operation")[0][1:7],
+                [operation.operation_id, operation.action_id, "refresh", "pending", "27", "no"])
+            self.assertEqual(rows(output, "terminal-handoff"), [])
+            self.assertEqual(output[-1], "complete\tsnapshot")
+
+    def test_lookup_timeout_preserves_active_identity_and_does_not_guess_absence(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, "refresh")
+            backend = self.backend()
+            backend.probe_operation.side_effect = provider.SnapshotFailure("timeout", "Lookup expired")
+            output = self.snapshot(journal, backend)
+            self.assertEqual(rows(output, "active-operation")[0][1], operation.operation_id)
+            self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
+            self.assertIn(["error", "recovery", "timeout", "Lookup expired"], rows(output, "error"))
+
+    def test_absent_refresh_becomes_durable_interrupted_handoff(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, "refresh")
+            output = self.snapshot(journal, self.backend())
+            self.assertEqual(rows(output, "active-operation"), [])
+            self.assertEqual(rows(output, "terminal-handoff"),
+                [["terminal-handoff", operation.operation_id, operation.action_id, "refresh"]])
+            self.assertEqual(provider.load_journal_state(journal.chain).terminals[operation.slot].state, "interrupted")
+
+    def test_terminalized_update_is_completed_and_pruned_before_handoff(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, state="running", session_restart="session")
+            with provider.lock_writable_journal(journal):
+                provider.advance_journal_operation(journal, operation, replace(operation,
+                    state="succeeded", finished_at="2026-09-05T01:00:00Z", terminal_monotonic=100))
+            backend = self.backend()
+            backend.session_started.return_value = 200
+            output = self.snapshot(journal, backend)
+            backend.probe_operation.assert_not_called()
+            backend.operation_history.assert_not_called()
+            self.assertEqual(self.restart_row(output)[2:4], ["available", "none"])
+            self.assertEqual(rows(output, "terminal-handoff")[0][1], operation.operation_id)
+            self.assertIsNone(provider.load_journal_state(journal.chain).active)
+
+    def test_stranded_regional_state_is_not_emitted_as_packagekit_active(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, "timezone")
+            backend = self.backend()
+            output = self.snapshot(journal, backend)
+            backend.probe_operation.assert_not_called()
+            self.assertEqual(rows(output, "active-operation"), [])
+            self.assertEqual(rows(output, "terminal-handoff")[0][1], operation.operation_id)
+            self.assertEqual(provider.load_journal_state(journal.chain).terminals[operation.slot].state, "interrupted")
+
+    def test_prune_failure_retains_prior_guidance_without_publishing_handoff(self):
+        with self.journal() as journal:
+            self.restart(journal, session="security-session", session_cutoff=100)
+            backend = self.backend()
+            backend.session_started.return_value = 200
+            with mock.patch.object(provider, "commit_writable_journal_path", side_effect=provider.JournalCommitError("Injected write failure")):
+                output = self.snapshot(journal, backend)
+            self.assertEqual(self.restart_row(output)[2:4], ["partial", "security-session"])
+            self.assertEqual(rows(output, "active-operation") + rows(output, "terminal-handoff"), [])
+            self.assertEqual(provider.load_journal_state(journal.chain).restart.session, "security-session")
+
+    def test_unsafe_journal_does_not_hide_readable_inventory_or_touch_replacement(self):
+        with self.journal() as journal:
+            path = pathlib.Path(journal.chain.path) / "handoff"
+            path.chmod(0o644)
+            try:
+                before = path.read_bytes()
+                backend = self.backend(updates=(package(9, "held;2;x86_64;updates", "Held"),))
+                output = self.snapshot(journal, backend)
+                self.assertEqual(len(rows(output, "update")), 1)
+                self.assertEqual(rows(output, "active-operation") + rows(output, "terminal-handoff"), [])
+                self.assertEqual(self.restart_row(output)[2:4], ["partial", "unknown"])
+                self.assertEqual(path.read_bytes(), before)
+                self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o644)
+            finally:
+                path.chmod(0o600)
+
+    def test_backend_construction_failure_still_completes_durable_handoff(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, "refresh")
+            with provider.lock_writable_journal(journal):
+                provider.advance_journal_operation(journal, operation, replace(operation,
+                    state="failed", error_code="internal", finished_at="2026-09-05T01:00:00Z", terminal_monotonic=100))
+            with mock.patch.dict(os.environ, {"XDG_STATE_HOME": str(pathlib.Path(journal.chain.path).parents[1])}), \
+                    mock.patch.object(provider, "read_boot_id", return_value=self.boot_id), \
+                    mock.patch.object(provider, "PackageKitBackend", side_effect=provider.SnapshotFailure("missing-provider", "Bindings missing")), \
+                    contextlib.redirect_stdout(io.StringIO()) as stdout:
+                self.assertEqual(provider.main(["snapshot"]), 0)
+            self.assertEqual(rows(stdout.getvalue().splitlines(), "terminal-handoff")[0][1], operation.operation_id)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Integrate fixed-journal initialization, bounded recovery, restart satisfaction, active identities, and exact terminal handoffs into the public finite snapshot.
- Keep package discovery readable when journal or logind evidence fails. Publish durable restart guidance rather than passive discovery guidance; retain validated prior guidance when persistence is unavailable.
- Preserve partial restart values in QML and accept exact retained handoffs for the closed operation-kind set while keeping live active rows PackageKit-only.
- Leave mutation and cancel commands disabled. Snapshot cancelability remains unavailable until the exact-ID control boundary; live watch streams still report PackageKit observations.

## Validation
- 15 focused recovery-snapshot tests and all 268 provider tests pass.
- `scripts/run-tests make check-quickshell-system-management`: pass, including partial-guidance, regional-handoff, invalid-handoff, and lifecycle X11 fixtures.
- `scripts/run-tests make clean all` and `scripts/run-tests`: pass, including staged/repeated installation, release archive validation, and workspace cleanup.
- `shellcheck install.sh scripts/*.sh tests/*.sh` and `shfmt -d install.sh scripts/*.sh tests/*.sh`: pass.
- Configured QML lint through the Quickshell skill helper and repository gate: pass; existing unrelated PanelTooltip/RunningApps warnings remain.
- Fedora 44 nested X11 closed CPU: Settings 0.067%, large surfaces 0.00%.
- Local CodeRabbit review: no findings. Required post-full-gate Codex review: no actionable findings.
- Native isolated Gio watch -> finite journal snapshot -> exact CLI acknowledgment: pass, retaining reboot guidance after acknowledgment. Discovery and session values were fixtures; no host PackageKit connection or package mutation was used in that test.
- Native Fedora read-only snapshot with an isolated XDG journal: complete protocol, 36 fixed files, and 23 readable updates. Actual logind lookup for this process is unavailable and is explicitly reported as partial recovery.

## Known limits and next boundary
The native PackageKit dependency preview still fails an existing validator assumption: it returns all 23 requested IDs in 29 rows (18 update, 5 install, 6 remove), but requested IDs labeled install are rejected. This is tracked in TASKS.md for a separate focused correction before confirmed execution is enabled. No successful host package update or native dependency-plan acceptance is claimed.

Root-owned operation UI/confirmation, public cancel/mutation controls, remaining Phase 6 administration surfaces, and combined installed-runtime qualification remain. No installed shell/configuration, host packages, or login session were changed.