### PR TITLE
fix(system): offer validated update actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versions from `config.mk`.
 
 ### Changed
 
+- Offer confirmed update actions only after complete idle recovery and the
+  PackageKit security check. Installation also requires a supported dependency
+  preview; failures preserve readable inventory and explicit refresh guidance.
+  Verify the backend with signed disposable Fedora 44 guest packages, including
+  dependency changes, stale confirmation rejection, denial, and retained replay.
+
 - Add visible System Settings confirmation for metadata refresh and update
   installation, with complete dependency-change previews, fresh-state guards,
   verified progress/audit logs, and exact-ID cancellation. Keyboard navigation

--- a/TASKS.md
+++ b/TASKS.md
@@ -133,15 +133,19 @@ six removals), without the prior malformed-plan error. No package mutation was
 performed; this agent process still lacks a logind session, reported separately
 as partial recovery evidence; that session therefore cannot enable execution.
 
-- [ ] Add user-initiated Fedora update discovery and status through the selected
+- [x] Add user-initiated Fedora update discovery and status through the selected
   stable package-management interface.
-- [ ] Add confirmed update execution with transparent progress and logs, strict
+- [x] Add confirmed update execution with transparent progress and logs, strict
   success detection, cancellation, and overlap rejection. Keep an operation
   delegated when the platform cannot expose a safe cancellation contract.
-- [ ] Distinguish authorization denial, network or repository failure, package
+- [x] Distinguish authorization denial, network or repository failure, package
   conflicts, interrupted transactions, completed updates, and reboot guidance.
-- [ ] Preserve recovery guidance across Settings closure or helper interruption
+- [x] Preserve recovery guidance across Settings closure or helper interruption
   without claiming ambiguous success.
+- [ ] Complete combined installed Fedora 44 X11 update qualification under
+  P6-VALIDATE, including graphical authorization. Record real in-flight
+  cancellation, crash recovery, and hardware restart as untested unless exercised;
+  the current fixture and guest evidence does not establish those runtime paths.
 
 Acceptance:
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -52,8 +52,7 @@ Acceptance:
 Progress: Read-only PackageKit discovery and its Settings pane are implemented.
 The journal now supports durable pending admission, identity-checked lifecycle
 transitions, restart pruning, recoverable terminal commits, exact retained-result
-lookup, and handoff acknowledgment. These are tested foundations, not an enabled
-Settings update execution workflow. Operation owners can retain every journal file
+lookup, and handoff acknowledgment. Operation owners can retain every journal file
 identity across unlocked service waits and reacquire bounded exclusive intervals
 for checkpoints; unlocked state access and stale ownership are rejected.
 The operation formatter reserves required lifecycle records separately from its
@@ -105,8 +104,14 @@ are not exposed by IPC. Settings now requires a visible confirmation, fresh
 discovery, available recovery and action evidence, and an empty operation owner.
 The confirmation copies every package change and invalidates on global events,
 replacement reads, generation changes, or closure. Explicit cancellation keeps
-the owner alive until a verified outcome. Real PackageKit execution qualification
-and the combined phase acceptance evidence remain outstanding.
+the owner alive until a verified outcome. Managed snapshots now offer origins
+only after complete, idle recovery and the PackageKit security check; installation
+also requires a complete supported dependency preview. A disposable Fedora 44
+guest exercised real refresh, signed fixture updates with dependency installation
+and obsoletion, stale-generation rejection, authorization denial, retained replay,
+and acknowledgment. See `docs/P6-UPDATE-EVIDENCE.md` for exact identities and
+limitations. Combined installed-X11 acceptance remains outstanding; real in-flight
+cancellation and crash recovery remain fixture-qualified, not guest-qualified.
 The fixed `watch-updates` command now observes only global PackageKit discovery
 changes and daemon ownership changes. It establishes subscriptions before
 reporting readiness, bounds setup to ten seconds, and never starts a transaction.

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -916,6 +916,15 @@ path, or elevation mechanism.
 
 ## Operation Lifecycle and Audit
 
+- Managed snapshots offer update origins only after complete durable recovery,
+  no active operation or unacknowledged handoff, and the existing PackageKit
+  security-floor/running-daemon check. Installation additionally requires a
+  nonempty, complete supported dependency preview. Explicit metadata refresh
+  can remain available for non-malformed discovery failures or failed simulation, since it is a
+  separately confirmed recovery action. Malformed update inventory blocks both
+  origins. An unavailable security check does not
+  hide readable inventory. Availability is advisory: admission repeats journal,
+  session, backend security, and confirmed-generation checks at dispatch.
 - Passive discovery uses the fixed maximum cache-age hint and never calls
   `RefreshCache` or starts a mutable update; after discovery it may invoke only
   the unjournaled `SIMULATE|ONLY_TRUSTED` read-only transaction defined below.
@@ -1721,6 +1730,10 @@ remain a separate implementation boundary.
   defines a narrow interface.
 
 ## Validation and Rollback
+
+Real Fedora 44 PackageKit execution evidence and its explicit limitations are
+recorded in [P6-UPDATE-EVIDENCE.md](P6-UPDATE-EVIDENCE.md). This does not replace
+the combined installed-X11 Phase 6 acceptance check.
 
 Each implementation boundary must cover valid, malformed, missing-provider,
 authorization-denied, canceled, interrupted, overlapping, and failed states.

--- a/docs/P6-UPDATE-EVIDENCE.md
+++ b/docs/P6-UPDATE-EVIDENCE.md
@@ -1,0 +1,122 @@
+# Phase 6 Update Backend Evidence
+
+## Scope and Environment
+
+On 2026-09-06, a disposable Fedora 44 x86_64 guest exercised the installed
+`dwm-system-management` CLI against real PackageKit, DNF5, polkit, logind, and
+the guest RPM database. This is an existing-system backend test, not qualification
+of a released dwm image or the installed host desktop.
+
+- Base repository: `66fb5356a7ad51232f49fcce7c0eb2045f71a04a` (PR #240).
+- The first refresh/update exercised that base; the second update and action
+  availability exercised the initial availability fix, provider SHA-256
+  `e948be461166d68bbb51a7fe95f9466a39ed2eb92f4344451786ffde2c34753e`.
+- Image: `Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2`, from the
+  [official Fedora Cloud download](https://fedoraproject.org/cloud/download/).
+- Image SHA-256:
+  `28680fe5b371a5a82ebf43a31926e086a168e59949d03969c5093e7071f90b7f`.
+- The signed `Fedora-Cloud-44-1.7-x86_64-CHECKSUM` verified with Fedora 44 key
+  `36F612DCF27F7D1A48A835E4DBFCF71C6D9F90A6`, matching both the installed Fedora
+  key and the [published fingerprint](https://fedoraproject.org/security/).
+- QEMU/KVM, BIOS boot, four virtual CPUs, 4 GiB RAM, 20 GiB disposable qcow2
+  overlay. No host filesystem, RPM database, or service-bus mounts.
+- User-mode networking exposed SSH only on host loopback. No host firewall,
+  SSH-server, security-policy, package, or desktop changes were made.
+- Guest: PackageKit `1.3.6-1.fc44`, libdnf5 `5.4.3.0-2.fc44`, polkit
+  `127-2.fc44.2`; SELinux remained enforcing. No failed systemd units at exit.
+- The default `fedora` SSH PAM session supplied real logind session evidence.
+  One verified SSH ControlMaster served all subsequent commands.
+- The provider was installed root-owned, mode 0755, at
+  `/usr/local/bin/dwm-system-management`. Successful mutations used the guest's
+  normal sudo authorization; unprivileged attempts exercised real denial.
+
+## Fixture and Isolation
+
+Guest-only prerequisite installation added PackageKit, Python GObject bindings,
+RPM build/signing tools, createrepo_c, and polkit with their dependencies.
+Original Fedora repository files were moved to a private guest backup before
+the test. The sole test repository used `file:///var/lib/p6-fixture-repo`,
+`gpgcheck=1`, and signed packages; no unsigned-install flag was used.
+PackageKit was restarted after switching repositories so its cached Fedora
+inventory did not become the selected update set.
+
+Four inert noarch RPMs were built with rpmbuild and signed with an ephemeral
+guest-only RSA key. They had no scriptlets, services, or executable payloads:
+
+| Package | Relationship and payload |
+| --- | --- |
+| `p6-fixture-1-1` | Requires `p6-legacy = 1-1`; version file containing `1` |
+| `p6-legacy-1-1` | Inert legacy component file |
+| `p6-fixture-2-1` | Requires `p6-dependency = 1-1`; obsoletes `p6-legacy < 2`; version file `2` |
+| `p6-dependency-1-1` | Inert dependency component file |
+
+The initial guest installation contained only fixture version 1 and the legacy
+component. The repository offered version 2 and the new dependency. A later
+version 3, with the same dependency relationship as version 2, exercised stale
+confirmation rejection and the patched availability path. Only the public
+fixture signing key was imported into the guest RPM database; host trust was
+not changed.
+
+## Observed Results
+
+1. Passive `snapshot` calls and dependency simulations did not install the
+   fixture update. Recovery was `available`, with real boot/session evidence.
+2. Before polkit was installed in the minimal cloud guest, explicit refresh
+   ended `permission-denied`, exit 1, with matching audit and completion.
+   `watch-operation` replayed that denial, and `snapshot` still returned the
+   complete two-update/three-change inventory and exact terminal handoff.
+3. After installing polkit, refresh
+   `op-65a3d144364b1d6d549f3bb58d9aef19` succeeded at `06:00:39Z`, exit 0.
+   Exact-ID replay and acknowledgment passed; refresh age became available.
+4. The confirmed version-2 generation was
+   `aebe93e61a90ef68bd038a078c3621ee03c3ea14c30aff136d4c064bb4213166`.
+   The complete preview contained dependency install, fixture update, and
+   legacy obsoletion. Update `op-f0bf80de649ea8083ca5076af1c46e3a` succeeded
+   at `06:00:52Z`, with terminal, audit, completion, and exit 0. Actual observed
+   counts were install=1, update=1, obsolete=1, unknown=0; comparison was
+   `different=no`, mismatch-samples=0.
+5. RPM queries and payload checks confirmed version 2, the new dependency,
+   and removal of the legacy file. A separate provider process replayed the
+   durable result. Acknowledgment removed the handoff, and discovery returned
+   zero updates. Replay correctly did not claim to retain the in-memory
+   package-comparison digest.
+6. The patched unprivileged snapshot offered refresh and install for version 3,
+   with generation
+   `9ac2decf8325a6c7a22a6cf0f6d21a198d432eba7cb4ca082e3fff1d92f1cd89`.
+   Reusing the older generation failed before admission with `conflict` and
+   explicit fresh-preview guidance, exit 1.
+7. Unprivileged SSH refresh and version-3 install attempts ended in real
+   `permission-denied` results. No authentication agent was available for the
+   remote session. Their exact results replayed, and readable discovery and
+   recovery remained available. Origins stayed unavailable until acknowledgment.
+8. Authorized version-3 update `op-4f25031885735364f7ff4cb3c383f92d` succeeded
+   at `06:04:48Z`, exit 0, with update=1, unknown=0, `different=no`, and a
+   matching audit. A fresh process replayed and acknowledged it. Final RPM
+   state was `p6-fixture-3-1` plus `p6-dependency-1-1`, with no legacy file.
+9. Final unprivileged discovery reported recovery/updates available, zero
+   updates, refresh available, and install/cancel unavailable. No active
+   operation or terminal handoff remained in either test user's journal.
+
+The focused provider suite added seven availability tests, bringing it to 316
+tests. The regression first failed against the old unconditional unavailable
+actions, then passed with recovery/security/preview checks. Coverage includes
+missing session evidence, active ownership, unacknowledged results, unsafe
+backends, failed discovery, and failed/incomplete/unsupported simulations.
+A subsequent malformed-inventory regression first failed, then proved both
+origins unavailable. This additional fail-closed branch was fixture-tested; the
+valid real-service paths above were not repeated after that narrow change.
+
+## Restoration and Limits
+
+The guest was powered off normally. The SSH master closed and the managed test
+runner removed the exact guest workspace, overlay, base download, seed image,
+private keys, and logs. No guest registration or background QEMU process remains.
+
+This test did not exercise a graphical polkit prompt, real in-flight cancellation,
+power loss, crash adoption, repository-network failures, hardware restart
+requirements, or the installed host Settings workflow. Cancellation, interrupted
+ownership, network/malformed responses, and UI closure/reopening remain covered
+by the existing private-bus and nested-X11 fixtures, not by this guest run.
+The tiny local transactions never supplied an observable cancelable interval.
+Combined Phase 6 installed-file parity, real X11 acceptance, and the remaining
+regional/information surfaces are still required before phase completion.

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -3476,8 +3476,23 @@ def read_recovery_snapshot(backend: PackageKitBackend) -> RecoverySnapshot:
 def build_managed_snapshot(backend: PackageKitBackend) -> list[str]:
     """Combine readable discovery with independently validated durable recovery."""
     recovery = read_recovery_snapshot(backend)
-    lines = build_snapshot(backend)
     state = recovery.state
+    mutation_blocker = None
+    mutation_failure = None
+    if recovery.failures or state is None:
+        mutation_blocker = "Complete durable recovery evidence is required; reload status and inspect recovery errors"
+    elif state.active is not None or state.handoff is not None:
+        mutation_blocker = "An operation or its unacknowledged result still owns the update workflow"
+    else:
+        try:
+            backend.require_mutation_safe()
+        except SnapshotFailure as failure:
+            mutation_failure = failure
+            mutation_blocker = failure.detail
+    # This is advisory availability, not admission. The mutation command repeats
+    # its security, journal-ownership, session, and generation checks at dispatch.
+    lines = build_snapshot(backend, mutation_blocker=mutation_blocker,
+        mutation_failure=mutation_failure)
     restart = state.restart if state is not None else recovery.prior_restart
     value = "unknown"
     if restart is not None and restart.system != "unknown":
@@ -3519,8 +3534,13 @@ def build_managed_snapshot(backend: PackageKitBackend) -> list[str]:
     return lines
 
 
-def build_snapshot(backend: UpdateBackend) -> list[str]:
+def build_snapshot(backend: UpdateBackend, *,
+                   mutation_blocker: str | None = "Managed recovery and backend safety have not been verified",
+                   mutation_failure: SnapshotFailure | None = None) -> list[str]:
+    """Render bounded discovery; only the managed caller can offer mutations."""
     errors: list[tuple[str, str]] = []
+    if mutation_failure is not None:
+        errors.append((mutation_failure.code, mutation_failure.detail))
     last_refresh_status = "unavailable"
     last_refresh_value = "unknown"
     last_refresh_detail = "PackageKit refresh history is unavailable"
@@ -3553,6 +3573,8 @@ def build_snapshot(backend: UpdateBackend) -> list[str]:
     try:
         result = backend.updates()
     except SnapshotFailure as failure:
+        if failure.code == "malformed":
+            mutation_blocker = mutation_blocker or failure.detail
         summary_status = failure.status
         restart_status = failure.status
         summary_detail = failure.detail
@@ -3565,6 +3587,7 @@ def build_snapshot(backend: UpdateBackend) -> list[str]:
             summary_detail = "PackageKit update discovery completed"
             inventory_ok = True
         except SnapshotFailure as failure:
+            mutation_blocker = mutation_blocker or failure.detail
             summary_status = failure.status
             summary_detail = failure.detail
             errors.append((failure.code, failure.detail))
@@ -3580,6 +3603,7 @@ def build_snapshot(backend: UpdateBackend) -> list[str]:
     installable_ids = [
         row.package_id for row in update_rows if row.installability == "installable"
     ]
+    plan_ok = False
     plan_detail = (
         "No installable updates require a dependency preview"
         if inventory_ok
@@ -3597,14 +3621,16 @@ def build_snapshot(backend: UpdateBackend) -> list[str]:
                 )
                 errors.append(("unsupported", plan_detail))
             else:
+                plan_ok = True
                 plan_detail = "PackageKit dependency preview completed"
         except SnapshotFailure as failure:
             plan_detail = failure.detail
             errors.append((failure.code, failure.detail))
 
     generation = snapshot_generation(installable_ids, plan_rows)
-    provider_status = "partial" if inventory_ok else summary_status
-    if provider_status not in {"partial", "restricted", "unavailable", "unsupported"}:
+    mutation_ready = mutation_blocker is None and mutation_failure is None
+    provider_status = ("available" if mutation_ready and not errors else "partial") if inventory_ok else summary_status
+    if provider_status not in {"available", "partial", "restricted", "unavailable", "unsupported"}:
         provider_status = "partial"
 
     lines = [
@@ -3618,8 +3644,7 @@ def build_snapshot(backend: UpdateBackend) -> list[str]:
                 "delegated",
                 "PackageKit",
                 clean_text(
-                    "Read-only update discovery is available; managed update controls "
-                    "are not enabled in Settings"
+                    "PackageKit discovery is readable; update actions require explicit confirmation and platform authorization"
                     if inventory_ok
                     else summary_detail
                 ),
@@ -3654,17 +3679,18 @@ def build_snapshot(backend: UpdateBackend) -> list[str]:
                 clean_text(restart_detail),
             )
         ),
-        "action\tupdates-refresh\tunavailable\tdelegated\tupdates\tRefresh updates\t"
-        "Managed update controls are not enabled in Settings",
+        "\t".join(("action", "updates-refresh", "available" if mutation_ready else "unavailable",
+            "delegated", "updates", "Refresh updates", clean_text(mutation_blocker or
+                "Confirm a PackageKit metadata refresh; package installation is a separate action"))),
         "\t".join(
             (
                 "action",
                 "updates-install-all",
-                "unavailable",
+                "available" if mutation_ready and plan_ok else "unavailable",
                 "delegated",
                 "updates",
                 "Install all updates",
-                clean_text(f"Managed update controls are not enabled in Settings; {plan_detail}"),
+                clean_text(f"{mutation_blocker}; {plan_detail}" if mutation_blocker else plan_detail),
             )
         ),
         "action\tupdates-cancel\tunavailable\tdelegated\tupdates\tCancel update\t"

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -6928,6 +6928,7 @@ class RecoverySnapshotTests(unittest.TestCase):
 
     def backend(self, **kwargs):
         backend = FixtureBackend(**kwargs)
+        backend.require_mutation_safe = mock.Mock()
         backend.session_started = mock.Mock(return_value=0)
         backend.probe_operation = mock.Mock(return_value=provider.RecoveryEvidence(False))
         backend.operation_history = mock.Mock(return_value=())
@@ -6955,7 +6956,7 @@ class RecoverySnapshotTests(unittest.TestCase):
     def restart_row(self, output):
         return next(row for row in rows(output, "state") if row[1] == "update-restart")
 
-    def test_cli_initializes_only_its_fixed_journal_and_keeps_actions_disabled(self):
+    def test_cli_initializes_only_its_fixed_journal_and_offers_safe_refresh(self):
         with tempfile.TemporaryDirectory() as directory, \
                 mock.patch.dict(os.environ, {"XDG_STATE_HOME": directory}), \
                 mock.patch.object(provider, "read_boot_id", return_value=self.boot_id), \
@@ -6965,10 +6966,96 @@ class RecoverySnapshotTests(unittest.TestCase):
             output = stdout.getvalue().splitlines()
             self.assertEqual(output[-1], "complete\tsnapshot")
             self.assertEqual(self.restart_row(output)[2:4], ["available", "none"])
-            self.assertEqual([row[2] for row in rows(output, "action")], ["unavailable"] * 3)
+            self.assertEqual([row[2] for row in rows(output, "action")],
+                ["available", "unavailable", "unavailable"])
             path = pathlib.Path(directory) / "dwm-titus" / "system-management"
             self.assertEqual({item.name for item in path.iterdir()}, set(provider.JOURNAL_NAMES))
             self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o700)
+
+    def test_complete_safe_plan_offers_confirmed_origins_without_dispatch(self):
+        update = package(8, "fixture;2;noarch;updates", "Update")
+        backend = self.backend(updates=(update,), plan=(
+            package(11, update.package_id, "Update"),
+            package(12, "dependency;1;noarch;updates", "Dependency"),
+            package(15, "old;1;noarch;installed", "Obsolete")))
+        with self.journal() as journal:
+            output = self.snapshot(journal, backend)
+            self.assertEqual([row[2] for row in rows(output, "action")],
+                ["available", "available", "unavailable"])
+            self.assertEqual(rows(output, "provider")[0][2], "available")
+            self.assertEqual(len(rows(output, "package-change")), 3)
+            backend.require_mutation_safe.assert_called_once_with()
+            self.assertIsNone(provider.load_journal_state(journal.chain).active)
+            self.assertIsNone(provider.load_journal_state(journal.chain).handoff)
+
+    def test_unsafe_backend_blocks_origins_without_hiding_inventory(self):
+        update = package(8, "fixture;2;noarch;updates", "Update")
+        backend = self.backend(updates=(update,), plan=(package(11, update.package_id, "Update"),))
+        backend.require_mutation_safe.side_effect = provider.SnapshotFailure(
+            "unsupported", "PackageKit security floor is not satisfied", "unsupported")
+        with self.journal() as journal:
+            output = self.snapshot(journal, backend)
+            self.assertEqual([row[2] for row in rows(output, "action")], ["unavailable"] * 3)
+            self.assertEqual(len(rows(output, "update")), 1)
+            self.assertEqual(len(rows(output, "package-change")), 1)
+            self.assertIn(["error", "updates", "unsupported", "PackageKit security floor is not satisfied"],
+                rows(output, "error"))
+
+    def test_failed_or_unsupported_plan_blocks_only_install(self):
+        update = package(8, "fixture;2;noarch;updates", "Update")
+        cases = (
+            {"plan_failure": provider.SnapshotFailure("timeout", "Simulation timed out")},
+            {"plan": ()},
+            {"plan": (package(11, update.package_id, "Update"),
+                      package(19, "extra;1;noarch;installed", "Reinstall"))},
+        )
+        for case in cases:
+            with self.subTest(case=case), self.journal() as journal:
+                output = self.snapshot(journal, self.backend(updates=(update,), **case))
+                self.assertEqual([row[2] for row in rows(output, "action")],
+                    ["available", "unavailable", "unavailable"])
+                self.assertEqual(len(rows(output, "update")), 1)
+
+    def test_failed_discovery_can_offer_explicit_refresh_but_not_install(self):
+        with self.journal() as journal:
+            output = self.snapshot(journal, self.backend(updates_failure=
+                provider.SnapshotFailure("network", "Repository is offline")))
+            self.assertEqual([row[2] for row in rows(output, "action")],
+                ["available", "unavailable", "unavailable"])
+            self.assertIn(["error", "updates", "network", "Repository is offline"], rows(output, "error"))
+
+    def test_incomplete_recovery_blocks_origins_and_skips_security_probe(self):
+        backend = self.backend()
+        backend.session_started.side_effect = provider.SnapshotFailure("timeout", "Logind timed out")
+        with self.journal() as journal:
+            output = self.snapshot(journal, backend)
+            self.assertEqual([row[2] for row in rows(output, "action")], ["unavailable"] * 3)
+            backend.require_mutation_safe.assert_not_called()
+
+    def test_malformed_inventory_blocks_all_origins(self):
+        for result in (
+            {"updates": (package(99, "fixture;2;noarch;updates", "Invalid info"),)},
+            {"updates_failure": provider.SnapshotFailure("malformed", "Invalid transaction output")},
+        ):
+            with self.subTest(result=result), self.journal() as journal:
+                output = self.snapshot(journal, self.backend(**result))
+                self.assertEqual([row[2] for row in rows(output, "action")], ["unavailable"] * 3)
+                self.assertEqual(rows(output, "update"), [])
+                self.assertEqual(rows(output, "package-change"), [])
+                self.assertIn("malformed", [row[2] for row in rows(output, "error")])
+
+    def test_existing_owner_or_handoff_blocks_origins_and_skips_security_probe(self):
+        for active in (True, False):
+            with self.subTest(active=active), self.journal() as journal:
+                operation = self.begin(journal, "refresh")
+                backend = self.backend()
+                if active:
+                    backend.probe_operation.return_value = provider.RecoveryEvidence(True, allow_cancel=True)
+                output = self.snapshot(journal, backend)
+                self.assertEqual([row[2] for row in rows(output, "action")][:2], ["unavailable"] * 2)
+                backend.require_mutation_safe.assert_not_called()
+                self.assertEqual(rows(output, "active-operation" if active else "terminal-handoff")[0][1],
+                    operation.operation_id)
 
     def test_durable_restart_overrides_discovery_and_survives_missing_packagekit(self):
         for unavailable in (False, True):


### PR DESCRIPTION
## Summary
- Complete the remaining provider-to-Settings integration: offer confirmed update origins only after complete idle recovery and the existing PackageKit security/running-daemon check.
- Require a nonempty supported dependency preview for installation. Keep separately confirmed metadata refresh usable for non-malformed discovery failures; malformed update inventory blocks both origins.
- Preserve readable state and typed failures when execution cannot be offered. Availability remains advisory; dispatch still repeats journal, session, security, and confirmed-generation checks.
- Add seven provider regression tests and detailed disposable Fedora 44 backend evidence in `docs/P6-UPDATE-EVIDENCE.md`. No QML, package-map, privilege-policy, or phase-boundary expansion.

## Validation
- `scripts/run-tests python3 tests/test-system-management.py RecoverySnapshotTests SnapshotTests SnapshotValidationTests`: 40 tests passed after red/green regressions.
- `scripts/run-tests make check-system-management`: 316 tests passed.
- `scripts/run-tests make clean all`: passed.
- `scripts/run-tests`: passed, including 316 provider tests, 1,454 native system-management assertions, configured QML/shell checks, 66-package dependency map, staged install/uninstall, repeated-install preservation, and release archive validation.
- Closed Settings CPU: 0.067%; large closed surfaces: 0.00%.
- `npm --prefix docs run build`: passed, 15 files with no diagnostics and 11 pages built.
- Independent local CodeRabbit review: zero findings on all six files.
- Local Codex review: no actionable regressions.
- Exact managed workspaces and disposable guest resources cleaned. The first full run was deliberately stopped before adding the malformed-inventory regression; only the final corrected-tree run is counted as passed.

## Real-service evidence
Fedora 44 Cloud 44-1.7 image signature/checksum verified; QEMU/KVM guest with SELinux enforcing, PackageKit 1.3.6-1.fc44 and libdnf5 5.4.3.0-2.fc44. Only loopback SSH and a disposable disk; no host filesystem, RPM database, or bus sharing.
- Real refresh and signed fixture update succeeded with matching terminal/audit/completion/exit evidence.
- Dependency install, fixture upgrade, and legacy obsoletion matched the full preview (`different=no`).
- Stale generation rejected before admission.
- Missing polkit and unprivileged SSH authorization denial remained auditable and replayable without hiding readable state.
- Separate-process retained replay, handoff blocking, acknowledgment and final zero-update state verified.
- The initial availability fix was guest-qualified; the subsequent narrow malformed-inventory branch was red/green fixture-qualified without repeating valid guest paths.

## Limits and remaining Phase 6 work
The guest used its normal sudo path for successful mutations and had no graphical authentication agent. This does not qualify an interactive graphical polkit prompt, real in-flight cancellation, power loss/crash adoption, or hardware restart requirements. Those failure/lifecycle paths retain existing private-bus/native-fixture coverage. No host packages, installed desktop files, or login session were changed. Combined installed-X11 acceptance plus regional/delegated and information/recovery surfaces remain outstanding. No Phase 7 work.

Prerequisite PR #240 is already merged; this PR is based directly on main.