### PR TITLE
feat(system): observe PackageKit discovery changes

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -38,8 +38,10 @@ jobs:
           source scripts/dwm-packages.sh
           mapfile -t required_packages < <(dwm_packages fedora required | awk 'NF' | sort -u)
           mapfile -t qml_packages < <(dwm_packages fedora qml-validation | awk 'NF' | sort -u)
+          mapfile -t system_management_packages < <(dwm_packages fedora system-management | awk 'NF' | sort -u)
           dnf install -y --setopt=install_weak_deps=False \
             "${required_packages[@]}" "${qml_packages[@]}" \
+            "${system_management_packages[@]}" \
             diffutils dbus-daemon inotify-tools jq \
             pkgconf-pkg-config ShellCheck shfmt pykickstart \
             xorg-x11-server-Xvfb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ versions from `config.mk`.
 
 ### Added
 
+- Add a read-only PackageKit change monitor with fixed global subscriptions,
+  bounded setup, and explicit readiness. Private-bus tests verify signal
+  filtering, daemon replacement, closure, and lost output. Settings discovery
+  coalescing and confirmation invalidation remain pending integration.
+
 - Restore journaled system operations in the shell root and keep their progress
   visible across Settings closure. Verify complete terminal results before exact
   acknowledgment; retain guidance after bounded recovery or acknowledgment

--- a/TASKS.md
+++ b/TASKS.md
@@ -97,6 +97,12 @@ failed-result replay, stale collector data, restart adoption, and failed process
 starts without host service calls. Originating mutation, confirmation, and cancel
 UI integration plus event-driven discovery invalidation must be completed before
 this boundary can be accepted. Settings mutation actions remain disabled.
+The fixed `watch-updates` command now observes only global PackageKit discovery
+changes and daemon ownership changes. It establishes subscriptions before
+reporting readiness, bounds setup to ten seconds, and never starts a transaction.
+Private-bus and callback fixtures cover filtering, startup races, cleanup, and
+lost output. The pane-scoped subscriber and bounded dirty-state coalescing remain
+the next integration step; this helper alone does not invalidate Settings state.
 The preview validators now preserve requested `install` as well as `update`
 actions, matching the PackageKit DNF5 backend's discovery/simulation contract.
 Missing or duplicate requested IDs, outbound requested actions, and unrequested

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -72,6 +72,7 @@ The update command grammar is fixed:
 
 ```text
 dwm-system-management snapshot
+dwm-system-management watch-updates
 dwm-system-management watch-operation OPERATION_ID
 dwm-system-management ack-operation OPERATION_ID
 dwm-system-management updates-refresh
@@ -1462,6 +1463,42 @@ path, or elevation mechanism.
   infers that the delegated tool's internal work succeeded.
 
 ## Event and Resource Contract
+
+The implemented fixed `dwm-system-management watch-updates` command accepts no
+arguments. It subscribes to the three global PackageKit signals below and the
+bus daemon's `NameOwnerChanged` for exactly `org.freedesktop.PackageKit`. It never
+activates PackageKit, reads its properties, or creates a transaction. An
+explicit successful asynchronous `AddMatch` reply for each fixed bus match rule
+and verified `GetNameOwner` result precede the fixed
+`update-event<TAB>ready` record. Every later matching signal emits the fixed
+`update-event<TAB>changed` record; startup changes coalesce into one such record
+after readiness. Consumers must establish this monitor before their initial
+read, invalidate confirmations on every change, and apply the bounded cycle
+below, rather than launching one process per event.
+
+One ten-second monotonic deadline covers connection and all setup round trips.
+Only a verified `NameHasNoOwner` response is accepted as an absent daemon;
+lookup denial or another failure cannot report readiness. Local callbacks use
+the explicitly tracked unique sender, and an owner notification received during
+lookup takes precedence over its older result.
+Setup or bus failure and lost output exit 1 with best-effort explicit-refresh
+guidance.
+Writes are nonblocking and each fixed row fits `PIPE_BUF`; a full output pipe
+or short write stops monitoring with the same failure instead of queuing events
+or blocking signal handling. Consumers must treat any unexpected exit as lost
+monitoring and invalidate their preview. There is no userspace output backlog.
+The command restores stdout's original blocking mode on exit, preserving a
+writer retained by a calling shell group. Failure diagnostics are nonblocking
+and best-effort too, including when stderr shares a full stdout pipe; their
+original descriptor mode is restored. Exit status is authoritative when the
+diagnostic cannot be delivered.
+SIGTERM, SIGINT, or SIGHUP stop the subscriptions and exit 0. A missing PackageKit
+owner does not prevent readiness: the monitor waits for owner changes without
+activating the service, while finite discovery reports availability separately.
+There is no idle timer or automatic reconnect. This helper is an event stream,
+not a snapshot, action, journal record, or operation stream; its two exact record
+forms are independent of the cumulative snapshot minor. QML subscription and
+dirty-cycle integration remain pending.
 
 - PackageKit `UpdatesChanged` and `InstalledChanged` invalidate update
   discovery; `RepoListChanged` invalidates both repository and update discovery

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -10,6 +10,7 @@ import hashlib
 import os
 import re
 import shlex
+import signal
 import stat
 import struct
 import sys
@@ -5446,12 +5447,240 @@ def update_command(action_id: str, generation: str | None = None) -> int:
         return 1
 
 
+class UpdateEventMonitor:
+    """Read-only manager signals, with bounded setup and no transaction calls."""
+
+    def __init__(self, Gio, GLib, GLibUnix, emit: Callable[[str], None]) -> None:
+        self.Gio, self.GLib, self.GLibUnix = Gio, GLib, GLibUnix
+        self.emit = emit
+        self.loop = GLib.MainLoop()
+        self.cancellable = Gio.Cancellable()
+        self.connection = None
+        self.subscriptions: list[int] = []
+        self.match_rules: list[str] = []
+        self.installed_rules: list[str] = []
+        self.sources: list[int] = []
+        self.closed_handler = 0
+        self.deadline_source = 0
+        self.stopped = False
+        self.ready = False
+        self.dirty = False
+        self.exit_code = 1
+        self.deadline = 0.0
+        self.owner = ""
+        self.owner_epoch = 0
+
+    def stop(self, code: int) -> None:
+        if self.stopped:
+            return
+        self.stopped = True
+        self.exit_code = code
+        self.cancellable.cancel()
+        self.loop.quit()
+
+    def write(self, record: str) -> None:
+        try:
+            self.emit(record)
+        except OSError:
+            self.stop(1)
+
+    def changed(self, *_args) -> None:
+        if self.stopped:
+            return
+        if not self.ready:
+            self.dirty = True
+        else:
+            self.write("update-event\tchanged")
+
+    def global_changed(self, _connection, sender, _path, _interface, _member, _parameters, _data) -> None:
+        # The bus-side match restricts the well-known sender. Avoid GDBus's
+        # implicit name cache, whose lookup failures cannot be observed here.
+        if not self.ready or sender == self.owner:
+            self.changed()
+
+    def owner_changed(self, _connection, _sender, _path, _interface, _member, parameters, _data) -> None:
+        if self.stopped:
+            return
+        name, _old, new = parameters.unpack()
+        if name == PACKAGEKIT_NAME:
+            self.owner_epoch += 1
+            self.owner = new
+            self.changed()
+
+    def owner_resolved(self, connection, result, epoch) -> None:
+        if self.stopped:
+            return
+        if time.monotonic() >= self.deadline:
+            self.stop(1)
+            return
+        try:
+            owner = connection.call_finish(result).unpack()[0]
+        except self.GLib.Error as error:
+            if self.Gio.dbus_error_get_remote_error(error) != "org.freedesktop.DBus.Error.NameHasNoOwner":
+                self.stop(1)
+                return
+            owner = ""
+        # A newer owner notification wins over an older in-flight lookup.
+        if self.owner_epoch == epoch:
+            self.owner = owner
+        self.GLib.source_remove(self.deadline_source)
+        self.deadline_source = 0
+        self.ready = True
+        self.write("update-event\tready")
+        if self.dirty and not self.stopped:
+            self.write("update-event\tchanged")
+        self.dirty = False
+
+    def match_finished(self, connection, result, rule) -> None:
+        if self.stopped:
+            return
+        if time.monotonic() >= self.deadline:
+            self.stop(1)
+            return
+        try:
+            connection.call_finish(result)
+        except self.GLib.Error:
+            self.stop(1)
+            return
+        self.installed_rules.append(rule)
+        if len(self.installed_rules) < len(self.match_rules):
+            self.add_match()
+            return
+        self.connection.call("org.freedesktop.DBus", "/org/freedesktop/DBus",
+            "org.freedesktop.DBus", "GetNameOwner", self.GLib.Variant("(s)", (PACKAGEKIT_NAME,)),
+            self.GLib.VariantType.new("(s)"), self.Gio.DBusCallFlags.NONE,
+            10000, self.cancellable, self.owner_resolved, self.owner_epoch)
+
+    def add_match(self) -> None:
+        rule = self.match_rules[len(self.installed_rules)]
+        # NO_MATCH_RULE local subscriptions plus explicit AddMatch replies make
+        # denial observable; signal_subscribe alone cannot report bus rejection.
+        self.connection.call("org.freedesktop.DBus", "/org/freedesktop/DBus",
+            "org.freedesktop.DBus", "AddMatch", self.GLib.Variant("(s)", (rule,)),
+            self.GLib.VariantType.new("()"), self.Gio.DBusCallFlags.NONE,
+            10000, self.cancellable, self.match_finished, rule)
+
+    def connected(self, _source, result, _data) -> None:
+        if self.stopped:
+            return
+        if time.monotonic() >= self.deadline:
+            self.stop(1)
+            return
+        try:
+            self.connection = self.Gio.bus_get_finish(result)
+            self.connection.set_exit_on_close(False)
+            self.closed_handler = self.connection.connect("closed", lambda *_args: self.stop(1))
+            for member in ("UpdatesChanged", "InstalledChanged", "RepoListChanged"):
+                self.subscriptions.append(self.connection.signal_subscribe(
+                    None, PACKAGEKIT_INTERFACE, member, PACKAGEKIT_PATH,
+                    None, self.Gio.DBusSignalFlags.NO_MATCH_RULE, self.global_changed, None))
+                self.match_rules.append(f"type='signal',sender='{PACKAGEKIT_NAME}',interface='{PACKAGEKIT_INTERFACE}',member='{member}',path='{PACKAGEKIT_PATH}'")
+            # Daemon disappearance/replacement invalidates the old preview too.
+            self.subscriptions.append(self.connection.signal_subscribe(
+                "org.freedesktop.DBus", "org.freedesktop.DBus", "NameOwnerChanged",
+                "/org/freedesktop/DBus", PACKAGEKIT_NAME,
+                self.Gio.DBusSignalFlags.NO_MATCH_RULE, self.owner_changed, None))
+            self.match_rules.append(f"type='signal',sender='org.freedesktop.DBus',interface='org.freedesktop.DBus',member='NameOwnerChanged',path='/org/freedesktop/DBus',arg0='{PACKAGEKIT_NAME}'")
+            self.add_match()
+        except self.GLib.Error:
+            self.stop(1)
+
+    def run(self) -> int:
+        def timeout():
+            self.deadline_source = 0
+            self.stop(1)
+            return self.GLib.SOURCE_REMOVE
+
+        def terminate():
+            self.stop(0)
+            return self.GLib.SOURCE_CONTINUE
+
+        try:
+            self.deadline = time.monotonic() + 10
+            self.deadline_source = self.GLib.timeout_add(10000, timeout)
+            for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+                self.sources.append(self.GLibUnix.signal_add(self.GLib.PRIORITY_DEFAULT, signum, terminate))
+            self.Gio.bus_get(self.Gio.BusType.SYSTEM, self.cancellable, self.connected, None)
+            self.loop.run()
+        finally:
+            self.stopped = True
+            self.cancellable.cancel()
+            if self.connection is not None:
+                for subscription in self.subscriptions:
+                    self.connection.signal_unsubscribe(subscription)
+                if self.closed_handler:
+                    self.connection.disconnect(self.closed_handler)
+                for rule in self.installed_rules:
+                    # Best-effort asynchronous cleanup cannot delay pane close.
+                    # Process/bus disconnection also removes every match rule.
+                    self.connection.call("org.freedesktop.DBus", "/org/freedesktop/DBus",
+                        "org.freedesktop.DBus", "RemoveMatch", self.GLib.Variant("(s)", (rule,)),
+                        None, self.Gio.DBusCallFlags.NONE, 1000, None, None, None)
+            for source in self.sources + ([self.deadline_source] if self.deadline_source else []):
+                self.GLib.source_remove(source)
+        return self.exit_code
+
+
+def watch_update_events() -> int:
+    output_descriptor = None
+    original_blocking = None
+
+    def emit(record: str) -> None:
+        payload = (record + "\n").encode("ascii")
+        # Each fixed row fits PIPE_BUF. Never block GLib callbacks behind a
+        # stalled reader or queue unbounded notifications. Overflow is an
+        # explicit monitoring failure; the consumer must refresh finite state.
+        if os.write(output_descriptor, payload) != len(payload):
+            raise OSError("Incomplete event output")
+
+    try:
+        import gi
+
+        gi.require_version("Gio", "2.0")
+        gi.require_version("GLibUnix", "2.0")
+        from gi.repository import Gio, GLib, GLibUnix
+
+        output_descriptor = sys.stdout.fileno()
+        original_blocking = os.get_blocking(output_descriptor)
+        os.set_blocking(output_descriptor, False)
+        code = UpdateEventMonitor(Gio, GLib, GLibUnix, emit).run()
+    except (ImportError, ValueError, OSError):
+        code = 1
+    finally:
+        if output_descriptor is not None and original_blocking is not None:
+            try:
+                # File status flags belong to the shared open-file description.
+                # A shell group may retain this writer for its next command.
+                os.set_blocking(output_descriptor, original_blocking)
+            except OSError:
+                code = 1
+    if code:
+        error_descriptor = None
+        error_blocking = None
+        try:
+            error_descriptor = sys.stderr.fileno()
+            error_blocking = os.get_blocking(error_descriptor)
+            os.set_blocking(error_descriptor, False)
+            os.write(error_descriptor, b"PackageKit live change monitoring is unavailable; reload status explicitly\n")
+        except (OSError, ValueError):
+            # Exit status remains authoritative when even diagnostics cannot
+            # be delivered (including stderr sharing the full stdout pipe).
+            pass
+        finally:
+            if error_descriptor is not None and error_blocking is not None:
+                with contextlib.suppress(OSError):
+                    os.set_blocking(error_descriptor, error_blocking)
+    return code
+
+
 def usage() -> int:
-    print(f"usage: {sys.argv[0]} snapshot | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID", file=sys.stderr)
+    print(f"usage: {sys.argv[0]} snapshot | watch-updates | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID", file=sys.stderr)
     return 2
 
 
 def main(argv: Sequence[str]) -> int:
+    if list(argv) == ["watch-updates"]:
+        return watch_update_events()
     if list(argv) == ["updates-refresh"]:
         return update_command("updates-refresh")
     if len(argv) == 2 and argv[0] == "updates-install-all" and JOURNAL_GENERATION_PATTERN.fullmatch(argv[1]):

--- a/tests/fixtures/system-update-events-bus.py
+++ b/tests/fixtures/system-update-events-bus.py
@@ -1,0 +1,189 @@
+#!/usr/bin/python3
+"""Exercise the real update monitor on a private bus, never host PackageKit."""
+
+import fcntl
+import os
+import pathlib
+import selectors
+import signal
+import subprocess
+import sys
+import time
+
+import gi
+
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio, GLib
+
+
+NAME = "org.freedesktop.PackageKit"
+PATH = "/org/freedesktop/PackageKit"
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+address = os.environ["DBUS_SESSION_BUS_ADDRESS"]
+environment = dict(os.environ, DBUS_SYSTEM_BUS_ADDRESS=address)
+processes = []
+retained_writers = []
+
+
+def name_call(method, connection=bus):
+    parameters = GLib.Variant("(su)", (NAME, 0)) if method == "RequestName" else GLib.Variant("(s)", (NAME,))
+    return connection.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus",
+        "org.freedesktop.DBus", method, parameters, GLib.VariantType.new("(u)"),
+        Gio.DBusCallFlags.NONE, 3000, None).unpack()[0]
+
+
+def launch(monitor_environment=environment):
+    process = subprocess.Popen([sys.argv[1], "watch-updates"], env=monitor_environment,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0)
+    processes.append(process)
+    return process
+
+
+def line(process, timeout=3):
+    output = b""
+    deadline = time.monotonic() + timeout
+    with selectors.DefaultSelector() as selector:
+        selector.register(process.stdout, selectors.EVENT_READ)
+        while b"\n" not in output and time.monotonic() < deadline:
+            if selector.select(max(0, deadline - time.monotonic())):
+                chunk = os.read(process.stdout.fileno(), 1)
+                if not chunk:
+                    break
+                output += chunk
+    return output
+
+
+def emit(member, *, path=PATH, interface=NAME, parameters=None, connection=bus):
+    connection.emit_signal(None, path, interface, member, parameters)
+    connection.flush_sync(None)
+
+
+try:
+    assert name_call("RequestName") == 1
+    process = launch()
+    assert line(process) == b"update-event\tready\n"
+    # No PackageKit methods are exported. Reaching ready proves setup only
+    # calls the bus daemon, without activating a transaction or reading state.
+    for member in ("UpdatesChanged", "InstalledChanged", "RepoListChanged"):
+        emit(member)
+        assert line(process) == b"update-event\tchanged\n", member
+
+    emit("TransactionListChanged", parameters=GLib.Variant("(ao)", (["/18_fixture"],)))
+    emit("UpdatesChanged", path="/18_fixture", interface=NAME + ".Transaction")
+    emit("Finished", path="/18_fixture", interface=NAME + ".Transaction",
+        parameters=GLib.Variant("(uu)", (1, 0)))
+    outsider = Gio.DBusConnection.new_for_address_sync(address,
+        Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT | Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION, None, None)
+    emit("UpdatesChanged", connection=outsider)
+    assert line(process, 0.2) == b"", "Unrelated signals triggered discovery"
+    outsider.close_sync(None)
+
+    assert name_call("ReleaseName") == 1
+    assert line(process) == b"update-event\tchanged\n"
+    assert name_call("RequestName") == 1
+    assert line(process) == b"update-event\tchanged\n"
+    emit("InstalledChanged")
+    assert line(process) == b"update-event\tchanged\n", "Replacement owner not monitored"
+    for _ in range(100):
+        emit("UpdatesChanged")
+    assert all(line(process) == b"update-event\tchanged\n" for _ in range(100))
+    assert line(process, 0.2) == b"", "Idle monitor emitted output"
+    process.send_signal(signal.SIGTERM)
+    assert process.wait(timeout=3) == 0
+    assert process.stderr.read() == b""
+
+    # Lost stdout is not a successful monitor or an interpreter flush failure.
+    broken = launch()
+    assert line(broken) == b"update-event\tready\n"
+    broken.stdout.close()
+    emit("UpdatesChanged")
+    assert broken.wait(timeout=3) == 1
+    error = broken.stderr.read()
+    assert b"reload status explicitly" in error and b"Traceback" not in error
+
+    # Shell groups can retain the same write-side open-file description for
+    # later commands. Restore its original mode on both clean and failed exits.
+    for originally_blocking, overflow, merged in ((True, False, False), (False, False, False),
+            (True, True, False), (True, True, True)):
+        reader, writer = os.pipe()
+        retained_writers.append(writer)
+        os.set_blocking(writer, originally_blocking)
+        inherited = subprocess.Popen([sys.argv[1], "watch-updates"], env=environment,
+            stdout=writer, stderr=subprocess.STDOUT if merged else subprocess.PIPE, bufsize=0)
+        processes.append(inherited)
+        inherited.stdout = os.fdopen(reader, "rb", buffering=0)
+        fcntl.fcntl(writer, fcntl.F_SETPIPE_SZ, 4096)
+        assert line(inherited) == b"update-event\tready\n"
+        if overflow:
+            for _ in range(1000):
+                emit("UpdatesChanged")
+                if inherited.poll() is not None:
+                    break
+        else:
+            inherited.send_signal(signal.SIGTERM)
+        assert inherited.wait(timeout=3) == int(overflow)
+        assert os.get_blocking(writer) == originally_blocking, "Inherited stdout mode was not restored"
+
+    # A reader that remains open but stops draining cannot pin the GLib loop
+    # and its subscriptions. Overflow exits explicitly, with no event queue.
+    stalled = launch()
+    fcntl.fcntl(stalled.stdout.fileno(), fcntl.F_SETPIPE_SZ, 4096)
+    assert line(stalled) == b"update-event\tready\n"
+    for _ in range(1000):
+        emit("UpdatesChanged")
+        if stalled.poll() is not None:
+            break
+    assert stalled.wait(timeout=3) == 1, "Full stdout pipe prevented monitor shutdown"
+    error = stalled.stderr.read()
+    assert b"reload status explicitly" in error and b"Traceback" not in error
+
+    # Missing PackageKit does not prevent an installed subscription; finite
+    # discovery separately reports capability availability.
+    assert name_call("ReleaseName") == 1
+    absent = launch()
+    assert line(absent) == b"update-event\tready\n"
+    absent.send_signal(signal.SIGINT)
+    assert absent.wait(timeout=3) == 0
+
+    # A separate disposable bus lets the fixture prove connection loss without
+    # terminating its own control bus or touching any host session/system bus.
+    daemon = subprocess.Popen(["dbus-daemon", "--session", "--nofork", "--print-address=1"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0)
+    processes.append(daemon)
+    private_address = line(daemon).decode().strip()
+    assert private_address.startswith("unix:")
+    disconnected = launch(dict(environment, DBUS_SYSTEM_BUS_ADDRESS=private_address))
+    assert line(disconnected) == b"update-event\tready\n"
+    daemon.terminate()
+    daemon.wait(timeout=3)
+    assert disconnected.wait(timeout=3) == 1
+    assert b"reload status explicitly" in disconnected.stderr.read()
+
+    denied_bus = subprocess.Popen(["dbus-daemon", "--nofork", "--print-address=1",
+        "--config-file=" + str(pathlib.Path(__file__).with_name("system-update-events-denied.conf")),
+        "--address=unix:tmpdir=" + os.environ.get("TMPDIR", "/tmp")],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0)
+    processes.append(denied_bus)
+    denied_address = line(denied_bus).decode().strip()
+    assert denied_address.startswith("unix:")
+    denied_connection = Gio.DBusConnection.new_for_address_sync(denied_address,
+        Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT | Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION, None, None)
+    try:
+        assert name_call("RequestName", denied_connection) == 1
+        denied = launch(dict(environment, DBUS_SYSTEM_BUS_ADDRESS=denied_address))
+        assert denied.wait(timeout=3) == 1
+        assert denied.stdout.read() == b"", "Denied sender lookup falsely reported readiness"
+        assert b"reload status explicitly" in denied.stderr.read()
+    finally:
+        denied_connection.close_sync(None)
+    print("PackageKit private-bus event monitor: PASS")
+finally:
+    for process in processes:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=3)
+        for stream in (process.stdout, process.stderr):
+            if stream is not None:
+                stream.close()
+    for writer in retained_writers:
+        os.close(writer)

--- a/tests/fixtures/system-update-events-denied.conf
+++ b/tests/fixtures/system-update-events-denied.conf
@@ -1,0 +1,14 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <type>session</type>
+  <listen>unix:tmpdir=/tmp</listen>
+  <auth>EXTERNAL</auth>
+  <policy context="default">
+    <allow send_destination="*"/>
+    <allow receive_sender="*"/>
+    <allow own="*"/>
+    <deny send_destination="org.freedesktop.DBus"
+          send_interface="org.freedesktop.DBus" send_member="GetNameOwner"/>
+  </policy>
+</busconfig>

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -83,6 +83,187 @@ def rows(lines, kind):
     return [line.split("\t") for line in lines if line.startswith(f"{kind}\t")]
 
 
+class UpdateEventMonitorTests(unittest.TestCase):
+    def monitor(self):
+        class BusError(Exception):
+            pass
+
+        glib = mock.Mock(Error=BusError, SOURCE_REMOVE=False, SOURCE_CONTINUE=True,
+            PRIORITY_DEFAULT=0)
+        gio = mock.Mock()
+        unix = mock.Mock()
+        emitted = []
+        monitor = provider.UpdateEventMonitor(gio, glib, unix, emitted.append)
+        monitor.deadline = time.monotonic() + 10
+        monitor.deadline_source = 7
+        monitor.match_rules = ["fixture"]
+        monitor.connection = mock.Mock()
+        return monitor, emitted, gio, glib, unix
+
+    def test_subscriptions_are_fixed_and_setup_never_calls_packagekit(self):
+        monitor, emitted, gio, _glib, _unix = self.monitor()
+        monitor.match_rules = []
+        connection = gio.bus_get_finish.return_value
+        monitor.connected(None, object(), None)
+        calls = connection.signal_subscribe.call_args_list
+        self.assertEqual([call.args[:4] for call in calls], [
+            (None, provider.PACKAGEKIT_INTERFACE, member, provider.PACKAGEKIT_PATH)
+            for member in ("UpdatesChanged", "InstalledChanged", "RepoListChanged")
+        ] + [("org.freedesktop.DBus", "org.freedesktop.DBus", "NameOwnerChanged", "/org/freedesktop/DBus")])
+        self.assertEqual(calls[-1].args[4], provider.PACKAGEKIT_NAME)
+        self.assertEqual(connection.call.call_args.args[:4],
+            ("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus", "AddMatch"))
+        self.assertTrue(all(call.args[5] == gio.DBusSignalFlags.NO_MATCH_RULE for call in calls))
+        self.assertEqual(len(monitor.match_rules), 4)
+        self.assertEqual(emitted, [])
+
+    def test_setup_events_coalesce_and_ready_precedes_pending_invalidation(self):
+        monitor, emitted, _gio, glib, _unix = self.monitor()
+        for _ in range(1000):
+            monitor.changed()
+        self.assertEqual(emitted, [])
+        monitor.match_finished(mock.Mock(), object(), "fixture")
+        self.assertEqual(emitted, [])
+        connection = mock.Mock()
+        connection.call_finish.return_value.unpack.return_value = (":1.2",)
+        monitor.owner_resolved(connection, object(), 0)
+        self.assertEqual(emitted, ["update-event\tready", "update-event\tchanged"])
+        glib.source_remove.assert_called_once_with(7)
+        self.assertFalse(monitor.dirty)
+        self.assertEqual(monitor.deadline_source, 0)
+        monitor.changed()
+        self.assertEqual(len(emitted), 3)
+
+    def test_readiness_requires_all_four_successful_match_replies(self):
+        monitor, emitted, gio, _glib, _unix = self.monitor()
+        monitor.match_rules = []
+        monitor.connected(None, object(), None)
+        connection = gio.bus_get_finish.return_value
+        for index, rule in enumerate(monitor.match_rules):
+            self.assertEqual(emitted, [])
+            monitor.changed()
+            monitor.match_finished(connection, object(), rule)
+            self.assertEqual(len(monitor.installed_rules), index + 1)
+        self.assertEqual(connection.call.call_count, 5)
+        self.assertEqual(connection.call.call_args.args[3], "GetNameOwner")
+        self.assertEqual(emitted, [])
+        connection.call_finish.return_value.unpack.return_value = (":1.2",)
+        monitor.owner_resolved(connection, object(), 0)
+        self.assertEqual(emitted, ["update-event\tready", "update-event\tchanged"])
+
+    def test_denied_match_after_partial_setup_never_reports_ready(self):
+        monitor, emitted, gio, glib, _unix = self.monitor()
+        monitor.match_rules = []
+        monitor.connected(None, object(), None)
+        connection = gio.bus_get_finish.return_value
+        monitor.match_finished(connection, object(), monitor.match_rules[0])
+        connection.call_finish.side_effect = glib.Error("Policy denied subscription")
+        monitor.match_finished(connection, object(), monitor.match_rules[1])
+        self.assertTrue(monitor.stopped)
+        self.assertEqual(len(monitor.installed_rules), 1)
+        self.assertEqual(emitted, [])
+
+    def test_expired_setup_and_late_callbacks_cannot_publish_ready(self):
+        for callback in ("connected", "match_finished", "owner_resolved"):
+            with self.subTest(callback=callback):
+                monitor, emitted, gio, _glib, _unix = self.monitor()
+                monitor.deadline = time.monotonic() - 1
+                getattr(monitor, callback)(mock.Mock(), object(), None)
+                self.assertTrue(monitor.stopped)
+                self.assertEqual(monitor.exit_code, 1)
+                monitor.changed()
+                monitor.match_finished(mock.Mock(), object(), None)
+                monitor.connected(None, object(), None)
+                self.assertEqual(emitted, [])
+                gio.bus_get_finish.assert_not_called()
+
+    def test_connection_barrier_and_output_failures_stop_without_success(self):
+        for stage in ("connection", "barrier", "output"):
+            with self.subTest(stage=stage):
+                monitor, emitted, gio, glib, _unix = self.monitor()
+                connection = mock.Mock()
+                if stage == "connection":
+                    gio.bus_get_finish.side_effect = glib.Error("private error")
+                    monitor.connected(None, object(), None)
+                elif stage == "barrier":
+                    connection.call_finish.side_effect = glib.Error("private error")
+                    monitor.match_finished(connection, object(), "fixture")
+                else:
+                    monitor.emit = mock.Mock(side_effect=BrokenPipeError())
+                    connection.call_finish.return_value.unpack.return_value = (":1.2",)
+                    monitor.owner_resolved(connection, object(), 0)
+                self.assertTrue(monitor.stopped)
+                self.assertEqual(monitor.exit_code, 1)
+                self.assertEqual(emitted, [])
+                monitor.stop(0)
+                self.assertEqual(monitor.exit_code, 1)
+
+    def test_owner_resolution_absence_is_not_authorization_denial(self):
+        for missing in (True, False):
+            monitor, emitted, gio, glib, _unix = self.monitor()
+            connection = mock.Mock()
+            connection.call_finish.side_effect = glib.Error("Owner lookup failed")
+            gio.dbus_error_get_remote_error.return_value = "org.freedesktop.DBus.Error." + (
+                "NameHasNoOwner" if missing else "AccessDenied")
+            monitor.owner_resolved(connection, object(), 0)
+            self.assertEqual(monitor.ready, missing)
+            self.assertEqual(monitor.stopped, not missing)
+            self.assertEqual(emitted, ["update-event\tready"] if missing else [])
+
+    def test_owner_notification_wins_lookup_race_and_filters_old_senders(self):
+        monitor, emitted, _gio, _glib, _unix = self.monitor()
+        parameters = mock.Mock()
+        parameters.unpack.return_value = (provider.PACKAGEKIT_NAME, ":1.2", ":1.3")
+        monitor.owner_changed(None, None, None, None, None, parameters, None)
+        connection = mock.Mock()
+        connection.call_finish.return_value.unpack.return_value = (":1.2",)
+        monitor.owner_resolved(connection, object(), 0)
+        self.assertEqual(monitor.owner, ":1.3")
+        self.assertEqual(emitted, ["update-event\tready", "update-event\tchanged"])
+        monitor.global_changed(None, ":1.2", None, None, None, None, None)
+        self.assertEqual(len(emitted), 2)
+        monitor.global_changed(None, ":1.3", None, None, None, None, None)
+        self.assertEqual(len(emitted), 3)
+
+    def test_run_cleanup_cancels_callbacks_and_removes_all_sources(self):
+        monitor, _emitted, gio, glib, unix = self.monitor()
+        monitor.match_rules = []
+        connection = gio.bus_get_finish.return_value
+        connection.signal_subscribe.side_effect = [20, 21, 22, 23]
+        connection.connect.return_value = 24
+        glib.timeout_add.return_value = 10
+        unix.signal_add.side_effect = [11, 12, 13]
+        def run():
+            monitor.connected(None, object(), None)
+            monitor.match_finished(connection, object(), monitor.match_rules[0])
+            monitor.stop(0)
+        monitor.loop.run.side_effect = run
+        self.assertEqual(monitor.run(), 0)
+        self.assertEqual([call.args[0] for call in connection.signal_unsubscribe.call_args_list], [20, 21, 22, 23])
+        connection.disconnect.assert_called_once_with(24)
+        self.assertEqual(connection.call.call_args.args[3], "RemoveMatch")
+        self.assertEqual([call.args[0] for call in glib.source_remove.call_args_list], [11, 12, 13, 10])
+        self.assertTrue(monitor.cancellable.cancel.called)
+        self.assertEqual(gio.bus_get.call_args.args[0], gio.BusType.SYSTEM)
+
+    def test_watch_cli_is_argument_free_and_does_not_open_the_backend(self):
+        with mock.patch.object(provider, "watch_update_events", return_value=0) as watch, \
+                mock.patch.object(provider, "PackageKitBackend") as backend, \
+                contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(provider.main(["watch-updates"]), 0)
+            for arguments in (["watch-updates", "extra"], ["watch-updates", "--system"]):
+                self.assertEqual(provider.main(arguments), 2)
+            watch.assert_called_once_with()
+            backend.assert_not_called()
+
+    def test_real_private_bus_signals_lifecycle_and_lost_output(self):
+        result = subprocess.run(["dbus-run-session", "--", "/usr/bin/python3",
+            str(REPO / "tests/fixtures/system-update-events-bus.py"), str(PROVIDER_PATH)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "PackageKit private-bus event monitor: PASS\n")
+
+
 class OperationStreamTests(unittest.TestCase):
     operation_id = "op-" + "1" * 32
     started = "2026-09-05T01:00:00Z"


### PR DESCRIPTION
## Summary
- Add fixed, argument-free `dwm-system-management watch-updates` as a read-only event source.
- Subscribe only to PackageKit UpdatesChanged, InstalledChanged, RepoListChanged and exact daemon ownership changes. Four explicit AddMatch replies plus verified GetNameOwner/NameHasNoOwner evidence establish readiness within one 10-second aggregate deadline.
- Track the unique sender explicitly, preserve newer owner notifications across lookup races, and never activate PackageKit or create a transaction.
- Emit only fixed ready/change records. Nonblocking stdout fails closed on overflow; bounded, best-effort stderr cannot block merged-output shutdown. Restore inherited descriptor modes on exit.
- Add fake-callback and real private-bus fixtures, including lookup-denying bus policy; document the event grammar and still-pending Settings integration.

## Validation
- `scripts/run-tests /usr/bin/python3 tests/test-system-management.py UpdateEventMonitorTests`: 11 tests PASS.
- `scripts/run-tests make check-system-management`: 309 tests PASS.
- Private-bus cases include global signal filtering, ignored transaction-list/progress/outsider signals, owner replacement and lookup races, lookup denial, setup failures, bursts, missing service, clean shutdown, lost stdout, stalled readers, retained parent writers, merged stdout/stderr, and disconnected bus.
- Fedora 44 host read-only subscription: ready; 0.000% CPU over 5 seconds idle; clean exit 0. No PackageKit action or journal access.
- `scripts/run-tests make clean all` and `scripts/run-tests`: PASS, including all 309 provider tests, 778 native operation assertions, configured QML lint and shell gates, Fedora dependency checks, staged installation, repeated-install preservation, and release-archive validation. Managed workspaces were cleaned up.
- Closed Settings: 0.033% CPU; closed large surfaces: 0.00% CPU.
- Post-full-gate local Codex review: no actionable findings; independently reran all 11 monitor tests.
- Independent CodeRabbit CLI review: no findings across all seven files.

## Scope and limitations
This independently testable boundary adds the event helper only. It does not wire QML subscriptions, bounded discovery settling, confirmations, originating update controls, cancellation UI, or later Phase 6 surfaces. Existing Settings update mutations stay disabled. No host package update, installed-desktop synchronization, deployment, or Phase 7 work was performed. No new dependencies. Failure diagnostics are best-effort when their pipe is full; exit status remains authoritative.
