### PR TITLE
feat(system): coalesce update discovery events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,10 +62,14 @@ versions from `config.mk`.
 
 ### Added
 
+- Monitor update changes while the System Settings section is open. Coalesce
+  bursts into an initial read plus at most one settling read, preserve readable
+  status with reload guidance when state keeps changing or monitoring fails,
+  and stop optional discovery on closure without losing operation recovery.
+
 - Add a read-only PackageKit change monitor with fixed global subscriptions,
   bounded setup, and explicit readiness. Private-bus tests verify signal
-  filtering, daemon replacement, closure, and lost output. Settings discovery
-  coalescing and confirmation invalidation remain pending integration.
+  filtering, daemon replacement, closure, and lost output.
 
 - Restore journaled system operations in the shell root and keep their progress
   visible across Settings closure. Verify complete terminal results before exact

--- a/TASKS.md
+++ b/TASKS.md
@@ -95,14 +95,20 @@ across pane closure, verifies results before acknowledgment, and bounds failed
 recovery to three retries. Native nested-X11 fixtures exercise live progress,
 failed-result replay, stale collector data, restart adoption, and failed process
 starts without host service calls. Originating mutation, confirmation, and cancel
-UI integration plus event-driven discovery invalidation must be completed before
-this boundary can be accepted. Settings mutation actions remain disabled.
+UI integration must be completed before this boundary can be accepted.
+Settings mutation actions remain disabled.
 The fixed `watch-updates` command now observes only global PackageKit discovery
 changes and daemon ownership changes. It establishes subscriptions before
 reporting readiness, bounds setup to ten seconds, and never starts a transaction.
 Private-bus and callback fixtures cover filtering, startup races, cleanup, and
-lost output. The pane-scoped subscriber and bounded dirty-state coalescing remain
-the next integration step; this helper alone does not invalidate Settings state.
+lost output. The pane-scoped subscriber now waits for readiness before its first
+discovery read, reserves at most one settling read per automatic burst, and
+retains explicit-refresh guidance if that read changes again. Snapshot publication
+retains ownership through reentrant completion callbacks. Failed monitoring keeps
+finite status readable; pane closure stops the subscriber and optional reads
+without stopping required recovery or the root operation owner. PackageKit
+observer completion and uncertain exit also invalidate discovery without relying
+on a global signal. Confirmation invalidation is exposed for the next UI boundary.
 The preview validators now preserve requested `install` as well as `update`
 actions, matching the PackageKit DNF5 backend's discovery/simulation contract.
 Missing or duplicate requested IDs, outbound requested actions, and unrequested

--- a/config/quickshell/settings/SystemSettingsPane.qml
+++ b/config/quickshell/settings/SystemSettingsPane.qml
@@ -161,6 +161,14 @@ Flickable {
             wrapMode: Text.WordWrap
         }
 
+        PlainText {
+            Layout.fillWidth: true
+            visible: text.length > 0
+            text: root.systemManagementModel.discoveryDetail
+            color: Theme.warning
+            wrapMode: Text.WordWrap
+        }
+
         SectionLabel { label: "Fedora updates" }
 
         GridLayout {

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -573,6 +573,12 @@ ShellRoot {
             return systemManagementModel.snapshotState;
         }
 
+        function systemManagementDiscoveryStatus(): string {
+            const discovery = systemManagementModel.discovery;
+            return discovery.phase + ":" + (discovery.ready ? "ready"
+                : discovery.failed ? "failed" : "inactive");
+        }
+
         function systemManagementOperationState(): string {
             return systemManagementModel.operation.state;
         }

--- a/config/quickshell/systemmanagement/SystemDiscoveryCycle.js
+++ b/config/quickshell/systemmanagement/SystemDiscoveryCycle.js
@@ -1,0 +1,71 @@
+// Serialized state only: no QML property signals inside the completion handoff.
+function create() {
+    return { epoch: 0, enabled: false, phase: "idle", dirty: false,
+        unresolved: false, forceSettle: false, settlingDirty: false };
+}
+
+function begin(cycle) {
+    cycle.epoch++;
+    cycle.enabled = true;
+    cycle.phase = "initial-pending";
+    cycle.dirty = false;
+    cycle.forceSettle = cycle.unresolved;
+    cycle.settlingDirty = false;
+}
+
+function close(cycle) {
+    cycle.epoch++;
+    cycle.enabled = false;
+    cycle.phase = "idle";
+    cycle.dirty = false;
+}
+
+function invalidate(cycle) {
+    if (!cycle.enabled) return;
+    if (cycle.phase === "idle") begin(cycle);
+    else if (cycle.phase === "initial-active" || cycle.phase === "initial-completing")
+        cycle.dirty = true;
+    else if (cycle.phase === "settling-active" || cycle.phase === "settling-completing") {
+        cycle.settlingDirty = true;
+        cycle.unresolved = true;
+    }
+    // Pending invalidations are covered by the reserved read. Blocked cycles
+    // retain their unresolved bit without scheduling a third automatic read.
+}
+
+function pending(cycle) {
+    return cycle.enabled && (cycle.phase === "initial-pending" || cycle.phase === "settling-pending");
+}
+
+function take(cycle) {
+    if (!pending(cycle)) return null;
+    const settling = cycle.phase === "settling-pending";
+    cycle.phase = settling ? "settling-active" : "initial-active";
+    cycle.settlingDirty = false;
+    return { epoch: cycle.epoch, settling: settling };
+}
+
+function owns(cycle, token) {
+    if (token === null || !cycle.enabled || token.epoch !== cycle.epoch) return false;
+    const prefix = token.settling ? "settling" : "initial";
+    return cycle.phase === prefix + "-active" || cycle.phase === prefix + "-completing";
+}
+
+function beforePublish(cycle, token) {
+    if (owns(cycle, token))
+        cycle.phase = token.settling ? "settling-completing" : "initial-completing";
+}
+
+function complete(cycle, token, successful) {
+    if (!owns(cycle, token)) return;
+    if (!successful) {
+        cycle.unresolved = true;
+        cycle.phase = "blocked";
+    } else if (token.settling) {
+        cycle.unresolved = cycle.settlingDirty;
+        cycle.phase = cycle.unresolved ? "blocked" : "idle";
+    } else if (cycle.dirty || cycle.forceSettle) {
+        cycle.dirty = false;
+        cycle.phase = "settling-pending";
+    } else cycle.phase = "idle";
+}

--- a/config/quickshell/systemmanagement/SystemManagementModel.qml
+++ b/config/quickshell/systemmanagement/SystemManagementModel.qml
@@ -6,6 +6,7 @@ import qs.core
 Scope {
     id: root
 
+    signal confirmationInvalidated()
     property bool settingsVisible: false
     property string snapshotState: "idle"
     property string message: "System management has not been loaded"
@@ -29,10 +30,14 @@ Scope {
     property string snapshotErrorDetail: ""
     property int requestGeneration: 0
     readonly property alias operation: operationModel
+    readonly property alias discovery: discoveryModel
 
     readonly property bool busy: snapshotOwned
-    readonly property string providerState: root.updateProvider.status
+    readonly property string providerState: root.settingsVisible
+        && (discoveryModel.unresolved || discoveryModel.failed) && root.updateProvider.status === "available"
+        ? "partial" : root.updateProvider.status
     readonly property string providerDetail: root.updateProvider.detail
+    readonly property string discoveryDetail: discoveryModel.detail
 
     function providerFallback(detail) {
         return { "status": "unavailable", "providerClass": "delegated",
@@ -557,11 +562,13 @@ Scope {
 
     function openSettings() {
         root.settingsVisible = true;
-        root.refresh();
+        discoveryModel.open();
+        root.refreshRecovery();
     }
 
     function closeSettings() {
         root.settingsVisible = false;
+        discoveryModel.close();
         root.snapshotPending = false;
         if (!root.snapshotRequired) {
             root.requestGeneration++;
@@ -571,11 +578,15 @@ Scope {
 
     function refresh() {
         if (!root.settingsVisible) return;
+        discoveryModel.refresh();
+        root.refreshRecovery();
+    }
+
+    function refreshRecovery() {
         const requiredRecovery = operationModel.waitingSnapshot || operationModel.blocked
             || operationModel.state === "recovering";
         operationModel.resetRecovery();
         if (requiredRecovery) operationModel.requestSnapshot();
-        else root.requestSnapshot(false);
     }
 
     function requestSnapshot(required) {
@@ -585,14 +596,19 @@ Scope {
             root.requiredPending = root.requiredPending || required;
             return;
         }
+        required = required || root.requiredPending;
+        if (!required && !discoveryModel.canTake()) return;
         root.snapshotPending = false;
         root.requiredPending = false;
+        // Claim the owner before any QML signal from discovery.take/publication.
+        root.snapshotOwned = true;
+        snapshotProcess.cycleToken = discoveryModel.take();
         root.requestGeneration++;
         snapshotProcess.generation = root.requestGeneration;
         root.snapshotRequired = required;
         root.snapshotHasOutput = false;
         root.snapshotErrorDetail = "";
-        root.snapshotOwned = true;
+        root.confirmationInvalidated();
         root.snapshotState = "loading";
         root.message = "Reading system update status...";
         snapshotProcess.running = true;
@@ -601,8 +617,7 @@ Scope {
     function finishSnapshot(exitCode, normalExit) {
         if (!root.snapshotOwned) return;
         const current = snapshotProcess.generation === root.requestGeneration;
-        root.snapshotOwned = false;
-        root.snapshotRequired = false;
+        discoveryModel.beforePublish(snapshotProcess.cycleToken);
         if (current) {
             if (normalExit && exitCode === 0 && root.snapshotHasOutput) {
                 if (root.parseSnapshot(snapshotOutput.text, snapshotProcess.generation))
@@ -614,6 +629,11 @@ Scope {
                 operationModel.snapshotFailed();
             }
         }
+        // Reentrant invalidations during parse/acceptSnapshot still belong to
+        // this completion handoff. Reserve the settling read before idle.
+        discoveryModel.complete(snapshotProcess.cycleToken, current && root.snapshotState !== "failure");
+        root.snapshotRequired = false;
+        root.snapshotOwned = false;
         // The old process emits runningChanged after exited. Queue the next
         // launch so that signal cannot finalize a new run's ownership.
         Qt.callLater(function() {
@@ -624,8 +644,15 @@ Scope {
 
     Component.onCompleted: Qt.callLater(function() { operationModel.requestSnapshot(); })
 
+    SystemUpdateDiscovery {
+        id: discoveryModel
+        onSnapshotRequested: root.requestSnapshot(false)
+        onInvalidated: root.confirmationInvalidated()
+    }
+
     SystemOperationModel {
         id: operationModel
+        onDiscoveryInvalidated: discoveryModel.invalidate()
         onSnapshotRequested: root.requestSnapshot(true)
         onAcknowledged: operationId => {
             if (root.terminalHandoff !== null && root.terminalHandoff.id === operationId)
@@ -638,6 +665,7 @@ Scope {
     Process {
         id: snapshotProcess
         property int generation: 0
+        property var cycleToken: null
         command: Commands.terminatingCheckedCommand(
             Commands.systemManagementCommand("snapshot", []))
         running: false

--- a/config/quickshell/systemmanagement/SystemOperationModel.qml
+++ b/config/quickshell/systemmanagement/SystemOperationModel.qml
@@ -10,6 +10,7 @@ Scope {
 
     signal snapshotRequested()
     signal acknowledged(string operationId)
+    signal discoveryInvalidated()
 
     property string state: "idle"
     property string detail: ""
@@ -87,6 +88,7 @@ Scope {
             const target = active !== null ? active : terminal;
             root.parser = Protocol.create(target.id, target.actionId);
             root.streamOwned = true;
+            if (active !== null) root.discoveryInvalidated();
             root.progress = active;
             root.state = "observing";
             root.detail = "Observing " + target.actionId;
@@ -123,6 +125,8 @@ Scope {
 
     function finishWatch(exitCode, normalExit) {
         if (!root.streamOwned) return;
+        if (root.parser.expectedAction === "updates-refresh" || root.parser.expectedAction === "updates-install-all")
+            root.discoveryInvalidated();
         root.streamOwned = false;
         if (!Protocol.finish(root.parser, exitCode, normalExit, true)) {
             root.recover(exitCode === 3 ? "Operation watch target changed (conflict)" : root.parser.failure);

--- a/config/quickshell/systemmanagement/SystemUpdateDiscovery.qml
+++ b/config/quickshell/systemmanagement/SystemUpdateDiscovery.qml
@@ -1,0 +1,161 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.core
+import "SystemDiscoveryCycle.js" as Cycle
+
+Scope {
+    id: root
+
+    signal snapshotRequested()
+    signal invalidated()
+    property var cycle: Cycle.create()
+    property bool visible: false
+    property bool monitorOwned: false
+    property bool stopping: false
+    property bool restartPending: false
+    property bool ready: false
+    property bool failed: false
+    property bool unresolved: false
+    property string phase: "idle"
+    readonly property bool fresh: root.visible && root.ready && !root.failed && !root.unresolved && root.phase === "idle"
+    readonly property string detail: !root.visible ? "" : root.failed
+        ? "Live update monitoring is unavailable. Reload status to retry; readable package state is preserved."
+        : root.unresolved
+        ? "Update state changed during the settling read. Reload status to reconcile it; automatic rereads are paused."
+        : !root.ready ? "Connecting to update change notifications..." : ""
+
+    function publish() {
+        root.unresolved = root.cycle.unresolved;
+        root.phase = root.cycle.phase;
+    }
+
+    function requestPending() {
+        if (root.visible && (root.ready || root.failed) && Cycle.pending(root.cycle))
+            root.snapshotRequested();
+    }
+
+    function open() {
+        root.visible = true;
+        Cycle.begin(root.cycle);
+        root.publish();
+        root.startMonitor();
+    }
+
+    function close() {
+        root.visible = false;
+        root.restartPending = false;
+        Cycle.close(root.cycle);
+        root.publish();
+        root.stopMonitor();
+    }
+
+    function refresh() {
+        if (!root.visible) return;
+        Cycle.begin(root.cycle);
+        root.publish();
+        if (!root.monitorOwned || root.stopping) root.startMonitor();
+        root.requestPending();
+    }
+
+    function invalidate() {
+        root.invalidated();
+        Cycle.invalidate(root.cycle);
+        root.publish();
+        root.requestPending();
+    }
+
+    function canTake() {
+        return root.visible && (root.ready || root.failed) && Cycle.pending(root.cycle);
+    }
+
+    function take() {
+        if (!root.canTake()) return null;
+        const token = Cycle.take(root.cycle);
+        root.publish();
+        return token;
+    }
+
+    function beforePublish(token) { Cycle.beforePublish(root.cycle, token); }
+
+    function complete(token, successful) {
+        Cycle.complete(root.cycle, token, successful);
+        root.publish();
+        // Process.runningChanged for the old snapshot follows its exit signal.
+        Qt.callLater(root.requestPending);
+    }
+
+    function startMonitor() {
+        if (!root.visible) return;
+        if (root.monitorOwned) {
+            if (root.stopping) {
+                root.restartPending = true;
+                // A new explicit cycle must wait for replacement subscriptions,
+                // not consume the previous monitor's failed-read fallback.
+                root.ready = false;
+                root.failed = false;
+            }
+            return;
+        }
+        root.restartPending = false;
+        root.ready = false;
+        root.failed = false;
+        root.stopping = false;
+        root.monitorOwned = true;
+        setupDeadline.restart();
+        monitor.running = true;
+    }
+
+    function stopMonitor() {
+        root.ready = false;
+        setupDeadline.stop();
+        if (!root.monitorOwned || root.stopping) return;
+        root.stopping = true;
+        monitor.signal(15);
+        stopDeadline.restart();
+    }
+
+    function failMonitor() {
+        if (!root.monitorOwned || root.stopping) return;
+        root.failed = true;
+        root.invalidated();
+        root.stopMonitor();
+        root.requestPending();
+    }
+
+    function event(line) {
+        if (!root.monitorOwned || root.stopping || !root.visible) return;
+        if (line === "update-event\tready" && !root.ready) {
+            setupDeadline.stop();
+            root.ready = true;
+            root.requestPending();
+        } else if (line === "update-event\tchanged" && root.ready) root.invalidate();
+        else root.failMonitor();
+    }
+
+    function finished() {
+        if (!root.monitorOwned) return;
+        const restart = root.restartPending;
+        root.monitorOwned = false;
+        root.ready = false;
+        setupDeadline.stop();
+        stopDeadline.stop();
+        if (!root.visible) return;
+        if (restart) Qt.callLater(root.startMonitor);
+        else {
+            root.failed = true;
+            root.invalidated();
+            root.requestPending();
+        }
+    }
+
+    Timer { id: setupDeadline; interval: 12000; repeat: false; onTriggered: root.failMonitor() }
+    Timer { id: stopDeadline; interval: 1500; repeat: false; onTriggered: monitor.signal(9) }
+    Process {
+        id: monitor
+        command: Commands.systemManagementCommand("watch-updates", [])
+        stdout: SplitParser { onRead: line => root.event(line) }
+        onExited: root.finished()
+        onRunningChanged: { if (!running && root.monitorOwned) root.finished(); }
+    }
+}

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -114,8 +114,8 @@ are terminated without canceling the PackageKit transaction. Three delayed
 snapshot-and-watch retries use one, two, and four seconds; exhaustion and failed
 acknowledgment retain explicit reload guidance. Pane-only reads still stop when
 Settings closes, while required recovery reads continue. Settings mutation
-actions remain unavailable until originating execution, confirmation,
-cancellation, and event-driven discovery invalidation are integrated.
+actions remain unavailable until originating execution, confirmation, and
+cancellation are integrated.
 An identity-free snapshot establishes an empty journal only when recovery is
 available. Incomplete journal evidence retains the readable snapshot and takes
 the same bounded recovery path; it cannot silently abandon an unknown owner.
@@ -1497,8 +1497,28 @@ owner does not prevent readiness: the monitor waits for owner changes without
 activating the service, while finite discovery reports availability separately.
 There is no idle timer or automatic reconnect. This helper is an event stream,
 not a snapshot, action, journal record, or operation stream; its two exact record
-forms are independent of the cumulative snapshot minor. QML subscription and
-dirty-cycle integration remain pending.
+forms are independent of the cumulative snapshot minor.
+
+The pane-scoped `SystemUpdateDiscovery` subscriber now consumes this stream.
+It starts a discovery cycle only after readiness, with a 12-second frontend
+startup deadline covering the helper's ten-second setup and process startup.
+Failure falls back to a finite read with visible monitoring-unavailable guidance;
+there is no automatic reconnect. Explicit reload or section reopen retries the
+monitor. Closing the section sends TERM and uses a 1.5-second KILL grace if the
+observer does not exit. Required startup/recovery snapshots and root-owned
+operation streams are independent of that optional subscriber.
+
+`SystemDiscoveryCycle.js` serializes initial, settling, and blocked cycles.
+Snapshot ownership spans parsing and recovery publication, so invalidations in
+either completion callback are included before the next read is reserved or the
+provider becomes idle. A failed read or invalidated settling read retains dirty
+state until a later explicit cycle completes a quiet settling read. Readable
+inventory and backend diagnostics remain intact when monitoring fails; available
+update state becomes partial with separate reload guidance. Conservative
+PackageKit observer completion, uncertain exit, and active adoption share the
+same invalidation path. The model exposes confirmation invalidation for every
+global change and replacement read; originating mutation and confirmation UI
+remain a separate implementation boundary.
 
 - PackageKit `UpdatesChanged` and `InstalledChanged` invalidate update
   discovery; `RepoListChanged` invalidates both repository and update discovery

--- a/tests/fixtures/system-discovery-provider.py
+++ b/tests/fixtures/system-discovery-provider.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python3
+"""Private event/snapshot fixture; never accesses PackageKit or a host journal."""
+
+import fcntl
+import os
+from pathlib import Path
+import signal
+import stat
+import sys
+import time
+
+
+directory = Path(os.environ["DWM_DISCOVERY_FIXTURE"])
+fifo = directory / "events"
+mode_file = directory / "mode"
+
+
+def row(*fields):
+    print("\t".join(fields), flush=True)
+
+
+def mode():
+    return mode_file.read_text() if mode_file.exists() else "quiet"
+
+
+def changed(count):
+    # Only the monitor creates the pipe. Missing readers fail this fixture
+    # promptly instead of hanging it or accidentally creating a regular file.
+    with os.fdopen(os.open(fifo, os.O_WRONLY | os.O_NONBLOCK | os.O_NOFOLLOW), "w") as stream:
+        if not stat.S_ISFIFO(os.fstat(stream.fileno()).st_mode):
+            raise RuntimeError("event target is not the monitor pipe")
+        stream.write("update-event\tchanged\n" * count)
+
+
+def main():
+    action = sys.argv[1]
+    if action == "fixture-control":
+        if sys.argv[2] == "events":
+            changed(100)
+        elif sys.argv[2] == "restart-quiet":
+            (directory / "require-monitored-read").touch()
+            mode_file.write_text("quiet")
+        else:
+            mode_file.write_text(sys.argv[2])
+        return
+    if action == "watch-updates":
+        if mode() == "fail-monitor":
+            sys.exit(1)
+        if mode() in ("ignore-term", "failed-stopping"):
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        with (directory / "monitor-lock").open("w") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            if not fifo.exists():
+                os.mkfifo(fifo, 0o600)
+            (directory / "monitor-ready").unlink(missing_ok=True)
+            with os.fdopen(os.open(fifo, os.O_RDWR), "r") as stream:
+                if mode() != "no-ready":
+                    malformed = mode() in ("malformed", "failed-stopping")
+                    if not malformed:
+                        (directory / "monitor-ready").touch()
+                    row("update-event", "changed" if malformed else "ready")
+                for line in stream:
+                    print(line, end="", flush=True)
+        return
+    if action != "snapshot":
+        sys.exit(2)
+    with (directory / "snapshot-lock").open("w") as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            (directory / "overlap").touch()
+            raise
+        counter = directory / "snapshots"
+        if (directory / "require-monitored-read").exists() and not (directory / "monitor-ready").exists():
+            (directory / "unmonitored-read").touch()
+        count = int(counter.read_text()) + 1 if counter.exists() else 1
+        counter.write_text(str(count))
+        if mode() == "self":
+            changed(30)
+        time.sleep(0.5 if mode() == "slow" else 0.1)
+        row("system-management-protocol", "1", "0")
+        row("snapshot-generation", f"{count:064x}")
+        row("provider", "updates", "available", "delegated", "PackageKit", "Private fixture")
+        row("provider", "recovery", "available", "user-session", "dwm-system-management", "Empty private journal")
+        row("state", "update-summary", "available", "1", "One update")
+        row("state", "update-last-refresh", "available", "10", "Recent fixture refresh")
+        row("state", "update-restart", "available", "none", "No restart")
+        for action_id in ("updates-refresh", "updates-install-all", "updates-cancel"):
+            row("action", action_id, "unavailable", "delegated", "updates", action_id, "Private fixture")
+        row("update", "alpha;1;x86_64;updates", "security", "installable", "alpha", "1", "Fixture update")
+        row("package-change", "alpha;1;x86_64;updates", "update", "alpha", "1", "Fixture update")
+        row("complete", "snapshot")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/system-operation-provider.py
+++ b/tests/fixtures/system-operation-provider.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import sys
 import time
+import signal
 
 
 def row(*fields):
@@ -33,7 +34,10 @@ def snapshot():
     row("system-management-protocol", "1", "0")
     row("snapshot-generation", "a" * 64)
     row("provider", "updates", "unsupported", "delegated", "PackageKit", "Isolated fixture")
-    row("provider", "recovery", "partial" if incomplete or os.environ.get("DWM_OPERATION_FIXTURE") else "available",
+    recovery_partial = incomplete or bool(os.environ.get("DWM_OPERATION_FIXTURE"))
+    if delayed_snapshot and not captured_handoff:
+        recovery_partial = False
+    row("provider", "recovery", "partial" if recovery_partial else "available",
         "user-session", "dwm-system-management", "Isolated fixture")
     for name in ("update-summary", "update-last-refresh", "update-restart"):
         row("state", name, "unsupported", "unknown", "Isolated fixture")
@@ -62,6 +66,10 @@ def snapshot():
 
 
 def main():
+    if sys.argv[1:] == ["watch-updates"]:
+        row("update-event", "ready")
+        while True:
+            signal.pause()
     if sys.argv[1:] == ["snapshot"]:
         snapshot()
         return 0

--- a/tests/qml/SystemDiscovery.qml
+++ b/tests/qml/SystemDiscovery.qml
@@ -1,0 +1,222 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.core
+import qs.systemmanagement
+import "systemmanagement/SystemDiscoveryCycle.js" as Cycle
+
+ShellRoot {
+    id: root
+    property int assertions: 0
+    property int stage: 0
+    property int ticks: 0
+    property int expected: 0
+    property int boundaryEvents: 0
+    property string continuation: ""
+    property double stoppedAt: 0
+    property bool done: false
+
+    function check(condition, detail) {
+        root.assertions++;
+        if (!condition) {
+            console.error("Discovery FAILED: " + detail);
+            Qt.callLater(function() { Qt.quit(); });
+            throw new Error(detail);
+        }
+    }
+
+    function unitTests() {
+        const c = Cycle.create();
+        Cycle.begin(c);
+        for (let i = 0; i < 100; i++) Cycle.invalidate(c);
+        const first = Cycle.take(c);
+        Cycle.beforePublish(c, first);
+        Cycle.complete(c, first, true);
+        root.check(c.phase === "idle", "Pending burst is covered by the reserved initial read");
+        Cycle.invalidate(c);
+        const initial = Cycle.take(c);
+        for (let i = 0; i < 100; i++) Cycle.invalidate(c);
+        Cycle.beforePublish(c, initial);
+        Cycle.invalidate(c);
+        Cycle.complete(c, initial, true);
+        root.check(c.phase === "settling-pending", "Initial completion reserves exactly one settling read");
+        Cycle.complete(c, initial, true);
+        root.check(c.phase === "settling-pending", "Duplicate completion cannot consume the reserved rerun");
+        const settling = Cycle.take(c);
+        Cycle.complete(c, initial, false);
+        root.check(c.phase === "settling-active", "Stale initial completion cannot fail the settling read");
+        Cycle.beforePublish(c, settling);
+        Cycle.invalidate(c);
+        Cycle.complete(c, settling, true);
+        root.check(c.unresolved && c.phase === "blocked", "Settling completion invalidation remains unresolved");
+        for (let i = 0; i < 100; i++) Cycle.invalidate(c);
+        root.check(!Cycle.pending(c) && Cycle.take(c) === null, "No automatic third read");
+        Cycle.begin(c);
+        const retry = Cycle.take(c);
+        Cycle.complete(c, retry, true);
+        root.check(c.unresolved && Cycle.pending(c), "Explicit retry cannot clear sticky state with its first read");
+        Cycle.complete(c, Cycle.take(c), true);
+        root.check(!c.unresolved && c.phase === "idle", "Quiet settling clears sticky state");
+        Cycle.invalidate(c);
+        const obsolete = Cycle.take(c);
+        Cycle.close(c);
+        Cycle.begin(c);
+        Cycle.complete(c, obsolete, true);
+        root.check(c.phase === "initial-pending", "Old closed-cycle completion cannot consume a reopened cycle");
+        Cycle.complete(c, Cycle.take(c), false);
+        root.check(c.unresolved && c.phase === "blocked", "Failed snapshots stop automatic rereads");
+    }
+
+    function count() { return parseInt(model.generation, 16); }
+
+    function control(mode, next) {
+        root.continuation = next;
+        controlProcess.command = Commands.systemManagementCommand("fixture-control", [mode]);
+        controlProcess.running = true;
+    }
+
+    function controlled() {
+        if (root.continuation === "open") { root.stage = 1; model.openSettings(); }
+        else if (root.continuation === "self") { root.stage = 2; model.refresh(); }
+        else if (root.continuation === "events") { root.stage = 3; root.ticks = 0; }
+        else if (root.continuation === "quiet") { root.stage = 4; model.refresh(); }
+        else if (root.continuation === "clear-boundary") { root.stage = 6; model.refresh(); }
+        else if (root.continuation === "slow") { root.stage = 7; model.refresh(); }
+        else if (root.continuation === "reopen") { root.stage = 9; model.openSettings(); }
+        else if (root.continuation === "fail") { root.stage = 10; model.closeSettings(); model.openSettings(); }
+        else if (root.continuation === "retry-monitor") { root.stage = 11; model.refresh(); }
+        else if (root.continuation === "ignore-term") { root.stage = 12; model.closeSettings(); model.openSettings(); }
+        else if (root.continuation === "malformed") { root.stage = 14; model.openSettings(); }
+        else if (root.continuation === "no-ready") {
+            root.stage = 15;
+            root.stoppedAt = Date.now();
+            model.closeSettings();
+            model.openSettings();
+        }
+        else if (root.continuation === "failed-stopping") { root.stage = 17; model.openSettings(); }
+        else if (root.continuation === "early-retry") { root.stage = 18; model.refresh(); }
+    }
+
+    function advance() {
+        if (root.done || controlProcess.running) return;
+        const idle = !model.busy;
+        if (root.stage === 0 && idle && model.snapshotState === "ready") {
+            root.check(root.count() === 1 && !model.discovery.monitorOwned, "Closed startup has exactly one required read, no monitor");
+            root.stage = -1;
+            root.control("quiet", "open");
+        } else if (root.stage === 1 && idle && model.discovery.fresh) {
+            root.check(root.count() === 2, "Pane opening reads after the readiness handshake");
+            root.stage = -1;
+            root.control("self", "self");
+        } else if (root.stage === 2 && idle && model.discovery.phase === "blocked") {
+            root.check(root.count() === 4, "Self-generated global events stop after initial plus settling reads");
+            root.check(model.providerState === "partial" && model.updates.length === 1
+                && model.packageChanges.length === 1 && model.discoveryDetail.indexOf("Reload status") >= 0,
+                "Dirty state preserves readable inventory and recovery guidance");
+            root.stage = -1;
+            root.control("events", "events");
+        } else if (root.stage === 3 && ++root.ticks >= 5) {
+            root.check(root.count() === 4 && idle && model.discovery.unresolved, "Further global bursts cannot start work");
+            root.stage = -1;
+            root.control("quiet", "quiet");
+        } else if (root.stage === 4 && idle && model.discovery.fresh) {
+            root.check(root.count() === 6 && !model.discovery.unresolved, "Explicit quiet retry performs its settling read");
+            root.stage = 5;
+            model.refresh();
+        } else if (root.stage === 5 && idle && model.discovery.phase === "blocked") {
+            root.check(root.count() === 8 && root.boundaryEvents === 2,
+                "Reentrant completion-boundary events cannot be lost or schedule a third read");
+            root.stage = -1;
+            root.control("quiet", "clear-boundary");
+        } else if (root.stage === 6 && idle && model.discovery.fresh) {
+            root.check(root.count() === 10, "Boundary-dirty retry settles exactly once");
+            root.stage = -1;
+            root.control("slow", "slow");
+        } else if (root.stage === 7 && model.busy) {
+            root.stage = 8;
+            model.closeSettings();
+        } else if (root.stage === 8 && idle && !model.discovery.monitorOwned) {
+            root.check(!model.discovery.visible && !model.discovery.fresh, "Pane closure stops optional read and monitor");
+            root.stage = -1;
+            root.control("quiet", "reopen");
+        } else if (root.stage === 9 && idle && model.discovery.fresh) {
+            root.check(root.count() > 10, "Reopen reads new state after a new monitor baseline");
+            root.expected = root.count() + 1;
+            root.stage = -1;
+            root.control("fail-monitor", "fail");
+        } else if (root.stage === 10 && idle && model.discovery.failed && root.count() === root.expected) {
+            root.check(model.providerState === "partial" && model.updates.length === 1 && !model.discovery.fresh,
+                "Startup monitor failure retains finite readable status without freshness");
+            root.stage = -1;
+            root.control("quiet", "retry-monitor");
+        } else if (root.stage === 11 && idle && model.discovery.fresh) {
+            root.check(root.count() === root.expected + 1, "Explicit retry restores failed monitoring");
+            root.stage = -1;
+            root.control("ignore-term", "ignore-term");
+        } else if (root.stage === 12 && idle && model.discovery.fresh) {
+            root.stage = 13;
+            root.stoppedAt = Date.now();
+            model.closeSettings();
+        } else if (root.stage === 13 && !model.discovery.monitorOwned) {
+            root.check(Date.now() - root.stoppedAt >= 1000 && Date.now() - root.stoppedAt < 4000,
+                "Unresponsive monitor is killed after bounded close grace");
+            root.expected = root.count() + 1;
+            root.stage = -1;
+            root.control("malformed", "malformed");
+        } else if (root.stage === 14 && idle && model.discovery.failed && root.count() === root.expected) {
+            root.check(!model.discovery.ready && model.updates.length === 1,
+                "A changed record before readiness fails monitoring without hiding the snapshot");
+            root.expected++;
+            root.stage = -1;
+            root.control("no-ready", "no-ready");
+        } else if (root.stage === 15 && idle && model.discovery.failed && root.count() === root.expected) {
+            root.check(Date.now() - root.stoppedAt >= 11000 && Date.now() - root.stoppedAt < 17000,
+                "Missing readiness falls back to a finite snapshot within the setup deadline");
+            model.closeSettings();
+            root.stage = 16;
+        } else if (root.stage === 16 && !model.discovery.monitorOwned) {
+            root.expected = root.count() + 1;
+            root.stage = -1;
+            root.control("failed-stopping", "failed-stopping");
+        } else if (root.stage === 17 && idle && model.discovery.failed && root.count() === root.expected) {
+            root.check(model.discovery.monitorOwned && model.discovery.stopping,
+                "Retry fixture retains the failed monitor during its shutdown grace");
+            root.expected++;
+            root.stage = -1;
+            root.control("restart-quiet", "early-retry");
+        } else if (root.stage === 18 && idle && model.discovery.fresh) {
+            root.check(root.count() === root.expected, "Queued replacement monitor has exactly one baseline read");
+            model.closeSettings();
+            root.stage = 19;
+        } else if (root.stage === 19 && !model.discovery.monitorOwned) {
+            root.done = true;
+            console.info("Discovery native tests: PASS (" + root.assertions + " assertions)");
+            Qt.quit();
+        }
+    }
+
+    SystemManagementModel {
+        id: model
+        onSnapshotStateChanged: {
+            if (root.stage === 5 && snapshotState === "ready") {
+                root.check(snapshotOwned, "Snapshot ownership covers all publication callbacks");
+                root.boundaryEvents++;
+                discovery.invalidate();
+            }
+        }
+    }
+    Process {
+        id: controlProcess
+        onExited: (code, status) => {
+            root.check(code === 0 && status === 0, "Private fixture control succeeds");
+            Qt.callLater(root.controlled);
+        }
+    }
+    Timer { interval: 50; repeat: true; running: true; onTriggered: root.advance() }
+    Timer {
+        interval: 45000; running: true
+        onTriggered: root.check(false, "Discovery scenario timed out at stage " + root.stage + ", phase "
+            + model.discovery.phase + ", snapshot " + model.snapshotState + ", count " + root.count())
+    }
+    Component.onCompleted: root.unitTests()
+}

--- a/tests/qml/SystemOperationOwner.qml
+++ b/tests/qml/SystemOperationOwner.qml
@@ -7,6 +7,7 @@ ShellRoot {
     property int scenario: 0
     property int assertions: 0
     property int snapshotRequests: 0
+    property int discoveryInvalidations: 0
     property bool sawProgress: false
     property bool sawVerifying: false
     property bool emptyReplay: false
@@ -38,6 +39,7 @@ ShellRoot {
         }
         root.scenario++;
         root.snapshotRequests = 0;
+        root.discoveryInvalidations = 0;
         root.sawProgress = false;
         root.sawVerifying = false;
         root.emptyReplay = false;
@@ -55,6 +57,7 @@ ShellRoot {
 
     SystemOperationModel {
         id: model
+        onDiscoveryInvalidated: root.discoveryInvalidations++
         onSnapshotRequested: {
             root.snapshotRequests++;
             if (root.scenario === 6) {
@@ -81,6 +84,8 @@ ShellRoot {
                 Qt.callLater(root.finishControlFailure);
         }
         onAcknowledged: operationId => {
+            root.check(root.scenario === 2 ? root.discoveryInvalidations === 0 : root.discoveryInvalidations > 0,
+                "Only PackageKit results invalidate discovery even without a global signal");
             root.check(operationId === root.target.id, "Acknowledgment must name exact validated identity");
             root.check(root.sawProgress && root.sawVerifying, "Stream progress must arrive before exit");
             root.check(result.state === (root.scenario === 2 ? "permission-denied" : "succeeded"),
@@ -104,6 +109,7 @@ ShellRoot {
 
     function finishFailure() {
         if (root.completed || (root.failedStart && !root.integrated.operation.blocked)) return;
+        root.check(root.discoveryInvalidations > 0, "Uncertain PackageKit observer exit invalidates discovery");
         root.check(model.blocked && !model.busy, "Exhausted recovery must stop all automatic work");
         root.check(root.snapshotRequests === 3 && model.retries === 3, "Exactly three bounded recovery reads");
         if (root.failedStart) {
@@ -132,20 +138,25 @@ ShellRoot {
     }
 
     Component { id: integratedComponent; SystemManagementModel {} }
+
+    function finishDelayedSnapshot() {
+        if (root.completed || !root.delayedSnapshot || !root.sawLateAck || root.integrated === null
+                || root.integrated.snapshotState !== "ready" || !root.integrated.discovery.fresh) return;
+        root.check(root.integrated.terminalHandoff === null && root.integrated.activeOperation === null,
+            "Delayed snapshot cannot restore acknowledged UI state");
+        root.check(!root.integrated.operation.controlOwned && !root.integrated.operation.blocked,
+            "Delayed snapshot cannot send a redundant acknowledgment or show failure");
+        root.check(root.integrated.operation.state === "result", "Verified result survives delayed discovery");
+        root.complete();
+    }
+
     Connections {
         target: root.integrated
-        function onSnapshotStateChanged() {
-            if (root.delayedSnapshot && root.sawLateAck && root.integrated.snapshotState === "ready") {
-                Qt.callLater(function() {
-                    root.check(root.integrated.terminalHandoff === null && root.integrated.activeOperation === null,
-                        "Delayed snapshot cannot restore acknowledged UI state");
-                    root.check(!root.integrated.operation.controlOwned && !root.integrated.operation.blocked,
-                        "Delayed snapshot cannot send a redundant acknowledgment or show failure");
-                    root.check(root.integrated.operation.state === "result", "Verified result survives delayed discovery");
-                    root.complete();
-                });
-            }
-        }
+        function onSnapshotStateChanged() { Qt.callLater(root.finishDelayedSnapshot); }
+    }
+    Connections {
+        target: root.integrated === null ? null : root.integrated.discovery
+        function onFreshChanged() { Qt.callLater(root.finishDelayedSnapshot); }
     }
     Connections {
         target: root.integrated === null ? null : root.integrated.operation
@@ -193,6 +204,7 @@ ShellRoot {
             if (root.delayedSnapshot) {
                 root.check(!root.sawLateAck, "The committed handoff is acknowledged exactly once");
                 root.sawLateAck = true;
+                Qt.callLater(root.finishDelayedSnapshot);
                 return;
             }
             if (root.closeRetry) {

--- a/tests/test-quickshell-system-management-xvfb.sh
+++ b/tests/test-quickshell-system-management-xvfb.sh
@@ -41,7 +41,12 @@ cleanup() {
 	set +e
 	stop_process "${quickshell_pid:-}"
 	if [ -n "${helper:-}" ]; then
-		for helper_pid in $(pgrep -f "$helper snapshot" 2>/dev/null || true); do
+		for helper_pid in $(pgrep -f "$helper " 2>/dev/null || true); do
+			stop_process "$helper_pid"
+		done
+	fi
+	if [ -n "${discovery_helper:-}" ]; then
+		for helper_pid in $(pgrep -f "$discovery_helper " 2>/dev/null || true); do
 			stop_process "$helper_pid"
 		done
 	fi
@@ -85,6 +90,11 @@ set -eu
 fixture=${DWM_SYSTEM_MANAGEMENT_TEST_FIXTURE:?}
 mode=$(sed -n '1p' "$fixture/mode")
 case ${1:-} in
+watch-updates)
+	[ "$mode" != monitor-failure ] || exit 1
+	printf '%s\n' "$$" >"$fixture/monitor-pid"
+	exec /usr/bin/python3 -c 'import signal; print("update-event\tready", flush=True); signal.pause()' "$0" watch-updates
+	;;
 watch-operation | ack-operation)
 	case ${2:-} in
 	op-11111111111111111111111111111111) action=timezone-set; kind=timezone ;;
@@ -127,7 +137,7 @@ snapshot() {
 }
 
 case $mode in
-valid)
+valid | monitor-failure)
 	snapshot
 	;;
 requested-install)
@@ -268,6 +278,47 @@ while [ "$i" -lt 100 ]; do
 done
 DISPLAY=$display xprop -root >/dev/null
 
+# Exercise pane-scoped events and atomic dirty-cycle handoffs on a private bus.
+mkdir -p "$work/discovery" "$work/discovery-data/dwm-titus/scripts" "$work/discovery-state"
+cp -a "$repo/config/quickshell/core" "$repo/config/quickshell/systemmanagement" "$work/discovery/"
+cp "$repo/tests/qml/SystemDiscovery.qml" "$work/discovery/shell.qml"
+discovery_helper=$work/discovery-data/dwm-titus/scripts/dwm-system-management
+cp "$repo/tests/fixtures/system-discovery-provider.py" "$discovery_helper"
+chmod +x "$discovery_helper"
+for pipe_case in absent regular no-reader; do
+	pipe_fixture=$work/discovery-pipe-$pipe_case
+	mkdir -p "$pipe_fixture"
+	case $pipe_case in
+	regular) : >"$pipe_fixture/events" ;;
+	no-reader) mkfifo "$pipe_fixture/events" ;;
+	esac
+	pipe_status=0
+	timeout --kill-after=1s 2s env DWM_DISCOVERY_FIXTURE="$pipe_fixture" \
+		"$discovery_helper" fixture-control events >"$pipe_fixture/log" 2>&1 || pipe_status=$?
+	if [ "$pipe_status" -eq 0 ] || [ "$pipe_status" -eq 124 ] || [ "$pipe_status" -eq 137 ]; then
+		printf 'Fixture event writer did not fail promptly for %s\n' "$pipe_case" >&2
+		exit 1
+	fi
+	[ ! -s "$pipe_fixture/events" ]
+	[ "$pipe_case" != absent ] || [ ! -e "$pipe_fixture/events" ]
+done
+printf 'Discovery fixture event-writer failure cases: PASS\n'
+timeout --foreground --kill-after=2s 50s env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
+	XDG_DATA_HOME="$work/discovery-data" XDG_RUNTIME_DIR="$runtime" QT_QPA_PLATFORMTHEME= \
+	DWM_DISCOVERY_FIXTURE="$work/discovery-state" \
+	quickshell --no-duplicate --path "$work/discovery/shell.qml" >"$work/discovery.log" 2>&1 &
+quickshell_pid=$!
+discovery_status=0
+wait "$quickshell_pid" || discovery_status=$?
+quickshell_pid=
+if [ "$discovery_status" -ne 0 ] || ! grep -F 'Discovery native tests: PASS' "$work/discovery.log" ||
+	grep -Fq 'Discovery FAILED:' "$work/discovery.log" || [ -e "$work/discovery-state/overlap" ] ||
+	[ -e "$work/discovery-state/unmonitored-read" ]; then
+	[ ! -e "$work/discovery-state/unmonitored-read" ] || printf 'Discovery snapshot preceded replacement readiness\n' >&2
+	cat "$work/discovery.log" >&2
+	exit 1
+fi
+
 # Run the isolated operation parser on the same nested display before loading
 # the managed shell. This fixture never connects to host PackageKit.
 mkdir -p "$work/operation-parser"
@@ -388,7 +439,7 @@ if ! grep -F 'Operation owner native tests: PASS' "$work/operation-owner-delayed
 	cat "$work/operation-owner-delayed-snapshot.log" >&2
 	exit 1
 fi
-[ "$(sed -n '1p' "$work/owner-state/delayed-snapshots")" -eq 2 ]
+[ "$(sed -n '1p' "$work/owner-state/delayed-snapshots")" -eq 3 ]
 [ "$(sed -n '1p' "$work/owner-state/ack-operation-16")" -eq 1 ]
 cp "$repo/tests/qml/SystemOperationHandoff.qml" "$work/operation-owner/handoff.qml"
 timeout --foreground --kill-after=2s 10s env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
@@ -447,7 +498,11 @@ wait_state() {
 			return 1
 		fi
 		state=$(ipc systemManagementSnapshotState 2>/dev/null || true)
-		[ "$state" != "$expected" ] || return 0
+		if [ "$state" = "$expected" ]; then
+			case $(ipc systemManagementDiscoveryStatus) in
+			idle:* | blocked:*) return 0 ;;
+			esac
+		fi
 		i=$((i + 1))
 		sleep 0.05
 	done
@@ -459,6 +514,19 @@ wait_state() {
 
 wait_state ready
 [ "$(ipc systemManagementUpdateCount)" -eq 1 ]
+[ "$(pgrep -f "$helper watch-updates")" = "$(sed -n '1p' "$fixture/monitor-pid")" ]
+
+printf 'monitor-failure\n' >"$fixture/mode"
+ipc close >/dev/null
+ipc open >/dev/null
+ipc select system >/dev/null
+wait_state ready
+[ "$(ipc systemManagementDiscoveryStatus)" = idle:failed ]
+[ "$(ipc systemManagementUpdateCount)" -eq 1 ]
+if [ -n "${DWM_SYSTEM_MANAGEMENT_CAPTURE_DIR:-}" ]; then
+	mkdir -p -- "$DWM_SYSTEM_MANAGEMENT_CAPTURE_DIR"
+	DISPLAY=$display import -window root "$DWM_SYSTEM_MANAGEMENT_CAPTURE_DIR/discovery-unavailable.png"
+fi
 
 printf 'requested-install\n' >"$fixture/mode"
 ipc refresh >/dev/null

--- a/tests/test-quickshell-system-management.sh
+++ b/tests/test-quickshell-system-management.sh
@@ -5,6 +5,7 @@ repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 model=$repo/config/quickshell/systemmanagement/SystemManagementModel.qml
 pane=$repo/config/quickshell/settings/SystemSettingsPane.qml
 commands=$repo/config/quickshell/core/Commands.qml
+discovery=$repo/config/quickshell/systemmanagement/SystemUpdateDiscovery.qml
 settings=$repo/config/quickshell/settings/SettingsModel.qml
 settings_window=$repo/config/quickshell/settings/SettingsWindow.qml
 shell=$repo/config/quickshell/shell.qml
@@ -22,6 +23,13 @@ grep -Fq "2>\"\$error_file\" &" "$commands"
 grep -Fq "head -c 512 \"\$error_file\" >&2" "$commands"
 grep -Fq 'command: Commands.terminatingCheckedCommand(' "$model"
 [ "$(grep -Fc 'Process {' "$model")" -eq 1 ]
+[ "$(grep -Fc 'Process {' "$discovery")" -eq 1 ]
+grep -Fq 'Commands.systemManagementCommand("watch-updates", [])' "$discovery"
+grep -Fq 'stdout: SplitParser' "$discovery"
+if grep -Fq 'repeat: true' "$discovery"; then
+	printf 'Update discovery must not poll.\n' >&2
+	exit 1
+fi
 if grep -Fq 'repeat: true' "$model"; then
 	printf 'System-management model must not poll.\n' >&2
 	exit 1
@@ -104,6 +112,7 @@ pane_model_members=$(grep -Eo 'systemManagementModel\.[A-Za-z][A-Za-z0-9]*' "$pa
 expected_pane_model_members=$(printf '%s\n' \
 	'systemManagementModel.activeOperation' \
 	'systemManagementModel.busy' \
+	'systemManagementModel.discoveryDetail' \
 	'systemManagementModel.errors' \
 	'systemManagementModel.message' \
 	'systemManagementModel.operation' \


### PR DESCRIPTION
## Summary

- Consume the merged `watch-updates` helper only while the System Settings section is open, with a readiness handshake, bounded startup/close deadlines, finite-read fallback, and explicit monitoring-unavailable guidance.
- Serialize discovery into an initial read plus at most one settling read. Repeated invalidation retains visible partial state and reload guidance instead of starting an automatic third read.
- Keep snapshot ownership through publication and recovery callbacks; preserve required recovery across pane closure. PackageKit observer completion, uncertain exit, and active adoption also invalidate discovery without relying on global signals.
- Expose confirmation invalidation for the next UI boundary. Add native lifecycle and failure fixtures, including the explicit-reload/replacement-readiness race found during review.

## Validation

- `scripts/run-tests make clean all` and `scripts/run-tests`: passed for the complete production diff, including 309 provider tests, 830 native assertions, QML and shell gates, staged installation, repeated-install preservation, package mapping, and release archive checks.
- Final test-only event-writer hardening was followed by the complete focused `scripts/run-tests make check-quickshell-system-management` suite: 830 native assertions and three negative pipe cases passed. ShellCheck, shfmt, and diff checks also passed.
- The restart regression failed against the unfixed implementation with "snapshot preceded replacement readiness", then passed after the fix.
- Final local Codex review: no actionable defects. Fresh independent CodeRabbit review: zero findings across all 15 files.
- Fedora 44 / Quickshell 0.2.1 nested X11: Settings closed CPU 0.033%; large surfaces 0.00%. The 1024x768 monitoring-unavailable screenshot was manually checked for readable inventory and unclipped warning text; captures are retained outside version control.
- Test workspaces were cleaned. No host PackageKit mutation, cancellation, or session restart was performed.

## Scope and remaining work

This is the pane-discovery boundary after #237, not Phase 6 completion. Update execution/confirmation/cancel UI, regional/delegated entry points, information/recovery surfaces, and combined installed-runtime qualification remain. Mutation buttons are not enabled by this PR. Existing provider diagnostics and unavailable capabilities remain readable.

Hosted checks and exact-head reviews must complete before merge.