### PR TITLE
feat(system): validate regional choices and locale overrides

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -156,6 +156,14 @@ Acceptance:
 
 ### REGIONAL-ENTRY-001: Regional and Delegated Administration
 
+Progress: Pure provider validators now bound timezone and locale choice lists,
+require exact selected identities, preserve the full allowlisted locale override
+set, and reject undisplayable confirmations without truncation. Effective-locale
+comparison accepts redundant LC-category elision while checking preserved values.
+These helpers perform no I/O and enable no command, D-Bus mutation, or new
+protocol minor. Service readers, lifecycle integration, and Settings controls
+remain outstanding.
+
 - [ ] Add date, time, timezone, and locale status plus safe common actions
   through stable platform services.
 - [ ] Add user-account, printer, and software-source entry points through trusted

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -31,6 +31,19 @@ CANCEL_GRACE_SECONDS = 5
 MAX_OPERATION_PROGRESS_RECORDS = 252
 MAX_OPERATION_MISMATCH_SAMPLES = 128
 
+REGIONAL_TIMEZONE_MAX = 255
+REGIONAL_TIMEZONE_COUNT = 2048
+REGIONAL_TIMEZONE_BYTES = 256 * 1024
+REGIONAL_LOCALE_MAX = 128
+REGIONAL_LOCALE_COUNT = 4096
+REGIONAL_LOCALE_OUTPUT_BYTES = 2 * 1024 * 1024
+REGIONAL_LOCALE_ARRAY_BYTES = 8192
+REGIONAL_LOCALE_KEYS = (
+    "LANG", "LANGUAGE", "LC_CTYPE", "LC_NUMERIC", "LC_TIME", "LC_COLLATE",
+    "LC_MONETARY", "LC_MESSAGES", "LC_PAPER", "LC_NAME", "LC_ADDRESS",
+    "LC_TELEPHONE", "LC_MEASUREMENT", "LC_IDENTIFICATION",
+)
+
 JOURNAL_MAGIC = b"DWMJNL1\0"
 JOURNAL_FRAME_MAJOR = 1
 JOURNAL_FRAME_MINOR = 0
@@ -192,6 +205,136 @@ class SnapshotFailure(Exception):
         self.code = code
         self.detail = clean_text(detail)
         self.status = status
+
+
+def validate_timezone_name(value: object) -> str:
+    """Validate a timezone identity without normalizing or resolving its path."""
+    if (not isinstance(value, str) or not value
+            or len(value) > REGIONAL_TIMEZONE_MAX or not value.isascii()
+            or any(ord(char) < 32 or ord(char) == 127 for char in value)
+            or any(part in ("", ".", "..") for part in value.split("/"))):
+        raise SnapshotFailure("malformed", "Invalid regional timezone identity")
+    return value
+
+
+def validate_timezone_choices(values: object) -> tuple[str, ...]:
+    """Validate one complete unpacked ListTimezones reply and its payload bounds."""
+    if not isinstance(values, (list, tuple)) or len(values) > REGIONAL_TIMEZONE_COUNT:
+        raise SnapshotFailure("malformed", "Invalid regional timezone list")
+    result = tuple(validate_timezone_name(value) for value in values)
+    if (len(set(result)) != len(result)
+            or sum(len(value) for value in result) > REGIONAL_TIMEZONE_BYTES):
+        raise SnapshotFailure("malformed", "Duplicate or oversized timezone list")
+    return result
+
+
+def prepare_timezone_change(value: object, choices: object) -> str:
+    """Require exact membership in the caller's fresh ListTimezones reply."""
+    timezone = validate_timezone_name(value)
+    if timezone not in validate_timezone_choices(choices):
+        raise SnapshotFailure("conflict", "The selected timezone is no longer available")
+    return timezone
+
+
+def validate_locale_name(value: object) -> str:
+    """Validate a locale identity; installed availability needs a fresh allowlist."""
+    if (not isinstance(value, str) or not value
+            or len(value) > REGIONAL_LOCALE_MAX or not value.isascii()
+            or any(char.isspace() or ord(char) < 32 or ord(char) == 127
+                   for char in value)):
+        raise SnapshotFailure("malformed", "Invalid regional locale identity")
+    return value
+
+
+def validate_locale_choices(output: object) -> tuple[str, ...]:
+    """Validate complete bounded locale -a stdout without stripping identities."""
+    if not isinstance(output, bytes) or len(output) > REGIONAL_LOCALE_OUTPUT_BYTES:
+        raise SnapshotFailure("malformed", "Invalid regional locale output")
+    try:
+        text = output.decode("ascii")
+    except UnicodeDecodeError as error:
+        raise SnapshotFailure("malformed", "Non-ASCII regional locale output") from error
+    if not text:
+        return ()
+    lines = text.removesuffix("\n").split("\n", REGIONAL_LOCALE_COUNT)
+    if len(lines) > REGIONAL_LOCALE_COUNT:
+        raise SnapshotFailure("malformed", "Too many regional locale choices")
+    result = tuple(validate_locale_name(line) for line in lines)
+    if len(set(result)) != len(result):
+        raise SnapshotFailure("malformed", "Duplicate regional locale choices")
+    return result
+
+
+@dataclass(frozen=True)
+class LocaleConfiguration:
+    """Canonical, fully displayable locale1 assignments, not an authorization."""
+
+    assignments: tuple[str, ...]
+    lang: str
+    detail: str
+
+
+def parse_locale_configuration(values: object) -> LocaleConfiguration:
+    """Preserve the complete allowlisted locale array or reject it without truncation."""
+    if not isinstance(values, (list, tuple)) or len(values) > len(REGIONAL_LOCALE_KEYS):
+        raise SnapshotFailure("malformed", "Invalid regional locale assignment array")
+    assignments: dict[str, str] = {}
+    total_bytes = 0
+    for assignment in values:
+        if not isinstance(assignment, str) or len(assignment) > MAX_TEXT_BYTES:
+            raise SnapshotFailure("malformed", "Invalid regional locale assignment")
+        try:
+            encoded = assignment.encode("utf-8")
+        except UnicodeEncodeError as error:
+            raise SnapshotFailure("malformed", "Non-UTF-8 locale assignment") from error
+        total_bytes += len(encoded) + 1
+        key, separator, value = assignment.partition("=")
+        if (not separator or key not in REGIONAL_LOCALE_KEYS or key in assignments
+                or len(encoded) > MAX_TEXT_BYTES
+                or total_bytes > REGIONAL_LOCALE_ARRAY_BYTES
+                or not assignment.isprintable()):
+            raise SnapshotFailure("malformed", "Unsafe or oversized locale assignment")
+        assignments[key] = value
+    ordered = tuple(f"{key}={assignments[key]}" for key in REGIONAL_LOCALE_KEYS
+                    if key in assignments)
+    detail = ", ".join(f"{key}={assignments[key]}" for key in REGIONAL_LOCALE_KEYS[1:]
+                       if assignments.get(key)) or "none"
+    if len(detail.encode("utf-8")) > MAX_TEXT_BYTES:
+        raise SnapshotFailure("malformed", "Locale overrides are too large to confirm safely")
+    return LocaleConfiguration(ordered, assignments.get("LANG", "unknown"), detail)
+
+
+def prepare_locale_change(
+    values: object, argument: object, choice_output: object
+) -> LocaleConfiguration:
+    """Prepare only LANG using caller-supplied fresh reads, preserving every override."""
+    if not isinstance(argument, str) or not argument.startswith("LANG="):
+        raise SnapshotFailure("malformed", "Only LANG=LOCALE is accepted")
+    locale = validate_locale_name(argument[5:])
+    choices = validate_locale_choices(choice_output)
+    if locale not in choices:
+        raise SnapshotFailure("conflict", "The selected locale is no longer available")
+    current = parse_locale_configuration(values)
+    preserved = [value for value in current.assignments if not value.startswith("LANG=")]
+    return parse_locale_configuration([f"LANG={locale}", *preserved])
+
+
+def locale_change_matches(expected_values: object, observed_values: object) -> bool:
+    """Compare effective LC values, permitting omission of redundant overrides."""
+    expected = dict(value.split("=", 1) for value in
+                    parse_locale_configuration(expected_values).assignments)
+    observed = dict(value.split("=", 1) for value in
+                    parse_locale_configuration(observed_values).assignments)
+    if expected.get("LANG", "") != observed.get("LANG", ""):
+        return False
+    # LANGUAGE is a preference list, not an LC category with LANG fallback.
+    # Only a pre-existing explicit assignment has a preservation requirement.
+    if ("LANGUAGE" in expected
+            and ("LANGUAGE" not in observed or expected["LANGUAGE"] != observed["LANGUAGE"])):
+        return False
+    return all((expected.get(key) or expected.get("LANG", ""))
+               == (observed.get(key) or observed.get("LANG", ""))
+               for key in REGIONAL_LOCALE_KEYS[2:])
 
 
 class JournalFrameError(ValueError):

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -83,6 +83,137 @@ def rows(lines, kind):
     return [line.split("\t") for line in lines if line.startswith(f"{kind}\t")]
 
 
+class RegionalValidationTests(unittest.TestCase):
+    def malformed(self, function, *args):
+        with self.assertRaises(provider.SnapshotFailure) as caught:
+            function(*args)
+        self.assertEqual(caught.exception.code, "malformed")
+
+    def test_timezone_names_are_exact_bounded_ascii_paths(self):
+        for name in ("UTC", "America/Chicago", "Etc/GMT+5", "x" * 255):
+            self.assertEqual(provider.validate_timezone_name(name), name)
+        for name in (None, 1, "", "x" * 256, "/UTC", "UTC/", "A//B",
+                     ".", "..", "A/../B", "A/./B", "A\nB", "A\x7fB", "é"):
+            with self.subTest(name=name):
+                self.malformed(provider.validate_timezone_name, name)
+
+    def test_timezone_choices_preserve_order_and_reject_duplicates(self):
+        self.assertEqual(provider.validate_timezone_choices(["UTC", "Etc/UTC"]),
+                         ("UTC", "Etc/UTC"))
+        self.assertEqual(provider.validate_timezone_choices([]), ())
+        for values in ("UTC", {"UTC"}, ["UTC", "UTC"], ["UTC", None]):
+            self.malformed(provider.validate_timezone_choices, values)
+        self.assertEqual(len(provider.validate_timezone_choices(
+            [f"Zone/{index}" for index in range(2048)])), 2048)
+        self.malformed(provider.validate_timezone_choices,
+                       [f"Zone/{index}" for index in range(2049)])
+
+    def test_timezone_reply_byte_limit_is_inclusive(self):
+        values = [f"{index:04d}" + "x" * 124 for index in range(2048)]
+        self.assertEqual(sum(len(value) for value in values), 256 * 1024)
+        self.assertEqual(len(provider.validate_timezone_choices(values)), 2048)
+        values[-1] += "x"
+        self.malformed(provider.validate_timezone_choices, values)
+
+    def test_timezone_choice_requires_exact_fresh_membership(self):
+        self.assertEqual(provider.prepare_timezone_change("UTC", ["UTC"]), "UTC")
+        for choices in ([], ["Etc/UTC"], ["utc"]):
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                provider.prepare_timezone_change("UTC", choices)
+            self.assertEqual(caught.exception.code, "conflict")
+        self.malformed(provider.prepare_timezone_change, "UTC", ["UTC", "UTC"])
+
+    def test_locale_names_and_output_are_strict_and_not_normalized(self):
+        for name in ("C", "C.utf8", "en_US.utf8", "sr_RS@latin", "x" * 128):
+            self.assertEqual(provider.validate_locale_name(name), name)
+        for name in (None, "", "x" * 129, "en US", "C\t", "C\r", "C\n",
+                     "C\x00", "C\x7f", "é", "\ud800"):
+            self.malformed(provider.validate_locale_name, name)
+        self.assertEqual(provider.validate_locale_choices(b"C\nen_US.utf8\n"),
+                         ("C", "en_US.utf8"))
+        self.assertEqual(provider.validate_locale_choices(b"C"), ("C",))
+        self.assertEqual(provider.validate_locale_choices(b""), ())
+        for output in ("C\n", b"\n", b"C\n\n", b"C\r\n", b"C\nC\n",
+                       b"C\n\xff", b"x" * (2 * 1024 * 1024 + 1)):
+            self.malformed(provider.validate_locale_choices, output)
+
+    def test_locale_record_count_and_name_limits_are_inclusive(self):
+        names = [f"{index:04d}" + "x" * 124 for index in range(4096)]
+        self.assertEqual(provider.validate_locale_choices(
+            ("\n".join(names) + "\n").encode("ascii")), tuple(names))
+        self.malformed(provider.validate_locale_choices,
+                       ("\n".join(names) + "\nextra\n").encode("ascii"))
+
+    def test_locale_configuration_preserves_and_orders_all_allowlisted_keys(self):
+        values = [f"{key}=C" for key in reversed(provider.REGIONAL_LOCALE_KEYS)]
+        parsed = provider.parse_locale_configuration(values)
+        self.assertEqual(parsed.assignments,
+                         tuple(f"{key}=C" for key in provider.REGIONAL_LOCALE_KEYS))
+        self.assertEqual(parsed.lang, "C")
+        self.assertEqual(parsed.detail, ", ".join(parsed.assignments[1:]))
+        empty = provider.parse_locale_configuration(["LC_TIME=", "LANGUAGE="])
+        self.assertEqual(empty.lang, "unknown")
+        self.assertEqual(empty.detail, "none")
+        self.assertEqual(empty.assignments, ("LANGUAGE=", "LC_TIME="))
+        self.assertEqual(provider.parse_locale_configuration([]).assignments, ())
+        self.assertEqual(provider.parse_locale_configuration(["LANG="]).lang, "")
+
+    def test_locale_configuration_rejects_malformed_arrays_without_sanitizing(self):
+        for values in ("LANG=C", {"LANG=C"}, [None], ["LANG"], ["=C"],
+                       ["LC_ALL=C"], ["PATH=/tmp"], ["LANG=C", "LANG=C"],
+                       ["LANG=C\n"], ["LANG=\x00"], ["LANG=\x85"],
+                       ["LANG=C\u2028x"], ["LANG=C\u2029x"], ["LANG=C\u202ex"],
+                       ["LANG=\ud800"], ["LANG=C"] * 15):
+            with self.subTest(values=values):
+                self.malformed(provider.parse_locale_configuration, values)
+
+    def test_locale_assignment_and_detail_utf8_limits_are_inclusive(self):
+        # LANG is not an override, so its assignment limit can be tested alone.
+        self.assertEqual(len(provider.parse_locale_configuration(
+            ["LANG=" + "é" * 253 + "x"]).lang.encode("utf-8")), 507)
+        self.malformed(provider.parse_locale_configuration, ["LANG=" + "é" * 254])
+        values = ["LANG=C", "LC_TIME=" + "é" * 250, "LC_NUMERIC=x"]
+        self.malformed(provider.parse_locale_configuration, values)
+        values = ["LC_TIME=" + "x" * 493, "LC_NAME=x"]
+        self.assertEqual(len(provider.parse_locale_configuration(values).detail), 512)
+        values[-1] += "x"
+        self.malformed(provider.parse_locale_configuration, values)
+
+    def test_locale_change_requires_exact_fresh_choice_and_preserves_overrides(self):
+        before = ["LC_TIME=de_DE.utf8", "LANG=en_US.utf8", "LANGUAGE=de:en"]
+        result = provider.prepare_locale_change(before, "LANG=fr_FR.utf8",
+                                                b"C\nfr_FR.utf8\n")
+        self.assertEqual(result.assignments,
+                         ("LANG=fr_FR.utf8", "LANGUAGE=de:en", "LC_TIME=de_DE.utf8"))
+        self.assertEqual(before[1], "LANG=en_US.utf8")
+        for argument in ("fr_FR.utf8", "LC_TIME=fr_FR.utf8", "LANG=", None):
+            self.malformed(provider.prepare_locale_change, before, argument,
+                           b"fr_FR.utf8\n")
+        with self.assertRaises(provider.SnapshotFailure) as caught:
+            provider.prepare_locale_change(before, "LANG=fr_FR.utf8", b"C\n")
+        self.assertEqual(caught.exception.code, "conflict")
+        with self.assertRaises(provider.SnapshotFailure):
+            provider.prepare_locale_change(before, "LANG=fr_FR.UTF-8", b"fr_FR.utf8\n")
+
+    def test_effective_locale_comparison_preserves_overrides_not_array_spelling(self):
+        expected = ["LANG=C", "LC_TIME=C", "LC_NUMERIC=de_DE.utf8", "LANGUAGE=de:en"]
+        self.assertTrue(provider.locale_change_matches(expected,
+            ["LANGUAGE=de:en", "LC_NUMERIC=de_DE.utf8", "LANG=C"]))
+        for observed in (["LANG=C", "LANGUAGE=de:en"],
+                         ["LANG=C", "LC_NUMERIC=de_DE.utf8"],
+                         ["LANG=C", "LC_NUMERIC=de_DE.utf8", "LANGUAGE=en:de"],
+                         ["LANG=C", "LC_NUMERIC=de_DE.utf8", "LANGUAGE=de:en", "LC_TIME=fr"],
+                         ["LANG=fr", "LC_NUMERIC=de_DE.utf8", "LANGUAGE=de:en"]):
+            self.assertFalse(provider.locale_change_matches(expected, observed))
+        self.assertTrue(provider.locale_change_matches(["LANG=C", "LC_TIME="], ["LANG=C"]))
+        self.assertTrue(provider.locale_change_matches(["LANG=C"], ["LANG=C", "LANGUAGE=en"]))
+        self.assertFalse(provider.locale_change_matches(["LANG=C", "LANGUAGE="],
+                                                        ["LANG=C", "LANGUAGE=en"]))
+        self.assertFalse(provider.locale_change_matches(["LANG=C", "LANGUAGE="],
+                                                        ["LANG=C"]))
+        self.malformed(provider.locale_change_matches, ["LANG=C"], ["LC_ALL=C"])
+
+
 class UpdateEventMonitorTests(unittest.TestCase):
     def monitor(self):
         class BusError(Exception):


### PR DESCRIPTION
## Summary

Add pure, bounded regional validators before wiring systemd readers or mutations. Timezone and locale choices retain exact spelling and enforce record/byte limits. Locale parsing preserves all 14 allowlisted keys in canonical order, refuses an undisplayable override set without truncation, and prepares only a freshly enumerated LANG. Effective comparison permits redundant LC-category elision but preserves explicit LANGUAGE presence and value.

This is a three-file internal foundation boundary. No new CLI, D-Bus call, polling source, privilege path, visible control, or protocol minor is enabled. Regional service and Settings integration remain unchecked in TASKS.md.

## Validation

- Eleven focused regional tests cover exact limits, malformed/duplicate/stale choices, unsafe identities, UTF-8 byte bounds, canonical ordering, override preservation and effective comparison.
- The provider suite passed all 327 tests.
- Real Fedora 44 read-only inputs passed: 598 timedate1 timezone choices, 39 locale -a names, and one locale1 assignment. No mutating method or file change was performed.
- Documentation build passed with no diagnostics.
- Independent CodeRabbit review is clean after fixing and regression-testing explicit empty LANGUAGE presence. The post-full-gate local Codex review found no actionable defects.

- `scripts/run-tests make clean all` and `scripts/run-tests` passed on the final tree, including 327 provider tests, 1,454 native system-management assertions, configured QML and shell gates, package resolution, staged/repeated installs, and release-archive validation. Closed Settings CPU was 0.067%; large surfaces were 0.00%. Temporary workspaces were removed.

Installed-X11 regional actions are not claimed: this change enables no runtime action. Phase 6 remains active. The first full run was intentionally stopped to fix the LANGUAGE finding; only the later completed run supplies full-gate evidence.