### PR TITLE
feat(system): recover operations in the shell root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ versions from `config.mk`.
 
 ### Added
 
+- Restore journaled system operations in the shell root and keep their progress
+  visible across Settings closure. Verify complete terminal results before exact
+  acknowledgment; retain guidance after bounded recovery or acknowledgment
+  failure. Update mutation controls remain disabled pending confirmation and
+  execution integration.
+
 - Add a bounded Quickshell operation-stream parser with strict identity,
   lifecycle, audit, UTF-8, and exit-status checks. Native nested-X11 fixtures
   verify live progress and failed-result streams; Settings operation ownership

--- a/TASKS.md
+++ b/TASKS.md
@@ -89,9 +89,13 @@ without inventing a journal transaction; uncertain admission, output, or later
 observation failures retain recovery guidance and never fabricate a terminal
 result. A standalone Quickshell parser now validates cumulative raw-byte streams,
 preserves split UTF-8, retains bounded progress, and requires matching terminal,
-audit, completion, and process-exit evidence. Native nested-X11 fixtures exercise
-it without host service calls; it is not yet connected to operation ownership.
-The root-scoped confirmation and operation UI must be completed before
+audit, completion, and process-exit evidence. A root-scoped observer now restores
+exact active and retained identities from startup snapshots, preserves its stream
+across pane closure, verifies results before acknowledgment, and bounds failed
+recovery to three retries. Native nested-X11 fixtures exercise live progress,
+failed-result replay, stale collector data, restart adoption, and failed process
+starts without host service calls. Originating mutation, confirmation, and cancel
+UI integration plus event-driven discovery invalidation must be completed before
 this boundary can be accepted. Settings mutation actions remain disabled.
 The preview validators now preserve requested `install` as well as `update`
 actions, matching the PackageKit DNF5 backend's discovery/simulation contract.

--- a/config/quickshell/settings/SystemSettingsPane.qml
+++ b/config/quickshell/settings/SystemSettingsPane.qml
@@ -191,17 +191,31 @@ Flickable {
         }
 
         StatusCard {
-            visible: root.systemManagementModel.activeOperation !== null
-            label: root.systemManagementModel.activeOperation === null ? "Active operation"
-                : root.systemManagementModel.activeOperation.actionId
+            readonly property var operation: root.systemManagementModel.operation.progress
+                || root.systemManagementModel.activeOperation
+            visible: operation !== null
+            label: operation === null ? "Active operation" : operation.actionId
             status: "partial"
-            value: root.systemManagementModel.activeOperation === null ? ""
-                : root.systemManagementModel.activeOperation.percent === "unknown"
-                    ? root.systemManagementModel.activeOperation.state
-                    : root.systemManagementModel.activeOperation.state + " / "
-                        + root.systemManagementModel.activeOperation.percent + "%"
-            detail: root.systemManagementModel.activeOperation === null ? ""
-                : root.systemManagementModel.activeOperation.detail
+            value: operation === null ? "" : operation.percent === "unknown"
+                ? operation.state : operation.state + " / " + operation.percent + "%"
+            detail: operation === null ? "" : operation.detail
+        }
+
+        StatusCard {
+            readonly property var result: root.systemManagementModel.operation.result
+            visible: result !== null
+            label: result === null ? "Verified operation result" : result.actionId
+            status: result !== null && result.state === "succeeded" ? "available" : "partial"
+            value: result === null ? "" : result.state
+            detail: result === null ? "" : result.detail
+        }
+
+        PlainText {
+            Layout.fillWidth: true
+            visible: root.systemManagementModel.operation.detail.length > 0
+            text: root.systemManagementModel.operation.detail
+            color: root.systemManagementModel.operation.blocked ? Theme.danger : Theme.menuMutedText
+            wrapMode: Text.WordWrap
         }
 
         StatusCard {

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -573,6 +573,15 @@ ShellRoot {
             return systemManagementModel.snapshotState;
         }
 
+        function systemManagementOperationState(): string {
+            return systemManagementModel.operation.state;
+        }
+
+        function systemManagementOperationResult(): string {
+            const result = systemManagementModel.operation.result;
+            return result === null ? "" : result.actionId + ":" + result.state;
+        }
+
         function inputAccessibilityValue(settingId: string): string {
             const setting = settingsModel.inputSettings.find(function(item) {
                 return item.device === "accessx" && item.id === settingId;

--- a/config/quickshell/systemmanagement/SystemManagementModel.qml
+++ b/config/quickshell/systemmanagement/SystemManagementModel.qml
@@ -22,9 +22,15 @@ Scope {
     property var activeOperation: null
     property var terminalHandoff: null
     property bool snapshotPending: false
+    property bool requiredPending: false
+    property bool snapshotOwned: false
+    property bool snapshotRequired: false
+    property bool snapshotHasOutput: false
+    property string snapshotErrorDetail: ""
     property int requestGeneration: 0
+    readonly property alias operation: operationModel
 
-    readonly property bool busy: snapshotProcess.running
+    readonly property bool busy: snapshotOwned
     readonly property string providerState: root.updateProvider.status
     readonly property string providerDetail: root.updateProvider.detail
 
@@ -148,7 +154,7 @@ Scope {
     }
 
     function parseSnapshot(text, responseGeneration) {
-        if (responseGeneration !== root.requestGeneration || !root.settingsVisible) return;
+        if (responseGeneration !== root.requestGeneration) return false;
         if (root.utf8Bytes(text) > 8 * 1024 * 1024) {
             root.clearState("System management provider returned an oversized response");
             return;
@@ -474,8 +480,10 @@ Scope {
         }
 
         root.generation = parsedGeneration;
-        root.activeOperation = parsedActive;
-        root.terminalHandoff = parsedHandoff;
+        root.activeOperation = parsedActive !== null && operationModel.wasAcknowledged(parsedActive.id)
+            ? null : parsedActive;
+        root.terminalHandoff = parsedHandoff !== null && operationModel.wasAcknowledged(parsedHandoff.id)
+            ? null : parsedHandoff;
         if (updatesInvalid) {
             const detail = "System management provider returned malformed update state";
             root.updateProvider = { "status": "partial", "providerClass": "delegated",
@@ -541,6 +549,10 @@ Scope {
         root.message = root.snapshotState === "ready"
             ? parsedUpdates.length + " updates reported"
             : "System management state is incomplete";
+        // No identities is evidence of an empty journal only after successful
+        // recovery. A partial response may have failed to read the owner at all.
+        return !recoveryInvalid && (parsedActive !== null || parsedHandoff !== null
+            || parsedRecoveryProvider.status === "available");
     }
 
     function openSettings() {
@@ -550,23 +562,77 @@ Scope {
 
     function closeSettings() {
         root.settingsVisible = false;
-        root.requestGeneration++;
         root.snapshotPending = false;
-        snapshotProcess.running = false;
+        if (!root.snapshotRequired) {
+            root.requestGeneration++;
+            snapshotProcess.running = false;
+        }
     }
 
     function refresh() {
         if (!root.settingsVisible) return;
-        if (snapshotProcess.running) {
-            root.snapshotPending = true;
+        const requiredRecovery = operationModel.waitingSnapshot || operationModel.blocked
+            || operationModel.state === "recovering";
+        operationModel.resetRecovery();
+        if (requiredRecovery) operationModel.requestSnapshot();
+        else root.requestSnapshot(false);
+    }
+
+    function requestSnapshot(required) {
+        if (!required && !root.settingsVisible) return;
+        if (root.snapshotOwned) {
+            root.snapshotPending = root.snapshotPending || !required;
+            root.requiredPending = root.requiredPending || required;
             return;
         }
         root.snapshotPending = false;
+        root.requiredPending = false;
         root.requestGeneration++;
         snapshotProcess.generation = root.requestGeneration;
+        root.snapshotRequired = required;
+        root.snapshotHasOutput = false;
+        root.snapshotErrorDetail = "";
+        root.snapshotOwned = true;
         root.snapshotState = "loading";
         root.message = "Reading system update status...";
         snapshotProcess.running = true;
+    }
+
+    function finishSnapshot(exitCode, normalExit) {
+        if (!root.snapshotOwned) return;
+        const current = snapshotProcess.generation === root.requestGeneration;
+        root.snapshotOwned = false;
+        root.snapshotRequired = false;
+        if (current) {
+            if (normalExit && exitCode === 0 && root.snapshotHasOutput) {
+                if (root.parseSnapshot(snapshotOutput.text, snapshotProcess.generation))
+                    operationModel.acceptSnapshot(root.activeOperation, root.terminalHandoff);
+                else operationModel.snapshotFailed();
+            } else {
+                root.clearState("System management snapshot process failed"
+                    + (root.snapshotErrorDetail ? ": " + root.snapshotErrorDetail : ""));
+                operationModel.snapshotFailed();
+            }
+        }
+        // The old process emits runningChanged after exited. Queue the next
+        // launch so that signal cannot finalize a new run's ownership.
+        Qt.callLater(function() {
+            if (root.requiredPending) root.requestSnapshot(true);
+            else if (root.snapshotPending && root.settingsVisible) root.requestSnapshot(false);
+        });
+    }
+
+    Component.onCompleted: Qt.callLater(function() { operationModel.requestSnapshot(); })
+
+    SystemOperationModel {
+        id: operationModel
+        onSnapshotRequested: root.requestSnapshot(true)
+        onAcknowledged: operationId => {
+            if (root.terminalHandoff !== null && root.terminalHandoff.id === operationId)
+                root.terminalHandoff = null;
+            if (root.activeOperation !== null && root.activeOperation.id === operationId)
+                root.activeOperation = null;
+        }
     }
 
     Process {
@@ -577,24 +643,21 @@ Scope {
         running: false
         stdout: StdioCollector {
             id: snapshotOutput
+            onStreamFinished: { if (root.snapshotOwned) root.snapshotHasOutput = true; }
         }
         stderr: StdioCollector {
             id: snapshotError
+            onStreamFinished: {
+                if (root.snapshotOwned) {
+                    const rawError = text.replace(/\s+/g, " ").trim();
+                    root.snapshotErrorDetail = root.utf8Bytes(rawError) <= 512 ? rawError
+                        : "Provider error detail exceeded the protocol limit";
+                }
+            }
         }
+        onExited: (exitCode, exitStatus) => root.finishSnapshot(exitCode, exitStatus === 0)
         onRunningChanged: {
-            if (!running && snapshotProcess.generation === root.requestGeneration
-                    && root.settingsVisible) {
-                root.parseSnapshot(snapshotOutput.text, snapshotProcess.generation);
-                const rawError = snapshotError.text.replace(/\s+/g, " ").trim();
-                const detail = root.utf8Bytes(rawError) <= 512 ? rawError
-                    : "Provider error detail exceeded the protocol limit";
-                if (root.snapshotState === "failure" && detail.length > 0)
-                    root.message = "System management snapshot process failed: " + detail;
-            }
-            if (!running && root.snapshotPending && root.settingsVisible) {
-                root.snapshotPending = false;
-                Qt.callLater(root.refresh);
-            }
+            if (!running && root.snapshotOwned) root.finishSnapshot(-1, false);
         }
     }
 }

--- a/config/quickshell/systemmanagement/SystemOperationModel.qml
+++ b/config/quickshell/systemmanagement/SystemOperationModel.qml
@@ -1,0 +1,240 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.core
+import "SystemOperationProtocol.js" as Protocol
+
+// Root-owned observation and journal acknowledgment; never starts a mutation.
+Scope {
+    id: root
+
+    signal snapshotRequested()
+    signal acknowledged(string operationId)
+
+    property string state: "idle"
+    property string detail: ""
+    property var progress: null
+    property var result: null
+    property var audit: null
+    property var operationError: null
+    property var handoff: null
+    property var snapshotActive: null
+    property var acknowledgedIds: []
+    property var parser: null
+    property bool streamOwned: false
+    property bool controlOwned: false
+    property bool waitingSnapshot: false
+    property bool blocked: false
+    property int retries: 0
+    property string controlId: ""
+    property bool controlInvalid: false
+    readonly property bool busy: streamOwned || controlOwned || waitingSnapshot || retryTimer.running
+
+    function matches(left, right) {
+        return left !== null && right !== null && left.id === right.id
+            && left.actionId === right.actionId && left.kind === right.kind;
+    }
+
+    function wasAcknowledged(operationId) {
+        return root.acknowledgedIds.indexOf(operationId) >= 0;
+    }
+
+    function requestSnapshot() {
+        root.waitingSnapshot = true;
+        root.snapshotRequested();
+    }
+
+    function resetRecovery() {
+        retryTimer.stop();
+        root.retries = 0;
+        root.blocked = false;
+    }
+
+    function recover(reason) {
+        root.waitingSnapshot = false;
+        root.detail = reason;
+        if (root.retries >= 3) {
+            root.blocked = true;
+            root.state = "failure";
+            root.detail += ". Open System Settings and reload status to retry recovery.";
+            return;
+        }
+        root.state = "recovering";
+        retryTimer.interval = [1000, 2000, 4000][root.retries++];
+        retryTimer.restart();
+    }
+
+    function snapshotFailed() {
+        root.waitingSnapshot = false;
+        if (root.streamOwned || root.controlOwned || root.blocked || retryTimer.running) return;
+        root.recover("Operation recovery could not read complete journal evidence");
+    }
+
+    // Only fully accepted snapshots may enter this method. A live stream is
+    // the sole observer even before it emits its first operation identity.
+    function acceptSnapshot(active, terminal) {
+        if (active !== null && root.wasAcknowledged(active.id)) active = null;
+        if (terminal !== null && root.wasAcknowledged(terminal.id)) terminal = null;
+        root.waitingSnapshot = false;
+        root.snapshotActive = active;
+        root.handoff = terminal;
+        if (root.streamOwned || root.controlOwned || root.blocked || retryTimer.running) return;
+        if (terminal !== null && root.matches(terminal, root.result)) {
+            root.startAcknowledgment();
+        } else if (active !== null && root.matches(active, root.result)) {
+            root.recover("Snapshot still reports a completed operation as active");
+        } else if (active !== null || terminal !== null) {
+            const target = active !== null ? active : terminal;
+            root.parser = Protocol.create(target.id, target.actionId);
+            root.streamOwned = true;
+            root.progress = active;
+            root.state = "observing";
+            root.detail = "Observing " + target.actionId;
+            watchProcess.command = Commands.systemManagementCommand("watch-operation", [target.id]);
+            Qt.callLater(function() { if (root.streamOwned) watchProcess.running = true; });
+        } else {
+            root.retries = 0;
+            root.progress = null;
+            root.state = root.result === null ? "idle" : "result";
+            root.detail = root.result === null ? "" : root.result.detail;
+        }
+    }
+
+    function consume(data) {
+        if (!root.streamOwned) return;
+        if (!Protocol.consume(root.parser, data)) {
+            root.detail = root.parser.failure;
+            watchProcess.signal(9);
+            return;
+        }
+        // A terminal row is provisional until EOF, audit, completion AND the
+        // exit status pass. Never display it as successful or acknowledge it.
+        for (let i = root.parser.records.length - 1; i >= 0; i--) {
+            if (!Protocol.terminal(root.parser.records[i].state)) {
+                root.progress = root.parser.records[i];
+                break;
+            }
+        }
+        if (root.parser.operation !== null && Protocol.terminal(root.parser.operation.state)) {
+            root.state = "verifying";
+            root.detail = "Verifying the complete operation result...";
+        }
+    }
+
+    function finishWatch(exitCode, normalExit) {
+        if (!root.streamOwned) return;
+        root.streamOwned = false;
+        if (!Protocol.finish(root.parser, exitCode, normalExit, true)) {
+            root.recover(exitCode === 3 ? "Operation watch target changed (conflict)" : root.parser.failure);
+            return;
+        }
+        root.result = root.parser.operation;
+        root.audit = root.parser.audit;
+        root.operationError = root.parser.error;
+        root.progress = null;
+        root.state = "result";
+        root.detail = root.result.detail;
+        // Even a replay that began from an active snapshot needs a committed
+        // handoff snapshot before ack. Never infer that handoff from stdout.
+        Qt.callLater(function() {
+            if (root.matches(root.handoff, root.result)) root.startAcknowledgment();
+            else root.requestSnapshot();
+        });
+    }
+
+    function startAcknowledgment() {
+        if (root.streamOwned || root.controlOwned || root.blocked
+                || !root.matches(root.handoff, root.result)
+                || root.wasAcknowledged(root.result.id)) return;
+        root.controlId = root.result.id;
+        root.controlInvalid = false;
+        root.controlOwned = true;
+        root.state = "acknowledging";
+        root.detail = "Acknowledging the verified operation result...";
+        ackProcess.command = Commands.systemManagementCommand("ack-operation", [root.controlId]);
+        Qt.callLater(function() {
+            if (root.controlOwned) {
+                controlDeadline.restart();
+                ackProcess.running = true;
+            }
+        });
+    }
+
+    function finishAcknowledgment(exitCode, normalExit) {
+        if (!root.controlOwned) return;
+        controlDeadline.stop();
+        root.controlOwned = false;
+        root.state = "result";
+        if (!normalExit || exitCode !== 0 || root.controlInvalid) {
+            root.blocked = true;
+            root.detail = "The verified result could not be acknowledged. Reload status to retry recovery.";
+            return;
+        }
+        if (root.matches(root.handoff, root.result)) root.handoff = null;
+        // Match the bounded retained journal: late discovery output must not
+        // resurrect an acknowledged identity or send a duplicate ack control.
+        root.acknowledgedIds = root.acknowledgedIds.concat([root.controlId]).slice(-32);
+        root.retries = 0;
+        root.detail = root.result.detail;
+        root.acknowledged(root.controlId);
+        // Another client can admit or finish its operation after the helper
+        // clears our handoff but before that helper exits. Do not drop a newer
+        // snapshot received while the acknowledgment process was still owned.
+        Qt.callLater(function() {
+            if (root.snapshotActive !== null || root.handoff !== null)
+                root.acceptSnapshot(root.snapshotActive, root.handoff);
+        });
+    }
+
+    Timer { id: retryTimer; repeat: false; onTriggered: root.requestSnapshot() }
+    Timer {
+        id: controlDeadline
+        interval: 10000
+        repeat: false
+        onTriggered: {
+            root.controlInvalid = true;
+            if (ackProcess.running) ackProcess.signal(9);
+        }
+    }
+
+    Process {
+        id: watchProcess
+        stdout: StdioCollector { waitForEnd: false; onDataChanged: root.consume(data) }
+        stderr: StdioCollector {
+            waitForEnd: false
+            onDataChanged: {
+                if (root.streamOwned && data.byteLength > 8192) {
+                    Protocol.fail(root.parser, "Operation error output exceeded its limit");
+                    watchProcess.signal(9);
+                }
+            }
+        }
+        onExited: (exitCode, exitStatus) => root.finishWatch(exitCode, exitStatus === 0)
+        // FailedToStart has no exited signal. Normal exits finalize ownership
+        // above BEFORE runningChanged. Never read retained collector data here.
+        onRunningChanged: { if (!running && root.streamOwned) root.finishWatch(-1, false); }
+    }
+    Process {
+        id: ackProcess
+        stdout: StdioCollector {
+            waitForEnd: false
+            onDataChanged: {
+                if (root.controlOwned && data.byteLength > 0) {
+                    root.controlInvalid = true;
+                    if (data.byteLength > 8192) ackProcess.signal(9);
+                }
+            }
+        }
+        stderr: StdioCollector {
+            waitForEnd: false
+            onDataChanged: {
+                if (root.controlOwned && data.byteLength > 8192) {
+                    root.controlInvalid = true;
+                    ackProcess.signal(9);
+                }
+            }
+        }
+        onExited: (exitCode, exitStatus) => root.finishAcknowledgment(exitCode, exitStatus === 0)
+        onRunningChanged: { if (!running && root.controlOwned) root.finishAcknowledgment(-1, false); }
+    }
+}

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -103,8 +103,32 @@ supply an ID, the command instead returns 1 without a stream and with fixed
 recovery guidance. Once an admission write may have started or output has been
 attempted, a failure never falls back to that rejected-request stream. It
 returns 1 with recovery guidance and leaves the actual journal for observation.
-Settings mutation actions remain unavailable until root-scoped confirmation,
-observation, and acknowledgment are integrated.
+The root-scoped Quickshell observer now restores active operations and terminal
+handoffs from a finite startup snapshot, retains a sole exact-ID watch across
+Settings closure, and acknowledges only a fully validated matching result.
+Stream parsing consumes each run's raw-byte notifications; process completion
+never reuses output retained by an earlier collector run. Terminal text is
+provisional until audit, completion, and normal exit pass. Malformed observers
+are terminated without canceling the PackageKit transaction. Three delayed
+snapshot-and-watch retries use one, two, and four seconds; exhaustion and failed
+acknowledgment retain explicit reload guidance. Pane-only reads still stop when
+Settings closes, while required recovery reads continue. Settings mutation
+actions remain unavailable until originating execution, confirmation,
+cancellation, and event-driven discovery invalidation are integrated.
+An identity-free snapshot establishes an empty journal only when recovery is
+available. Incomplete journal evidence retains the readable snapshot and takes
+the same bounded recovery path; it cannot silently abandon an unknown owner.
+An exact validated active identity or handoff remains usable when unrelated
+restart or session evidence is partial.
+Snapshots received while acknowledgment is in flight retain any newer active
+identity or handoff. The root resumes observation after that control exits,
+without clearing a different operation's handoff or overlapping live streams.
+Opening or explicitly refreshing Settings during recovery may replace its
+backoff with an immediate read, but that replacement remains required recovery
+work. Closing the pane cannot cancel it and strand the operation.
+The root retains the last 32 successful acknowledgment identities in memory,
+matching the journal's retention bound. A delayed snapshot cannot resurrect
+their active/handoff cards or send an acknowledgment that already succeeded.
 
 `OPERATION_ID` must exactly match the `op-` prefix followed by 32 lowercase
 hexadecimal digits emitted for the currently visible operation. The provider

--- a/tests/fixtures/system-operation-provider.py
+++ b/tests/fixtures/system-operation-provider.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python3
+"""Private Quickshell protocol fixtures. Never opens a service or host journal."""
+
+import os
+from pathlib import Path
+import sys
+import time
+
+
+def row(*fields):
+    print("\t".join(fields), flush=True)
+
+
+def snapshot():
+    incomplete = os.environ.get("DWM_OWNER_INCOMPLETE_RECOVERY") == "1"
+    close_retry = os.environ.get("DWM_OWNER_CLOSE_RETRY") == "1"
+    delayed_snapshot = os.environ.get("DWM_OWNER_DELAYED_SNAPSHOT") == "1"
+    captured_handoff = False
+    if delayed_snapshot:
+        directory = Path(os.environ["DWM_OPERATION_FIXTURE"])
+        counter = directory / "delayed-snapshots"
+        count = int(counter.read_text()) + 1 if counter.exists() else 1
+        counter.write_text(str(count))
+        captured_handoff = not (directory / "ack-operation-16").exists()
+        if count > 1:
+            time.sleep(1)
+    if close_retry:
+        counter = Path(os.environ["DWM_OPERATION_FIXTURE"]) / "retry-snapshots"
+        count = int(counter.read_text()) + 1 if counter.exists() else 1
+        counter.write_text(str(count))
+        if count > 1:
+            time.sleep(0.2)
+    row("system-management-protocol", "1", "0")
+    row("snapshot-generation", "a" * 64)
+    row("provider", "updates", "unsupported", "delegated", "PackageKit", "Isolated fixture")
+    row("provider", "recovery", "partial" if incomplete or os.environ.get("DWM_OPERATION_FIXTURE") else "available",
+        "user-session", "dwm-system-management", "Isolated fixture")
+    for name in ("update-summary", "update-last-refresh", "update-restart"):
+        row("state", name, "unsupported", "unknown", "Isolated fixture")
+    for action in ("updates-refresh", "updates-install-all", "updates-cancel"):
+        row("action", action, "unavailable", "delegated", "updates", action, "Isolated fixture")
+    fixture = os.environ.get("DWM_OPERATION_FIXTURE")
+    if incomplete:
+        directory = Path(fixture)
+        counter = directory / "incomplete-snapshots"
+        counter.write_text(str(int(counter.read_text()) + 1 if counter.exists() else 1))
+        row("error", "recovery", "malformed", "Transient journal read failure")
+    elif delayed_snapshot:
+        if captured_handoff:
+            row("terminal-handoff", f"op-{16:032x}", "updates-refresh", "refresh")
+    elif fixture:
+        directory = Path(fixture)
+        scenario = 15 if close_retry else 10
+        operation_id = f"op-{scenario:032x}"
+        if not (directory / f"ack-operation-{scenario}").exists():
+            if (directory / f"finished-{scenario}").exists():
+                row("terminal-handoff", operation_id, "updates-refresh", "refresh")
+            else:
+                row("active-operation", operation_id, "updates-refresh", "refresh",
+                    "running", "30", "no", "Restored fixture")
+    row("complete", "snapshot")
+
+
+def main():
+    if sys.argv[1:] == ["snapshot"]:
+        snapshot()
+        return 0
+    if len(sys.argv) != 3 or sys.argv[1] not in ("watch-operation", "ack-operation"):
+        return 2
+    operation_id = sys.argv[2]
+    scenario = int(operation_id[-2:], 16)
+    directory = Path(os.environ["DWM_OPERATION_FIXTURE"])
+    counter = directory / (sys.argv[1] + "-" + str(scenario))
+    count = int(counter.read_text()) + 1 if counter.exists() else 1
+    counter.write_text(str(count))
+    if sys.argv[1] == "ack-operation":
+        if scenario == 16 and count > 1:
+            return 3  # The real provider rejects an already cleared handoff.
+        if scenario in (12, 13):
+            time.sleep(0.15)  # Snapshot can arrive after ack commits but before EOF.
+        if scenario == 4:
+            return 3
+        if scenario == 9:
+            print("unexpected control output")
+        return 0
+    if scenario == 1 and count > 1:
+        return 0  # Same-ID empty second run must not reuse collector data.
+    if scenario == 3:
+        return 3
+    if scenario == 15 and count == 1:
+        return 3
+    if scenario == 8:
+        sys.stderr.write("x" * 9000)
+        sys.stderr.flush()
+        time.sleep(5)
+        return 0
+    action = "timezone-set" if scenario == 2 else "updates-refresh"
+    kind = "timezone" if scenario == 2 else "refresh"
+    row("system-management-protocol", "1", "0")
+    row("operation", operation_id, action, kind, "pending", "unknown", "no", "Pending fixture")
+    time.sleep(0.1)
+    if scenario == 7:
+        sys.stdout.buffer.write(b"future\t\xe2\x82")
+        sys.stdout.buffer.flush()
+        return 0
+    result = "permission-denied" if scenario == 2 else "succeeded"
+    row("operation", operation_id, action, kind,
+        "authorizing" if scenario == 2 else "running", "50", "no", "Live fixture")
+    if scenario in (10, 15):
+        (directory / f"finished-{scenario}").write_text("terminal")
+    row("operation", operation_id, action, kind, result, "100", "no", "Terminal fixture")
+    row("audit", operation_id, action, kind, result,
+        "2026-09-05T12:00:00Z", "2026-09-05T12:01:00Z", "Audit fixture")
+    row("complete", "operation")
+    time.sleep(0.1)  # Valid terminal text remains provisional until process exit.
+    if scenario == 5:
+        row("future", "after completion")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/qml/SystemOperationHandoff.qml
+++ b/tests/qml/SystemOperationHandoff.qml
@@ -1,0 +1,71 @@
+import QtQuick
+import Quickshell
+import qs.systemmanagement
+
+ShellRoot {
+    id: root
+    property int assertions: 0
+    property int acknowledgments: 0
+    property int snapshots: 0
+    property var first: target(12)
+    property var second: target(13)
+    property var third: target(14)
+
+    function target(value) {
+        return { id: "op-" + value.toString(16).padStart(32, "0"),
+            actionId: "updates-refresh", kind: "refresh", state: "running",
+            percent: "30", cancelable: false, detail: "Concurrent fixture" };
+    }
+
+    function check(condition, detail) {
+        root.assertions++;
+        if (!condition) {
+            console.error("Operation handoff FAILED: " + detail);
+            Qt.callLater(function() { Qt.quit(); });
+            throw new Error(detail);
+        }
+    }
+
+    SystemOperationModel {
+        id: model
+        onStateChanged: {
+            if (state === "acknowledging" && controlId !== root.third.id) snapshotTimer.restart();
+        }
+        onSnapshotRequested: {
+            root.snapshots++;
+            root.check(result.id === root.second.id && root.acknowledgments === 1,
+                "Only the newly active owner needs a fresh handoff snapshot");
+            model.acceptSnapshot(null, root.second);
+        }
+        onAcknowledged: operationId => {
+            const expected = [root.first.id, root.second.id, root.third.id][root.acknowledgments++];
+            root.check(operationId === expected, "New owners must be observed and acknowledged in order");
+            root.check(result.id === operationId, "Ack must retain the exact verified result");
+            if (root.acknowledgments === 3) {
+                root.check(root.snapshots === 1, "Retained handoff replay needs no redundant snapshot");
+                const latest = model.result;
+                model.acceptSnapshot(null, root.first);
+                root.check(!model.controlOwned && model.handoff === null, "Late handoff cannot acknowledge twice");
+                model.acceptSnapshot(root.second, null);
+                root.check(!model.streamOwned && model.snapshotActive === null, "Late active row cannot resurrect progress");
+                root.check(model.result === latest && !model.blocked, "Late snapshots preserve the latest verified result");
+                root.check(model.acknowledgedIds.length === 3, "Successful acknowledgment identities are retained");
+                console.info("Operation handoff native tests: PASS (" + root.assertions + " assertions)");
+                Qt.quit();
+            }
+        }
+    }
+
+    Timer {
+        id: snapshotTimer
+        interval: 20
+        onTriggered: {
+            root.check(model.controlOwned && !model.streamOwned, "One acknowledgment owns the control channel");
+            if (model.controlId === root.first.id) model.acceptSnapshot(root.second, null);
+            else model.acceptSnapshot(null, root.third);
+            root.check(!model.streamOwned, "A new watcher must wait for the old acknowledgment exit");
+        }
+    }
+    Component.onCompleted: Qt.callLater(function() { model.acceptSnapshot(null, root.first); })
+    Timer { interval: 5000; running: true; onTriggered: root.check(false, "Deferred snapshot was lost") }
+}

--- a/tests/qml/SystemOperationOwner.qml
+++ b/tests/qml/SystemOperationOwner.qml
@@ -1,0 +1,251 @@
+import QtQuick
+import Quickshell
+import qs.systemmanagement
+
+ShellRoot {
+    id: root
+    property int scenario: 0
+    property int assertions: 0
+    property int snapshotRequests: 0
+    property bool sawProgress: false
+    property bool sawVerifying: false
+    property bool emptyReplay: false
+    property var target: null
+    property var integrated: null
+    property bool reloaded: false
+    property bool failedStart: Quickshell.env("DWM_OWNER_FAILED_START") === "1"
+    property bool incompleteRecovery: Quickshell.env("DWM_OWNER_INCOMPLETE_RECOVERY") === "1"
+    property bool closeRetry: Quickshell.env("DWM_OWNER_CLOSE_RETRY") === "1"
+    property bool closedDuringRetry: false
+    property bool delayedSnapshot: Quickshell.env("DWM_OWNER_DELAYED_SNAPSHOT") === "1"
+    property bool lateSnapshotOpened: false
+    property bool sawLateAck: false
+    property bool completed: false
+
+    function check(condition, detail) {
+        root.assertions++;
+        if (!condition) {
+            console.error("Operation owner FAILED: " + detail);
+            Qt.callLater(function() { Qt.quit(); });
+            throw new Error(detail);
+        }
+    }
+
+    function next() {
+        if (root.scenario === 9) {
+            root.integrated = integratedComponent.createObject(root);
+            return;
+        }
+        root.scenario++;
+        root.snapshotRequests = 0;
+        root.sawProgress = false;
+        root.sawVerifying = false;
+        root.emptyReplay = false;
+        root.target = { id: "op-" + root.scenario.toString(16).padStart(32, "0"),
+            actionId: root.scenario === 2 ? "timezone-set" : "updates-refresh",
+            kind: root.scenario === 2 ? "timezone" : "refresh" };
+        model.resetRecovery();
+        model.result = null;
+        model.acceptSnapshot(root.scenario === 6 ? root.target : null,
+            root.scenario === 6 ? null : root.target);
+        const parser = model.parser;
+        model.acceptSnapshot(null, root.scenario === 6 ? null : root.target);
+        root.check(model.parser === parser, "Repeated snapshot must not replace owned stream");
+    }
+
+    SystemOperationModel {
+        id: model
+        onSnapshotRequested: {
+            root.snapshotRequests++;
+            if (root.scenario === 6) {
+                root.check(model.result !== null, "Active watch must validate result before handoff read");
+                model.acceptSnapshot(null, root.target);
+            } else {
+                model.acceptSnapshot(root.emptyReplay ? root.target : null,
+                    root.emptyReplay ? null : root.target);
+            }
+        }
+        onProgressChanged: {
+            if (progress !== null) root.sawProgress = true;
+        }
+        onStateChanged: {
+            if (state === "verifying") {
+                root.sawVerifying = true;
+                root.check(!controlOwned, "Cannot acknowledge provisional terminal text");
+                if (!root.emptyReplay) root.check(result === null, "Cannot publish provisional success");
+            }
+            if (state === "failure") Qt.callLater(root.finishFailure);
+        }
+        onBlockedChanged: {
+            if (blocked && (root.scenario === 4 || root.scenario === 9))
+                Qt.callLater(root.finishControlFailure);
+        }
+        onAcknowledged: operationId => {
+            root.check(operationId === root.target.id, "Acknowledgment must name exact validated identity");
+            root.check(root.sawProgress && root.sawVerifying, "Stream progress must arrive before exit");
+            root.check(result.state === (root.scenario === 2 ? "permission-denied" : "succeeded"),
+                "Replay exit zero must accept failed results without relabeling success");
+            root.check(!busy && !blocked, "Acknowledgment must return to idle ownership");
+            if (root.scenario === 6) root.check(root.snapshotRequests === 1, "One handoff reconciliation read");
+            if (root.scenario === 1 && !root.emptyReplay) {
+                root.emptyReplay = true;
+                const previousResult = model.result;
+                Qt.callLater(function() {
+                    // Exercise collector reuse independently of the separate
+                    // acknowledged-identity filter (covered by handoff tests).
+                    model.acknowledgedIds = [];
+                    model.result = null;
+                    model.acceptSnapshot(root.target, null);
+                    model.result = previousResult;
+                });
+            } else Qt.callLater(root.next);
+        }
+    }
+
+    function finishFailure() {
+        if (root.completed || (root.failedStart && !root.integrated.operation.blocked)) return;
+        root.check(model.blocked && !model.busy, "Exhausted recovery must stop all automatic work");
+        root.check(root.snapshotRequests === 3 && model.retries === 3, "Exactly three bounded recovery reads");
+        if (root.failedStart) {
+            root.check(root.integrated.operation.blocked && !root.integrated.busy,
+                "Snapshot FailedToStart also exhausts bounded recovery without stale output");
+            root.complete();
+            return;
+        }
+        if (root.emptyReplay) root.check(model.result !== null, "Previous verified result remains visible");
+        else root.check(model.result === null, "Malformed or missing output cannot publish a result");
+        root.check(model.detail.indexOf("reload status") >= 0, "Exhaustion has explicit recovery guidance");
+        Qt.callLater(root.next);
+    }
+
+    function finishControlFailure() {
+        root.check(model.result !== null && model.handoff !== null, "Failed ack retains result and handoff");
+        root.check(!model.busy && root.snapshotRequests === 0, "Ack failure cannot loop automatically");
+        Qt.callLater(root.next);
+    }
+
+    function complete() {
+        if (root.completed) return;
+        root.completed = true;
+        console.info("Operation owner native tests: PASS (" + root.assertions + " assertions)");
+        Qt.quit();
+    }
+
+    Component { id: integratedComponent; SystemManagementModel {} }
+    Connections {
+        target: root.integrated
+        function onSnapshotStateChanged() {
+            if (root.delayedSnapshot && root.sawLateAck && root.integrated.snapshotState === "ready") {
+                Qt.callLater(function() {
+                    root.check(root.integrated.terminalHandoff === null && root.integrated.activeOperation === null,
+                        "Delayed snapshot cannot restore acknowledged UI state");
+                    root.check(!root.integrated.operation.controlOwned && !root.integrated.operation.blocked,
+                        "Delayed snapshot cannot send a redundant acknowledgment or show failure");
+                    root.check(root.integrated.operation.state === "result", "Verified result survives delayed discovery");
+                    root.complete();
+                });
+            }
+        }
+    }
+    Connections {
+        target: root.integrated === null ? null : root.integrated.operation
+        function onStateChanged() {
+            if (root.delayedSnapshot) {
+                if (root.integrated.operation.state === "observing" && !root.lateSnapshotOpened) {
+                    root.lateSnapshotOpened = true;
+                    lateSnapshotTimer.start();
+                }
+                return;
+            }
+            if (root.incompleteRecovery && root.integrated.operation.blocked) {
+                root.check(root.integrated.operation.retries === 3, "Incomplete recovery exhausts exactly three retries");
+                root.check(root.integrated.generation.length === 64 && root.integrated.errors.length === 1,
+                    "Incomplete recovery preserves the readable snapshot and diagnostic");
+                root.check(root.integrated.recoveryProvider.status === "partial", "Incomplete recovery stays visible");
+                root.check(root.integrated.operation.result === null, "Incomplete recovery never fabricates completion");
+                root.complete();
+                return;
+            }
+            if (root.closeRetry) {
+                if (root.integrated.operation.state === "recovering" && !root.closedDuringRetry) {
+                    root.closedDuringRetry = true;
+                    closeRetryTimer.start();
+                }
+                return;
+            }
+            if (root.integrated.operation.state === "observing") {
+                root.check(!root.integrated.settingsVisible, "Startup recovery works before Settings opens");
+                if (root.reloaded) {
+                    root.integrated.openSettings();
+                    root.integrated.closeSettings();
+                    root.check(root.integrated.operation.streamOwned, "Pane closure preserves the root watcher");
+                }
+            }
+            if (root.failedStart && root.integrated.operation.blocked && model.blocked)
+                Qt.callLater(root.finishFailure);
+        }
+        function onProgressChanged() {
+            if (root.closeRetry || root.delayedSnapshot) return;
+            if (!root.reloaded && root.integrated.operation.progress !== null
+                    && root.integrated.operation.progress.state === "pending") reloadTimer.start();
+        }
+        function onAcknowledged(operationId) {
+            if (root.delayedSnapshot) {
+                root.check(!root.sawLateAck, "The committed handoff is acknowledged exactly once");
+                root.sawLateAck = true;
+                return;
+            }
+            if (root.closeRetry) {
+                root.check(root.closedDuringRetry && !root.integrated.settingsVisible,
+                    "Recovery continues after opening and closing during backoff");
+                root.check(root.integrated.operation.result.id === operationId
+                    && root.integrated.operation.result.state === "succeeded", "Recovered result is exact");
+                root.complete();
+                return;
+            }
+            root.check(root.reloaded, "Reload must adopt the persisted operation");
+            root.check(!root.integrated.settingsVisible, "Result is acknowledged while Settings remains closed");
+            root.check(root.integrated.operation.result.id === operationId, "Integrated result is exact");
+            root.complete();
+        }
+    }
+    Timer {
+        id: lateSnapshotTimer
+        interval: 10
+        onTriggered: root.integrated.openSettings()
+    }
+    Timer {
+        id: closeRetryTimer
+        interval: 0
+        onTriggered: {
+            root.integrated.openSettings();
+            root.integrated.closeSettings();
+            root.check(root.integrated.snapshotOwned && root.integrated.snapshotRequired,
+                "Replacing a scheduled retry retains required snapshot ownership");
+            root.check(root.integrated.operation.waitingSnapshot, "Recovery still waits for the required read");
+        }
+    }
+    Timer {
+        id: reloadTimer
+        interval: 0
+        onTriggered: {
+            root.check(root.integrated.operation.streamOwned, "Reload interrupts a live observer");
+            root.integrated.destroy();
+            root.integrated = null;
+            root.reloaded = true;
+            Qt.callLater(function() { root.integrated = integratedComponent.createObject(root); });
+        }
+    }
+    Component.onCompleted: Qt.callLater(function() {
+        if (root.incompleteRecovery || root.closeRetry || root.delayedSnapshot) {
+            root.integrated = integratedComponent.createObject(root);
+            return;
+        }
+        if (root.failedStart) {
+            root.integrated = integratedComponent.createObject(root);
+            root.scenario = 2;
+        }
+        root.next();
+    })
+    Timer { interval: 55000; running: true; onTriggered: root.check(false, "Fixture timed out") }
+}

--- a/tests/test-quickshell-health-xvfb.sh
+++ b/tests/test-quickshell-health-xvfb.sh
@@ -32,6 +32,8 @@ data_home=$home/.local/share
 mkdir -p "$config_home/quickshell" "$config_home/dwm-titus" "$data_home/dwm-titus/scripts" "$runtime"
 chmod 700 "$runtime"
 cp -a "$repo/config/quickshell/." "$config_home/quickshell/"
+cp "$repo/tests/fixtures/system-operation-provider.py" "$data_home/dwm-titus/scripts/dwm-system-management"
+chmod +x "$data_home/dwm-titus/scripts/dwm-system-management"
 cp "$repo/config/"*.toml "$config_home/dwm-titus/"
 # Simulate an existing preserved rule file. The generic control-center title
 # rule must also cover the newly added utility window.

--- a/tests/test-quickshell-large-surfaces-xvfb.sh
+++ b/tests/test-quickshell-large-surfaces-xvfb.sh
@@ -27,6 +27,7 @@ if [ "$(id -u)" -eq 0 ] && [ "${DWM_LARGE_SURFACE_UNPRIVILEGED:-0}" != 1 ]; then
 	cp -a "$test_repo/config" "$test_repo/scripts" "$fixture_repo/"
 	cp "$test_repo/dwm" "$fixture_repo/dwm"
 	cp "$0" "$fixture_repo/tests/test-quickshell-large-surfaces-xvfb.sh"
+	cp -a "$test_repo/tests/fixtures" "$fixture_repo/tests/"
 	chown -R "$unprivileged_uid:$unprivileged_gid" "$root_runner_work"
 	chmod 700 "$fixture_repo/dwm" "$root_runner_work/runtime"
 	if HOME="$root_runner_work" TMPDIR="$root_runner_work" \
@@ -98,6 +99,8 @@ if [ "${#runtime}" -gt 64 ]; then
 	runtime=$runtime_alias_dir/runtime
 fi
 cp -a "$repo/config/quickshell/." "$config_home/quickshell/"
+cp "$repo/tests/fixtures/system-operation-provider.py" "$data_home/dwm-titus/scripts/dwm-system-management"
+chmod +x "$data_home/dwm-titus/scripts/dwm-system-management"
 cp "$repo/config/"*.toml "$config_home/dwm-titus/"
 cp "$repo/scripts/dwm-settings-provider" "$repo/scripts/dwm-system-health" \
 	"$repo/scripts/dwm-settings-display" "$repo/scripts/dwm-settings-input" \

--- a/tests/test-quickshell-settings-xvfb.sh
+++ b/tests/test-quickshell-settings-xvfb.sh
@@ -33,6 +33,7 @@ if [ "$(id -u)" -eq 0 ] && [ "${DWM_SETTINGS_XVFB_UNPRIVILEGED:-0}" != 1 ]; then
 	cp -a "$repo/config" "$repo/scripts" "$fixture_repo/"
 	cp "$repo/dwm" "$fixture_repo/dwm"
 	cp "$0" "$fixture_repo/tests/test-quickshell-settings-xvfb.sh"
+	cp -a "$repo/tests/fixtures" "$fixture_repo/tests/"
 	chown -R "$unprivileged_uid:$unprivileged_gid" "$root_runner_work"
 	chmod 700 "$fixture_repo/dwm" "$root_runner_work/runtime"
 	if HOME="$root_runner_work" TMPDIR="$root_runner_work" \
@@ -329,6 +330,8 @@ glib-compile-schemas "$schema_dir"
 export GSETTINGS_SCHEMA_DIR="$schema_dir"
 export GSETTINGS_BACKEND=keyfile
 cp -a "$repo/config/quickshell/." "$config_home/quickshell/"
+cp "$repo/tests/fixtures/system-operation-provider.py" "$data_home/dwm-titus/scripts/dwm-system-management"
+chmod +x "$data_home/dwm-titus/scripts/dwm-system-management"
 cp "$repo/config/quickshell/assets/ctt_logo.png" "$home/Pictures/backgrounds/test-wallpaper.png"
 # Keep this nested-X11 fixture independent from the host system UPower service
 # so versioned helper battery records exercise the fallback parser.

--- a/tests/test-quickshell-system-management-xvfb.sh
+++ b/tests/test-quickshell-system-management-xvfb.sh
@@ -82,16 +82,39 @@ cat >"$helper" <<'HELPER'
 #!/bin/sh
 set -eu
 
-[ "${1:-}" = snapshot ] || exit 2
 fixture=${DWM_SYSTEM_MANAGEMENT_TEST_FIXTURE:?}
 mode=$(sed -n '1p' "$fixture/mode")
+case ${1:-} in
+watch-operation | ack-operation)
+	case ${2:-} in
+	op-11111111111111111111111111111111) action=timezone-set; kind=timezone ;;
+	op-22222222222222222222222222222222) action=updates-refresh; kind=refresh ;;
+	*) exit 3 ;;
+	esac
+	if [ "$1" = ack-operation ]; then
+		: >"$fixture/ack-$2"
+		exit 0
+	fi
+	printf 'system-management-protocol\t1\t0\n'
+	printf 'operation\t%s\t%s\t%s\tpending\tunknown\tno\tRestoring operation\n' "$2" "$action" "$kind"
+	printf 'operation\t%s\t%s\t%s\trunning\t50\tno\tObserving operation\n' "$2" "$action" "$kind"
+	sleep 0.1
+	: >"$fixture/finished-$2"
+	printf 'operation\t%s\t%s\t%s\tsucceeded\t100\tno\tVerified fixture result\n' "$2" "$action" "$kind"
+	printf 'audit\t%s\t%s\t%s\tsucceeded\t2026-09-05T12:00:00Z\t2026-09-05T12:01:00Z\tFixture result\n' "$2" "$action" "$kind"
+	printf 'complete\toperation\n'
+	exit 0
+	;;
+snapshot) ;;
+*) exit 2 ;;
+esac
 
 snapshot() {
 	printf '%b\n' \
 		'system-management-protocol	1	0' \
 		'snapshot-generation	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' \
 		'provider	updates	partial	delegated	PackageKit	Read-only update state' \
-		'provider	recovery	unsupported	user-session	dwm-system-management	Recovery unavailable' \
+		'provider	recovery	available	user-session	dwm-system-management	Isolated journal recovery' \
 		'state	update-summary	available	1	One update' \
 		'state	update-last-refresh	available	10	Recently refreshed' \
 		'state	update-restart	available	system	Restart required' \
@@ -121,12 +144,22 @@ partial-restart)
 	snapshot | sed 's/state\tupdate-restart\tavailable\tsystem/state\tupdate-restart\tpartial\tsecurity-session/'
 	;;
 cancelable-active)
-	snapshot | sed \
-		-e 's/action\tupdates-cancel\tunavailable/action\tupdates-cancel\tavailable/' \
-		-e '/^complete\t/i\active-operation\top-11111111111111111111111111111111\tupdates-refresh\trefresh\trunning\t45\tyes\tCancelable fixture'
+	if [ -f "$fixture/ack-op-22222222222222222222222222222222" ]; then
+		snapshot
+	elif [ -f "$fixture/finished-op-22222222222222222222222222222222" ]; then
+		snapshot | sed '/^complete\t/i\terminal-handoff\top-22222222222222222222222222222222\tupdates-refresh\trefresh'
+	else
+		snapshot | sed \
+			-e 's/action\tupdates-cancel\tunavailable/action\tupdates-cancel\tavailable/' \
+			-e '/^complete\t/i\active-operation\top-22222222222222222222222222222222\tupdates-refresh\trefresh\trunning\t45\tyes\tCancelable fixture'
+	fi
 	;;
 regional-handoff)
-	snapshot | sed '/^complete\t/i\terminal-handoff\top-11111111111111111111111111111111\ttimezone-set\ttimezone'
+	if [ -f "$fixture/ack-op-11111111111111111111111111111111" ]; then
+		snapshot
+	else
+		snapshot | sed '/^complete\t/i\terminal-handoff\top-11111111111111111111111111111111\ttimezone-set\ttimezone'
+	fi
 	;;
 invalid-handoff)
 	snapshot | sed '/^complete\t/i\terminal-handoff\top-11111111111111111111111111111111\ttimezone-set\tdelegate'
@@ -257,6 +290,125 @@ if ! grep -F 'Operation parser native tests: PASS' "$work/operation-parser.log";
 	exit 1
 fi
 
+# Exercise the real root-owned Process lifecycle with a private fixed helper.
+mkdir -p "$work/operation-owner" "$work/owner-data/dwm-titus/scripts" "$work/owner-state"
+cp -a "$repo/config/quickshell/core" "$repo/config/quickshell/systemmanagement" "$work/operation-owner/"
+cp "$repo/tests/qml/SystemOperationOwner.qml" "$work/operation-owner/shell.qml"
+cp "$repo/tests/fixtures/system-operation-provider.py" "$work/owner-data/dwm-titus/scripts/dwm-system-management"
+chmod +x "$work/owner-data/dwm-titus/scripts/dwm-system-management"
+timeout --foreground --kill-after=2s 60s env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
+	XDG_DATA_HOME="$work/owner-data" XDG_RUNTIME_DIR="$runtime" QT_QPA_PLATFORMTHEME= \
+	DWM_OPERATION_FIXTURE="$work/owner-state" \
+	quickshell --no-duplicate --path "$work/operation-owner/shell.qml" \
+	>"$work/operation-owner.log" 2>&1 &
+quickshell_pid=$!
+owner_status=0
+wait "$quickshell_pid" || owner_status=$?
+quickshell_pid=
+if [ "$owner_status" -ne 0 ]; then
+	cat "$work/operation-owner.log" >&2
+	exit "$owner_status"
+fi
+if ! grep -F 'Operation owner native tests: PASS' "$work/operation-owner.log" || grep -Fq 'Operation owner FAILED:' "$work/operation-owner.log"; then
+	cat "$work/operation-owner.log" >&2
+	exit 1
+fi
+[ "$(sed -n '1p' "$work/owner-state/watch-operation-10")" -eq 2 ]
+[ "$(sed -n '1p' "$work/owner-state/ack-operation-10")" -eq 1 ]
+quickshell_binary=$(command -v quickshell)
+timeout --foreground --kill-after=2s 15s env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
+	XDG_DATA_HOME="$work/owner-data" XDG_RUNTIME_DIR="$runtime" QT_QPA_PLATFORMTHEME= \
+	DWM_OWNER_FAILED_START=1 PATH="$work/no-executables" \
+	"$quickshell_binary" --no-duplicate --path "$work/operation-owner/shell.qml" \
+	>"$work/operation-owner-start-failure.log" 2>&1 &
+quickshell_pid=$!
+owner_status=0
+wait "$quickshell_pid" || owner_status=$?
+quickshell_pid=
+if [ "$owner_status" -ne 0 ]; then
+	cat "$work/operation-owner-start-failure.log" >&2
+	exit "$owner_status"
+fi
+if ! grep -F 'Operation owner native tests: PASS' "$work/operation-owner-start-failure.log" || grep -Fq 'Operation owner FAILED:' "$work/operation-owner-start-failure.log"; then
+	cat "$work/operation-owner-start-failure.log" >&2
+	exit 1
+fi
+timeout --foreground --kill-after=2s 15s env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
+	XDG_DATA_HOME="$work/owner-data" XDG_RUNTIME_DIR="$runtime" QT_QPA_PLATFORMTHEME= \
+	DWM_OPERATION_FIXTURE="$work/owner-state" DWM_OWNER_INCOMPLETE_RECOVERY=1 \
+	"$quickshell_binary" --no-duplicate --path "$work/operation-owner/shell.qml" \
+	>"$work/operation-owner-incomplete-recovery.log" 2>&1 &
+quickshell_pid=$!
+owner_status=0
+wait "$quickshell_pid" || owner_status=$?
+quickshell_pid=
+if [ "$owner_status" -ne 0 ]; then
+	cat "$work/operation-owner-incomplete-recovery.log" >&2
+	exit "$owner_status"
+fi
+if ! grep -F 'Operation owner native tests: PASS' "$work/operation-owner-incomplete-recovery.log" || grep -Fq 'Operation owner FAILED:' "$work/operation-owner-incomplete-recovery.log"; then
+	cat "$work/operation-owner-incomplete-recovery.log" >&2
+	exit 1
+fi
+[ "$(sed -n '1p' "$work/owner-state/incomplete-snapshots")" -eq 4 ]
+timeout --foreground --kill-after=2s 15s env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
+	XDG_DATA_HOME="$work/owner-data" XDG_RUNTIME_DIR="$runtime" QT_QPA_PLATFORMTHEME= \
+	DWM_OPERATION_FIXTURE="$work/owner-state" DWM_OWNER_CLOSE_RETRY=1 \
+	"$quickshell_binary" --no-duplicate --path "$work/operation-owner/shell.qml" \
+	>"$work/operation-owner-close-retry.log" 2>&1 &
+quickshell_pid=$!
+owner_status=0
+wait "$quickshell_pid" || owner_status=$?
+quickshell_pid=
+if [ "$owner_status" -ne 0 ]; then
+	cat "$work/operation-owner-close-retry.log" >&2
+	exit "$owner_status"
+fi
+if ! grep -F 'Operation owner native tests: PASS' "$work/operation-owner-close-retry.log" || grep -Fq 'Operation owner FAILED:' "$work/operation-owner-close-retry.log"; then
+	cat "$work/operation-owner-close-retry.log" >&2
+	exit 1
+fi
+[ "$(sed -n '1p' "$work/owner-state/retry-snapshots")" -eq 3 ]
+[ "$(sed -n '1p' "$work/owner-state/watch-operation-15")" -eq 2 ]
+[ "$(sed -n '1p' "$work/owner-state/ack-operation-15")" -eq 1 ]
+timeout --foreground --kill-after=2s 15s env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
+	XDG_DATA_HOME="$work/owner-data" XDG_RUNTIME_DIR="$runtime" QT_QPA_PLATFORMTHEME= \
+	DWM_OPERATION_FIXTURE="$work/owner-state" DWM_OWNER_DELAYED_SNAPSHOT=1 \
+	"$quickshell_binary" --no-duplicate --path "$work/operation-owner/shell.qml" \
+	>"$work/operation-owner-delayed-snapshot.log" 2>&1 &
+quickshell_pid=$!
+owner_status=0
+wait "$quickshell_pid" || owner_status=$?
+quickshell_pid=
+if [ "$owner_status" -ne 0 ]; then
+	cat "$work/operation-owner-delayed-snapshot.log" >&2
+	exit "$owner_status"
+fi
+if ! grep -F 'Operation owner native tests: PASS' "$work/operation-owner-delayed-snapshot.log" || grep -Fq 'Operation owner FAILED:' "$work/operation-owner-delayed-snapshot.log"; then
+	cat "$work/operation-owner-delayed-snapshot.log" >&2
+	exit 1
+fi
+[ "$(sed -n '1p' "$work/owner-state/delayed-snapshots")" -eq 2 ]
+[ "$(sed -n '1p' "$work/owner-state/ack-operation-16")" -eq 1 ]
+cp "$repo/tests/qml/SystemOperationHandoff.qml" "$work/operation-owner/handoff.qml"
+timeout --foreground --kill-after=2s 10s env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
+	XDG_DATA_HOME="$work/owner-data" XDG_RUNTIME_DIR="$runtime" QT_QPA_PLATFORMTHEME= \
+	DWM_OPERATION_FIXTURE="$work/owner-state" \
+	"$quickshell_binary" --no-duplicate --path "$work/operation-owner/handoff.qml" \
+	>"$work/operation-handoff.log" 2>&1 &
+quickshell_pid=$!
+owner_status=0
+wait "$quickshell_pid" || owner_status=$?
+quickshell_pid=
+if [ "$owner_status" -ne 0 ]; then
+	cat "$work/operation-handoff.log" >&2
+	exit "$owner_status"
+fi
+if ! grep -F 'Operation handoff native tests: PASS' "$work/operation-handoff.log" || grep -Fq 'Operation handoff FAILED:' "$work/operation-handoff.log"; then
+	cat "$work/operation-handoff.log" >&2
+	exit 1
+fi
+
 DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
 	XDG_RUNTIME_DIR=$runtime "$repo/dwm" >"$work/dwm.log" 2>&1 &
 dwm_pid=$!
@@ -299,7 +451,8 @@ wait_state() {
 		i=$((i + 1))
 		sleep 0.05
 	done
-	printf 'System-management state did not become %s\n' "$expected" >&2
+	printf 'System-management state did not become %s (mode=%s, state=%s, operation=%s)\n' \
+		"$expected" "$(sed -n '1p' "$fixture/mode")" "$state" "$(ipc systemManagementOperationState 2>/dev/null || true)" >&2
 	tail -60 "$work/quickshell.log" >&2
 	return 1
 }
@@ -355,12 +508,31 @@ printf 'regional-handoff\n' >"$fixture/mode"
 ipc refresh >/dev/null
 wait_state ready
 [ "$(ipc systemManagementUpdateCount)" -eq 1 ]
+i=0
+while [ "$i" -lt 100 ]; do
+	[ "$(ipc systemManagementOperationState)" = result ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$(ipc systemManagementOperationResult)" = timezone-set:succeeded ]
+[ -f "$fixture/ack-op-11111111111111111111111111111111" ]
+if [ -n "${DWM_SYSTEM_MANAGEMENT_CAPTURE_DIR:-}" ]; then
+	mkdir -p -- "$DWM_SYSTEM_MANAGEMENT_CAPTURE_DIR"
+	DISPLAY=$display import -window root "$DWM_SYSTEM_MANAGEMENT_CAPTURE_DIR/verified-operation.png"
+fi
 
 printf 'cancelable-active\n' >"$fixture/mode"
 ipc refresh >/dev/null
 wait_state ready
 [ "$(ipc systemManagementUpdateCount)" -eq 1 ]
 [ -z "$(ipc systemManagementErrorCodes)" ]
+i=0
+while [ "$i" -lt 100 ]; do
+	[ -f "$fixture/ack-op-22222222222222222222222222222222" ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ -f "$fixture/ack-op-22222222222222222222222222222222" ]
 
 printf 'invalid-handoff\n' >"$fixture/mode"
 ipc refresh >/dev/null
@@ -410,6 +582,13 @@ printf 'fail-after-output\n' >"$fixture/mode"
 ipc refresh >/dev/null
 wait_state failure
 [ "$(ipc systemManagementUpdateCount)" -eq 0 ]
+
+# Finish the preceding recovery before testing cancellation of a pane-only
+# read. A replacement recovery snapshot must survive closure (tested above).
+printf 'valid\n' >"$fixture/mode"
+ipc refresh >/dev/null
+wait_state ready
+[ "$(ipc systemManagementOperationState)" = result ]
 
 printf 'delay-once\n' >"$fixture/mode"
 printf '0\n' >"$fixture/count"

--- a/tests/test-quickshell-system-management.sh
+++ b/tests/test-quickshell-system-management.sh
@@ -68,13 +68,14 @@ grep -Fq "Number(states[\"\$update-summary\"].value) !== parsedUpdates.length" "
 grep -Fq 'parsedActive !== null || parsedHandoff !== null' "$model"
 [ "$(grep -Fc 'root.updateActionKind(fields[2]).length === 0' "$model")" -eq 1 ]
 grep -Fq 'root.operationActionKind(fields[2]).length === 0' "$model"
-grep -Fq 'responseGeneration !== root.requestGeneration || !root.settingsVisible' "$model"
-grep -Fq 'if (snapshotProcess.running)' "$model"
-grep -Fq 'root.snapshotPending = true;' "$model"
-grep -Fq 'if (!running && root.snapshotPending && root.settingsVisible)' "$model"
+grep -Fq 'responseGeneration !== root.requestGeneration' "$model"
+grep -Fq 'if (root.snapshotOwned)' "$model"
+grep -Fq 'root.requiredPending = root.requiredPending || required;' "$model"
+grep -Fq 'root.snapshotPending && root.settingsVisible' "$model"
 grep -Fq 'snapshotProcess.running = false;' "$model"
-grep -Fq 'root.snapshotState === "failure"' "$model"
-grep -Fq 'root.parseSnapshot(snapshotOutput.text, snapshotProcess.generation);' "$model"
+grep -Fq 'root.snapshotState = "failure"' "$model"
+grep -Fq 'root.parseSnapshot(snapshotOutput.text, snapshotProcess.generation)' "$model"
+grep -Fq 'onExited: (exitCode, exitStatus) => root.finishSnapshot(exitCode, exitStatus === 0)' "$model"
 
 grep -Fq 'required property var systemManagementModel' "$pane"
 grep -Fq 'required property var capabilities' "$pane"
@@ -105,6 +106,7 @@ expected_pane_model_members=$(printf '%s\n' \
 	'systemManagementModel.busy' \
 	'systemManagementModel.errors' \
 	'systemManagementModel.message' \
+	'systemManagementModel.operation' \
 	'systemManagementModel.packageChanges' \
 	'systemManagementModel.providerDetail' \
 	'systemManagementModel.providerState' \


### PR DESCRIPTION
## Scope

Restore and observe journaled operations in one shell-root model. This is the next UPDATE-001 boundary after #235; it does not enable update mutations or begin another roadmap phase.

- Read a finite recovery snapshot at startup, adopt an exact active PackageKit operation or retained handoff, and preserve its sole watcher across Settings closure.
- Validate per-run raw bytes, terminal/audit/completion, and normal exit before publishing a result. Acknowledge only an exact snapshot-authorized handoff.
- Limit failed recovery to three non-overlapping attempts after 1, 2, and 4 seconds. Preserve results and actionable guidance after failure.
- Handle incomplete recovery evidence, new owners discovered during acknowledgment, opening/closing during recovery backoff, and delayed snapshots that contain already-acknowledged identities.
- Show live progress and verified results in the existing System pane. No elevation, idle polling, host package mutation, or update/cancel buttons.

## Validation

Passed on Fedora 44, Qt 6.11.2 / Quickshell 0.2.1, nested X11:

- `scripts/run-tests make check-quickshell-system-management`
- `scripts/run-tests make clean all`
- `scripts/run-tests`: 298 provider tests plus all relevant Settings, accessibility, appearance, connectivity, staged/repeated installation, dependency, static image, and release-archive gates.
- 778 native assertions: 674 parser, 72 owner, four each for failed starts/incomplete recovery/pane closure during retry/delayed snapshots, and 16 handoff-race assertions. Fixtures never fall back to host PackageKit.
- After the full gate, strengthened only the native log failure checks. A mixed PASS/FAILED fault injection was rejected; reran the affected managed native suite and `shellcheck install.sh scripts/*.sh tests/*.sh` / `shfmt -d install.sh scripts/*.sh tests/*.sh`.
- Final post-full Codex review: no actionable findings across snapshot, stream, acknowledgment, and pane lifecycle interleavings. Fresh independent CodeRabbit review: clean across all 15 files.
- Inspected the 1024x768 nested-X11 screenshot: the verified result card is legible and unclipped. Closed Settings CPU: 0.033%; power lifecycle baseline 0.100%, after 0.033%; closed large surfaces: 0.00%.

All task-owned test workspaces and the fault-injection wrapper were removed. Configured QML lint reports the installed metadata's missing `QProcess::ExitStatus` type; native fixtures verify the actual normal-exit value.

## Remaining Phase 6 work

Originating execution/confirmation, cancellation UI, PackageKit invalidation subscriptions, regional/delegated entry points, information/recovery surfaces, and combined qualification remain outstanding. Settings mutation controls remain disabled. This PR does not claim a real package update or full Phase 6 completion.