### PR TITLE
feat(system): validate live operation streams in Quickshell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ versions from `config.mk`.
 
 ### Added
 
+- Add a bounded Quickshell operation-stream parser with strict identity,
+  lifecycle, audit, UTF-8, and exit-status checks. Native nested-X11 fixtures
+  verify live progress and failed-result streams; Settings operation ownership
+  and update confirmation remain pending integration.
+
 - Add explicit metadata-refresh and generation-confirmed install CLI commands
   backed by durable PackageKit execution and exact terminal results. Rejected
   requests do not fabricate transactions, and uncertain admission or observation

--- a/TASKS.md
+++ b/TASKS.md
@@ -87,7 +87,11 @@ a terminal result. Explicit refresh and generation-confirmed install CLI command
 now use the existing execution owner. Pre-admission failures emit a failed request
 without inventing a journal transaction; uncertain admission, output, or later
 observation failures retain recovery guidance and never fabricate a terminal
-result. The root-scoped confirmation and operation UI must be completed before
+result. A standalone Quickshell parser now validates cumulative raw-byte streams,
+preserves split UTF-8, retains bounded progress, and requires matching terminal,
+audit, completion, and process-exit evidence. Native nested-X11 fixtures exercise
+it without host service calls; it is not yet connected to operation ownership.
+The root-scoped confirmation and operation UI must be completed before
 this boundary can be accepted. Settings mutation actions remain disabled.
 The preview validators now preserve requested `install` as well as `update`
 actions, matching the PackageKit DNF5 backend's discovery/simulation contract.

--- a/config/quickshell/systemmanagement/SystemOperationProtocol.js
+++ b/config/quickshell/systemmanagement/SystemOperationProtocol.js
@@ -1,0 +1,192 @@
+.pragma library
+
+// A parser owns one stream. It never runs a command or acknowledges a journal.
+// Feed cumulative StdioCollector.data (ArrayBuffer), not arbitrary QString
+// chunks: a pipe read can split a UTF-8 character or a protocol record.
+function create(expectedId, expectedAction) {
+    const parser = {
+        expectedId: expectedId || "", expectedAction: expectedAction || "",
+        offset: 0, line: "", remaining: 0, codepoint: 0, minimum: 0,
+        header: false, complete: false, ended: false, failure: "",
+        operation: null, audit: null, error: null, records: []
+    };
+    if ((parser.expectedId && !/^op-[0-9a-f]{32}$/.test(parser.expectedId))
+            || (parser.expectedAction && !actionKind(parser.expectedAction)))
+        fail(parser, "Invalid expected operation identity");
+    return parser;
+}
+
+function fail(parser, detail) {
+    if (!parser.failure) parser.failure = detail;
+    return false;
+}
+
+function actionKind(action) {
+    if (action === "updates-refresh") return "refresh";
+    if (action === "updates-install-all") return "update";
+    if (action === "timezone-set") return "timezone";
+    if (action === "ntp-set") return "ntp";
+    if (action === "locale-set") return "locale";
+    if (["accounts-open", "password-open", "printers-open", "sources-open"].indexOf(action) >= 0)
+        return "delegate";
+    return "";
+}
+
+function owner(action) {
+    const kind = actionKind(action);
+    if (kind === "refresh" || kind === "update") return "updates";
+    if (kind === "timezone" || kind === "ntp" || kind === "locale") return "regional";
+    if (action === "accounts-open" || action === "password-open") return "accounts";
+    if (action === "printers-open") return "printers";
+    if (action === "sources-open") return "sources";
+    return "";
+}
+
+function terminal(state) {
+    return ["permission-denied", "canceled", "failed", "interrupted", "succeeded"].indexOf(state) >= 0;
+}
+
+function transition(previous, next) {
+    if (terminal(previous)) return false;
+    // Same-state records update progress without inventing a new transition.
+    if (previous === next) return true;
+    if (previous === "pending") return ["authorizing", "running", "canceled", "failed", "interrupted"].indexOf(next) >= 0;
+    if (previous === "authorizing") return ["running", "permission-denied", "canceled", "failed", "interrupted"].indexOf(next) >= 0;
+    if (previous === "running") return ["cancel-requested", "succeeded", "failed", "interrupted"].indexOf(next) >= 0;
+    if (previous === "cancel-requested") return ["canceled", "succeeded", "failed", "interrupted"].indexOf(next) >= 0;
+    return false;
+}
+
+function utf8Bytes(text) {
+    let count = 0;
+    for (let i = 0; i < text.length; i++) {
+        const code = text.charCodeAt(i);
+        if (code < 0x80) count++;
+        else if (code < 0x800) count += 2;
+        else if (code >= 0xd800 && code <= 0xdbff) { count += 4; i++; }
+        else count += 3;
+    }
+    return count;
+}
+
+function fieldsFit(fields, count) {
+    if (fields.length < count) return false;
+    for (let i = 1; i < count; i++)
+        if (utf8Bytes(fields[i]) > 512) return false;
+    return true;
+}
+
+function timestamp(value) {
+    if (!/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/.test(value)
+            || value.slice(0, 4) === "0000") return false;
+    const date = new Date(value);
+    return !isNaN(date.getTime()) && date.toISOString() === value.slice(0, -1) + ".000Z";
+}
+
+function acceptLine(parser, line) {
+    if (parser.complete) return fail(parser, "Records after operation completion");
+    const fields = line.split("\t");
+    const type = fields[0];
+    if (!parser.header) {
+        if (type !== "system-management-protocol" || !fieldsFit(fields, 3)
+                || fields[1] !== "1" || fields[2] !== "0")
+            return fail(parser, "Unsupported or missing operation protocol header");
+        parser.header = true;
+        return true;
+    }
+    if (type === "system-management-protocol") return fail(parser, "Duplicate protocol header");
+    if (type === "operation") {
+        if (!fieldsFit(fields, 8) || !/^op-[0-9a-f]{32}$/.test(fields[1])
+                || !actionKind(fields[2]) || actionKind(fields[2]) !== fields[3]
+                || !/^(unknown|0|[1-9][0-9]?|100)$/.test(fields[5])
+                || (fields[6] !== "yes" && fields[6] !== "no"))
+            return fail(parser, "Invalid operation fields");
+        const previous = parser.operation;
+        if ((parser.expectedId && fields[1] !== parser.expectedId)
+                || (parser.expectedAction && fields[2] !== parser.expectedAction)
+                || (previous && (fields[1] !== previous.id || fields[2] !== previous.actionId)))
+            return fail(parser, "Operation identity changed or does not match");
+        if ((!previous && fields[4] !== "pending")
+                || (previous && !transition(previous.state, fields[4]))
+                || (terminal(fields[4]) && fields[6] !== "no"))
+            return fail(parser, "Invalid operation transition or terminal cancelability");
+        if (fields[4] === "failed" && !parser.error)
+            return fail(parser, "Failed operation has no preceding error");
+        if (!terminal(fields[4]) && parser.records.length >= 256)
+            return fail(parser, "Too many operation progress records");
+        parser.operation = { id: fields[1], actionId: fields[2], kind: fields[3],
+            state: fields[4], percent: fields[5], cancelable: fields[6] === "yes", detail: fields[7] };
+        parser.records.push(parser.operation);
+    } else if (type === "error") {
+        if (!fieldsFit(fields, 4) || parser.error || !parser.operation
+                || terminal(parser.operation.state) || fields[1] !== owner(parser.operation.actionId)
+                || ["network", "repository", "conflict", "signature", "package", "unsupported",
+                    "malformed", "missing-provider", "permission-denied", "canceled", "timeout",
+                    "interrupted", "internal"].indexOf(fields[2]) < 0)
+            return fail(parser, "Invalid operation error");
+        parser.error = { provider: fields[1], code: fields[2], detail: fields[3] };
+    } else if (type === "audit") {
+        const operation = parser.operation;
+        if (!fieldsFit(fields, 8) || parser.audit || !operation || !terminal(operation.state)
+                || fields[1] !== operation.id || fields[2] !== operation.actionId
+                || fields[3] !== operation.kind || fields[4] !== operation.state
+                || !timestamp(fields[5]) || !timestamp(fields[6]))
+            return fail(parser, "Invalid terminal audit");
+        parser.audit = { id: fields[1], actionId: fields[2], kind: fields[3], result: fields[4],
+            started: fields[5], finished: fields[6], detail: fields[7] };
+    } else if (type === "complete") {
+        if (!fieldsFit(fields, 2) || fields[1] !== "operation" || !parser.audit)
+            return fail(parser, "Incomplete operation result");
+        parser.complete = true;
+    } else if (["snapshot-generation", "provider", "state", "update", "package-change",
+                "repository", "account", "filesystem", "action", "active-operation",
+                "terminal-handoff"].indexOf(type) >= 0) {
+        return fail(parser, "Snapshot record in operation stream");
+    }
+    // Unknown records and trailing fields are append-only extension space.
+    return true;
+}
+
+function consume(parser, buffer) {
+    if (parser.failure) return false;
+    if (parser.ended || !(buffer instanceof ArrayBuffer) || buffer.byteLength < parser.offset)
+        return fail(parser, "Operation byte stream was replaced or already ended");
+    if (buffer.byteLength > 8 * 1024 * 1024) return fail(parser, "Operation stream exceeds byte limit");
+    const bytes = new Uint8Array(buffer);
+    while (parser.offset < bytes.length) {
+        const byte = bytes[parser.offset++];
+        if (parser.remaining) {
+            if ((byte & 0xc0) !== 0x80) return fail(parser, "Invalid operation UTF-8");
+            parser.codepoint = (parser.codepoint << 6) | (byte & 0x3f);
+            if (--parser.remaining) continue;
+            if (parser.codepoint < parser.minimum || parser.codepoint > 0x10ffff
+                    || (parser.codepoint >= 0xd800 && parser.codepoint <= 0xdfff))
+                return fail(parser, "Invalid operation UTF-8");
+            parser.line += String.fromCodePoint(parser.codepoint);
+        } else if (byte === 10) {
+            if (!acceptLine(parser, parser.line)) return false;
+            parser.line = "";
+        } else if (byte < 0x80) {
+            if (byte === 0 || byte === 13) return fail(parser, "Noncanonical operation text");
+            parser.line += String.fromCharCode(byte);
+        } else {
+            if (byte >= 0xc2 && byte <= 0xdf) { parser.remaining = 1; parser.minimum = 0x80; parser.codepoint = byte & 0x1f; }
+            else if (byte >= 0xe0 && byte <= 0xef) { parser.remaining = 2; parser.minimum = 0x800; parser.codepoint = byte & 0x0f; }
+            else if (byte >= 0xf0 && byte <= 0xf4) { parser.remaining = 3; parser.minimum = 0x10000; parser.codepoint = byte & 0x07; }
+            else return fail(parser, "Invalid operation UTF-8");
+        }
+    }
+    return true;
+}
+
+function finish(parser, exitCode, normalExit, replay) {
+    if (parser.failure) return false;
+    if (parser.ended) return fail(parser, "Operation stream already ended");
+    parser.ended = true;
+    if (parser.remaining || parser.line.length || !parser.complete)
+        return fail(parser, "Truncated operation stream");
+    const expectedExit = replay || parser.operation.state === "succeeded" ? 0 : 1;
+    if (!normalExit || exitCode !== expectedExit)
+        return fail(parser, "Operation process exit does not match its result");
+    return true;
+}

--- a/config/quickshell/systemmanagement/SystemOperationProtocol.js
+++ b/config/quickshell/systemmanagement/SystemOperationProtocol.js
@@ -113,6 +113,8 @@ function acceptLine(parser, line) {
             return fail(parser, "Invalid operation transition or terminal cancelability");
         if (fields[4] === "failed" && !parser.error)
             return fail(parser, "Failed operation has no preceding error");
+        if (fields[4] === "succeeded" && parser.error)
+            return fail(parser, "Successful operation carries an error");
         if (!terminal(fields[4]) && parser.records.length >= 256)
             return fail(parser, "Too many operation progress records");
         parser.operation = { id: fields[1], actionId: fields[2], kind: fields[3],

--- a/config/quickshell/systemmanagement/SystemOperationProtocol.js
+++ b/config/quickshell/systemmanagement/SystemOperationProtocol.js
@@ -87,6 +87,7 @@ function acceptLine(parser, line) {
     if (parser.complete) return fail(parser, "Records after operation completion");
     const fields = line.split("\t");
     const type = fields[0];
+    if (!type) return fail(parser, "Empty operation record type");
     if (!parser.header) {
         if (type !== "system-management-protocol" || !fieldsFit(fields, 3)
                 || fields[1] !== "1" || fields[2] !== "0")

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -771,7 +771,8 @@ An operation stream accepts at most one error row. A `failed` terminal operation
 requires exactly one preceding error row whose capability is the provider that
 owns the operation: `updates` for `refresh` and `update`, `regional` for
 `timezone`, `ntp`, and `locale`, and the action's declared provider for
-`delegate`. Other terminal results do not require an error row.
+`delegate`. A `succeeded` terminal result forbids an error row, matching the
+durable journal contract. Other terminal results do not require an error row.
 The first operation record must be `pending`; consumers reject any other
 initial state. Audit timestamps are canonical UTC RFC 3339 whole seconds in the
 exact `YYYY-MM-DDTHH:MM:SSZ` form and both are required on the terminal audit
@@ -790,6 +791,10 @@ for another terminal result; retained-result watchers require exit 0 regardless
 of the terminal result. Protocol completion alone never proves process success
 or authorizes handoff acknowledgment. This parser does not start processes,
 own a journal, or enable Settings mutation controls.
+The minor's active-ID table governs snapshot capability advertisement, not the
+closed journal action-to-kind mapping: as specified for `watch-operation`, a
+1.0 stream can replay an exact retained regional or delegated result without
+advertising or invoking that action.
 
 Allowed operation transitions are:
 

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -780,6 +780,17 @@ row. Consumers do not compare their wall-clock order: `finished` may precede
 order and the validated operation transition sequence remain
 authoritative for lifecycle ordering.
 
+The standalone `SystemOperationProtocol.js` consumer accepts cumulative raw
+`StdioCollector.data` buffers and validates complete newline-delimited records
+incrementally. It never decodes arbitrary pipe chunks as independent strings,
+so split UTF-8 remains intact. Its caller must stop accepting a faulted stream,
+call `finish` after normal or abnormal process exit, and accept a result only
+when that call succeeds. Originating streams require exit 0 for success or 1
+for another terminal result; retained-result watchers require exit 0 regardless
+of the terminal result. Protocol completion alone never proves process success
+or authorizes handoff acknowledgment. This parser does not start processes,
+own a journal, or enable Settings mutation controls.
+
 Allowed operation transitions are:
 
 | From | Allowed next state |
@@ -790,8 +801,9 @@ Allowed operation transitions are:
 | `cancel-requested` | `cancel-requested`, `canceled`, `succeeded`, `failed`, or `interrupted` |
 | Any terminal state | None |
 
-Repeated `running` and `cancel-requested` records carry progress or cancellation
-updates. `succeeded` after `cancel-requested` is valid because completion can
+Repeated nonterminal records (`pending`, `authorizing`, `running`, and
+`cancel-requested`) carry progress or cancelability updates without changing
+the lifecycle state. `succeeded` after `cancel-requested` is valid because completion can
 race cancellation. `permission-denied`, `canceled`, `failed`, `interrupted`,
 and `succeeded` are terminal and appear exactly once.
 

--- a/tests/qml/SystemOperationParser.qml
+++ b/tests/qml/SystemOperationParser.qml
@@ -68,6 +68,7 @@ ShellRoot {
             good.replace(running, "\tunnamed extension\n" + running),
             good.replace(pending, running), good.replace(running, ""),
             good.replace(running, root.operation("permission-denied")),
+            good.replace(running, "error\tupdates\tinternal\tConflicting failure\n" + running),
             good.replace("\tsucceeded\tunknown\tno", "\tsucceeded\tunknown\tyes"),
             good.replace("\tunknown\tno", "\t101\tno"),
             good.replace("\tunknown\tno", "\t01\tno"),

--- a/tests/qml/SystemOperationParser.qml
+++ b/tests/qml/SystemOperationParser.qml
@@ -1,0 +1,197 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "SystemOperationProtocol.js" as Protocol
+
+ShellRoot {
+    id: root
+    property string operationId: "op-11111111111111111111111111111111"
+    property string header: "system-management-protocol\t1\t0\n"
+    property var streamParser: null
+    property bool sawLivePending: false
+    property int assertions: 0
+
+    function check(condition, detail) {
+        root.assertions++;
+        if (!condition) throw new Error(detail);
+    }
+
+    function operation(state, action, detail) {
+        action = action || "updates-refresh";
+        return ["operation", root.operationId, action, Protocol.actionKind(action), state,
+            "unknown", "no", detail || "Fixture"].join("\t") + "\n";
+    }
+
+    function audit(state, action) {
+        action = action || "updates-refresh";
+        return ["audit", root.operationId, action, Protocol.actionKind(action), state,
+            "2026-09-05T12:00:00Z", "2026-09-04T12:00:00Z", "Clock rollback is valid"].join("\t") + "\n";
+    }
+
+    function fixture(state, action) {
+        action = action || "updates-refresh";
+        let text = root.header + root.operation("pending", action);
+        if (state === "succeeded") text += root.operation("running", action);
+        if (state === "permission-denied") text += root.operation("authorizing", action);
+        if (state === "failed") text += "error\t" + Protocol.owner(action) + "\tconflict\tFixture failure\n";
+        return text + root.operation(state, action) + root.audit(state, action) + "complete\toperation\n";
+    }
+
+    function bytes(text) {
+        const encoded = unescape(encodeURIComponent(text));
+        const result = new Uint8Array(encoded.length);
+        for (let i = 0; i < encoded.length; i++) result[i] = encoded.charCodeAt(i);
+        return result.buffer;
+    }
+
+    function parse(text, code, replay) {
+        const parser = Protocol.create(root.operationId, "");
+        return Protocol.consume(parser, root.bytes(text)) && Protocol.finish(parser, code, true, replay === true);
+    }
+
+    function unitTests() {
+        for (const action of ["updates-refresh", "updates-install-all", "timezone-set", "ntp-set",
+                "locale-set", "accounts-open", "password-open", "printers-open", "sources-open"]) {
+            for (const state of ["succeeded", "permission-denied", "failed", "interrupted", "canceled"]) {
+                root.check(root.parse(root.fixture(state, action), state === "succeeded" ? 0 : 1), action + ": " + state);
+                root.check(root.parse(root.fixture(state, action), 0, true), action + ": replay " + state);
+            }
+        }
+        const good = root.fixture("succeeded");
+        const pending = root.operation("pending");
+        const running = root.operation("running");
+        const failed = root.fixture("failed");
+        const invalid = [
+            good.slice(root.header.length), good.replace("\t1\t0", "\t2\t0"),
+            good.replace("\t1\t0", "\t1\t1"), root.header + good,
+            good.replace(pending, running), good.replace(running, ""),
+            good.replace(running, root.operation("permission-denied")),
+            good.replace("\tsucceeded\tunknown\tno", "\tsucceeded\tunknown\tyes"),
+            good.replace("\tunknown\tno", "\t101\tno"),
+            good.replace("\tunknown\tno", "\t01\tno"),
+            good.replace("\tunknown\tno", "\tunknown\ttrue"),
+            good.replace("\tpending\t", "\tinvented\t"),
+            good.replace(pending, pending.replace("updates-refresh", "updates-install-all")),
+            good.replace(pending, pending.replace(root.operationId, "op-22222222222222222222222222222222")),
+            good.replace(pending, pending.replace(root.operationId, "op-ABC")),
+            good.replace(pending, pending.replace("updates-refresh", "updates-cancel")),
+            good.replace(pending, pending.replace("\trefresh\t", "\tdelegate\t")),
+            good.replace("Fixture", "x".repeat(513)),
+            good.replace("Fixture", "\u20ac".repeat(171)),
+            good.replace("Fixture", "\u0000"), good.replace("Fixture", "\r"),
+            good.replace("complete\toperation\n", ""), good.slice(0, -1),
+            good + "complete\toperation\n", good + "future\tx\n", good + "\n",
+            good.replace("complete\toperation", "complete\tsnapshot"),
+            good.replace(root.audit("succeeded"), ""),
+            good.replace(root.audit("succeeded"), root.audit("succeeded") + root.audit("succeeded")),
+            good.replace(root.audit("succeeded"), root.audit("failed")),
+            good.replace("2026-09-04T12:00:00Z", "2026-02-30T12:00:00Z"),
+            good.replace("2026-09-04T12:00:00Z", "2026-09-04T12:00:60Z"),
+            good.replace("2026-09-04T12:00:00Z", "0000-09-04T12:00:00Z"),
+            good.replace("2026-09-04T12:00:00Z", "2026-09-04T12:00:00+00:00"),
+            good.replace(running, root.audit("succeeded") + running),
+            good.replace("complete\toperation", running + "complete\toperation"),
+            failed.replace("error\tupdates\tconflict\tFixture failure\n", ""),
+            failed.replace("error\tupdates", "error\trecovery"),
+            failed.replace("error\tupdates", "error\tregional"),
+            failed.replace("\tconflict\t", "\tDBus.Error\t"),
+            failed.replace("error\tupdates\tconflict\tFixture failure\n", "error\tupdates\tconflict\tX\nerror\tupdates\tconflict\tY\n")
+        ];
+        for (const type of ["snapshot-generation", "provider", "state", "update", "package-change",
+                "repository", "account", "filesystem", "action", "active-operation", "terminal-handoff"])
+            invalid.push(good.replace(running, type + "\tx\n" + running));
+        for (const text of invalid) root.check(!root.parse(text, text.indexOf("\tfailed\t") >= 0 ? 1 : 0), "Accepted malformed fixture: " + text);
+        for (const type of ["operation", "error", "audit", "complete"])
+            root.check(!root.parse(good.replace(running, type + "\n" + running), 0), "Missing fields: " + type);
+        root.check(root.parse(good.replace(running, "future\tx\n" + running), 0), "Unknown record");
+        root.check(root.parse(good.trim().split("\n").map(line => line + "\t" + "x".repeat(513)).join("\n") + "\n", 0), "Trailing extension fields");
+        root.check(root.parse(good.replace("Fixture", "\u20ac".repeat(170) + "ab"), 0), "512-byte field");
+        root.check(!root.parse(good, 1), "Success with failed exit");
+        root.check(!root.parse(failed, 0), "Failed origin with successful exit");
+        root.check(!root.parse(failed, 1, true), "Failed replay with failed exit");
+        const progress = good.replace(running, pending + root.operation("authorizing")
+            + root.operation("authorizing") + running + running + root.operation("cancel-requested")
+            + root.operation("cancel-requested"));
+        root.check(root.parse(progress, 0), "Same-state progress and completion/cancel race");
+        root.check(root.parse(good.replace(running, running.repeat(255)), 0), "256 nonterminal records");
+        root.check(!root.parse(good.replace(running, running.repeat(256)), 0), "257 nonterminal records");
+
+        const unicode = root.bytes(good.replace("Fixture", "split \u00a2\u20ac\ud83d\ude00"));
+        const parser = Protocol.create(root.operationId, "updates-refresh");
+        for (let i = 0; i <= unicode.byteLength; i++)
+            root.check(Protocol.consume(parser, unicode.slice(0, i)), "Byte boundary " + i);
+        root.check(Protocol.finish(parser, 0, true, false), "Split Unicode completion");
+        root.check(parser.records[0].detail === "split \u00a2\u20ac\ud83d\ude00", "Unicode preserved");
+        root.check(!Protocol.consume(parser, unicode), "Data after EOF");
+        for (const malformed of [[0xc0, 0xaf], [0xe0, 0x80, 0xaf], [0xed, 0xa0, 0x80],
+                [0xf4, 0x90, 0x80, 0x80], [0x80], [0xc2, 0x20]])
+            root.check(!Protocol.consume(Protocol.create(), new Uint8Array(malformed).buffer), "Malformed UTF-8");
+        const truncated = Protocol.create();
+        root.check(Protocol.consume(truncated, new Uint8Array([0xe2]).buffer), "Pending UTF-8");
+        root.check(!Protocol.finish(truncated, 0, true, false), "Truncated UTF-8");
+        root.check(!Protocol.consume(Protocol.create(), new ArrayBuffer(8 * 1024 * 1024 + 1)), "Byte limit");
+        const extension = "future\t" + "x".repeat(8 * 1024 * 1024 - root.bytes(good).byteLength - 8) + "\n";
+        root.check(root.parse(good.replace(running, extension + running), 0), "Exact byte limit with ignored extension");
+        const replaced = Protocol.create();
+        Protocol.consume(replaced, root.bytes(root.header));
+        root.check(!Protocol.consume(replaced, new ArrayBuffer(0)), "Shrinking collector");
+        root.check(!Protocol.consume(Protocol.create("bad"), root.bytes(good)), "Invalid expected ID");
+        root.check(!Protocol.consume(Protocol.create("", "health-open"), root.bytes(good)), "Invalid expected action");
+        root.check(!Protocol.consume(Protocol.create("", "updates-install-all"), root.bytes(good)), "Mismatched expected action");
+        const crashed = Protocol.create();
+        Protocol.consume(crashed, root.bytes(good));
+        root.check(!Protocol.finish(crashed, 0, false, false), "Crash is not success");
+    }
+
+    Component.onCompleted: {
+        try {
+            root.unitTests();
+            root.streamParser = Protocol.create(root.operationId, "updates-refresh");
+            // Deliberately split a multibyte field across separate native pipe
+            // reads, and leave pending visible before a valid failed exit.
+            const payload = root.fixture("failed").replace("Fixture", "split \u20ac\ud83d\ude00");
+            process.command = ["/usr/bin/python3", "-c", "import os,time; data=" + JSON.stringify(payload)
+                + ".encode('utf-8'); cut=data.index(bytes([226])); "
+                + "os.write(1,data[:cut+1]); time.sleep(.15); os.write(1,data[cut+1:cut+2]); "
+                + "time.sleep(.15); end=data.index(b'\\n',cut)+1; os.write(1,data[cut+2:end]); "
+                + "time.sleep(.15); os.write(1,data[end:]); raise SystemExit(1)"];
+            process.running = true;
+        } catch (error) {
+            console.error("Operation parser fixture failed: " + error);
+            Qt.quit();
+        }
+    }
+
+    Process {
+        id: process
+        stdout: StdioCollector {
+            id: output
+            waitForEnd: false
+            onDataChanged: {
+                if (!root.streamParser) return;
+                Protocol.consume(root.streamParser, output.data);
+                if (root.streamParser.operation && root.streamParser.operation.state === "pending" && process.running)
+                    root.sawLivePending = true;
+            }
+        }
+        onExited: (exitCode, exitStatus) => {
+            try {
+                root.check(Protocol.consume(root.streamParser, output.data), root.streamParser.failure);
+                // Quickshell 0.2.1 passes QProcess::ExitStatus but does not
+                // export that enum on Process; Qt defines NormalExit as zero.
+                root.check(Protocol.finish(root.streamParser, exitCode, exitStatus === 0, false), root.streamParser.failure);
+                root.check(root.sawLivePending, "Progress was not delivered live");
+                root.check(root.streamParser.records[0].detail === "split \u20ac\ud83d\ude00", "Native UTF-8 was corrupted");
+                console.info("Operation parser native tests: PASS (" + root.assertions + " assertions)");
+            } catch (error) {
+                console.error("Operation parser native fixture failed: " + error);
+            }
+            Qt.quit();
+        }
+    }
+    Timer {
+        interval: 15000
+        running: true
+        onTriggered: { console.error("Operation parser fixture timed out"); Qt.quit(); }
+    }
+}

--- a/tests/qml/SystemOperationParser.qml
+++ b/tests/qml/SystemOperationParser.qml
@@ -64,6 +64,8 @@ ShellRoot {
         const invalid = [
             good.slice(root.header.length), good.replace("\t1\t0", "\t2\t0"),
             good.replace("\t1\t0", "\t1\t1"), root.header + good,
+            good.replace(pending, "\n" + pending),
+            good.replace(running, "\tunnamed extension\n" + running),
             good.replace(pending, running), good.replace(running, ""),
             good.replace(running, root.operation("permission-denied")),
             good.replace("\tsucceeded\tunknown\tno", "\tsucceeded\tunknown\tyes"),
@@ -158,7 +160,7 @@ ShellRoot {
             process.running = true;
         } catch (error) {
             console.error("Operation parser fixture failed: " + error);
-            Qt.quit();
+            Qt.callLater(function() { Qt.quit(); });
         }
     }
 

--- a/tests/test-quickshell-system-management-xvfb.sh
+++ b/tests/test-quickshell-system-management-xvfb.sh
@@ -3,7 +3,7 @@ set -eu
 
 repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 
-for command_name in Xvfb dbus-run-session quickshell xprop pgrep; do
+for command_name in Xvfb dbus-run-session quickshell xprop pgrep timeout; do
 	if ! command -v "$command_name" >/dev/null 2>&1; then
 		printf 'SKIP: %s is unavailable\n' "$command_name"
 		exit 77
@@ -234,6 +234,28 @@ while [ "$i" -lt 100 ]; do
 	sleep 0.05
 done
 DISPLAY=$display xprop -root >/dev/null
+
+# Run the isolated operation parser on the same nested display before loading
+# the managed shell. This fixture never connects to host PackageKit.
+mkdir -p "$work/operation-parser"
+cp "$repo/tests/qml/SystemOperationParser.qml" "$work/operation-parser/shell.qml"
+cp "$repo/config/quickshell/systemmanagement/SystemOperationProtocol.js" "$work/operation-parser/"
+timeout --foreground --kill-after=2s 20s env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
+	XDG_DATA_HOME="$data_home" XDG_RUNTIME_DIR="$runtime" QT_QPA_PLATFORMTHEME= \
+	quickshell --no-duplicate --path "$work/operation-parser/shell.qml" \
+	>"$work/operation-parser.log" 2>&1 &
+quickshell_pid=$!
+parser_status=0
+wait "$quickshell_pid" || parser_status=$?
+quickshell_pid=
+if [ "$parser_status" -ne 0 ]; then
+	cat "$work/operation-parser.log" >&2
+	exit "$parser_status"
+fi
+if ! grep -F 'Operation parser native tests: PASS' "$work/operation-parser.log"; then
+	cat "$work/operation-parser.log" >&2
+	exit 1
+fi
 
 DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
 	XDG_RUNTIME_DIR=$runtime "$repo/dwm" >"$work/dwm.log" 2>&1 &


### PR DESCRIPTION
## Summary
- Add a standalone Quickshell 1.0 operation-protocol consumer, without enabling mutation controls or starting any service operation.
- Validate raw cumulative ArrayBuffer data incrementally: exact identity/action/kind, legal lifecycle transitions, bounded progress and UTF-8 text, owner-scoped errors, canonical matching audit, final completion, and originating versus replay exit semantics.
- Preserve UTF-8 across arbitrary pipe-read boundaries; cap input at 8 MiB and progress at 256 nonterminal records plus one terminal. Unknown records/trailing fields retain append-only compatibility.
- Add native Quickshell fixtures to the existing isolated Xvfb gate. An external 20-second timeout with two-second kill grace bounds the fixture even if its event loop stalls. Clarify same-state nonterminal progress already emitted by the provider.

## Validation
- `scripts/run-tests make clean all`: PASS.
- `scripts/run-tests`: PASS, including all 298 provider tests, QML lint, Settings and large-surface nested-X11/idle checks, connectivity, dependency resolution, staged install, repeated install preservation, and release archive validation.
- `scripts/run-tests make check-quickshell-system-management`: final rerun PASS, including 674 native assertions and the existing managed System Settings lifecycle. Tests cover all nine action IDs and five terminal results, exact identities, malformed streams/UTF-8, every single-byte split of Unicode, audit clock rollback/calendar validity, progress limits, exact 8 MiB acceptance and over-limit rejection, live pending delivery, and valid failed-origin exit 1.
- Same parser assertions passed in a private offscreen Quickshell fixture; native X11 validation above is authoritative for the integration.
- Native environment: Fedora 44 x86_64, Quickshell 0.2.1 revision dacfa9de, Qt 6.11.2. Settings closed-idle CPU 0.067%; power baseline 0.100%, after 0.067%, delta 0.033 points.
- Configured skill QML lint plus `shellcheck install.sh scripts/*.sh tests/*.sh`, `shfmt -d install.sh scripts/*.sh tests/*.sh`, and `git diff --check`: PASS. Existing unrelated QML metadata warnings remain unchanged.
- Fault injection into the test harness: a stalled parser returned 124 with its diagnostic log; an immediate failure preserved exit 42 and printed its log. Temporary fixtures and managed test workspaces were removed.
- Final independent local CodeRabbit review: clean across all six files. Post-full-gate Codex review: no actionable defects; it also independently ran parser fixtures under Node and shell checks.

## Scope and remaining work
This is an independently testable parser foundation, not Phase 6 completion. It does not acknowledge journal handoffs, own operation processes, change the installed desktop, or enable update buttons. Root-scoped ownership/recovery, event-driven invalidation, confirmation/progress UI, regional/delegated and information capabilities, and combined Phase 6 qualification remain. No host package mutation was performed. No visible UI change requires a screenshot.

Hosted checks and exact-head reviews must pass before merging.

## Review follow-up
The hosted review found that an internal blank record was being treated as an unknown extension. The new regression reproduced that acceptance before the fix. Empty record names now fail before extension handling; both a blank line and an unnamed tab-separated record are covered. The fixture also defers early failure exit until the QML engine has connected its quit handler. The complete local suite was repeated successfully (298 provider tests and 674 native parser assertions), with clean independent CodeRabbit and post-full-gate Codex reviews of the follow-up. No host service mutation was performed.

## Additional Codex review follow-up
The thread-level review identified a contradictory error-plus-success bundle. A native regression reproduced its acceptance; successful terminals now reject any preceding error, matching journal validation. The complete suite was rerun with 298 provider tests and 674 native assertions. The separate suggestion to reject regional/delegated 1.0 retained results was invalid: the existing watch/replay contract explicitly supports all closed journal kinds under 1.0, independently of snapshot capability advertisement. Both all-kind journal/replay tests and a direct formatter-only probe passed; documentation clarifies this existing distinction. The isolated QML fixture also passed configured lint, with the installed Quickshell metadata warning for QProcess::ExitStatus; actual numeric exit handling is native-tested.