### PR TITLE
feat(system): own update starts and cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ versions from `config.mk`.
 
 ### Changed
 
+- Add root-owned update start/cancel lifecycle and bounded verified progress
+  logs. Cancellation remains an exact-ID request, never a fabricated result;
+  interrupted origins recover by observation. Settings mutation controls remain
+  disabled pending their visible confirmation workflow.
+
 - Preserve Fedora DNF5 dependency previews when a requested update is reported
   as an install. Keep the actual package actions visible and retain strict
   missing, duplicate, and unexpected-update checks; confirmed update execution

--- a/TASKS.md
+++ b/TASKS.md
@@ -96,7 +96,14 @@ recovery to three retries. Native nested-X11 fixtures exercise live progress,
 failed-result replay, stale collector data, restart adoption, and failed process
 starts without host service calls. Originating mutation, confirmation, and cancel
 UI integration must be completed before this boundary can be accepted.
-Settings mutation actions remain disabled.
+The root owner now accepts only fixed update origins, enforces origin-specific
+exit/result validation, and preserves a bounded verified progress log. A shared
+exact-ID cancellation/acknowledgment control preserves the live observer and
+reconciles a terminal handoff that wins the cancellation race. Native private
+fixtures cover rejected admission, uncertain start, denial, revoked cancellation,
+control failure and timeout, and overlap rejection. These internal entry points
+are not exposed by IPC. Settings mutation actions remain disabled until visible
+confirmation and action-availability guards are integrated.
 The fixed `watch-updates` command now observes only global PackageKit discovery
 changes and daemon ownership changes. It establishes subscriptions before
 reporting readiness, bounds setup to ten seconds, and never starts a transaction.

--- a/config/quickshell/systemmanagement/SystemOperationModel.qml
+++ b/config/quickshell/systemmanagement/SystemOperationModel.qml
@@ -4,7 +4,8 @@ import Quickshell.Io
 import qs.core
 import "SystemOperationProtocol.js" as Protocol
 
-// Root-owned observation and journal acknowledgment; never starts a mutation.
+// Root-owned operation streams and exact-ID controls. The Settings caller owns
+// visible confirmation; this model accepts only fixed update commands.
 Scope {
     id: root
 
@@ -18,18 +19,33 @@ Scope {
     property var result: null
     property var audit: null
     property var operationError: null
+    property var log: []
     property var handoff: null
     property var snapshotActive: null
     property var acknowledgedIds: []
     property var parser: null
+    property bool streamReplay: true
+    property bool streamFailed: false
+    property bool terminalPending: false
+    property bool snapshotKnown: false
     property bool streamOwned: false
     property bool controlOwned: false
+    property bool controlFinishing: false
     property bool waitingSnapshot: false
     property bool blocked: false
     property int retries: 0
     property string controlId: ""
+    property string controlPurpose: ""
+    property string cancelRequestedId: ""
+    property string cancelDetail: ""
     property bool controlInvalid: false
     readonly property bool busy: streamOwned || controlOwned || waitingSnapshot || retryTimer.running
+    readonly property bool canStart: root.snapshotKnown && !root.busy && !root.blocked
+        && root.snapshotActive === null && root.handoff === null
+    readonly property bool canCancel: root.streamOwned && !root.controlOwned && !root.streamFailed
+        && !root.terminalPending && root.log.length > 0 && root.progress !== null && root.progress.cancelable
+        && (root.progress.kind === "update" || root.progress.kind === "refresh")
+        && root.progress.state !== "cancel-requested" && root.cancelRequestedId !== root.progress.id
 
     function matches(left, right) {
         return left !== null && right !== null && left.id === right.id
@@ -66,6 +82,7 @@ Scope {
     }
 
     function snapshotFailed() {
+        root.snapshotKnown = false;
         root.waitingSnapshot = false;
         if (root.streamOwned || root.controlOwned || root.blocked || retryTimer.running) return;
         root.recover("Operation recovery could not read complete journal evidence");
@@ -74,12 +91,16 @@ Scope {
     // Only fully accepted snapshots may enter this method. A live stream is
     // the sole observer even before it emits its first operation identity.
     function acceptSnapshot(active, terminal) {
+        root.snapshotKnown = false;
         if (active !== null && root.wasAcknowledged(active.id)) active = null;
         if (terminal !== null && root.wasAcknowledged(terminal.id)) terminal = null;
         root.waitingSnapshot = false;
         root.snapshotActive = active;
         root.handoff = terminal;
-        if (root.streamOwned || root.controlOwned || root.blocked || retryTimer.running) return;
+        if (root.streamOwned || root.controlOwned || root.blocked || retryTimer.running) {
+            root.snapshotKnown = true;
+            return;
+        }
         if (terminal !== null && root.matches(terminal, root.result)) {
             root.startAcknowledgment();
         } else if (active !== null && root.matches(active, root.result)) {
@@ -87,7 +108,14 @@ Scope {
         } else if (active !== null || terminal !== null) {
             const target = active !== null ? active : terminal;
             root.parser = Protocol.create(target.id, target.actionId);
+            root.progress = null;
+            root.log = [];
             root.streamOwned = true;
+            root.streamReplay = true;
+            root.streamFailed = false;
+            root.terminalPending = false;
+            root.cancelRequestedId = "";
+            root.cancelDetail = "";
             if (active !== null) root.discoveryInvalidated();
             root.progress = active;
             root.state = "observing";
@@ -100,49 +128,140 @@ Scope {
             root.state = root.result === null ? "idle" : "result";
             root.detail = root.result === null ? "" : root.result.detail;
         }
+        root.snapshotKnown = true;
+    }
+
+    // This internal entry point is not exposed by IPC. A future Settings
+    // confirmation must also validate fresh discovery and action availability.
+    function startUpdate(action, generation) {
+        // Recheck fields rather than a UI binding during reentrant publication.
+        if (!root.snapshotKnown || root.streamOwned || root.controlOwned || root.waitingSnapshot
+                || root.blocked || retryTimer.running || root.snapshotActive !== null || root.handoff !== null
+                || typeof generation !== "string"
+                || (action !== "updates-refresh" && action !== "updates-install-all")
+                || (action === "updates-install-all" ? !/^[0-9a-f]{64}$/.test(generation) : generation !== ""))
+            return false;
+        const command = Commands.systemManagementCommand(action,
+            action === "updates-install-all" ? [generation] : []);
+        root.snapshotKnown = false;
+        root.parser = Protocol.create("", action);
+        root.progress = null;
+        root.log = [];
+        root.streamOwned = true;
+        root.streamReplay = false;
+        root.streamFailed = false;
+        root.terminalPending = false;
+        root.result = null;
+        root.audit = null;
+        root.operationError = null;
+        root.cancelRequestedId = "";
+        root.cancelDetail = "";
+        root.state = "observing";
+        root.detail = "Starting " + action;
+        watchProcess.command = command;
+        root.discoveryInvalidated();
+        Qt.callLater(function() { if (root.streamOwned) watchProcess.running = true; });
+        return true;
     }
 
     function consume(data) {
         if (!root.streamOwned) return;
         if (!Protocol.consume(root.parser, data)) {
+            root.streamFailed = true;
             root.detail = root.parser.failure;
             watchProcess.signal(9);
             return;
         }
         // A terminal row is provisional until EOF, audit, completion AND the
         // exit status pass. Never display it as successful or acknowledge it.
+        if (root.parser.operation !== null && Protocol.terminal(root.parser.operation.state)) {
+            root.terminalPending = true;
+            root.state = "verifying";
+            root.detail = "Verifying the complete operation result...";
+        }
         for (let i = root.parser.records.length - 1; i >= 0; i--) {
             if (!Protocol.terminal(root.parser.records[i].state)) {
                 root.progress = root.parser.records[i];
                 break;
             }
         }
-        if (root.parser.operation !== null && Protocol.terminal(root.parser.operation.state)) {
-            root.state = "verifying";
-            root.detail = "Verifying the complete operation result...";
-        }
+        root.log = root.parser.records.filter(record => !Protocol.terminal(record.state));
     }
 
     function finishWatch(exitCode, normalExit) {
         if (!root.streamOwned) return;
         if (root.parser.expectedAction === "updates-refresh" || root.parser.expectedAction === "updates-install-all")
             root.discoveryInvalidated();
-        root.streamOwned = false;
-        if (!Protocol.finish(root.parser, exitCode, normalExit, true)) {
+        if (!Protocol.finish(root.parser, exitCode, normalExit, root.streamReplay)) {
+            root.streamFailed = true;
             root.recover(exitCode === 3 ? "Operation watch target changed (conflict)" : root.parser.failure);
+            root.streamOwned = false;
             return;
         }
         root.result = root.parser.operation;
         root.audit = root.parser.audit;
         root.operationError = root.parser.error;
         root.progress = null;
+        root.waitingSnapshot = true;
         root.state = "result";
         root.detail = root.result.detail;
+        root.log = root.parser.records.slice();
+        root.streamOwned = false;
         // Even a replay that began from an active snapshot needs a committed
         // handoff snapshot before ack. Never infer that handoff from stdout.
         Qt.callLater(function() {
-            if (root.matches(root.handoff, root.result)) root.startAcknowledgment();
+            if (root.matches(root.handoff, root.result) && !root.controlOwned) root.startAcknowledgment();
             else root.requestSnapshot();
+        });
+    }
+
+    function cancelTarget() {
+        const current = root.parser === null ? null : root.parser.operation;
+        if (!root.streamOwned || root.controlOwned || root.streamFailed || current === null
+                || root.parser.failure.length > 0 || Protocol.terminal(current.state)
+                || (current.kind !== "update" && current.kind !== "refresh")
+                || !current.cancelable || current.state === "cancel-requested"
+                || root.state === "verifying" || root.cancelRequestedId === current.id) return null;
+        return current;
+    }
+
+    function requestCancel() {
+        // Recheck the parser itself: QML log/progress callbacks can run before
+        // a binding catches up with the latest AllowCancel or terminal record.
+        const target = root.cancelTarget();
+        if (target === null) return false;
+        root.controlOwned = true;
+        root.controlId = target.id;
+        root.controlPurpose = "cancel";
+        root.controlInvalid = false;
+        root.cancelDetail = "Requesting cancellation from PackageKit...";
+        ackProcess.command = Commands.systemManagementCommand("updates-cancel", [root.controlId]);
+        Qt.callLater(root.launchControl);
+        return true;
+    }
+
+    function launchControl() {
+        if (!root.controlOwned) return;
+        controlDeadline.restart();
+        ackProcess.running = true;
+    }
+
+    function finishCancellation(exitCode, normalExit) {
+        const accepted = normalExit && exitCode === 0 && !root.controlInvalid;
+        if (accepted) root.cancelRequestedId = root.controlId;
+        root.cancelDetail = accepted
+            ? "Cancellation requested. Waiting for PackageKit's verified terminal result."
+            : exitCode === 3 && normalExit && !root.controlInvalid
+            ? "The cancellation target changed. Reloading recovery state; no cancellation was confirmed."
+            : "Cancellation was not confirmed. PackageKit still owns the operation; continue watching or reload status.";
+        root.controlOwned = false;
+        // The operation may finish and a newer handoff may arrive while this
+        // control is running. Reconcile only after its final Process signals.
+        Qt.callLater(function() {
+            if (!root.streamOwned) {
+                if (root.snapshotKnown) root.acceptSnapshot(root.snapshotActive, root.handoff);
+                else if (!root.waitingSnapshot) root.snapshotFailed();
+            } else if (exitCode === 3) root.requestSnapshot();
         });
     }
 
@@ -150,36 +269,48 @@ Scope {
         if (root.streamOwned || root.controlOwned || root.blocked
                 || !root.matches(root.handoff, root.result)
                 || root.wasAcknowledged(root.result.id)) return;
-        root.controlId = root.result.id;
-        root.controlInvalid = false;
         root.controlOwned = true;
+        root.controlId = root.result.id;
+        root.controlPurpose = "ack";
+        root.controlInvalid = false;
+        root.waitingSnapshot = false;
         root.state = "acknowledging";
         root.detail = "Acknowledging the verified operation result...";
         ackProcess.command = Commands.systemManagementCommand("ack-operation", [root.controlId]);
-        Qt.callLater(function() {
-            if (root.controlOwned) {
-                controlDeadline.restart();
-                ackProcess.running = true;
-            }
-        });
+        Qt.callLater(root.launchControl);
     }
 
     function finishAcknowledgment(exitCode, normalExit) {
-        if (!root.controlOwned) return;
+        if (!root.controlOwned || root.controlFinishing) return;
+        root.controlFinishing = true;
         controlDeadline.stop();
-        root.controlOwned = false;
+        // Keep ownership until the old Process has emitted runningChanged.
+        // Reentrant UI callbacks may request another control on release.
+        Qt.callLater(function() { root.completeControl(exitCode, normalExit); });
+    }
+
+    function completeControl(exitCode, normalExit) {
+        root.controlFinishing = false;
+        if (root.controlPurpose === "cancel") {
+            root.finishCancellation(exitCode, normalExit);
+            return;
+        }
         root.state = "result";
         if (!normalExit || exitCode !== 0 || root.controlInvalid) {
             root.blocked = true;
             root.detail = "The verified result could not be acknowledged. Reload status to retry recovery.";
+            root.controlOwned = false;
             return;
         }
         if (root.matches(root.handoff, root.result)) root.handoff = null;
+        if (root.snapshotActive !== null && root.snapshotActive.id === root.controlId)
+            root.snapshotActive = null;
         // Match the bounded retained journal: late discovery output must not
         // resurrect an acknowledged identity or send a duplicate ack control.
         root.acknowledgedIds = root.acknowledgedIds.concat([root.controlId]).slice(-32);
         root.retries = 0;
         root.detail = root.result.detail;
+        root.controlOwned = false;
         root.acknowledged(root.controlId);
         // Another client can admit or finish its operation after the helper
         // clears our handoff but before that helper exits. Do not drop a newer
@@ -208,6 +339,7 @@ Scope {
             waitForEnd: false
             onDataChanged: {
                 if (root.streamOwned && data.byteLength > 8192) {
+                    root.streamFailed = true;
                     Protocol.fail(root.parser, "Operation error output exceeded its limit");
                     watchProcess.signal(9);
                 }

--- a/config/quickshell/systemmanagement/SystemOperationModel.qml
+++ b/config/quickshell/systemmanagement/SystemOperationModel.qml
@@ -37,6 +37,7 @@ Scope {
     property string controlId: ""
     property string controlPurpose: ""
     property string cancelRequestedId: ""
+    property string cancelUncertainId: ""
     property string cancelDetail: ""
     property bool controlInvalid: false
     readonly property bool busy: streamOwned || controlOwned || waitingSnapshot || retryTimer.running
@@ -46,6 +47,7 @@ Scope {
         && !root.terminalPending && root.log.length > 0 && root.progress !== null && root.progress.cancelable
         && (root.progress.kind === "update" || root.progress.kind === "refresh")
         && root.progress.state !== "cancel-requested" && root.cancelRequestedId !== root.progress.id
+        && root.cancelUncertainId !== root.progress.id
 
     function matches(left, right) {
         return left !== null && right !== null && left.id === right.id
@@ -114,8 +116,9 @@ Scope {
             root.streamReplay = true;
             root.streamFailed = false;
             root.terminalPending = false;
-            root.cancelRequestedId = "";
-            root.cancelDetail = "";
+            if (root.cancelRequestedId !== target.id) root.cancelRequestedId = "";
+            if (root.cancelUncertainId !== target.id) root.cancelUncertainId = "";
+            if (!root.cancelRequestedId && !root.cancelUncertainId) root.cancelDetail = "";
             if (active !== null) root.discoveryInvalidated();
             root.progress = active;
             root.state = "observing";
@@ -155,6 +158,7 @@ Scope {
         root.audit = null;
         root.operationError = null;
         root.cancelRequestedId = "";
+        root.cancelUncertainId = "";
         root.cancelDetail = "";
         root.state = "observing";
         root.detail = "Starting " + action;
@@ -221,7 +225,8 @@ Scope {
                 || root.parser.failure.length > 0 || Protocol.terminal(current.state)
                 || (current.kind !== "update" && current.kind !== "refresh")
                 || !current.cancelable || current.state === "cancel-requested"
-                || root.state === "verifying" || root.cancelRequestedId === current.id) return null;
+                || root.state === "verifying" || root.cancelRequestedId === current.id
+                || root.cancelUncertainId === current.id) return null;
         return current;
     }
 
@@ -248,19 +253,25 @@ Scope {
 
     function finishCancellation(exitCode, normalExit) {
         const accepted = normalExit && exitCode === 0 && !root.controlInvalid;
+        const unavailable = normalExit && exitCode === 3 && !root.controlInvalid;
         if (accepted) root.cancelRequestedId = root.controlId;
+        // Exit 1 (or lost/malformed control output) cannot prove Cancel was not
+        // dispatched. Keep a distinct guard without claiming acceptance, even
+        // if a recovered same-ID stream repeats an old AllowCancel=true hint.
+        if (!accepted && !unavailable) root.cancelUncertainId = root.controlId;
         root.cancelDetail = accepted
             ? "Cancellation requested. Waiting for PackageKit's verified terminal result."
-            : exitCode === 3 && normalExit && !root.controlInvalid
+            : unavailable
             ? "The cancellation target changed. Reloading recovery state; no cancellation was confirmed."
-            : "Cancellation was not confirmed. PackageKit still owns the operation; continue watching or reload status.";
+            : "Cancellation was not confirmed. A repeat request is blocked for this operation. Continue watching or reload status.";
         root.controlOwned = false;
         // The operation may finish and a newer handoff may arrive while this
         // control is running. Reconcile only after its final Process signals.
         Qt.callLater(function() {
             if (!root.streamOwned) {
+                if (root.waitingSnapshot) return;
                 if (root.snapshotKnown) root.acceptSnapshot(root.snapshotActive, root.handoff);
-                else if (!root.waitingSnapshot) root.snapshotFailed();
+                else root.snapshotFailed();
             } else if (exitCode === 3) root.requestSnapshot();
         });
     }

--- a/config/quickshell/systemmanagement/SystemOperationModel.qml
+++ b/config/quickshell/systemmanagement/SystemOperationModel.qml
@@ -38,6 +38,7 @@ Scope {
     property string controlPurpose: ""
     property string cancelRequestedId: ""
     property string cancelUncertainId: ""
+    property string cancelConflictId: ""
     property string cancelDetail: ""
     property bool controlInvalid: false
     readonly property bool busy: streamOwned || controlOwned || waitingSnapshot || retryTimer.running
@@ -48,6 +49,7 @@ Scope {
         && (root.progress.kind === "update" || root.progress.kind === "refresh")
         && root.progress.state !== "cancel-requested" && root.cancelRequestedId !== root.progress.id
         && root.cancelUncertainId !== root.progress.id
+        && root.cancelConflictId !== root.progress.id
 
     function matches(left, right) {
         return left !== null && right !== null && left.id === right.id
@@ -118,7 +120,8 @@ Scope {
             root.terminalPending = false;
             if (root.cancelRequestedId !== target.id) root.cancelRequestedId = "";
             if (root.cancelUncertainId !== target.id) root.cancelUncertainId = "";
-            if (!root.cancelRequestedId && !root.cancelUncertainId) root.cancelDetail = "";
+            if (root.cancelConflictId !== target.id) root.cancelConflictId = "";
+            if (!root.cancelRequestedId && !root.cancelUncertainId && !root.cancelConflictId) root.cancelDetail = "";
             if (active !== null) root.discoveryInvalidated();
             root.progress = active;
             root.state = "observing";
@@ -159,6 +162,7 @@ Scope {
         root.operationError = null;
         root.cancelRequestedId = "";
         root.cancelUncertainId = "";
+        root.cancelConflictId = "";
         root.cancelDetail = "";
         root.state = "observing";
         root.detail = "Starting " + action;
@@ -226,7 +230,7 @@ Scope {
                 || (current.kind !== "update" && current.kind !== "refresh")
                 || !current.cancelable || current.state === "cancel-requested"
                 || root.state === "verifying" || root.cancelRequestedId === current.id
-                || root.cancelUncertainId === current.id) return null;
+                || root.cancelUncertainId === current.id || root.cancelConflictId === current.id) return null;
         return current;
     }
 
@@ -259,6 +263,10 @@ Scope {
         // dispatched. Keep a distinct guard without claiming acceptance, even
         // if a recovered same-ID stream repeats an old AllowCancel=true hint.
         if (!accepted && !unavailable) root.cancelUncertainId = root.controlId;
+        // A stale target cannot be made safe by the same observer's cached
+        // AllowCancel hint. Retire its control before releasing ownership;
+        // recovery of a different operation can establish a new target.
+        if (unavailable) root.cancelConflictId = root.controlId;
         root.cancelDetail = accepted
             ? "Cancellation requested. Waiting for PackageKit's verified terminal result."
             : unavailable

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -128,6 +128,9 @@ without claiming acceptance or resending the control. Same-ID observer recovery
 keeps that guard despite repeated `AllowCancel` hints; a different operation does
 not inherit it. The existing stream and bounded recovery remain the outcome
 owners.
+A stale-target cancellation response uses a distinct exact-ID conflict guard
+before releasing control ownership. Cached progress and same-ID recovery cannot
+resend that rejected control; a different operation establishes a new target.
 An identity-free snapshot establishes an empty journal only when recovery is
 available. Incomplete journal evidence retains the readable snapshot and takes
 the same bounded recovery path; it cannot silently abandon an unknown owner.

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -123,6 +123,11 @@ bounded control process with acknowledgment; it reports only an accepted request
 keeps the observer alive, and reconciles handoffs received while cancellation is
 running. These internal calls are not exposed by IPC. Settings mutation actions
 remain unavailable until visible confirmation and fresh action guards are added.
+An unconfirmed cancellation reply retains a separate exact-ID uncertainty guard,
+without claiming acceptance or resending the control. Same-ID observer recovery
+keeps that guard despite repeated `AllowCancel` hints; a different operation does
+not inherit it. The existing stream and bounded recovery remain the outcome
+owners.
 An identity-free snapshot establishes an empty journal only when recovery is
 available. Incomplete journal evidence retains the readable snapshot and takes
 the same bounded recovery path; it cannot silently abandon an unknown owner.

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -113,9 +113,16 @@ provisional until audit, completion, and normal exit pass. Malformed observers
 are terminated without canceling the PackageKit transaction. Three delayed
 snapshot-and-watch retries use one, two, and four seconds; exhaustion and failed
 acknowledgment retain explicit reload guidance. Pane-only reads still stop when
-Settings closes, while required recovery reads continue. Settings mutation
-actions remain unavailable until originating execution, confirmation, and
-cancellation are integrated.
+Settings closes, while required recovery reads continue. The root owner also
+accepts the two fixed update origins, validates their origin-specific exit code,
+and retains nonterminal progress logs until a verified terminal can be appended.
+Pre-admission failed requests reconcile a fresh empty journal without inventing
+a handoff or acknowledgment. Uncertain origins use the same bounded watch
+recovery without reissuing the mutable command. Exact-ID cancellation shares one
+bounded control process with acknowledgment; it reports only an accepted request,
+keeps the observer alive, and reconciles handoffs received while cancellation is
+running. These internal calls are not exposed by IPC. Settings mutation actions
+remain unavailable until visible confirmation and fresh action guards are added.
 An identity-free snapshot establishes an empty journal only when recovery is
 available. Incomplete journal evidence retains the readable snapshot and takes
 the same bounded recovery path; it cannot silently abandon an unknown owner.

--- a/tests/fixtures/system-update-action-provider.py
+++ b/tests/fixtures/system-update-action-provider.py
@@ -37,7 +37,8 @@ def main():
         (DIRECTORY / "cancel-sent").touch()
         if SCENARIO == "cancel-timeout":
             time.sleep(15)  # Frontend's 10-second deadline must kill only this control.
-        elif SCENARIO in ("cancel-race", "cancel-recovery", "cancel-recovery-denied", "cancel-recovery-failure"):
+        elif SCENARIO in ("cancel-race", "cancel-recovery", "cancel-recovery-denied",
+                          "cancel-recovery-failure", "cancel-pending-snapshot"):
             time.sleep(0.3)
         elif SCENARIO == "cancel-output":
             row("unexpected", "control output")
@@ -48,7 +49,8 @@ def main():
         else:
             time.sleep(0.08)
         (DIRECTORY / "control-active").unlink(missing_ok=True)
-        return 3 if SCENARIO == "cancel-conflict" else 1 if SCENARIO in ("cancel-denied", "cancel-recovery-denied") else 0
+        return 3 if SCENARIO == "cancel-conflict" else 1 if SCENARIO in (
+            "cancel-denied", "cancel-recovery-denied", "cancel-uncertain-recover") else 0
 
     replay = command == "watch-operation"
     action = "updates-install-all" if SCENARIO == "install" else "updates-refresh"
@@ -81,6 +83,8 @@ def main():
                 time.sleep(0.15)
                 if SCENARIO == "cancel-error-overflow":
                     (DIRECTORY / "control-active").unlink(missing_ok=True)
+                if SCENARIO == "cancel-uncertain-recover" and not replay:
+                    return 1  # Lost observation after an unconfirmed Cancel.
         if SCENARIO == "revoked":
             time.sleep(0.1)
             row("operation", OPERATION_ID, action, kind, "running", "80", "no", "Cancellation unsafe")

--- a/tests/fixtures/system-update-action-provider.py
+++ b/tests/fixtures/system-update-action-provider.py
@@ -1,0 +1,101 @@
+#!/usr/bin/python3
+"""Private native update-owner fixture; no service, privilege or host journal."""
+
+import os
+from pathlib import Path
+import sys
+import time
+
+
+DIRECTORY = Path(os.environ["DWM_UPDATE_ACTION_FIXTURE"])
+SCENARIO = os.environ["DWM_UPDATE_ACTION_SCENARIO"]
+OPERATION_ID = "op-" + "b" * 32
+
+
+def row(*fields):
+    print("\t".join(fields), flush=True)
+
+
+def main():
+    command = sys.argv[1]
+    if command not in ("updates-refresh", "updates-install-all", "updates-cancel",
+                       "watch-operation", "ack-operation"):
+        return 2
+    expected = ["c" * 64] if command == "updates-install-all" else (
+        [] if command == "updates-refresh" else [OPERATION_ID])
+    if sys.argv[2:] != expected:
+        (DIRECTORY / "invalid-arguments").touch()
+        return 2
+    counter = DIRECTORY / command
+    counter.write_text(str(int(counter.read_text()) + 1 if counter.exists() else 1))
+    if command == "ack-operation":
+        if (DIRECTORY / "control-active").exists():
+            (DIRECTORY / "control-overlap").touch()
+        return 0
+    if command == "updates-cancel":
+        (DIRECTORY / "control-active").touch()
+        (DIRECTORY / "cancel-sent").touch()
+        if SCENARIO == "cancel-timeout":
+            time.sleep(15)  # Frontend's 10-second deadline must kill only this control.
+        elif SCENARIO in ("cancel-race", "cancel-recovery", "cancel-recovery-denied", "cancel-recovery-failure"):
+            time.sleep(0.3)
+        elif SCENARIO == "cancel-output":
+            row("unexpected", "control output")
+        elif SCENARIO == "cancel-error-overflow":
+            sys.stderr.write("x" * 9000)
+            sys.stderr.flush()
+            time.sleep(15)
+        else:
+            time.sleep(0.08)
+        (DIRECTORY / "control-active").unlink(missing_ok=True)
+        return 3 if SCENARIO == "cancel-conflict" else 1 if SCENARIO in ("cancel-denied", "cancel-recovery-denied") else 0
+
+    replay = command == "watch-operation"
+    action = "updates-install-all" if SCENARIO == "install" else "updates-refresh"
+    kind = "update" if action == "updates-install-all" else "refresh"
+    row("system-management-protocol", "1", "0")
+    row("operation", OPERATION_ID, action, kind, "pending", "unknown", "no", "Pending fixture")
+    time.sleep(0.05)
+    failed = SCENARIO in ("rejected", "wrong-exit")
+    denied = SCENARIO == "denied"
+    result = "permission-denied" if denied else "failed" if failed else "succeeded"
+    if not failed:
+        row("operation", OPERATION_ID, action, kind, "authorizing" if denied else "running",
+            "30", "yes" if SCENARIO.startswith("cancel-") or SCENARIO == "revoked" else "no", "Live fixture")
+        if SCENARIO == "uncertain" and not replay:
+            return 1  # No complete result: recovery must watch, never reissue.
+        if SCENARIO.startswith("cancel-"):
+            deadline = time.monotonic() + 3
+            while not (DIRECTORY / "cancel-sent").exists():
+                if time.monotonic() >= deadline:
+                    return 1
+                time.sleep(0.01)
+            if SCENARIO == "cancel-accepted":
+                time.sleep(0.15)
+                row("operation", OPERATION_ID, action, kind, "cancel-requested", "30", "no", "Request accepted")
+                result = "canceled"
+            elif SCENARIO == "cancel-timeout":
+                time.sleep(10.5)
+                (DIRECTORY / "control-active").unlink(missing_ok=True)
+            else:
+                time.sleep(0.15)
+                if SCENARIO == "cancel-error-overflow":
+                    (DIRECTORY / "control-active").unlink(missing_ok=True)
+        if SCENARIO == "revoked":
+            time.sleep(0.1)
+            row("operation", OPERATION_ID, action, kind, "running", "80", "no", "Cancellation unsafe")
+            time.sleep(0.1)
+    if failed:
+        row("error", "updates", "conflict", "Confirmed generation changed")
+    row("operation", OPERATION_ID, action, kind, result, "100", "no", "Terminal fixture")
+    row("audit", OPERATION_ID, action, kind, result,
+        "2026-09-06T03:00:00Z", "2026-09-06T03:01:00Z", "Audited fixture")
+    row("complete", "operation")
+    time.sleep(0.08)  # Terminal records are provisional until normal exit.
+    if SCENARIO == "wrong-exit" and not replay:
+        return 0  # Invalid for an originating failed result; valid for its replay.
+    return 0 if replay or result == "succeeded" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/qml/SystemUpdateActionOwner.qml
+++ b/tests/qml/SystemUpdateActionOwner.qml
@@ -1,0 +1,145 @@
+import QtQuick
+import Quickshell
+import qs.systemmanagement
+
+ShellRoot {
+    id: root
+    property string scenario: Quickshell.env("DWM_UPDATE_ACTION_SCENARIO")
+    property int assertions: 0
+    property int snapshots: 0
+    property int invalidations: 0
+    property bool cancelSent: false
+    property bool sawCancelable: false
+    property bool sawRevoked: false
+    property bool sawVerifying: false
+    property bool sawHandoffDuringCancel: false
+    property bool done: false
+    property var identity: ({id: "op-" + "b".repeat(32), actionId: root.scenario === "install"
+        ? "updates-install-all" : "updates-refresh", kind: root.scenario === "install" ? "update" : "refresh"})
+
+    function check(condition, detail) {
+        root.assertions++;
+        if (!condition) {
+            console.error("Update action owner FAILED: " + root.scenario + ": " + detail);
+            Qt.callLater(function() { Qt.quit(); });
+            throw new Error(detail);
+        }
+    }
+
+    function finish() {
+        if (root.done) return;
+        root.done = true;
+        root.check(!model.busy && !model.blocked && model.canStart, "Verified recovery releases admission");
+        root.check(root.sawVerifying && model.audit !== null, "Audit and process exit verify the result");
+        root.check(root.invalidations >= 2, "Origin and completion invalidate discovery without global signals");
+        root.check(model.log.length > 1 && model.log[model.log.length - 1].state === model.result.state,
+            "Bounded log publishes the verified terminal result only after exit");
+        const expected = root.scenario === "denied" ? "permission-denied"
+            : root.scenario === "rejected" || root.scenario === "wrong-exit" ? "failed"
+            : root.scenario === "cancel-accepted" ? "canceled" : "succeeded";
+        root.check(model.result.state === expected, "Origin exit/result contract preserves failure and cancellation");
+        if (root.scenario === "rejected" || root.scenario === "wrong-exit")
+            root.check(model.operationError.code === "conflict", "Request failure retains typed diagnostics");
+        if (root.scenario === "uncertain" || root.scenario === "wrong-exit")
+            root.check(root.snapshots === 2, "Uncertain origin recovers by watch, not another origin");
+        if (root.scenario === "cancel-recovery" || root.scenario === "cancel-recovery-denied")
+            root.check(root.snapshots === 2 && model.retries === 0, "Failed read during cancellation resumes bounded recovery");
+        if (root.scenario === "cancel-race")
+            root.check(root.sawHandoffDuringCancel, "Terminal handoff is retained while cancellation owns control");
+        if (root.scenario.indexOf("cancel-") === 0) {
+            root.check(root.cancelSent && root.sawCancelable, "Only live AllowCancel enables the exact-ID control");
+            const accepted = root.scenario === "cancel-accepted" || root.scenario === "cancel-race"
+                || root.scenario === "cancel-recovery";
+            root.check(accepted ? model.cancelRequestedId === root.identity.id : model.cancelRequestedId === "",
+                "Only a valid successful control claims an accepted request");
+            root.check(model.cancelDetail.indexOf(accepted ? "Waiting" : "not confirmed") >= 0
+                || root.scenario === "cancel-conflict", "Cancellation outcome has separate guidance");
+        }
+        if (root.scenario === "revoked") root.check(root.sawCancelable && root.sawRevoked, "Revoked AllowCancel disables the control");
+        console.info("Update action owner native tests: PASS (" + root.scenario + ", " + root.assertions + " assertions)");
+        Qt.quit();
+    }
+
+    SystemOperationModel {
+        id: model
+        onDiscoveryInvalidated: {
+            root.invalidations++;
+            root.check(!model.startUpdate("updates-refresh", ""), "Reentrant invalidation cannot overlap an owned stream");
+        }
+        onSnapshotRequested: {
+            root.snapshots++;
+            if (root.scenario.indexOf("cancel-recovery") === 0
+                    && (root.snapshots === 1 || root.scenario === "cancel-recovery-failure")) {
+                root.check(!model.streamOwned && model.result !== null, "Terminal result precedes the failed recovery read");
+                if (root.snapshots === 1) root.check(model.controlOwned, "Cancellation still owns control when the read fails");
+                model.snapshotFailed();
+                return;
+            }
+            if (root.scenario === "failed-start") model.acceptSnapshot(root.identity, null);
+            else if (model.result !== null) {
+                if (model.controlOwned && model.controlPurpose === "cancel") root.sawHandoffDuringCancel = true;
+                model.acceptSnapshot(null, root.scenario === "rejected" ? null : root.identity);
+                if (root.scenario === "rejected") Qt.callLater(root.finish);
+            } else model.acceptSnapshot(root.identity, null);
+        }
+        onWaitingSnapshotChanged: {
+            if (!waitingSnapshot && root.snapshots > 0 && model.result === null && !model.streamOwned)
+                root.check(!model.startUpdate("updates-refresh", ""), "Recovery publication cannot admit a reentrant origin");
+        }
+        onControlIdChanged: {
+            root.check(!model.requestCancel(), "Control identity publication cannot admit a duplicate control");
+        }
+        onLogChanged: {
+            if (!model.streamOwned) return;
+            const current = model.parser.operation;
+            if (current === null) return;
+            if (current.cancelable) root.sawCancelable = true;
+            if (current.detail === "Cancellation unsafe") root.sawRevoked = true;
+            if (!current.cancelable) root.check(!model.requestCancel(), "Latest parser state rejects stale cancellation callbacks");
+            if (model.state === "verifying") {
+                root.check(model.result === null, "Terminal text cannot publish result before EOF");
+                root.check(model.log.every(record => record.state !== "succeeded" && record.state !== "failed"
+                    && record.state !== "permission-denied" && record.state !== "canceled"), "Provisional terminal is absent from logs");
+            }
+            if (root.scenario.indexOf("cancel-") === 0 && model.canCancel && !root.cancelSent) {
+                root.cancelSent = true;
+                root.check(model.requestCancel(), "Explicit live cancellation starts one control");
+                root.check(!model.requestCancel(), "Duplicate cancellation is rejected while control owns process");
+                root.check(model.streamOwned && model.result === null, "Cancellation request does not stop the observer or fabricate completion");
+            }
+        }
+        onStateChanged: {
+            if (state === "verifying") {
+                root.sawVerifying = true;
+                root.check(!model.canCancel && !model.requestCancel(), "Provisional terminal revokes cancellation");
+            }
+            if (state === "failure") Qt.callLater(function() {
+                const failedRead = root.scenario === "cancel-recovery-failure";
+                root.check(root.scenario === "failed-start" || failedRead, "Only unavailable evidence exhausts recovery");
+                root.check(root.snapshots === (failedRead ? 4 : 3) && !model.busy && model.blocked,
+                    "Exhaustion preserves exactly three bounded recovery attempts");
+                root.check((failedRead ? model.result !== null : model.result === null) && !model.canStart,
+                    "Unknown journal state preserves verified results without admitting a replacement");
+                console.info("Update action owner native tests: PASS (" + root.scenario + ", " + root.assertions + " assertions)");
+                root.done = true;
+                Qt.quit();
+            });
+        }
+        onAcknowledged: Qt.callLater(root.finish)
+    }
+
+    Component.onCompleted: {
+        root.check(!model.startUpdate("updates-refresh", ""), "No admission before an accepted empty recovery snapshot");
+        model.acceptSnapshot(null, null);
+        root.check(model.canStart, "Known empty recovery permits an internal confirmed call");
+        root.check(!model.startUpdate("timezone-set", "") && !model.startUpdate("updates-cancel", ""), "Origin allowlist excludes unrelated commands");
+        root.check(!model.startUpdate("updates-install-all", "wrong") && !model.startUpdate("updates-refresh", "c".repeat(64)), "Reject malformed and unexpected generation arguments");
+        model.snapshotFailed();
+        root.check(!model.startUpdate("updates-refresh", ""), "Lost journal evidence cannot admit an origin");
+        model.resetRecovery();
+        model.acceptSnapshot(null, null);
+        root.check(model.startUpdate(root.identity.actionId, root.scenario === "install" ? "c".repeat(64) : ""), "Fixed update command starts once");
+        root.check(!model.startUpdate("updates-refresh", ""), "No overlap before first output");
+    }
+    Timer { interval: 18000; running: true; onTriggered: root.check(false, "Scenario timed out in " + model.state) }
+}

--- a/tests/qml/SystemUpdateActionOwner.qml
+++ b/tests/qml/SystemUpdateActionOwner.qml
@@ -13,6 +13,9 @@ ShellRoot {
     property bool sawRevoked: false
     property bool sawVerifying: false
     property bool sawHandoffDuringCancel: false
+    property bool retryProbed: false
+    property bool sawUncertainRecovery: false
+    property bool seededActive: false
     property bool done: false
     property var identity: ({id: "op-" + "b".repeat(32), actionId: root.scenario === "install"
         ? "updates-install-all" : "updates-refresh", kind: root.scenario === "install" ? "update" : "refresh"})
@@ -44,14 +47,21 @@ ShellRoot {
             root.check(root.snapshots === 2, "Uncertain origin recovers by watch, not another origin");
         if (root.scenario === "cancel-recovery" || root.scenario === "cancel-recovery-denied")
             root.check(root.snapshots === 2 && model.retries === 0, "Failed read during cancellation resumes bounded recovery");
+        if (root.scenario === "cancel-uncertain-recover")
+            root.check(root.snapshots === 2 && root.sawUncertainRecovery, "Same-ID recovery retains uncertain cancellation ownership");
+        if (root.scenario === "cancel-pending-snapshot")
+            root.check(root.snapshots === 1 && model.retries === 0, "Awaited handoff is not delayed by cached-active recovery");
         if (root.scenario === "cancel-race")
             root.check(root.sawHandoffDuringCancel, "Terminal handoff is retained while cancellation owns control");
         if (root.scenario.indexOf("cancel-") === 0) {
             root.check(root.cancelSent && root.sawCancelable, "Only live AllowCancel enables the exact-ID control");
             const accepted = root.scenario === "cancel-accepted" || root.scenario === "cancel-race"
-                || root.scenario === "cancel-recovery";
+                || root.scenario === "cancel-recovery" || root.scenario === "cancel-pending-snapshot";
             root.check(accepted ? model.cancelRequestedId === root.identity.id : model.cancelRequestedId === "",
                 "Only a valid successful control claims an accepted request");
+            root.check(accepted || root.scenario === "cancel-conflict"
+                ? model.cancelUncertainId === "" : model.cancelUncertainId === root.identity.id,
+                "Unconfirmed dispatch has its own exact-ID guard, separate from acceptance");
             root.check(model.cancelDetail.indexOf(accepted ? "Waiting" : "not confirmed") >= 0
                 || root.scenario === "cancel-conflict", "Cancellation outcome has separate guidance");
         }
@@ -68,6 +78,10 @@ ShellRoot {
         }
         onSnapshotRequested: {
             root.snapshots++;
+            if (root.scenario === "cancel-pending-snapshot" && root.snapshots === 1) {
+                delayedSnapshot.start();
+                return;
+            }
             if (root.scenario.indexOf("cancel-recovery") === 0
                     && (root.snapshots === 1 || root.scenario === "cancel-recovery-failure")) {
                 root.check(!model.streamOwned && model.result !== null, "Terminal result precedes the failed recovery read");
@@ -89,11 +103,26 @@ ShellRoot {
         onControlIdChanged: {
             root.check(!model.requestCancel(), "Control identity publication cannot admit a duplicate control");
         }
+        onControlOwnedChanged: {
+            if (!controlOwned && model.controlPurpose === "cancel" && model.streamOwned
+                    && root.scenario !== "cancel-conflict" && !root.retryProbed) {
+                root.retryProbed = true;
+                root.check(!model.requestCancel(), "Accepted or uncertain cancellation cannot be dispatched twice");
+            }
+        }
         onLogChanged: {
             if (!model.streamOwned) return;
             const current = model.parser.operation;
             if (current === null) return;
             if (current.cancelable) root.sawCancelable = true;
+            if (root.scenario === "cancel-pending-snapshot" && current.cancelable && !root.seededActive) {
+                root.seededActive = true;
+                model.acceptSnapshot(root.identity, null);
+            }
+            if (root.scenario === "cancel-uncertain-recover" && model.streamReplay && current.cancelable) {
+                root.sawUncertainRecovery = true;
+                root.check(!model.canCancel && !model.requestCancel(), "New AllowCancel progress cannot repeat an ambiguous control");
+            }
             if (current.detail === "Cancellation unsafe") root.sawRevoked = true;
             if (!current.cancelable) root.check(!model.requestCancel(), "Latest parser state rejects stale cancellation callbacks");
             if (model.state === "verifying") {
@@ -138,8 +167,21 @@ ShellRoot {
         root.check(!model.startUpdate("updates-refresh", ""), "Lost journal evidence cannot admit an origin");
         model.resetRecovery();
         model.acceptSnapshot(null, null);
+        model.cancelUncertainId = "op-" + "d".repeat(32);
+        model.cancelRequestedId = "op-" + "d".repeat(32);
         root.check(model.startUpdate(root.identity.actionId, root.scenario === "install" ? "c".repeat(64) : ""), "Fixed update command starts once");
+        root.check(model.cancelUncertainId === "" && model.cancelRequestedId === "", "A new explicit origin clears previous-operation guards");
         root.check(!model.startUpdate("updates-refresh", ""), "No overlap before first output");
+    }
+    Timer {
+        id: delayedSnapshot
+        interval: 200
+        onTriggered: {
+            root.check(!model.controlOwned && model.waitingSnapshot && model.retries === 0,
+                "Control completion must wait for the replacement snapshot, not reuse cached active state");
+            model.acceptSnapshot(null, root.identity);
+            root.check(model.state === "acknowledging", "Fresh handoff can acknowledge immediately without an extra retry");
+        }
     }
     Timer { interval: 18000; running: true; onTriggered: root.check(false, "Scenario timed out in " + model.state) }
 }

--- a/tests/qml/SystemUpdateActionOwner.qml
+++ b/tests/qml/SystemUpdateActionOwner.qml
@@ -62,6 +62,9 @@ ShellRoot {
             root.check(accepted || root.scenario === "cancel-conflict"
                 ? model.cancelUncertainId === "" : model.cancelUncertainId === root.identity.id,
                 "Unconfirmed dispatch has its own exact-ID guard, separate from acceptance");
+            root.check(root.scenario === "cancel-conflict"
+                ? model.cancelConflictId === root.identity.id : model.cancelConflictId === "",
+                "Stale-target conflicts have a distinct guard without claiming dispatch or acceptance");
             root.check(model.cancelDetail.indexOf(accepted ? "Waiting" : "not confirmed") >= 0
                 || root.scenario === "cancel-conflict", "Cancellation outcome has separate guidance");
         }
@@ -94,7 +97,11 @@ ShellRoot {
                 if (model.controlOwned && model.controlPurpose === "cancel") root.sawHandoffDuringCancel = true;
                 model.acceptSnapshot(null, root.scenario === "rejected" ? null : root.identity);
                 if (root.scenario === "rejected") Qt.callLater(root.finish);
-            } else model.acceptSnapshot(root.identity, null);
+            } else {
+                model.acceptSnapshot(root.identity, null);
+                if (root.scenario === "cancel-conflict")
+                    root.check(!model.canCancel && !model.requestCancel(), "Same-ID snapshot cannot revive a stale cancellation target");
+            }
         }
         onWaitingSnapshotChanged: {
             if (!waitingSnapshot && root.snapshots > 0 && model.result === null && !model.streamOwned)
@@ -105,9 +112,9 @@ ShellRoot {
         }
         onControlOwnedChanged: {
             if (!controlOwned && model.controlPurpose === "cancel" && model.streamOwned
-                    && root.scenario !== "cancel-conflict" && !root.retryProbed) {
+                    && !root.retryProbed) {
                 root.retryProbed = true;
-                root.check(!model.requestCancel(), "Accepted or uncertain cancellation cannot be dispatched twice");
+                root.check(!model.requestCancel(), "Accepted, uncertain or conflicting cancellation cannot be dispatched twice");
             }
         }
         onLogChanged: {
@@ -169,8 +176,10 @@ ShellRoot {
         model.acceptSnapshot(null, null);
         model.cancelUncertainId = "op-" + "d".repeat(32);
         model.cancelRequestedId = "op-" + "d".repeat(32);
+        model.cancelConflictId = "op-" + "d".repeat(32);
         root.check(model.startUpdate(root.identity.actionId, root.scenario === "install" ? "c".repeat(64) : ""), "Fixed update command starts once");
-        root.check(model.cancelUncertainId === "" && model.cancelRequestedId === "", "A new explicit origin clears previous-operation guards");
+        root.check(model.cancelUncertainId === "" && model.cancelRequestedId === "" && model.cancelConflictId === "",
+            "A new explicit origin clears previous-operation guards");
         root.check(!model.startUpdate("updates-refresh", ""), "No overlap before first output");
     }
     Timer {

--- a/tests/test-quickshell-system-management-xvfb.sh
+++ b/tests/test-quickshell-system-management-xvfb.sh
@@ -354,9 +354,37 @@ update_action_helper=$work/update-action-data/dwm-titus/scripts/dwm-system-manag
 cp "$repo/tests/fixtures/system-update-action-provider.py" "$update_action_helper"
 chmod +x "$update_action_helper"
 quickshell_binary=$(command -v quickshell)
+assert_action_counter() {
+	counter_name=$1
+	counter_expected=$2
+	counter_file=$action_state/$counter_name
+	if [ "$counter_expected" = absent ]; then
+		[ -e "$counter_file" ] || return 0
+		counter_actual=present
+	else
+		counter_actual=$(sed -n '1p' "$counter_file" 2>/dev/null) || counter_actual=missing
+		[ "$counter_actual" -eq "$counter_expected" ] 2>/dev/null && return 0
+	fi
+	printf 'Update action counter FAILED: %s / %s: expected %s, got %s\n' \
+		"$action_scenario" "$counter_name" "$counter_expected" "$counter_actual" >&2
+	cat "$action_state/log" >&2
+	return 1
+}
+action_scenario=counter-diagnostic
+action_state=$work/counter-diagnostic
+mkdir -p "$action_state"
+printf 'Scenario-specific counter fixture log\n' >"$action_state/log"
+if assert_action_counter updates-refresh 1 >"$action_state/output" 2>&1; then
+	printf 'Missing action counter was accepted\n' >&2
+	exit 1
+fi
+grep -Fq 'counter-diagnostic / updates-refresh: expected 1, got missing' "$action_state/output"
+grep -Fq 'Scenario-specific counter fixture log' "$action_state/output"
+printf 'Update action counter diagnostics: PASS\n'
 for action_scenario in refresh install rejected denied uncertain wrong-exit revoked \
 	cancel-accepted cancel-race cancel-denied cancel-conflict cancel-output \
-	cancel-error-overflow cancel-timeout cancel-recovery cancel-recovery-denied cancel-recovery-failure failed-start; do
+	cancel-error-overflow cancel-timeout cancel-recovery cancel-recovery-denied cancel-recovery-failure \
+	cancel-uncertain-recover cancel-pending-snapshot failed-start; do
 	action_state=$work/update-action-$action_scenario
 	mkdir -p "$action_state"
 	action_path=$PATH
@@ -379,19 +407,19 @@ for action_scenario in refresh install rejected denied uncertain wrong-exit revo
 	[ "$action_scenario" != failed-start ] || continue
 	action_command=updates-refresh
 	[ "$action_scenario" != install ] || action_command=updates-install-all
-	[ "$(sed -n '1p' "$action_state/$action_command")" -eq 1 ]
+	assert_action_counter "$action_command" 1
 	if [ "$action_scenario" = rejected ] || [ "$action_scenario" = cancel-recovery-failure ]; then
-		[ ! -e "$action_state/ack-operation" ]
+		assert_action_counter ack-operation absent
 	else
-		[ "$(sed -n '1p' "$action_state/ack-operation")" -eq 1 ]
+		assert_action_counter ack-operation 1
 	fi
 	case $action_scenario in
-	uncertain | wrong-exit) [ "$(sed -n '1p' "$action_state/watch-operation")" -eq 1 ] ;;
-	*) [ ! -e "$action_state/watch-operation" ] ;;
+	uncertain | wrong-exit | cancel-uncertain-recover) assert_action_counter watch-operation 1 ;;
+	*) assert_action_counter watch-operation absent ;;
 	esac
 	case $action_scenario in
-	cancel-*) [ "$(sed -n '1p' "$action_state/updates-cancel")" -eq 1 ] ;;
-	*) [ ! -e "$action_state/updates-cancel" ] ;;
+	cancel-*) assert_action_counter updates-cancel 1 ;;
+	*) assert_action_counter updates-cancel absent ;;
 	esac
 done
 

--- a/tests/test-quickshell-system-management-xvfb.sh
+++ b/tests/test-quickshell-system-management-xvfb.sh
@@ -50,6 +50,11 @@ cleanup() {
 			stop_process "$helper_pid"
 		done
 	fi
+	if [ -n "${update_action_helper:-}" ]; then
+		for helper_pid in $(pgrep -f "$update_action_helper " 2>/dev/null || true); do
+			stop_process "$helper_pid"
+		done
+	fi
 	stop_process "${dwm_pid:-}"
 	stop_process "${xvfb_pid:-}"
 	if [ "$cleanup_status" -ne 0 ]; then
@@ -342,6 +347,54 @@ if ! grep -F 'Operation parser native tests: PASS' "$work/operation-parser.log";
 fi
 
 # Exercise the real root-owned Process lifecycle with a private fixed helper.
+mkdir -p "$work/update-action" "$work/update-action-data/dwm-titus/scripts"
+cp -a "$repo/config/quickshell/core" "$repo/config/quickshell/systemmanagement" "$work/update-action/"
+cp "$repo/tests/qml/SystemUpdateActionOwner.qml" "$work/update-action/shell.qml"
+update_action_helper=$work/update-action-data/dwm-titus/scripts/dwm-system-management
+cp "$repo/tests/fixtures/system-update-action-provider.py" "$update_action_helper"
+chmod +x "$update_action_helper"
+quickshell_binary=$(command -v quickshell)
+for action_scenario in refresh install rejected denied uncertain wrong-exit revoked \
+	cancel-accepted cancel-race cancel-denied cancel-conflict cancel-output \
+	cancel-error-overflow cancel-timeout cancel-recovery cancel-recovery-denied cancel-recovery-failure failed-start; do
+	action_state=$work/update-action-$action_scenario
+	mkdir -p "$action_state"
+	action_path=$PATH
+	[ "$action_scenario" != failed-start ] || action_path=$work/no-executables
+	timeout --foreground --kill-after=2s 20s env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
+		XDG_DATA_HOME="$work/update-action-data" XDG_RUNTIME_DIR="$runtime" QT_QPA_PLATFORMTHEME= \
+		DWM_UPDATE_ACTION_FIXTURE="$action_state" DWM_UPDATE_ACTION_SCENARIO="$action_scenario" PATH="$action_path" \
+		"$quickshell_binary" --no-duplicate --path "$work/update-action/shell.qml" \
+		>"$action_state/log" 2>&1 &
+	quickshell_pid=$!
+	action_status=0
+	wait "$quickshell_pid" || action_status=$?
+	quickshell_pid=
+	if [ "$action_status" -ne 0 ] || ! grep -F 'Update action owner native tests: PASS' "$action_state/log" ||
+		grep -Fq 'Update action owner FAILED:' "$action_state/log" || [ -e "$action_state/invalid-arguments" ] ||
+		[ -e "$action_state/control-overlap" ]; then
+		cat "$action_state/log" >&2
+		exit 1
+	fi
+	[ "$action_scenario" != failed-start ] || continue
+	action_command=updates-refresh
+	[ "$action_scenario" != install ] || action_command=updates-install-all
+	[ "$(sed -n '1p' "$action_state/$action_command")" -eq 1 ]
+	if [ "$action_scenario" = rejected ] || [ "$action_scenario" = cancel-recovery-failure ]; then
+		[ ! -e "$action_state/ack-operation" ]
+	else
+		[ "$(sed -n '1p' "$action_state/ack-operation")" -eq 1 ]
+	fi
+	case $action_scenario in
+	uncertain | wrong-exit) [ "$(sed -n '1p' "$action_state/watch-operation")" -eq 1 ] ;;
+	*) [ ! -e "$action_state/watch-operation" ] ;;
+	esac
+	case $action_scenario in
+	cancel-*) [ "$(sed -n '1p' "$action_state/updates-cancel")" -eq 1 ] ;;
+	*) [ ! -e "$action_state/updates-cancel" ] ;;
+	esac
+done
+
 mkdir -p "$work/operation-owner" "$work/owner-data/dwm-titus/scripts" "$work/owner-state"
 cp -a "$repo/config/quickshell/core" "$repo/config/quickshell/systemmanagement" "$work/operation-owner/"
 cp "$repo/tests/qml/SystemOperationOwner.qml" "$work/operation-owner/shell.qml"


### PR DESCRIPTION
## Summary

- Add two fixed internal update origins to the root operation owner, with a known-empty recovery requirement, exact generation validation, origin-specific exit checks, and overlap rejection.
- Keep nonterminal progress in a bounded log; publish terminal log/result/audit only after complete protocol and process-exit verification. A pre-admission rejection does not invent a journal handoff or acknowledgment.
- Share one bounded exact-ID control process between cancellation and acknowledgment. Cancellation never stops the observer or claims a terminal result. Preserve a handoff that arrives while cancellation is still running.
- Guard reentrant snapshot, identity, terminal, and process-completion publication. Retain a separate uncertainty guard after an unconfirmed cancellation, including same-ID observer recovery; wait for pending replacement snapshots instead of reusing cached active state. Retire a conflicting cancellation target before releasing control, so cached progress and same-ID recovery cannot resend it.

## Validation

- `scripts/run-tests make check-quickshell-system-management`: passed, including 20 new native scenarios and 1,406 total native assertions.
- `scripts/run-tests make clean all` and `scripts/run-tests`: passed, including 309 provider tests, the complete native suite, QML/shell checks, package mapping, staged installation, repeated-install preservation, and release checks.
- Local Codex and independent CodeRabbit reviews were clean for the initial boundary and repeated after each follow-up; the final three-file conflict fix has no findings from either reviewer.
- ShellCheck, shfmt, and diff checks passed. Counter-failure diagnostics have a negative test and include the scenario log. Test workspaces were cleaned.
- Fedora 44 / Quickshell 0.2.1 nested X11: closed Settings 0.067% CPU; closed large surfaces 0.00%. The operation fixtures cover cancellation acceptance/denial/conflict/timeout, revoked AllowCancel, completion racing cancellation, malformed control output, rejected admission, uncertain execution, and failed process startup.
- Hosted review follow-ups reproduce uncertain-control retry, stale-target retry, and pending-snapshot races in native tests before the fixes, then pass afterward. The fixes and all counter assertion groups are covered by the final clean review loop.
- An initial native run caught a stale cancellation-availability hint at provisional terminal publication. The request guard already rejected the target; the hint and publication ordering were fixed. Both local reviewers then found a cancellation/recovery handoff gap; a native regression reproduced the stall, and the fix resumes bounded recovery. The final focused/full gates and both fresh local reviews passed after this fix.

## Scope and limitations

This is a seven-file root-owner boundary after #238. Internal start/cancel calls are not exposed by IPC or enabled in Settings. Visible confirmation, fresh action guards, and update controls are the next PR; regional/delegated, information/recovery, and combined Phase 6 qualification remain. All mutation fixtures are private: no host PackageKit update, cancellation, or real journal mutation was performed. There is no visual UI change in this PR.

Local reviews are clean. Hosted reviews and exact-head CI must pass before merge.