### PR TITLE
feat(system): add bounded regional service readers

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -160,8 +160,12 @@ Progress: Pure provider validators now bound timezone and locale choice lists,
 require exact selected identities, preserve the full allowlisted locale override
 set, and reject undisplayable confirmations without truncation. Effective-locale
 comparison accepts redundant LC-category elision while checking preserved values.
-These helpers perform no I/O and enable no command, D-Bus mutation, or new
-protocol minor. Service readers, lifecycle integration, and Settings controls
+The validators perform no I/O. Separate fixed timedate1 and locale1 readers now
+bound connection setup, service replies, and decoding under a ten-second deadline.
+Typed private-bus tests cover success, denial, absence, malformed state, timeout,
+and late replies; read-only Fedora 44 probes also passed. No command, D-Bus
+mutation, or new protocol minor is enabled. The bounded locale catalog process,
+account/printer/source readers, lifecycle integration, and Settings controls
 remain outstanding.
 
 - [ ] Add date, time, timezone, and locale status plus safe common actions

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -310,6 +310,17 @@ interactive-authorization argument remains enabled so systemd and polkit own
 the decision. Arbitrary environment variables, keymaps, NTP servers, RTC mode,
 or manual timestamps are not accepted.
 
+The internal read-only regional reader now has three fixed requests: timedate1
+`GetAll`, locale1 `Get(Locale)`, and timedate1 `ListTimezones`. Each single-use
+reader bounds asynchronous bus connection, method reply, and decoding under one
+ten-second monotonic deadline. Timeout cancels local work and discards late
+callbacks without retrying or closing the shared bus connection. Required
+property signatures are checked before publication. The timedate1 property map
+accepts at most 64 unique bounded property names, ignores unknown properties,
+and validates the timezone and three NTP fields. Locale and timezone string
+array counts and serialized field sizes are checked before creating Python
+string copies. These readers enable no new CLI or snapshot minor on their own.
+
 The `Locale` array is parsed only as the allowlisted keys `LANG`, `LANGUAGE`,
 and `LC_CTYPE`, `LC_NUMERIC`, `LC_TIME`, `LC_COLLATE`, `LC_MONETARY`,
 `LC_MESSAGES`, `LC_PAPER`, `LC_NAME`, `LC_ADDRESS`, `LC_TELEPHONE`,

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -161,6 +161,20 @@ PACKAGEKIT_INTERFACE = "org.freedesktop.PackageKit"
 TRANSACTION_INTERFACE = "org.freedesktop.PackageKit.Transaction"
 PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
 
+REGIONAL_READ_SECONDS = 10
+REGIONAL_TIME_PROPERTY_COUNT = 64
+REGIONAL_READ_REQUESTS = {
+    "time-state": ("org.freedesktop.timedate1", "/org/freedesktop/timedate1",
+                   PROPERTIES_INTERFACE, "GetAll", "(s)",
+                   ("org.freedesktop.timedate1",), "(a{sv})"),
+    "locale-state": ("org.freedesktop.locale1", "/org/freedesktop/locale1",
+                     PROPERTIES_INTERFACE, "Get", "(ss)",
+                     ("org.freedesktop.locale1", "Locale"), "(v)"),
+    "timezone-choices": ("org.freedesktop.timedate1", "/org/freedesktop/timedate1",
+                         "org.freedesktop.timedate1", "ListTimezones", None,
+                         None, "(as)"),
+}
+
 ROLE_REFRESH_CACHE = 13
 EXIT_SUCCESS = 1
 G_MAXUINT = (1 << 32) - 1
@@ -335,6 +349,194 @@ def locale_change_matches(expected_values: object, observed_values: object) -> b
     return all((expected.get(key) or expected.get("LANG", ""))
                == (observed.get(key) or observed.get("LANG", ""))
                for key in REGIONAL_LOCALE_KEYS[2:])
+
+
+@dataclass(frozen=True)
+class RegionalTimeState:
+    """Typed timedate1 state, independent of locale and mutation availability."""
+
+    timezone: str
+    can_ntp: bool
+    ntp_enabled: bool
+    ntp_synchronized: bool
+
+
+def regional_string_array(values: object, count: int, field_bytes: int,
+                          total_bytes: int, *, separators: bool = False) -> tuple[str, ...]:
+    """Bound serialized string sizes before allocating Python copies of a reply."""
+    if values.get_type_string() != "as" or values.n_children() > count:
+        raise SnapshotFailure("malformed", "Invalid regional string array")
+    result = []
+    size = 0
+    for index in range(values.n_children()):
+        child = values.get_child_value(index)
+        # A serialized GVariant string includes its one terminating NUL byte.
+        payload_bytes = child.get_size() - 1
+        size += payload_bytes + int(separators)
+        if payload_bytes > field_bytes or size > total_bytes:
+            raise SnapshotFailure("malformed", "Oversized regional string array")
+        result.append(child.unpack())
+    return tuple(result)
+
+
+def decode_regional_reply(kind: str, reply: object) -> object:
+    """Validate the exact reply signature and required regional property types."""
+    if not isinstance(kind, str) or kind not in REGIONAL_READ_REQUESTS:
+        raise SnapshotFailure("malformed", "Unknown regional read")
+    if reply.get_type_string() != REGIONAL_READ_REQUESTS[kind][-1]:
+        raise SnapshotFailure("malformed", "Unexpected regional reply signature")
+    if kind == "timezone-choices":
+        return validate_timezone_choices(regional_string_array(reply.get_child_value(0),
+            REGIONAL_TIMEZONE_COUNT, REGIONAL_TIMEZONE_MAX, REGIONAL_TIMEZONE_BYTES))
+    if kind == "locale-state":
+        values = reply.get_child_value(0).get_variant()
+        return parse_locale_configuration(regional_string_array(values,
+            len(REGIONAL_LOCALE_KEYS), MAX_TEXT_BYTES, REGIONAL_LOCALE_ARRAY_BYTES,
+            separators=True))
+    properties = reply.get_child_value(0)
+    if properties.n_children() > REGIONAL_TIME_PROPERTY_COUNT:
+        raise SnapshotFailure("malformed", "Too many timedate1 properties")
+    keys = set()
+    for index in range(properties.n_children()):
+        key = properties.get_child_value(index).get_child_value(0)
+        if key.get_size() > MAX_TEXT_BYTES + 1 or key.unpack() in keys:
+            raise SnapshotFailure("malformed", "Duplicate or oversized timedate1 property name")
+        keys.add(key.unpack())
+    values = []
+    for name, signature in (("Timezone", "s"), ("CanNTP", "b"),
+                            ("NTP", "b"), ("NTPSynchronized", "b")):
+        value = properties.lookup_value(name, None)
+        if (value is None or value.get_type_string() != signature
+                or (signature == "s" and value.get_size() > REGIONAL_TIMEZONE_MAX + 1)):
+            raise SnapshotFailure("malformed", "Missing or malformed timedate1 property")
+        values.append(value.unpack())
+    return RegionalTimeState(validate_timezone_name(values[0]), *values[1:])
+
+
+class RegionalRead:
+    """One fixed read with an aggregate connection, reply, and decoding deadline."""
+
+    def __init__(self, kind: str, Gio=None, GLib=None) -> None:
+        if not isinstance(kind, str) or kind not in REGIONAL_READ_REQUESTS:
+            raise SnapshotFailure("malformed", "Unknown regional read")
+        if Gio is None or GLib is None:
+            try:
+                import gi
+                gi.require_version("Gio", "2.0")
+                from gi.repository import Gio, GLib
+            except (ImportError, ValueError) as error:
+                raise SnapshotFailure("missing-provider", "System Python GObject bindings are unavailable",
+                                      "unavailable") from error
+        self.kind, self.Gio, self.GLib = kind, Gio, GLib
+        self.loop = GLib.MainLoop()
+        self.cancellable = Gio.Cancellable()
+        self.connection = None
+        self.deadline = 0.0
+        self.deadline_source = 0
+        self.started = False
+        self.done = False
+        self.value = None
+        self.failure = None
+
+    def finish(self, value=None, failure=None) -> None:
+        if self.done:
+            return
+        self.done = True
+        self.value, self.failure = value, failure
+        self.cancellable.cancel()
+        self.loop.quit()
+
+    def expire(self) -> bool:
+        self.deadline_source = 0
+        self.finish(failure=SnapshotFailure("timeout", "Regional read timed out", "unavailable"))
+        return self.GLib.SOURCE_REMOVE
+
+    def pending(self) -> bool:
+        if self.done:
+            return False
+        if time.monotonic() >= self.deadline:
+            self.finish(failure=SnapshotFailure("timeout", "Regional read timed out", "unavailable"))
+            return False
+        return True
+
+    def bus_failure(self, error: Exception) -> SnapshotFailure:
+        if time.monotonic() >= self.deadline:
+            return SnapshotFailure("timeout", "Regional read timed out", "unavailable")
+        name = self.Gio.dbus_error_get_remote_error(error)
+        code, status = {
+            "org.freedesktop.DBus.Error.ServiceUnknown": ("missing-provider", "unavailable"),
+            "org.freedesktop.DBus.Error.NameHasNoOwner": ("missing-provider", "unavailable"),
+            "org.freedesktop.DBus.Error.UnknownObject": ("missing-provider", "unavailable"),
+            "org.freedesktop.DBus.Error.AccessDenied": ("permission-denied", "restricted"),
+            "org.freedesktop.DBus.Error.AuthFailed": ("permission-denied", "restricted"),
+            "org.freedesktop.DBus.Error.InvalidArgs": ("malformed", "partial"),
+            "org.freedesktop.DBus.Error.InvalidSignature": ("malformed", "partial"),
+            "org.freedesktop.DBus.Error.UnknownMethod": ("unsupported", "unsupported"),
+            "org.freedesktop.DBus.Error.UnknownInterface": ("unsupported", "unsupported"),
+            "org.freedesktop.DBus.Error.Timeout": ("timeout", "unavailable"),
+            "org.freedesktop.DBus.Error.TimedOut": ("timeout", "unavailable"),
+            "org.freedesktop.DBus.Error.NoReply": ("timeout", "unavailable"),
+        }.get(name, ("internal", "unavailable"))
+        if (name is None and error.matches(self.Gio.io_error_quark(),
+                                          self.Gio.IOErrorEnum.TIMED_OUT)):
+            code, status = "timeout", "unavailable"
+        return SnapshotFailure(code, "Regional service read failed", status)
+
+    def connected(self, _source, result, _data) -> None:
+        if not self.pending():
+            return
+        try:
+            self.connection = self.Gio.bus_get_finish(result)
+            self.connection.set_exit_on_close(False)
+            name, path, interface, method, signature, args, reply_type = REGIONAL_READ_REQUESTS[self.kind]
+            parameters = None if signature is None else self.GLib.Variant(signature, args)
+            if not self.pending():
+                return
+            self.connection.call(name, path, interface, method, parameters,
+                self.GLib.VariantType.new(reply_type), self.Gio.DBusCallFlags.NONE,
+                max(1, int((self.deadline - time.monotonic()) * 1000)),
+                self.cancellable, self.replied, None)
+        except self.GLib.Error as error:
+            self.finish(failure=self.bus_failure(error))
+
+    def replied(self, connection, result, _data) -> None:
+        if not self.pending():
+            return
+        try:
+            value = decode_regional_reply(self.kind, connection.call_finish(result))
+            if self.pending():
+                self.finish(value=value)
+        except self.GLib.Error as error:
+            self.finish(failure=self.bus_failure(error))
+        except SnapshotFailure as error:
+            if self.pending():
+                self.finish(failure=error)
+
+    def run(self) -> object:
+        if self.started:
+            raise RuntimeError("Regional reads are single-use")
+        self.started = True
+        self.deadline = time.monotonic() + REGIONAL_READ_SECONDS
+        try:
+            self.deadline_source = self.GLib.timeout_add(REGIONAL_READ_SECONDS * 1000, self.expire)
+            self.Gio.bus_get(self.Gio.BusType.SYSTEM, self.cancellable, self.connected, None)
+            if not self.done:
+                self.loop.run()
+            if not self.done:
+                self.finish(failure=SnapshotFailure("internal", "Regional read ended without a reply", "unavailable"))
+        except self.GLib.Error as error:
+            self.finish(failure=self.bus_failure(error))
+        finally:
+            self.done = True
+            self.cancellable.cancel()
+            self.loop.quit()
+            if self.deadline_source:
+                self.GLib.source_remove(self.deadline_source)
+                self.deadline_source = 0
+            # bus_get returns a shared connection; never close another reader's bus.
+        if self.failure:
+            raise self.failure
+        return self.value
 
 
 class JournalFrameError(ValueError):

--- a/tests/fixtures/system-regional-read-bus.py
+++ b/tests/fixtures/system-regional-read-bus.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python3
+"""Qualify regional reads on a private bus with no host-service access."""
+
+import os
+import runpy
+import sys
+import time
+
+os.environ["DBUS_SYSTEM_BUS_ADDRESS"] = os.environ["DBUS_SESSION_BUS_ADDRESS"]
+from gi.repository import Gio, GLib
+
+provider = runpy.run_path(sys.argv[1], run_name="regional_read_fixture")
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+mode = "normal"
+calls = []
+held = []
+registrations = []
+properties = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.DBus.Properties">
+<method name="GetAll"><arg type="s" direction="in"/><arg type="a{sv}" direction="out"/></method>
+<method name="Get"><arg type="s" direction="in"/><arg type="s" direction="in"/><arg type="v" direction="out"/></method>
+</interface></node>""").interfaces[0]
+timedate = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.timedate1">
+<method name="ListTimezones"><arg type="as" direction="out"/></method>
+</interface></node>""").interfaces[0]
+
+
+def name_call(method, name):
+    args = GLib.Variant("(su)", (name, 0)) if method == "RequestName" else GLib.Variant("(s)", (name,))
+    return bus.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus",
+        "org.freedesktop.DBus", method, args, GLib.VariantType.new("(u)"),
+        Gio.DBusCallFlags.NONE, 3000, None).unpack()[0]
+
+
+def called(_bus, _sender, path, interface, method, args, invocation):
+    calls.append((path, interface, method, args.unpack()))
+    if mode == "denied":
+        invocation.return_dbus_error("org.freedesktop.DBus.Error.AccessDenied", "fixture denial")
+    elif mode == "stall":
+        held.append(invocation)
+    elif method == "GetAll":
+        invocation.return_value(GLib.Variant("(a{sv})", ({
+            "Timezone": GLib.Variant("s", "UTC"), "CanNTP": GLib.Variant("b", True),
+            "NTP": GLib.Variant("u", 1) if mode == "malformed" else GLib.Variant("b", False),
+            "NTPSynchronized": GLib.Variant("b", True)},)))
+    elif method == "Get":
+        invocation.return_value(GLib.Variant("(v)", (GLib.Variant("as", ["LANG=C"]),)))
+    else:
+        invocation.return_value(GLib.Variant("(as)", (["UTC", "Etc/UTC"],)))
+
+
+def failure(kind, expected):
+    try:
+        provider["RegionalRead"](kind).run()
+    except provider["SnapshotFailure"] as error:
+        assert error.code == expected, (error.code, expected)
+    else:
+        raise AssertionError("regional failure reported success")
+
+
+try:
+    for name in ("org.freedesktop.timedate1", "org.freedesktop.locale1"):
+        assert name_call("RequestName", name) == 1
+    for path, info in (("/org/freedesktop/timedate1", timedate),
+                       ("/org/freedesktop/timedate1", properties),
+                       ("/org/freedesktop/locale1", properties)):
+        registrations.append(bus.register_object(path, info, called, None, None))
+    assert provider["RegionalRead"]("time-state").run().timezone == "UTC"
+    assert provider["RegionalRead"]("locale-state").run().assignments == ("LANG=C",)
+    assert provider["RegionalRead"]("timezone-choices").run() == ("UTC", "Etc/UTC")
+    assert [call[2:] for call in calls] == [
+        ("GetAll", ("org.freedesktop.timedate1",)),
+        ("Get", ("org.freedesktop.locale1", "Locale")), ("ListTimezones", ())]
+    mode = "malformed"
+    failure("time-state", "malformed")
+    mode = "denied"
+    failure("locale-state", "permission-denied")
+    mode = "normal"
+    assert name_call("ReleaseName", "org.freedesktop.locale1") == 1
+    failure("locale-state", "missing-provider")
+    mode = "stall"
+    started = time.monotonic()
+    failure("timezone-choices", "timeout")
+    elapsed = time.monotonic() - started
+    assert 9.5 <= elapsed < 15, elapsed
+    assert len(held) == 1
+    held.pop().return_value(GLib.Variant("(as)", (["Late/Reply"],)))
+    mode = "normal"
+    assert provider["RegionalRead"]("timezone-choices").run() == ("UTC", "Etc/UTC")
+    assert all(call[2] in {"Get", "GetAll", "ListTimezones"} for call in calls)
+    print("Private-bus regional reads: PASS (typed replies, denial, absence, deadline, late reply)")
+finally:
+    for registration in registrations:
+        bus.unregister_object(registration)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -214,6 +214,246 @@ class RegionalValidationTests(unittest.TestCase):
         self.malformed(provider.locale_change_matches, ["LANG=C"], ["LC_ALL=C"])
 
 
+class RegionalReadTests(unittest.TestCase):
+    def reader(self, kind="time-state"):
+        from gi.repository import Gio, GLib
+        loop, cancellable, connection = mock.Mock(), mock.Mock(), mock.Mock()
+        glib = types.SimpleNamespace(Error=GLib.Error, Variant=GLib.Variant,
+            VariantType=GLib.VariantType, MainLoop=mock.Mock(return_value=loop),
+            timeout_add=mock.Mock(return_value=17), source_remove=mock.Mock(),
+            SOURCE_REMOVE=False)
+        gio = mock.Mock()
+        gio.Cancellable.return_value = cancellable
+        gio.bus_get_finish.return_value = connection
+        gio.dbus_error_get_remote_error.return_value = None
+        gio.io_error_quark.return_value = Gio.io_error_quark()
+        gio.IOErrorEnum.TIMED_OUT = Gio.IOErrorEnum.TIMED_OUT
+        read = provider.RegionalRead(kind, gio, glib)
+        return read, connection, gio, glib, GLib
+
+    def time_reply(self, glib, **overrides):
+        values = {"Timezone": glib.Variant("s", "UTC"),
+                  "CanNTP": glib.Variant("b", True),
+                  "NTP": glib.Variant("b", False),
+                  "NTPSynchronized": glib.Variant("b", True)}
+        values.update(overrides)
+        return glib.Variant("(a{sv})", (values,))
+
+    def deliver(self, read, connection):
+        read.connected(None, object(), None)
+        read.replied(connection, object(), None)
+
+    def test_only_three_fixed_read_requests_are_sent(self):
+        expected = {
+            "time-state": ("org.freedesktop.timedate1", "/org/freedesktop/timedate1",
+                           "org.freedesktop.DBus.Properties", "GetAll"),
+            "locale-state": ("org.freedesktop.locale1", "/org/freedesktop/locale1",
+                             "org.freedesktop.DBus.Properties", "Get"),
+            "timezone-choices": ("org.freedesktop.timedate1", "/org/freedesktop/timedate1",
+                                 "org.freedesktop.timedate1", "ListTimezones"),
+        }
+        for kind, target in expected.items():
+            read, connection, gio, glib, variant = self.reader(kind)
+            connection.call_finish.return_value = {
+                "time-state": self.time_reply(variant),
+                "locale-state": variant.Variant("(v)", (variant.Variant("as", ["LANG=C"]),)),
+                "timezone-choices": variant.Variant("(as)", (["UTC"],)),
+            }[kind]
+            read.loop.run.side_effect = lambda: self.deliver(read, connection)
+            result = read.run()
+            self.assertIsNotNone(result)
+            self.assertEqual(connection.call.call_args.args[:4], target)
+            self.assertEqual(connection.call.call_args.args[6], gio.DBusCallFlags.NONE)
+            self.assertGreater(connection.call.call_args.args[7], 0)
+            self.assertLessEqual(connection.call.call_args.args[7], 10000)
+            self.assertEqual(gio.bus_get.call_args.args[0], gio.BusType.SYSTEM)
+            glib.source_remove.assert_called_once_with(17)
+            self.assertTrue(read.cancellable.cancel.called)
+            connection.close_sync.assert_not_called()
+            if kind == "time-state":
+                self.assertEqual(result, provider.RegionalTimeState("UTC", True, False, True))
+            elif kind == "locale-state":
+                self.assertEqual(result.assignments, ("LANG=C",))
+            else:
+                self.assertEqual(result, ("UTC",))
+
+    def test_unknown_read_is_rejected_before_connecting(self):
+        for kind in ("SetNTP", "SetLocale", "Get", "", None, []):
+            with self.assertRaises(provider.SnapshotFailure):
+                provider.RegionalRead(kind, mock.Mock(), mock.Mock())
+
+    def test_time_property_types_and_required_fields_are_strict(self):
+        _read, _connection, _gio, _glib, variant = self.reader()
+        for name in ("Timezone", "CanNTP", "NTP", "NTPSynchronized"):
+            reply = self.time_reply(variant, **{name: variant.Variant("u", 1)})
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                provider.decode_regional_reply("time-state", reply)
+            self.assertEqual(caught.exception.code, "malformed")
+        for reply in (variant.Variant("(a{sv})", ({},)),
+                      variant.Variant("(s)", ("UTC",)),
+                      self.time_reply(variant, Timezone=variant.Variant("s", "../UTC"))):
+            with self.assertRaises(provider.SnapshotFailure):
+                provider.decode_regional_reply("time-state", reply)
+        result = provider.decode_regional_reply("time-state", self.time_reply(
+            variant, FutureProperty=variant.Variant("s", "ignored")))
+        self.assertEqual(result.timezone, "UTC")
+
+    def test_locale_and_timezone_replies_use_existing_bounds(self):
+        _read, _connection, _gio, _glib, variant = self.reader()
+        for kind, reply in (
+            ("locale-state", variant.Variant("(v)", (variant.Variant("s", "LANG=C"),))),
+            ("locale-state", variant.Variant("(v)", (variant.Variant("as", ["LC_ALL=C"]),))),
+            ("timezone-choices", variant.Variant("(as)", (["UTC", "UTC"],))),
+            ("timezone-choices", variant.Variant("(as)", (["x" * 256],))),
+            ("timezone-choices", variant.Variant("(as)", (["UTC"] * 2049,))),
+            ("locale-state", variant.Variant("(v)", (variant.Variant("as", ["LANG=C"] * 15),))),
+            ("locale-state", variant.Variant("(v)", (variant.Variant("as", ["LANG=" + "x" * 508]),))),
+        ):
+            with self.assertRaises(provider.SnapshotFailure):
+                provider.decode_regional_reply(kind, reply)
+
+    def test_serialized_string_array_bounds_count_utf8_before_unpacking(self):
+        _read, _connection, _gio, _glib, variant = self.reader()
+        self.assertEqual(provider.regional_string_array(variant.Variant("as", ["é"]),
+                                                       1, 2, 2), ("é",))
+        for field_bytes, total_bytes, separators in ((1, 2, False), (2, 1, False), (2, 2, True)):
+            with self.assertRaises(provider.SnapshotFailure):
+                provider.regional_string_array(variant.Variant("as", ["é"]),
+                    1, field_bytes, total_bytes, separators=separators)
+        oversized = mock.Mock()
+        oversized.get_type_string.return_value = "as"
+        oversized.n_children.return_value = 1
+        child = oversized.get_child_value.return_value
+        child.get_size.return_value = 1000
+        with self.assertRaises(provider.SnapshotFailure):
+            provider.regional_string_array(oversized, 1, 10, 10)
+        child.unpack.assert_not_called()
+
+    def test_oversized_or_duplicate_timedate_properties_are_rejected(self):
+        _read, _connection, _gio, _glib, variant = self.reader()
+        extra = {f"Extra{index}": variant.Variant("b", True) for index in range(61)}
+        with self.assertRaises(provider.SnapshotFailure):
+            provider.decode_regional_reply("time-state", self.time_reply(variant, **extra))
+        duplicate = variant.Variant.parse(None,
+            "({'Timezone': <'UTC'>, 'Timezone': <'Etc/UTC'>},)", None, None)
+        with self.assertRaises(provider.SnapshotFailure):
+            provider.decode_regional_reply("time-state", duplicate)
+
+    def test_deadline_covers_connection_and_ignores_late_callbacks(self):
+        read, connection, gio, glib, _variant = self.reader()
+        read.loop.run.side_effect = read.expire
+        with self.assertRaises(provider.SnapshotFailure) as caught:
+            read.run()
+        self.assertEqual(caught.exception.code, "timeout")
+        read.connected(None, object(), None)
+        read.replied(connection, object(), None)
+        gio.bus_get_finish.assert_not_called()
+        connection.call_finish.assert_not_called()
+        connection.call.assert_not_called()
+        glib.source_remove.assert_not_called()
+
+    def test_deadline_covers_method_and_cannot_publish_a_late_reply(self):
+        read, connection, _gio, _glib, variant = self.reader()
+        connection.call_finish.return_value = self.time_reply(variant)
+        def during_loop():
+            read.connected(None, object(), None)
+            read.expire()
+            read.replied(connection, object(), None)
+        read.loop.run.side_effect = during_loop
+        with self.assertRaises(provider.SnapshotFailure) as caught:
+            read.run()
+        self.assertEqual(caught.exception.code, "timeout")
+        connection.call.assert_called_once()
+        connection.call_finish.assert_not_called()
+        self.assertIsNone(read.value)
+
+    def test_elapsed_deadline_before_connection_dispatch_is_rejected(self):
+        read, connection, gio, _glib, _variant = self.reader()
+        read.deadline = 10
+        with mock.patch.object(provider.time, "monotonic", return_value=10):
+            read.connected(None, object(), None)
+        self.assertEqual(read.failure.code, "timeout")
+        gio.bus_get_finish.assert_not_called()
+        connection.call.assert_not_called()
+
+    def test_decoding_that_crosses_deadline_cannot_publish_success(self):
+        read, connection, _gio, _glib, variant = self.reader()
+        read.deadline = 10
+        connection.call_finish.return_value = self.time_reply(variant)
+        with mock.patch.object(provider.time, "monotonic", side_effect=[9, 10]):
+            read.replied(connection, object(), None)
+        self.assertEqual(read.failure.code, "timeout")
+        self.assertIsNone(read.value)
+
+    def test_malformed_decode_after_deadline_still_reports_timeout(self):
+        read, connection, _gio, _glib, variant = self.reader()
+        read.deadline = 10
+        connection.call_finish.return_value = variant.Variant("(s)", ("wrong",))
+        with mock.patch.object(provider.time, "monotonic", side_effect=[9, 10]):
+            read.replied(connection, object(), None)
+        self.assertEqual(read.failure.code, "timeout")
+
+    def test_synchronous_callback_completion_does_not_enter_a_dead_loop(self):
+        read, connection, gio, _glib, variant = self.reader()
+        connection.call_finish.return_value = self.time_reply(variant)
+        gio.bus_get.side_effect = lambda *_args: self.deliver(read, connection)
+        self.assertEqual(read.run().timezone, "UTC")
+        read.loop.run.assert_not_called()
+
+    def test_typed_bus_failures_preserve_capability_scope(self):
+        names = {
+            "ServiceUnknown": ("missing-provider", "unavailable"),
+            "AccessDenied": ("permission-denied", "restricted"),
+            "InvalidArgs": ("malformed", "partial"),
+            "UnknownMethod": ("unsupported", "unsupported"),
+            "NoReply": ("timeout", "unavailable"),
+            "Unexpected": ("internal", "unavailable"),
+        }
+        for name, expected in names.items():
+            read, connection, gio, _glib, variant = self.reader()
+            gio.dbus_error_get_remote_error.return_value = "org.freedesktop.DBus.Error." + name
+            connection.call_finish.side_effect = variant.Error("fixture failure")
+            read.loop.run.side_effect = lambda: self.deliver(read, connection)
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                read.run()
+            self.assertEqual((caught.exception.code, caught.exception.status), expected)
+
+    def test_bus_connect_failure_and_local_timeout_are_typed(self):
+        from gi.repository import Gio
+        read, connection, gio, _glib, variant = self.reader()
+        gio.bus_get_finish.side_effect = variant.Error.new_literal(
+            Gio.io_error_quark(), "fixture timeout", Gio.IOErrorEnum.TIMED_OUT)
+        read.loop.run.side_effect = lambda: read.connected(None, object(), None)
+        with self.assertRaises(provider.SnapshotFailure) as caught:
+            read.run()
+        self.assertEqual(caught.exception.code, "timeout")
+        connection.call.assert_not_called()
+
+    def test_single_use_and_unexpected_loop_exit_cannot_fake_a_result(self):
+        read, _connection, gio, glib, _variant = self.reader()
+        with self.assertRaises(provider.SnapshotFailure) as caught:
+            read.run()
+        self.assertEqual(caught.exception.code, "internal")
+        with self.assertRaises(RuntimeError):
+            read.run()
+        gio.bus_get.assert_called_once()
+        glib.source_remove.assert_called_once_with(17)
+
+    def test_real_regional_reads_use_an_isolated_private_bus(self):
+        process = subprocess.Popen(["dbus-run-session", "--", "/usr/bin/python3",
+            str(REPO / "tests/fixtures/system-regional-read-bus.py"), str(PROVIDER_PATH)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True)
+        try:
+            stdout, stderr = process.communicate(timeout=30)
+            self.assertEqual(process.returncode, 0, stderr.decode("utf-8", "replace"))
+            self.assertIn(b"Private-bus regional reads: PASS", stdout)
+        finally:
+            if process.poll() is None:
+                with contextlib.suppress(ProcessLookupError):
+                    os.killpg(process.pid, 9)
+                process.communicate(timeout=3)
+
+
 class UpdateEventMonitorTests(unittest.TestCase):
     def monitor(self):
         class BusError(Exception):


### PR DESCRIPTION
## Summary

Add three fixed read-only regional requests: timedate1 GetAll, locale1 Get(Locale), and timedate1 ListTimezones. Each single-use reader bounds asynchronous connection setup, method reply and typed decoding under one ten-second deadline. Timeout cancels local work and ignores late callbacks; shared bus connections are not closed.

Property signatures, bounded property names, duplicate keys and serialized string-array sizes are checked before publication or Python string copies. The existing pure regional validators enforce the locale/timezone contracts. No CLI, snapshot minor, mutation, authorization prompt, polling source or Settings control is enabled by this foundation.

## Validation

- Focused regional validation/reader suite: 27 tests passed.
- Provider suite: all 343 tests passed.
- Real private D-Bus fixture: success, malformed types, permission denial, absent service, ten-second timeout and late-reply isolation passed; only the three read methods are exported.
- Real Fedora 44 read-only probes: typed time state, one locale assignment and 598 timezone choices passed. No host setting or file was changed.
- Documentation build passed without diagnostics. Independent CodeRabbit review and the post-full-gate local Codex review are clean.
- Final-tree `scripts/run-tests make clean all` and `scripts/run-tests` passed, including 343 provider tests, 1,457 native system-management assertions, configured QML/shell checks, package map, staged/repeated installs and release validation. Closed Settings CPU was 0.033%; large surfaces were 0.00%. Temporary workspaces were removed.

## Prior validation failure and limits

The first full run failed while restoring an unchanged appearance baseline because its inventory watcher reported unavailable. The exact cause was not established. No appearance source, assertion, timeout or host limit was changed: the focused Settings/X11 rerun and second complete suite passed. Both failed-run and successful-run workspaces were removed. This intermittent failure is retained as evidence rather than claimed as a pass.

Regional locale-catalog process collection, account/printer/source readers, mutations, lifecycle integration and Settings controls remain outstanding. Installed-X11 regional action qualification is not claimed; this change enables only internal readers.