### PR TITLE
feat(system): add exact-operation cancellation control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ versions from `config.mk`.
 
 ### Added
 
+- Add exact-operation PackageKit cancellation with bounded peer, ownership,
+  and cancelability checks. Stale requests leave the journal unchanged, accepted
+  requests remain observable until the real terminal result, and lost replies
+  retain recovery guidance. New update execution and its Settings controls
+  remain disabled pending integration.
+
 - Add a pane-scoped Quickshell system-management model that strictly consumes
   the bounded 1.0 snapshot protocol, isolates malformed provider state, rejects
   ambiguous streams, coalesces user refreshes, and stops its read process when

--- a/TASKS.md
+++ b/TASKS.md
@@ -81,8 +81,10 @@ retained results without a service call or keep a verified PackageKit observer
 subscribed through completion without reissuing the action. Finite snapshots now
 integrate validated journal recovery, boot/session restart pruning, exact active
 identities, and terminal handoffs without hiding readable package discovery.
-Cancel and mutation-command integration and the root-scoped
-confirmation and operation UI must be completed before this boundary can be accepted.
+The exact-ID cancel control now pins the backend peer, revalidates ownership and
+cancelability, and records only an accepted cancellation request without claiming
+a terminal result. New mutation commands and the root-scoped confirmation and
+operation UI must be completed before this boundary can be accepted.
 The preview validators now preserve requested `install` as well as `update`
 actions, matching the PackageKit DNF5 backend's discovery/simulation contract.
 Missing or duplicate requested IDs, outbound requested actions, and unrequested

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -130,14 +130,29 @@ snapshot as the next recovery attempt.
 and `update`. Regional and delegated operations remain owned by their finite
 originating stream while active, but an exact retained terminal record for any
 valid kind can be replayed without reissuing its external action.
+The public cancel control pins PackageKit's unique D-Bus peer and uses one
+ten-second aggregate deadline for owner lookup, exact-object validation, and
+the `Cancel` request. It checks the transaction's exact role and invoking UID,
+observes cancelability revocation, completion, destruction, and owner changes,
+and revalidates the journal identity before sending. It drains at most 64 queued
+main-context dispatches after the bounded journal lock; excess activity rejects
+the control instead of creating an unbounded watcher. No D-Bus call runs under
+the journal lock. A successful method reply records `cancel-requested` only
+when the same operation is still `running`; pending/authorizing operations do
+not acquire a fabricated running phase. The existing observer alone records
+the eventual terminal result. An uncertain post-dispatch failure exits 1 with
+fixed observation guidance and no stream, preserving the operation for recovery.
+A typed backend stale-target rejection retains the stream-free status 3 above.
+
 Finite snapshots now initialize or validate the fixed journal, recover its
 bounded state, and apply restart satisfaction before publishing active or
 handoff identities. Journal or logind failure preserves readable update
 discovery and reports recovery errors; known restart guidance remains visible
-with `partial` status. This incremental build still leaves mutation and cancel
-commands unavailable, so snapshot active rows advertise `cancelable=no` until
-the exact-ID cancel control is integrated. Live watch streams continue to report
-the exact PackageKit cancelability observation.
+with `partial` status. This incremental build still leaves new mutation commands
+unavailable. Snapshot active rows and the cancel action now advertise the exact
+observed cancelability, or remain unavailable when no trustworthy observation
+exists. The public cancel command always revalidates that hint. Live watch
+streams continue to report the exact PackageKit cancelability observation.
 After bounded initial adoption validates the exact object, the live watcher
 keeps those same subscriptions without a silence deadline or polling timer.
 Bus loss, malformed evidence, or a failed output/checkpoint ends observation

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -221,6 +221,10 @@ class JournalAdmissionError(RuntimeError):
     """A valid journal state cannot admit another operation."""
 
 
+class CancelTargetUnavailable(JournalAdmissionError):
+    """An exact cancellation target was rejected without an accepted request."""
+
+
 @dataclass(frozen=True)
 class JournalFrame:
     sequence: int
@@ -3477,9 +3481,15 @@ def build_managed_snapshot(backend: PackageKitBackend) -> list[str]:
     if state is not None and state.active is not None:
         operation = state.active
         percent = recovery.evidence.percent if recovery.evidence is not None else None
+        cancelable = recovery.evidence is not None and recovery.evidence.allow_cancel
+        for index, line in enumerate(lines):
+            if line.startswith("action\tupdates-cancel\t"):
+                lines[index] = "\t".join(("action", "updates-cancel", "available" if cancelable else "unavailable",
+                    "delegated", "updates", "Cancel update", "Exact PackageKit transaction permits cancellation"
+                    if cancelable else "Exact PackageKit transaction does not currently permit cancellation"))
         lines.append("\t".join(("active-operation", operation.operation_id, operation.action_id,
-            operation.kind, operation.state, "unknown" if percent is None else str(percent), "no",
-            "Exact journaled operation remains active; use watch-operation. Cancellation controls are not enabled in this build")))
+            operation.kind, operation.state, "unknown" if percent is None else str(percent), "yes" if cancelable else "no",
+            "Exact journaled operation remains active; use watch-operation to observe its result")))
     elif state is not None and state.handoff is not None:
         operation = state.terminals[state.handoff.slot]
         lines.append("\t".join(("terminal-handoff", operation.operation_id, operation.action_id, operation.kind)))
@@ -4339,7 +4349,8 @@ class PackageKitBackend:
         return path
 
     def _recovery_call(self, path: str, interface: str, method: str,
-                       parameters: object, deadline: float, signature: str) -> object:
+                       parameters: object, deadline: float, signature: str, *,
+                       destination: str = PACKAGEKIT_NAME) -> object:
         """Dispatch signals in order during a bounded request; validate its reply locally.
 
         Local signature validation keeps a wrong reply type classified as
@@ -4371,7 +4382,7 @@ class PackageKitBackend:
 
         try:
             source = self.GLib.timeout_add(wait_ms, expired)
-            self.connection.call(PACKAGEKIT_NAME, path, interface, method, parameters,
+            self.connection.call(destination, path, interface, method, parameters,
                 None, self.Gio.DBusCallFlags.NONE,
                 wait_ms, request, completed, None)
             if reply is None and failure is None and source:
@@ -4388,6 +4399,104 @@ class PackageKitBackend:
         if reply.get_type_string() != signature:
             raise SnapshotFailure("malformed", "PackageKit recovery reply is malformed")
         return reply
+
+    def cancel_operation(self, operation: JournalOperation, before_send: Callable[[], object],
+                         on_dispatch: Callable[[], object]) -> None:
+        """Request cancellation from one pinned peer; never infer its final result."""
+        encode_journal_operation(operation)
+        if operation.kind not in {"refresh", "update"} or operation.state in JOURNAL_OPERATION_TERMINAL_STATES:
+            raise CancelTargetUnavailable("cancel target is unavailable")
+        deadline = time.monotonic() + 10
+        reply = self._recovery_call("/org/freedesktop/DBus", "org.freedesktop.DBus", "GetNameOwner",
+            self.GLib.Variant("(s)", (PACKAGEKIT_NAME,)), deadline, "(s)", destination="org.freedesktop.DBus")
+        peer = reply.unpack()[0]
+        if not isinstance(peer, str) or re.fullmatch(r":[0-9]+\.[0-9]+", peer) is None:
+            raise CancelTargetUnavailable("cancel target is unavailable")
+        fields = ("Role", "Uid", "Status", "AllowCancel")
+        observed = {}
+        pending = {}
+        snapshot_applied = False
+        blocked = False
+        live = True
+        subscriptions = []
+
+        def changed(_connection, _sender, _path, interface, member, variant, _data):
+            nonlocal blocked
+            if not live:
+                return
+            try:
+                if interface == "org.freedesktop.DBus":
+                    blocked = blocked or variant.get_type_string() != "(sss)" or variant.unpack()[1] != variant.unpack()[2]
+                elif interface == TRANSACTION_INTERFACE:
+                    if member in {"Finished", "Destroy"}:
+                        blocked = True
+                elif interface == PROPERTIES_INTERFACE:
+                    if variant.get_type_string() != "(sa{sv}as)":
+                        raise ValueError
+                    owner, values, invalidated = variant.unpack()
+                    if owner != TRANSACTION_INTERFACE or not isinstance(values, dict):
+                        raise ValueError
+                    target = observed if snapshot_applied else pending
+                    for key in fields:
+                        if key in invalidated:
+                            target[key] = None
+                        elif key in values:
+                            target[key] = values[key] if type(values[key]) in {int, bool} else None
+            except (TypeError, ValueError, IndexError):
+                blocked = True
+
+        def require_available():
+            expected_role = 13 if operation.kind == "refresh" else 22
+            if (blocked or type(observed.get("Role")) is not int or observed["Role"] != expected_role
+                    or type(observed.get("Uid")) is not int or observed["Uid"] != os.getuid()
+                    or type(observed.get("Status")) is not int or not 0 <= observed["Status"] <= 36
+                    or observed["Status"] == 18 or observed.get("AllowCancel") is not True):
+                raise CancelTargetUnavailable("cancel target is unavailable")
+
+        try:
+            subscriptions.append(self.connection.signal_subscribe(peer, TRANSACTION_INTERFACE, None,
+                operation.transaction_path, None, self.Gio.DBusSignalFlags.NONE, changed, None))
+            subscriptions.append(self.connection.signal_subscribe(peer, PROPERTIES_INTERFACE, "PropertiesChanged",
+                operation.transaction_path, TRANSACTION_INTERFACE, self.Gio.DBusSignalFlags.NONE, changed, None))
+            subscriptions.append(self.connection.signal_subscribe("org.freedesktop.DBus", "org.freedesktop.DBus",
+                "NameOwnerChanged", "/org/freedesktop/DBus", PACKAGEKIT_NAME, self.Gio.DBusSignalFlags.NONE, changed, None))
+            values = self._recovery_call(operation.transaction_path, PROPERTIES_INTERFACE, "GetAll",
+                self.GLib.Variant("(s)", (TRANSACTION_INTERFACE,)), deadline, "(a{sv})", destination=peer).unpack()[0]
+            if not isinstance(values, dict):
+                raise CancelTargetUnavailable("cancel target is unavailable")
+            observed.update({key: values.get(key) if type(values.get(key)) in {int, bool} else None for key in fields})
+            observed.update(pending)
+            pending.clear()
+            snapshot_applied = True
+            require_available()
+            before_send()  # Revalidate journal ownership without holding a lock across D-Bus.
+            # Dispatch queued property revocations after the bounded journal lock.
+            # A noisy peer cannot turn this finite control into an unbounded watcher.
+            context = self.GLib.MainContext.default()
+            for _ in range(64):
+                if not context.pending():
+                    break
+                context.iteration(False)
+            else:
+                raise CancelTargetUnavailable("cancel target is unavailable")
+            require_available()
+            self._timeout_ms(deadline)
+            on_dispatch()
+            try:
+                self._recovery_call(operation.transaction_path, TRANSACTION_INTERFACE, "Cancel",
+                    None, deadline, "()", destination=peer)
+            except SnapshotFailure as failure:
+                cause = failure.__cause__
+                if isinstance(cause, self.GLib.Error) and self.Gio.dbus_error_get_remote_error(cause) in {
+                        TRANSACTION_INTERFACE + ".NotRunning", TRANSACTION_INTERFACE + ".NoRole",
+                        TRANSACTION_INTERFACE + ".CannotCancel", TRANSACTION_INTERFACE + ".NoSuchTransaction",
+                        "org.freedesktop.DBus.Error.UnknownObject"}:
+                    raise CancelTargetUnavailable("cancel target is unavailable") from failure
+                raise
+        finally:
+            live = False
+            for subscription in subscriptions:
+                self.connection.signal_unsubscribe(subscription)
 
     def probe_operation(self, operation: JournalOperation, *,
                         on_restart: Callable[[int], object] | None = None,
@@ -5180,9 +5289,42 @@ def watch_journal_operation(
                   if terminal.kind == "update" else terminal.detail)
 
 
+def cancel_journal_operation(journal: JournalDescriptorSet, operation_id: str, *, boot_id: str,
+                             on_dispatch: Callable[[], object],
+                             backend_factory: Callable[[], PackageKitBackend] = PackageKitBackend) -> None:
+    """Cancel only one active identity, leaving completion to its observer."""
+    identity = ("operation_id", "action_id", "started_at", "kind", "generation", "transaction_path", "boot_id", "slot")
+    with lock_writable_journal(journal):
+        original = load_writable_journal_state(journal).active
+        if (original is None or original.operation_id != operation_id or original.kind not in {"refresh", "update"}
+                or original.state in JOURNAL_OPERATION_TERMINAL_STATES
+                or (original.kind == "update" and original.boot_id != boot_id)):
+            raise CancelTargetUnavailable("cancel target is unavailable")
+
+    def before_send():
+        with lock_writable_journal(journal):
+            current = load_writable_journal_state(journal).active
+            if (current is None or current.state in JOURNAL_OPERATION_TERMINAL_STATES
+                    or any(getattr(current, key) != getattr(original, key) for key in identity)):
+                raise CancelTargetUnavailable("cancel target is unavailable")
+
+    backend_factory().cancel_operation(original, before_send, on_dispatch)
+    with lock_writable_journal(journal):
+        current = load_writable_journal_state(journal).active
+        if (current is not None and current.state == "running"
+                and all(getattr(current, key) == getattr(original, key) for key in identity)):
+            advance_journal_operation(journal, current, replace(current, state="cancel-requested",
+                detail="Cancellation requested; waiting for PackageKit completion"))
+
+
 def operation_control(command: str, operation_id: str) -> int:
     """Keep stale control rejection stream-free and watch failure distinct."""
     started = False
+    cancel_dispatched = False
+
+    def dispatched():
+        nonlocal cancel_dispatched
+        cancel_dispatched = True
 
     def write(chunk):
         nonlocal started
@@ -5195,12 +5337,21 @@ def operation_control(command: str, operation_id: str) -> int:
         with open_journal_directory() as chain, retain_writable_journal(chain) as journal:
             if command == "watch-operation":
                 watch_journal_operation(journal, operation_id, write, boot_id=boot_id)
+            elif command == "updates-cancel":
+                cancel_journal_operation(journal, operation_id, boot_id=boot_id,
+                    on_dispatch=dispatched, backend_factory=PackageKitBackend)
             else:
                 control_journal_target(journal, operation_id, boot_id)
                 with lock_writable_journal(journal):
                     acknowledge_journal_handoff(journal, operation_id)
         return 0
     except (SnapshotFailure, JournalFrameError, JournalRecordError, JournalAdmissionError, OSError, OperationProtocolError) as error:
+        if command == "updates-cancel":
+            if cancel_dispatched and not isinstance(error, CancelTargetUnavailable):
+                print("cancellation request could not be confirmed; observe the existing operation", file=sys.stderr)
+                return 1
+            print("cancel target is unavailable", file=sys.stderr)
+            return 3
         if started:
             if isinstance(error, BrokenPipeError):
                 # Avoid a second buffered flush at interpreter shutdown changing
@@ -5214,12 +5365,12 @@ def operation_control(command: str, operation_id: str) -> int:
 
 
 def usage() -> int:
-    print(f"usage: {sys.argv[0]} snapshot | watch-operation OPERATION_ID | ack-operation OPERATION_ID", file=sys.stderr)
+    print(f"usage: {sys.argv[0]} snapshot | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID", file=sys.stderr)
     return 2
 
 
 def main(argv: Sequence[str]) -> int:
-    if len(argv) == 2 and argv[0] in {"watch-operation", "ack-operation"} and JOURNAL_OPERATION_ID_PATTERN.fullmatch(argv[1]):
+    if len(argv) == 2 and argv[0] in {"watch-operation", "ack-operation", "updates-cancel"} and JOURNAL_OPERATION_ID_PATTERN.fullmatch(argv[1]):
         return operation_control(argv[0], argv[1])
     if list(argv) != ["snapshot"]:
         return usage()

--- a/tests/test-quickshell-system-management-xvfb.sh
+++ b/tests/test-quickshell-system-management-xvfb.sh
@@ -120,6 +120,11 @@ requested-remove)
 partial-restart)
 	snapshot | sed 's/state\tupdate-restart\tavailable\tsystem/state\tupdate-restart\tpartial\tsecurity-session/'
 	;;
+cancelable-active)
+	snapshot | sed \
+		-e 's/action\tupdates-cancel\tunavailable/action\tupdates-cancel\tavailable/' \
+		-e '/^complete\t/i\active-operation\top-11111111111111111111111111111111\tupdates-refresh\trefresh\trunning\t45\tyes\tCancelable fixture'
+	;;
 regional-handoff)
 	snapshot | sed '/^complete\t/i\terminal-handoff\top-11111111111111111111111111111111\ttimezone-set\ttimezone'
 	;;
@@ -328,6 +333,12 @@ printf 'regional-handoff\n' >"$fixture/mode"
 ipc refresh >/dev/null
 wait_state ready
 [ "$(ipc systemManagementUpdateCount)" -eq 1 ]
+
+printf 'cancelable-active\n' >"$fixture/mode"
+ipc refresh >/dev/null
+wait_state ready
+[ "$(ipc systemManagementUpdateCount)" -eq 1 ]
+[ -z "$(ipc systemManagementErrorCodes)" ]
 
 printf 'invalid-handoff\n' >"$fixture/mode"
 ipc refresh >/dev/null

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -6203,11 +6203,12 @@ class OperationWatchTests(unittest.TestCase):
 
     def test_control_cli_has_fixed_syntax_and_stream_free_stale_diagnostics(self):
         for args in ([], ["watch-operation"], ["ack-operation", "bad"], ["watch-operation", "op-" + "a" * 32, "extra"],
-                     ["updates-refresh"]):
+                     ["updates-refresh"], ["updates-cancel"], ["updates-cancel", "bad"],
+                     ["updates-cancel", "op-" + "a" * 32, "extra"]):
             with self.subTest(args=args), contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(io.StringIO()):
                 self.assertEqual(provider.main(args), 2)
                 self.assertEqual(stdout.getvalue(), "")
-        for command, diagnostic in (("watch-operation", "watch"), ("ack-operation", "ack")):
+        for command, diagnostic in (("watch-operation", "watch"), ("ack-operation", "ack"), ("updates-cancel", "cancel")):
             with self.subTest(command=command), mock.patch.object(provider, "open_journal_directory", side_effect=provider.JournalLayoutError("Unsafe raw text")), \
                     mock.patch.object(provider, "read_boot_id", return_value=self.boot_id), \
                     contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(io.StringIO()) as stderr:
@@ -6282,6 +6283,218 @@ class OperationWatchTests(unittest.TestCase):
             self.assertEqual(result.returncode, 1)
             self.assertEqual(result.stderr, b"operation observation was interrupted\n")
             self.assertEqual(provider.load_journal_state(journal.chain).handoff.operation_id, operation.operation_id)
+
+
+class OperationCancelTests(unittest.TestCase):
+    boot_id = PackageKitExecutionTests.boot_id
+    package_id = PackageKitExecutionTests.package_id
+    journal = PackageKitExecutionTests.journal
+    begin = OperationRecoveryTests.begin
+    emit = RecoveryAdapterTests.emit
+    properties = RecoveryAdapterTests.properties
+
+    def backend(self, journal, *, changes=None, event=None):
+        backend = RecoveryAdapterTests.backend(self, journal)
+        backend.GLib.MainContext = types.SimpleNamespace(default=lambda: types.SimpleNamespace(pending=lambda: False))
+        def request(path, interface, method, parameters, deadline, signature, *, destination):
+            self.assertFalse(journal._exclusive)
+            if event is not None:
+                event(backend, method)
+            if method == "GetNameOwner":
+                self.assertEqual((destination, path, interface, parameters.unpack(), signature),
+                    ("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus", (provider.PACKAGEKIT_NAME,), "(s)"))
+                return SessionEvidenceTests.Variant("(s)", (":1.77",))
+            self.assertEqual((destination, path), (":1.77", "/1_test"))
+            if method == "GetAll":
+                self.assertEqual((interface, parameters.unpack(), signature),
+                    (provider.PROPERTIES_INTERFACE, (provider.TRANSACTION_INTERFACE,), "(a{sv})"))
+                return SessionEvidenceTests.Variant("(a{sv})", (self.properties(**(changes or {})),))
+            self.assertEqual((method, interface, parameters, signature), ("Cancel", provider.TRANSACTION_INTERFACE, None, "()"))
+            return SessionEvidenceTests.Variant("()", ())
+        backend._recovery_call = mock.Mock(side_effect=request)
+        return backend
+
+    def cancel(self, journal, operation, backend, *, boot_id=None):
+        dispatched = mock.Mock()
+        provider.cancel_journal_operation(journal, operation.operation_id, boot_id=boot_id or self.boot_id,
+            backend_factory=lambda: backend, on_dispatch=dispatched)
+        return dispatched
+
+    def cli(self, journal, operation_id, backend):
+        with mock.patch.dict(os.environ, {"XDG_STATE_HOME": str(pathlib.Path(journal.chain.path).parents[1])}), \
+                mock.patch.object(provider, "read_boot_id", return_value=self.boot_id), \
+                mock.patch.object(provider, "PackageKitBackend", return_value=backend), \
+                contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(io.StringIO()) as stderr:
+            code = provider.main(["updates-cancel", operation_id])
+        return code, stdout.getvalue(), stderr.getvalue()
+
+    def test_exact_cancel_is_unlocked_pinned_and_never_claims_completion(self):
+        for kind in ("refresh", "update"):
+            for state in ("pending", "authorizing", "running"):
+                with self.subTest(kind=kind, state=state), self.journal() as journal:
+                    operation = self.begin(journal, kind, **({} if state == "pending" else {"state": state}))
+                    backend = self.backend(journal, changes={"Role": 13 if kind == "refresh" else 22})
+                    dispatched = self.cancel(journal, operation, backend)
+                    dispatched.assert_called_once_with()
+                    current = provider.load_journal_state(journal.chain)
+                    self.assertEqual(current.active.state, "cancel-requested" if state == "running" else state)
+                    self.assertEqual(current.active.operation_id, operation.operation_id)
+                    self.assertIsNone(current.handoff)
+                    self.assertEqual(current.terminals, (None,) * 32)
+                    self.assertEqual([call.args[2] for call in backend._recovery_call.call_args_list],
+                                     ["GetNameOwner", "GetAll", "Cancel"])
+                    self.assertEqual(len({call.args[4] for call in backend._recovery_call.call_args_list}), 1)
+                    self.assertEqual(backend.connection.subscriptions, {})
+
+    def test_stale_terminal_regional_and_previous_boot_never_open_backend(self):
+        for case in ("stale", "terminal", "regional", "boot"):
+            with self.subTest(case=case), self.journal() as journal:
+                operation = self.begin(journal, "timezone" if case == "regional" else "update")
+                if case == "terminal":
+                    with provider.lock_writable_journal(journal):
+                        provider.advance_journal_operation(journal, operation, replace(operation, state="failed",
+                            error_code="internal", finished_at="2026-09-05T01:00:00Z", terminal_monotonic=100))
+                before = provider.load_journal_state(journal.chain)
+                factory = mock.Mock()
+                with self.assertRaises(provider.CancelTargetUnavailable):
+                    provider.cancel_journal_operation(journal, "op-" + "0" * 32 if case == "stale" else operation.operation_id,
+                        boot_id="abcdef01-2345-6789-abcd-ef0123456789" if case == "boot" else self.boot_id,
+                        backend_factory=factory, on_dispatch=mock.Mock())
+                factory.assert_not_called()
+                self.assertEqual(provider.load_journal_state(journal.chain), before)
+
+    def test_unavailable_identity_and_cancelability_leave_active_unchanged(self):
+        for changes in ({"Role": 13}, {"Role": 0}, {"Role": True}, {"Uid": os.getuid() + 1},
+                        {"Uid": True}, {"AllowCancel": False}, {"AllowCancel": 1},
+                        {"Status": 18}, {"Status": None}, {"Status": 37}):
+            with self.subTest(changes=changes), self.journal() as journal:
+                operation = self.begin(journal, state="running")
+                backend = self.backend(journal, changes=changes)
+                self.assertEqual(self.cli(journal, operation.operation_id, backend), (3, "", "cancel target is unavailable\n"))
+                self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
+                self.assertNotIn("Cancel", [call.args[2] for call in backend._recovery_call.call_args_list])
+                self.assertEqual(backend.connection.subscriptions, {})
+
+    def test_revocation_or_finish_during_getall_cannot_be_overwritten(self):
+        for member, signature, values, interface in (
+            ("PropertiesChanged", "(sa{sv}as)", (provider.TRANSACTION_INTERFACE, {"AllowCancel": False}, []), provider.PROPERTIES_INTERFACE),
+            ("PropertiesChanged", "(sa{sv}as)", (provider.TRANSACTION_INTERFACE, {}, ["Uid"]), provider.PROPERTIES_INTERFACE),
+            ("Finished", "(uu)", (1, 1), None), ("Destroy", "()", (), None),
+            ("NameOwnerChanged", "(sss)", (provider.PACKAGEKIT_NAME, ":1.77", ":1.88"), "org.freedesktop.DBus"),
+        ):
+            with self.subTest(member=member, values=values), self.journal() as journal:
+                operation = self.begin(journal)
+                def event(backend, method):
+                    if method == "GetAll":
+                        self.emit(backend, member, signature, values, interface)
+                backend = self.backend(journal, event=event)
+                self.assertEqual(self.cli(journal, operation.operation_id, backend), (3, "", "cancel target is unavailable\n"))
+                self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
+
+    def test_queued_revocation_after_journal_check_prevents_dispatch(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.backend(journal)
+            queued = [True]
+            def iterate(_blocking):
+                queued.clear()
+                self.emit(backend, "PropertiesChanged", "(sa{sv}as)",
+                    (provider.TRANSACTION_INTERFACE, {"AllowCancel": False}, []), provider.PROPERTIES_INTERFACE)
+            backend.GLib.MainContext = types.SimpleNamespace(default=lambda: types.SimpleNamespace(
+                pending=lambda: bool(queued), iteration=iterate))
+            self.assertEqual(self.cli(journal, operation.operation_id, backend), (3, "", "cancel target is unavailable\n"))
+            self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
+
+    def test_noisy_context_is_bounded_and_never_dispatches(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.backend(journal)
+            iterate = mock.Mock()
+            backend.GLib.MainContext = types.SimpleNamespace(default=lambda: types.SimpleNamespace(pending=lambda: True, iteration=iterate))
+            self.assertEqual(self.cli(journal, operation.operation_id, backend)[0], 3)
+            self.assertEqual(iterate.call_count, 64)
+            self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
+
+    def test_completion_during_lookup_is_rechecked_before_send(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, state="running")
+            def event(_backend, method):
+                if method == "GetAll":
+                    with provider.lock_writable_journal(journal):
+                        provider.advance_journal_operation(journal, operation, replace(operation, state="succeeded",
+                            finished_at="2026-09-05T01:00:00Z", terminal_monotonic=100))
+            backend = self.backend(journal, event=event)
+            self.assertEqual(self.cli(journal, operation.operation_id, backend)[0], 3)
+            self.assertEqual(provider.load_journal_state(journal.chain).active.state, "succeeded")
+            self.assertNotIn("Cancel", [call.args[2] for call in backend._recovery_call.call_args_list])
+
+    def test_accepted_cancel_cannot_advance_a_replacement_operation(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, state="running")
+            replacement = []
+            def event(_backend, method):
+                if method == "Cancel":
+                    with provider.lock_writable_journal(journal):
+                        provider.advance_journal_operation(journal, operation, replace(operation, state="succeeded",
+                            finished_at="2026-09-05T01:00:00Z", terminal_monotonic=100))
+                        provider.complete_journal_terminal(journal, boot_id=self.boot_id)
+                        provider.acknowledge_journal_handoff(journal, operation.operation_id)
+                    replacement.append(self.begin(journal, "refresh", state="running"))
+            self.assertEqual(self.cli(journal, operation.operation_id, self.backend(journal, event=event)), (0, "", ""))
+            self.assertEqual(provider.load_journal_state(journal.chain).active, replacement[0])
+
+    def test_lost_cancel_reply_is_not_stale_rejection_or_completion(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, state="running")
+            def event(_backend, method):
+                if method == "Cancel":
+                    raise provider.SnapshotFailure("timeout", "Lost cancel reply")
+            result = self.cli(journal, operation.operation_id, self.backend(journal, event=event))
+            self.assertEqual(result, (1, "", "cancellation request could not be confirmed; observe the existing operation\n"))
+            self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
+
+    def test_backend_stale_rejection_after_send_is_stream_free_status_three(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, state="running")
+            def event(backend, method):
+                if method == "Cancel":
+                    failure = provider.SnapshotFailure("internal", "Backend rejected stale cancel")
+                    failure.__cause__ = backend.GLib.Error("stale")
+                    raise failure
+            backend = self.backend(journal, event=event)
+            backend.Gio.dbus_error_get_remote_error = lambda _error: provider.TRANSACTION_INTERFACE + ".NotRunning"
+            self.assertEqual(self.cli(journal, operation.operation_id, backend), (3, "", "cancel target is unavailable\n"))
+            self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
+
+    def test_cancel_persistence_failure_retains_observation_guidance(self):
+        with self.journal() as journal:
+            operation = self.begin(journal, state="running")
+            with mock.patch.object(provider, "advance_journal_operation", side_effect=provider.JournalCommitError("Injected write failure")):
+                result = self.cli(journal, operation.operation_id, self.backend(journal))
+            self.assertEqual(result[0], 1)
+            self.assertEqual(result[1], "")
+            self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
+
+    def test_lookup_failure_cleans_subscriptions_without_dispatch_or_journal_change(self):
+        for stage in ("GetNameOwner", "GetAll"):
+            with self.subTest(stage=stage), self.journal() as journal:
+                operation = self.begin(journal)
+                def event(_backend, method):
+                    if method == stage:
+                        raise provider.SnapshotFailure("timeout", "Lookup timed out")
+                backend = self.backend(journal, event=event)
+                self.assertEqual(self.cli(journal, operation.operation_id, backend), (3, "", "cancel target is unavailable\n"))
+                self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
+                self.assertEqual(backend.connection.subscriptions, {})
+
+    def test_invalid_peer_is_rejected_before_object_access(self):
+        with self.journal() as journal:
+            operation = self.begin(journal)
+            backend = self.backend(journal)
+            backend._recovery_call = mock.Mock(return_value=SessionEvidenceTests.Variant("(s)", (provider.PACKAGEKIT_NAME,)))
+            self.assertEqual(self.cli(journal, operation.operation_id, backend), (3, "", "cancel target is unavailable\n"))
+            backend._recovery_call.assert_called_once()
+            self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
 
 
 class RecoverySnapshotTests(unittest.TestCase):
@@ -6398,7 +6611,8 @@ class RecoverySnapshotTests(unittest.TestCase):
             backend.probe_operation.side_effect = probe
             output = self.snapshot(journal, backend)
             self.assertEqual(rows(output, "active-operation")[0][1:7],
-                [operation.operation_id, operation.action_id, "refresh", "pending", "27", "no"])
+                [operation.operation_id, operation.action_id, "refresh", "pending", "27", "yes"])
+            self.assertEqual(next(row[2] for row in rows(output, "action") if row[1] == "updates-cancel"), "available")
             self.assertEqual(rows(output, "terminal-handoff"), [])
             self.assertEqual(output[-1], "complete\tsnapshot")
 
@@ -6409,6 +6623,8 @@ class RecoverySnapshotTests(unittest.TestCase):
             backend.probe_operation.side_effect = provider.SnapshotFailure("timeout", "Lookup expired")
             output = self.snapshot(journal, backend)
             self.assertEqual(rows(output, "active-operation")[0][1], operation.operation_id)
+            self.assertEqual(rows(output, "active-operation")[0][6], "no")
+            self.assertEqual(next(row[2] for row in rows(output, "action") if row[1] == "updates-cancel"), "unavailable")
             self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
             self.assertIn(["error", "recovery", "timeout", "Lookup expired"], rows(output, "error"))
 


### PR DESCRIPTION
## Summary
- Add the fixed `updates-cancel OPERATION_ID` control for only the exact active PackageKit refresh/update identity.
- Pin the unique backend peer, validate role/UID/status/AllowCancel under one 10-second deadline, subscribe to revocations and completion, and revalidate durable ownership before dispatch. No D-Bus call holds the journal lock; queued callback draining is capped at 64 dispatches.
- Stale controls return stream-free status 3 without journal changes. An accepted reply records only a cancellation request; the existing observer owns the eventual terminal result. Uncertain post-dispatch failures return status 1 with fixed recovery guidance.
- Expose observed cancellation availability in finite snapshots and update the contract, active task status, changelog, and regression coverage.

## Review boundary
This is one Phase 6 cancellation-control foundation, following merged PR #232. New refresh/install commands and Settings operation controls remain disabled. Phase 6 is not complete; the root-scoped operation/confirmation UI, regional and delegated entry points, information/recovery surfaces, and combined qualification remain.

## Validation
- `scripts/run-tests /usr/bin/python3 -B tests/test-system-management.py OperationCancelTests RecoverySnapshotTests RecoveryAdapterTests OperationWatchTests`: 66 tests passed.
- `scripts/run-tests /usr/bin/python3 -B tests/test-system-management.py`: all 285 tests passed.
- `scripts/run-tests make clean all` and `scripts/run-tests`: passed, including all 285 provider tests, nested-X11 Settings/System lifecycle checks, staged and repeated installation, dependency resolution, and release archive checks. Managed workspaces cleaned.
- `shellcheck install.sh scripts/*.sh tests/*.sh` and `shfmt -d install.sh scripts/*.sh tests/*.sh`: passed.
- `scripts/run-tests make check-quickshell-system-management`: static and nested-X11 contract tests passed.
- Native Gio/private D-Bus fixture: the exact transaction accepted one Cancel, subsequent AllowCancel=false rejected repetition without journal change, and the existing watcher consumed Finished(canceled) and durably handed off the result. No host PackageKit mutation.
- Fedora 44 / PackageKit 1.3.6 read-only snapshot with isolated XDG journal: all 23 requested IDs preserved in 29 preview rows (5 installs, 18 updates, 6 removals), no update-provider errors. This agent has no logind session; recovery reports that separate limitation.
- Closed Settings CPU: 0.100%, unchanged from its baseline. Large closed surfaces: 0.00%.
- Local CodeRabbit review: clean, all six changed files.
- Post-full-gate Codex review: no actionable defects; independently passed 47 cancellation/snapshot/watch tests plus syntax and diff checks.

## Safety and limitations
No host refresh/update/cancel, logout, installed configuration change, or package mutation was requested for qualification. Native cancellation was exercised on a private D-Bus fixture, not a host RPM transaction. PackageKit's separate property read and Cancel call cannot be made an atomic cross-client operation; subscriptions and immediate identity/cancelability revalidation bound the client-side observation gap. No QML source changed in this PR. Hosted exact-head checks and reviews are required before merge.