### PR TITLE
feat(system): expose confirmed update CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,11 +62,17 @@ versions from `config.mk`.
 
 ### Added
 
+- Add explicit metadata-refresh and generation-confirmed install CLI commands
+  backed by durable PackageKit execution and exact terminal results. Rejected
+  requests do not fabricate transactions, and uncertain admission or observation
+  retains recovery guidance. Settings update buttons remain disabled pending
+  confirmation and operation-model integration.
+
 - Add exact-operation PackageKit cancellation with bounded peer, ownership,
   and cancelability checks. Stale requests leave the journal unchanged, accepted
   requests remain observable until the real terminal result, and lost replies
-  retain recovery guidance. New update execution and its Settings controls
-  remain disabled pending integration.
+  retain recovery guidance. Settings update controls remain disabled pending
+  integration.
 
 - Add a pane-scoped Quickshell system-management model that strictly consumes
   the bounded 1.0 snapshot protocol, isolates malformed provider state, rejects

--- a/TASKS.md
+++ b/TASKS.md
@@ -53,7 +53,7 @@ Progress: Read-only PackageKit discovery and its Settings pane are implemented.
 The journal now supports durable pending admission, identity-checked lifecycle
 transitions, restart pruning, recoverable terminal commits, exact retained-result
 lookup, and handoff acknowledgment. These are tested foundations, not an enabled
-update execution workflow. Operation owners can retain every journal file
+Settings update execution workflow. Operation owners can retain every journal file
 identity across unlocked service waits and reacquire bounded exclusive intervals
 for checkpoints; unlocked state access and stale ownership are rejected.
 The operation formatter reserves required lifecycle records separately from its
@@ -75,16 +75,20 @@ The internal recovery coordinator now uses exact-object adoption and a bounded
 active list, plus at most 64 history records for updates only. It distinguishes
 lookup failure from absence, checkpoints adopted restart signals, rejects stale
 ownership, and durably recovers terminal evidence or conservative interruption.
-Previous-boot records cannot reintroduce satisfied guidance. Public mutation
-commands remain disabled. Exact-ID watch and acknowledgment controls now replay
+Previous-boot records cannot reintroduce satisfied guidance. Exact-ID watch and
+acknowledgment controls now replay
 retained results without a service call or keep a verified PackageKit observer
 subscribed through completion without reissuing the action. Finite snapshots now
 integrate validated journal recovery, boot/session restart pruning, exact active
 identities, and terminal handoffs without hiding readable package discovery.
 The exact-ID cancel control now pins the backend peer, revalidates ownership and
 cancelability, and records only an accepted cancellation request without claiming
-a terminal result. New mutation commands and the root-scoped confirmation and
-operation UI must be completed before this boundary can be accepted.
+a terminal result. Explicit refresh and generation-confirmed install CLI commands
+now use the existing execution owner. Pre-admission failures emit a failed request
+without inventing a journal transaction; uncertain admission, output, or later
+observation failures retain recovery guidance and never fabricate a terminal
+result. The root-scoped confirmation and operation UI must be completed before
+this boundary can be accepted. Settings mutation actions remain disabled.
 The preview validators now preserve requested `install` as well as `update`
 actions, matching the PackageKit DNF5 backend's discovery/simulation contract.
 Missing or duplicate requested IDs, outbound requested actions, and unrequested
@@ -92,7 +96,7 @@ updates still fail closed. A Fedora 44 / PackageKit 1.3.6 read-only snapshot
 preserved all 23 requested IDs in 29 preview rows (five installs, 18 updates,
 six removals), without the prior malformed-plan error. No package mutation was
 performed; this agent process still lacks a logind session, reported separately
-as partial recovery evidence. Confirmed execution remains disabled.
+as partial recovery evidence. Confirmed execution in Settings remains disabled.
 
 - [ ] Add user-initiated Fedora update discovery and status through the selected
   stable package-management interface.

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -84,6 +84,23 @@ with the confirmed snapshot. It is an opaque provider-created value, not a
 package ID or caller-selected transaction parameter. No update command accepts
 another option or trailing argument.
 
+The refresh and install CLI entry points now use the durable execution owner.
+An explicit install request requires the exact confirmed generation, repeats
+inventory and simulation, and rejects mismatch before mutable admission. These
+commands return 0 only after a durable `succeeded` result and complete stream;
+every other terminal result returns 1. A rejection before admission emits a
+`pending` then `failed` request, its typed error, audit, and completion, using a
+fresh ID collision-checked against validated journal identities under the lock.
+This rejected request is not persisted or replayable: no PackageKit path,
+active record, terminal slot, restart contribution, or handoff is fabricated.
+The original operation, if any, is unchanged. If the journal cannot safely
+supply an ID, the command instead returns 1 without a stream and with fixed
+recovery guidance. Once an admission write may have started or output has been
+attempted, a failure never falls back to that rejected-request stream. It
+returns 1 with recovery guidance and leaves the actual journal for observation.
+Settings mutation actions remain unavailable until root-scoped confirmation,
+observation, and acknowledgment are integrated.
+
 `OPERATION_ID` must exactly match the `op-` prefix followed by 32 lowercase
 hexadecimal digits emitted for the currently visible operation. The provider
 generates and reserves it while holding the exclusive journal lock, using the
@@ -148,8 +165,8 @@ Finite snapshots now initialize or validate the fixed journal, recover its
 bounded state, and apply restart satisfaction before publishing active or
 handoff identities. Journal or logind failure preserves readable update
 discovery and reports recovery errors; known restart guidance remains visible
-with `partial` status. This incremental build still leaves new mutation commands
-unavailable. Snapshot active rows and the cancel action now advertise the exact
+with `partial` status. This incremental build still leaves new mutation actions
+unavailable in Settings. Snapshot active rows and the cancel action now advertise the exact
 observed cancelability, or remain unavailable when no trustworthy observation
 exists. The public cancel command always revalidates that hint. Live watch
 streams continue to report the exact PackageKit cancelability observation.

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -85,6 +85,11 @@ package ID or caller-selected transaction parameter. No update command accepts
 another option or trailing argument.
 
 The refresh and install CLI entry points now use the durable execution owner.
+Before opening a backend, they require an empty active record and handoff and
+apply current-boot restart pruning under the journal lock. A direct CLI request
+after reboot therefore does not depend on a prior snapshot. Existing active or
+unacknowledged operations still reject as conflicts without changing their
+journal state; snapshot recovery and exact acknowledgment remain explicit.
 An explicit install request requires the exact confirmed generation, repeats
 inventory and simulation, and rejects mismatch before mutable admission. These
 commands return 0 only after a durable `succeeded` result and complete stream;

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -3263,6 +3263,26 @@ class OperationStream:
         self.closed = True
 
 
+def reject_unadmitted_operation(operation_id: str, action_id: str, started_at: str,
+                               failure: SnapshotFailure, write: Callable[[str], object]) -> None:
+    """Report a rejected request without inventing a durable transaction or result."""
+    if (not isinstance(action_id, str) or action_id not in {"updates-refresh", "updates-install-all"}
+            or not isinstance(failure, SnapshotFailure) or failure.code not in JOURNAL_ERROR_CODES):
+        raise OperationProtocolError("rejected update request is invalid")
+    _validate_journal_detail(failure.detail)
+    finished_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    stream = OperationStream(operation_id, action_id, started_at,
+        "Request rejected before operation admission; no package mutation was dispatched", write)
+    stream._send([
+        f"error\tupdates\t{failure.code}\t{failure.detail}",
+        stream._operation_line("failed", "unknown", False, failure.detail),
+        "\t".join(("audit", operation_id, action_id, stream.kind, "failed", started_at, finished_at, failure.detail)),
+        "complete\toperation",
+    ])
+    stream.state = "failed"
+    stream.closed = True
+
+
 def replay_terminal_operation(
     operation: JournalOperation, write: Callable[[str], object],
 ) -> None:
@@ -3597,8 +3617,8 @@ def build_snapshot(backend: UpdateBackend) -> list[str]:
                 "delegated",
                 "PackageKit",
                 clean_text(
-                    "Read-only update discovery is available; managed update operations "
-                    "are not enabled in this build"
+                    "Read-only update discovery is available; managed update controls "
+                    "are not enabled in Settings"
                     if inventory_ok
                     else summary_detail
                 ),
@@ -3634,7 +3654,7 @@ def build_snapshot(backend: UpdateBackend) -> list[str]:
             )
         ),
         "action\tupdates-refresh\tunavailable\tdelegated\tupdates\tRefresh updates\t"
-        "Managed update operations are not enabled in this build",
+        "Managed update controls are not enabled in Settings",
         "\t".join(
             (
                 "action",
@@ -3643,7 +3663,7 @@ def build_snapshot(backend: UpdateBackend) -> list[str]:
                 "delegated",
                 "updates",
                 "Install all updates",
-                clean_text(f"Managed update operations are not enabled; {plan_detail}"),
+                clean_text(f"Managed update controls are not enabled in Settings; {plan_detail}"),
             )
         ),
         "action\tupdates-cancel\tunavailable\tdelegated\tupdates\tCancel update\t"
@@ -4072,8 +4092,9 @@ def run_packagekit_mutation(
     journal: JournalDescriptorSet, backend: PackageKitBackend, action_id: str,
     write: Callable[[str], object], *, boot_id: str, session_started: int | None = None,
     generation: str | None = None,
+    on_admission: Callable[[], object] | None = None,
 ) -> JournalOperation:
-    """Revalidate and run a confirmed request; public commands remain disabled."""
+    """Revalidate and run a confirmed request with write-ahead ownership."""
     if action_id not in {"updates-refresh", "updates-install-all"}:
         raise SnapshotFailure("unsupported", "Unsupported PackageKit mutation", "unsupported")
     if action_id == "updates-install-all":
@@ -4091,6 +4112,9 @@ def run_packagekit_mutation(
     if not isinstance(path, str) or JOURNAL_PACKAGEKIT_PATH_PATTERN.fullmatch(path) is None:
         raise SnapshotFailure("malformed", "PackageKit returned an invalid operation path")
     with lock_writable_journal(journal):
+        if on_admission is not None:
+            prepare_journal_admission(journal)
+            on_admission()  # From here, even a failed commit may require recovery.
         operation = begin_journal_operation(journal, action_id,
             datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"), "Starting PackageKit operation",
             transaction_path=path, generation=generation, boot_id=boot_id)
@@ -5364,12 +5388,68 @@ def operation_control(command: str, operation_id: str) -> int:
         return 3
 
 
+def update_command(action_id: str, generation: str | None = None) -> int:
+    """Own an explicit CLI request; never replace a possibly admitted operation."""
+    admission_started = False
+    output_started = False
+
+    def admitted():
+        nonlocal admission_started
+        admission_started = True
+
+    def write(chunk):
+        nonlocal output_started
+        output_started = True  # A failed write may already have delivered bytes.
+        sys.stdout.write(chunk)
+        sys.stdout.flush()
+
+    try:
+        boot_id = read_boot_id()
+        with open_journal_directory() as chain:
+            initialize_journal_layout(chain.directory_descriptor, boot_id)
+            with retain_writable_journal(chain) as journal:
+                started_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                try:
+                    terminal = run_packagekit_mutation(journal, PackageKitBackend(), action_id, write,
+                        boot_id=boot_id, generation=generation, on_admission=admitted)
+                    return 0 if terminal.state == "succeeded" else 1
+                except (SnapshotFailure, JournalFrameError, JournalRecordError, JournalAdmissionError,
+                        OSError, OperationProtocolError) as error:
+                    if admission_started or output_started:
+                        raise
+                    # This ID represents only the rejected request. No active,
+                    # terminal, handoff, or restart payload is fabricated for it.
+                    with lock_writable_journal(journal):
+                        operation_id = generate_journal_operation_id(load_writable_journal_state(journal))
+                    if isinstance(error, SnapshotFailure):
+                        failure = error
+                    elif isinstance(error, (JournalAdmissionError, JournalLockError)):
+                        failure = SnapshotFailure("conflict", "Another operation or recovery state blocks this request; refresh status before retrying")
+                    elif isinstance(error, (JournalFrameError, JournalRecordError, OperationProtocolError)):
+                        failure = SnapshotFailure("malformed", "Operation preflight is malformed; refresh status and inspect recovery guidance")
+                    else:
+                        failure = SnapshotFailure("internal", "Operation preflight failed; check journal storage and refresh status before retrying")
+                    reject_unadmitted_operation(operation_id, action_id, started_at, failure, write)
+                    return 1
+    except (SnapshotFailure, JournalFrameError, JournalRecordError, JournalAdmissionError,
+            OSError, OperationProtocolError) as error:
+        if isinstance(error, BrokenPipeError):
+            with open(os.devnull, "w") as sink:
+                os.dup2(sink.fileno(), sys.stdout.fileno())
+        print("operation result could not be confirmed; refresh status and observe the existing operation", file=sys.stderr)
+        return 1
+
+
 def usage() -> int:
-    print(f"usage: {sys.argv[0]} snapshot | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID", file=sys.stderr)
+    print(f"usage: {sys.argv[0]} snapshot | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID", file=sys.stderr)
     return 2
 
 
 def main(argv: Sequence[str]) -> int:
+    if list(argv) == ["updates-refresh"]:
+        return update_command("updates-refresh")
+    if len(argv) == 2 and argv[0] == "updates-install-all" and JOURNAL_GENERATION_PATTERN.fullmatch(argv[1]):
+        return update_command("updates-install-all", argv[1])
     if len(argv) == 2 and argv[0] in {"watch-operation", "ack-operation", "updates-cancel"} and JOURNAL_OPERATION_ID_PATTERN.fullmatch(argv[1]):
         return operation_control(argv[0], argv[1])
     if list(argv) != ["snapshot"]:

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -5410,6 +5410,12 @@ def update_command(action_id: str, generation: str | None = None) -> int:
             with retain_writable_journal(chain) as journal:
                 started_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
                 try:
+                    with lock_writable_journal(journal):
+                        # A reboot satisfies restart guidance before any backend
+                        # work. Never clear an active owner or unacknowledged
+                        # handoff to make a replacement command admissible.
+                        prepare_journal_admission(journal)
+                        prune_journal_restart(journal, boot_id, None)
                     terminal = run_packagekit_mutation(journal, PackageKitBackend(), action_id, write,
                         boot_id=boot_id, generation=generation, on_admission=admitted)
                     return 0 if terminal.state == "succeeded" else 1

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -6203,7 +6203,7 @@ class OperationWatchTests(unittest.TestCase):
 
     def test_control_cli_has_fixed_syntax_and_stream_free_stale_diagnostics(self):
         for args in ([], ["watch-operation"], ["ack-operation", "bad"], ["watch-operation", "op-" + "a" * 32, "extra"],
-                     ["updates-refresh"], ["updates-cancel"], ["updates-cancel", "bad"],
+                     ["updates-refresh", "extra"], ["updates-cancel"], ["updates-cancel", "bad"],
                      ["updates-cancel", "op-" + "a" * 32, "extra"]):
             with self.subTest(args=args), contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(io.StringIO()):
                 self.assertEqual(provider.main(args), 2)
@@ -6283,6 +6283,205 @@ class OperationWatchTests(unittest.TestCase):
             self.assertEqual(result.returncode, 1)
             self.assertEqual(result.stderr, b"operation observation was interrupted\n")
             self.assertEqual(provider.load_journal_state(journal.chain).handoff.operation_id, operation.operation_id)
+
+
+class UpdateCommandTests(unittest.TestCase):
+    boot_id = PackageKitExecutionTests.boot_id
+    package_id = PackageKitExecutionTests.package_id
+    journal = PackageKitExecutionTests.journal
+    backend = PackageKitExecutionTests.backend
+    begin = OperationRecoveryTests.begin
+
+    def generation(self):
+        return provider.snapshot_generation([self.package_id],
+            [provider.PlanRow(self.package_id, "update", "example", "2", "Example")])
+
+    def invoke(self, journal, args, backend, output=None):
+        with mock.patch.dict(os.environ, {"XDG_STATE_HOME": str(pathlib.Path(journal.chain.path).parents[1])}), \
+                mock.patch.object(provider, "read_boot_id", return_value=self.boot_id), \
+                mock.patch.object(provider, "PackageKitBackend", **({"side_effect": backend} if isinstance(backend, Exception) else {"return_value": backend})), \
+                contextlib.redirect_stdout(io.StringIO() if output is None else output) as stdout, contextlib.redirect_stderr(io.StringIO()) as stderr:
+            code = provider.main(args)
+        return code, stdout.getvalue(), stderr.getvalue()
+
+    def test_fixed_grammar_rejects_before_opening_journal_or_backend(self):
+        for args in (["updates-refresh", "extra"], ["updates-install-all"], ["updates-install-all", "bad"],
+                     ["updates-install-all", "A" * 64], ["updates-install-all", "a" * 64, "extra"],
+                     ["updates-install-all", "--force"], ["--updates-refresh"]):
+            with self.subTest(args=args), mock.patch.object(provider, "open_journal_directory") as journal, \
+                    mock.patch.object(provider, "PackageKitBackend") as backend, \
+                    contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(provider.main(args), 2)
+                journal.assert_not_called()
+                backend.assert_not_called()
+                self.assertEqual(stdout.getvalue(), "")
+
+    def test_refresh_and_confirmed_install_use_real_owner_and_durable_handoff(self):
+        for update in (False, True):
+            with self.subTest(update=update), self.journal() as journal:
+                backend = self.backend(journal, [lambda bus: bus.progress(Status=3, Percentage=45),
+                    lambda bus: bus.emit("Finished", (1, 0))])
+                args = ["updates-install-all", self.generation()] if update else ["updates-refresh"]
+                code, output, diagnostic = self.invoke(journal, args, backend)
+                self.assertEqual((code, diagnostic), (0, ""))
+                state = provider.load_journal_state(journal.chain)
+                self.assertIsNone(state.active)
+                terminal = state.terminals[state.handoff.slot]
+                self.assertEqual(terminal.state, "succeeded")
+                self.assertEqual(rows(output.splitlines(), "audit")[0][1:5],
+                    [terminal.operation_id, args[0], "update" if update else "refresh", "succeeded"])
+                self.assertEqual(output.splitlines()[-1], "complete\toperation")
+                self.assertEqual(backend.connection.calls[0][3], "UpdatePackages" if update else "RefreshCache")
+                backend.require_mutation_safe.assert_called_once_with()
+
+    def test_denied_failed_and_canceled_terminal_results_exit_one(self):
+        for exit_code, error_code, expected in ((8, 48, "permission-denied"), (2, 1, "failed"), (3, 17, "canceled")):
+            with self.subTest(expected=expected), self.journal() as journal:
+                backend = self.backend(journal, [lambda bus: bus.emit("ErrorCode", (error_code, "Fixture result")),
+                    lambda bus: bus.emit("Finished", (exit_code, 0))])
+                code, output, diagnostic = self.invoke(journal, ["updates-refresh"], backend)
+                self.assertEqual((code, diagnostic), (1, ""))
+                self.assertEqual(rows(output.splitlines(), "operation")[-1][4], expected)
+                self.assertEqual(provider.load_journal_state(journal.chain).terminals[0].state, expected)
+
+    def test_preflight_and_backend_failures_emit_rejection_without_journal_change(self):
+        for stage in ("backend", "security", "inventory", "simulation", "generation", "create"):
+            with self.subTest(stage=stage), self.journal() as journal:
+                before = provider.load_journal_state(journal.chain)
+                backend = self.backend(journal, [])
+                failure = provider.SnapshotFailure("network", "Fixture preflight failure")
+                args = ["updates-install-all", self.generation()]
+                if stage == "backend":
+                    backend = failure
+                elif stage == "generation":
+                    args[1] = "0" * 64
+                else:
+                    attribute = {"security": "require_mutation_safe", "inventory": "updates",
+                                 "simulation": "simulate", "create": "create_mutation"}[stage]
+                    getattr(backend, attribute).side_effect = failure
+                code, output, diagnostic = self.invoke(journal, args, backend)
+                self.assertEqual((code, diagnostic), (1, ""))
+                self.assertEqual([row[4] for row in rows(output.splitlines(), "operation")], ["pending", "failed"])
+                self.assertEqual(rows(output.splitlines(), "error")[0][2], "conflict" if stage == "generation" else "network")
+                self.assertEqual(len(rows(output.splitlines(), "audit")), 1)
+                self.assertEqual(output.splitlines()[-1], "complete\toperation")
+                self.assertIn("no package mutation was dispatched", output)
+                self.assertEqual(provider.load_journal_state(journal.chain), before)
+                if stage != "backend":
+                    self.assertEqual(backend.connection.calls, [])
+
+    def test_active_and_handoff_conflicts_preserve_existing_identity(self):
+        for handoff in (False, True):
+            with self.subTest(handoff=handoff), self.journal() as journal:
+                operation = self.begin(journal)
+                if handoff:
+                    with provider.lock_writable_journal(journal):
+                        provider.advance_journal_operation(journal, operation, replace(operation, state="failed",
+                            error_code="internal", finished_at="2026-09-05T01:00:00Z", terminal_monotonic=100))
+                        provider.complete_journal_terminal(journal, boot_id=self.boot_id)
+                before = provider.load_journal_state(journal.chain)
+                backend = self.backend(journal, [])
+                code, output, diagnostic = self.invoke(journal, ["updates-refresh"], backend)
+                self.assertEqual((code, diagnostic), (1, ""))
+                self.assertEqual(rows(output.splitlines(), "error")[0][2], "conflict")
+                self.assertNotEqual(rows(output.splitlines(), "audit")[0][1], operation.operation_id)
+                self.assertEqual(provider.load_journal_state(journal.chain), before)
+                backend.require_mutation_safe.assert_not_called()
+                backend.create_mutation.assert_not_called()
+
+    def test_admission_race_rejects_before_any_write_attempt(self):
+        with self.journal() as journal:
+            backend = self.backend(journal, [])
+            competing = []
+            def create():
+                competing.append(self.begin(journal, "refresh"))
+                return "/1_test"
+            backend.create_mutation.side_effect = create
+            code, output, diagnostic = self.invoke(journal, ["updates-refresh"], backend)
+            self.assertEqual((code, diagnostic), (1, ""))
+            self.assertEqual(rows(output.splitlines(), "error")[0][2], "conflict")
+            self.assertEqual(provider.load_journal_state(journal.chain).active, competing[0])
+            self.assertEqual(backend.connection.calls, [])
+
+    def test_failed_admission_commit_never_fabricates_rejected_or_terminal_stream(self):
+        for after_commit in (False, True):
+            with self.subTest(after_commit=after_commit), self.journal() as journal:
+                backend = self.backend(journal, [])
+                begin = provider.begin_journal_operation
+                def fail(*args, **kwargs):
+                    if after_commit:
+                        begin(*args, **kwargs)
+                    raise provider.JournalCommitError("Uncertain commit")
+                with mock.patch.object(provider, "begin_journal_operation", side_effect=fail):
+                    code, output, diagnostic = self.invoke(journal, ["updates-refresh"], backend)
+                self.assertEqual((code, output), (1, ""))
+                self.assertIn("refresh status and observe the existing operation", diagnostic)
+                self.assertEqual(provider.load_journal_state(journal.chain).active is not None, after_commit)
+                self.assertEqual(backend.connection.calls, [])
+
+    def test_lost_observation_after_admission_keeps_one_incomplete_stream(self):
+        with self.journal() as journal:
+            backend = self.backend(journal, [])
+            backend.execute_mutation = mock.Mock(side_effect=provider.SnapshotFailure("interrupted", "Lost observation"))
+            code, output, diagnostic = self.invoke(journal, ["updates-refresh"], backend)
+            self.assertEqual(code, 1)
+            self.assertEqual(len(rows(output.splitlines(), "operation")), 1)
+            self.assertNotIn("complete\toperation", output)
+            self.assertNotIn("audit\t", output)
+            self.assertNotIn("Request rejected", output)
+            self.assertIsNotNone(provider.load_journal_state(journal.chain).active)
+            self.assertIn("observe the existing operation", diagnostic)
+
+    def test_unsafe_journal_or_id_generation_failure_has_fixed_stream_free_guidance(self):
+        for stage in ("open", "id"):
+            with self.subTest(stage=stage), self.journal() as journal:
+                failure = provider.SnapshotFailure("missing-provider", "Backend unavailable")
+                name = "open_journal_directory" if stage == "open" else "generate_journal_operation_id"
+                with mock.patch.object(provider, name, side_effect=provider.JournalLayoutError("Raw unsafe diagnostic")):
+                    code, output, diagnostic = self.invoke(journal, ["updates-refresh"], failure)
+                self.assertEqual((code, output), (1, ""))
+                self.assertEqual(diagnostic, "operation result could not be confirmed; refresh status and observe the existing operation\n")
+
+    def test_output_failure_before_or_after_dispatch_preserves_recovery_without_retry(self):
+        for phase in ("pending", "running"):
+            with self.subTest(phase=phase), self.journal() as journal:
+                class FailingOutput(io.StringIO):
+                    failed_writes = 0
+
+                    def write(self, value):
+                        if f"\t{phase}\t" in value:
+                            self.failed_writes += 1
+                            raise OSError("Injected output failure")
+                        return super().write(value)
+
+                output = FailingOutput()
+                backend = self.backend(journal, [lambda bus: bus.progress(Status=3),
+                    lambda bus: bus.emit("Finished", (1, 0))])
+                code, text, diagnostic = self.invoke(journal, ["updates-refresh"], backend, output)
+                self.assertEqual((code, output.failed_writes), (1, 1))
+                self.assertNotIn("Request rejected", text)
+                self.assertNotIn("complete\toperation", text)
+                self.assertIn("observe the existing operation", diagnostic)
+                state = provider.load_journal_state(journal.chain)
+                if phase == "pending":
+                    self.assertEqual(state.active.state, "pending")
+                    self.assertEqual(backend.connection.calls, [])
+                else:
+                    self.assertIsNone(state.active)
+                    self.assertEqual(state.terminals[state.handoff.slot].state, "succeeded")
+
+    def test_rejected_request_formatter_validates_before_output_and_never_builds_journal_payload(self):
+        for failure in (provider.SnapshotFailure("unknown", "Invalid"), None):
+            output = []
+            with self.assertRaises(provider.OperationProtocolError):
+                provider.reject_unadmitted_operation("op-" + "1" * 32, "updates-refresh",
+                    "2026-09-05T01:00:00Z", failure, output.append)
+            self.assertEqual(output, [])
+        output = []
+        with mock.patch.object(provider, "encode_journal_operation", side_effect=AssertionError("Must not fabricate a transaction")):
+            provider.reject_unadmitted_operation("op-" + "1" * 32, "updates-install-all",
+                "2026-09-05T01:00:00Z", provider.SnapshotFailure("conflict", "Changed preview"), output.append)
+        self.assertEqual(rows("".join(output).splitlines(), "audit")[0][2:5], ["updates-install-all", "update", "failed"])
 
 
 class OperationCancelTests(unittest.TestCase):

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -6296,9 +6296,9 @@ class UpdateCommandTests(unittest.TestCase):
         return provider.snapshot_generation([self.package_id],
             [provider.PlanRow(self.package_id, "update", "example", "2", "Example")])
 
-    def invoke(self, journal, args, backend, output=None):
+    def invoke(self, journal, args, backend, output=None, boot_id=None):
         with mock.patch.dict(os.environ, {"XDG_STATE_HOME": str(pathlib.Path(journal.chain.path).parents[1])}), \
-                mock.patch.object(provider, "read_boot_id", return_value=self.boot_id), \
+                mock.patch.object(provider, "read_boot_id", return_value=boot_id or self.boot_id), \
                 mock.patch.object(provider, "PackageKitBackend", **({"side_effect": backend} if isinstance(backend, Exception) else {"return_value": backend})), \
                 contextlib.redirect_stdout(io.StringIO() if output is None else output) as stdout, contextlib.redirect_stderr(io.StringIO()) as stderr:
             code = provider.main(args)
@@ -6385,6 +6385,50 @@ class UpdateCommandTests(unittest.TestCase):
                 self.assertEqual((code, diagnostic), (1, ""))
                 self.assertEqual(rows(output.splitlines(), "error")[0][2], "conflict")
                 self.assertNotEqual(rows(output.splitlines(), "audit")[0][1], operation.operation_id)
+                self.assertEqual(provider.load_journal_state(journal.chain), before)
+                backend.require_mutation_safe.assert_not_called()
+                backend.create_mutation.assert_not_called()
+
+    def test_direct_post_reboot_commands_prune_before_any_backend_preflight(self):
+        new_boot = "abcdef01-2345-6789-abcd-ef0123456789"
+        for update in (False, True):
+            with self.subTest(update=update), self.journal() as journal:
+                operation = self.begin(journal, state="running")
+                with provider.lock_writable_journal(journal):
+                    provider.advance_journal_operation(journal, operation, replace(operation, state="succeeded",
+                        system_restart="system", session_restart="session", application_restart=True,
+                        finished_at="2026-09-05T01:00:00Z", terminal_monotonic=100))
+                    provider.complete_journal_terminal(journal, boot_id=self.boot_id)
+                    provider.acknowledge_journal_handoff(journal, operation.operation_id)
+                backend = self.backend(journal, [lambda bus: bus.progress(Status=3),
+                    lambda bus: bus.emit("Finished", (1, 0))])
+                def preflight():
+                    state = provider.load_journal_state(journal.chain)
+                    self.assertEqual(state.restart, provider.JournalRestart(new_boot, None, "none", "none", 0, False, 0))
+                    self.assertIsNone(state.active)
+                    self.assertIsNone(state.handoff)
+                backend.require_mutation_safe.side_effect = preflight
+                args = ["updates-install-all", self.generation()] if update else ["updates-refresh"]
+                code, output, diagnostic = self.invoke(journal, args, backend, boot_id=new_boot)
+                self.assertEqual((code, diagnostic), (0, ""))
+                self.assertEqual(rows(output.splitlines(), "operation")[-1][4], "succeeded")
+                self.assertEqual(provider.load_journal_state(journal.chain).restart.boot_id, new_boot)
+
+    def test_old_boot_active_or_handoff_is_still_a_read_only_conflict(self):
+        new_boot = "abcdef01-2345-6789-abcd-ef0123456789"
+        for handoff in (False, True):
+            with self.subTest(handoff=handoff), self.journal() as journal:
+                operation = self.begin(journal)
+                if handoff:
+                    with provider.lock_writable_journal(journal):
+                        provider.advance_journal_operation(journal, operation, replace(operation, state="failed",
+                            error_code="internal", finished_at="2026-09-05T01:00:00Z", terminal_monotonic=100))
+                        provider.complete_journal_terminal(journal, boot_id=self.boot_id)
+                before = provider.load_journal_state(journal.chain)
+                backend = self.backend(journal, [])
+                code, output, diagnostic = self.invoke(journal, ["updates-refresh"], backend, boot_id=new_boot)
+                self.assertEqual((code, diagnostic), (1, ""))
+                self.assertEqual(rows(output.splitlines(), "error")[0][2], "conflict")
                 self.assertEqual(provider.load_journal_state(journal.chain), before)
                 backend.require_mutation_safe.assert_not_called()
                 backend.create_mutation.assert_not_called()


### PR DESCRIPTION
## Summary
- Expose only the fixed `updates-refresh` and `updates-install-all GENERATION` CLI grammar. The latter requires the confirmed 64-hex generation and uses the existing bounded fresh inventory/simulation check before mutable admission.
- Route both commands through the durable PackageKit owner, preserving exact progress, terminal/audit completion, restart evidence, and explicit nonzero failure results.
- Distinguish pre-admission rejection from possibly committed admission or delivered output. Rejected requests emit a validated failed-request stream without fabricating a PackageKit transaction or journal payload. Uncertain admission/output/observation instead retains journal recovery guidance.
- Keep Settings refresh/install actions unavailable until the root-scoped confirmation, observer, and acknowledgment are integrated.

## Review boundary
This follows merged PR #233 and contains only the CLI command boundary, regression tests, changelog, and matching contract/task updates. Phase 6 remains active. No new QML source or dependency is introduced.

## Validation
- `scripts/run-tests /usr/bin/python3 -B tests/test-system-management.py UpdateCommandTests OperationStreamTests PackageKitExecutionTests OperationWatchTests`: 63 tests passed.
- `scripts/run-tests /usr/bin/python3 -B tests/test-system-management.py`: all 296 tests passed.
- `scripts/run-tests make clean all` and `scripts/run-tests`: passed, including all 296 provider tests, nested-X11 Settings/System lifecycle, configured QML lint, staged/repeated installation, dependency and release archive gates.
- `shellcheck install.sh scripts/*.sh tests/*.sh` and `shfmt -d install.sh scripts/*.sh tests/*.sh`: passed.
- Native Gio/private D-Bus fixture: actual refresh/install method dispatch, exact arguments, complete operation streams, durable successful handoffs, and update restart checkpoint passed. Security admission and read-only preflight were fixture-controlled; no host PackageKit connection was used.
- Real closed-stdout-pipe subprocess: exact exit 1 and fixed diagnostic, retained pending journal, no PackageKit dispatch, no Python shutdown-flush error.
- Closed Settings: 0.100% CPU (power baseline 0.167%, after 0.100%). Large closed surfaces: 0.00%.
- Managed test workspaces cleaned.
- Local CodeRabbit review: no findings across all five changed files.

## Safety and follow-up
No host refresh, install, cancel, logout, or installed-configuration change was performed. Positive host RPM-transaction and integrated Settings acceptance remain for isolated Fedora qualification and later Phase 6 integration; fixture evidence is not claimed as a host update. A rejected request is deliberately not a retained/replayable journal operation; the existing owner and handoff are left unchanged. No new operation is inferred from a stale control. Exact-head hosted CI, code/security review, and independent review remain merge gates.
- Post-full-gate local Codex review: no actionable defects; independently passed all 11 UpdateCommandTests with fixture-only backends.

## Review follow-up: direct commands after reboot
- Reproduced the post-reboot defect with direct refresh and install regressions, then reconciled the idle journal boot before constructing a backend or creating a PackageKit transaction.
- Existing active operations and unacknowledged handoffs still reject as read-only conflicts, including across reboot. The command does not recover or acknowledge another operation just to admit its replacement.
- `scripts/run-tests /usr/bin/python3 -B tests/test-system-management.py UpdateCommandTests`: all 13 tests passed.
- Repeated `scripts/run-tests make clean all` and `scripts/run-tests`: passed, now including all 298 provider tests, nested X11, configured QML lint, staged/repeated install, and release archive validation. Workspaces cleaned.
- Repeated private native-Gio CLI and real closed-pipe qualifications: passed with no host PackageKit operations.
- Closed Settings 0.067% CPU; power baseline 0.133%, after 0.067%; large closed surfaces 0.00%.
- Fresh local CodeRabbit review: clean across the three follow-up files.
- Post-full-gate Codex review: clean; independently passed all 13 command tests using fixtures only.
