### PR TITLE
feat(system): bound installed locale enumeration

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -164,9 +164,11 @@ The validators perform no I/O. Separate fixed timedate1 and locale1 readers now
 bound connection setup, service replies, and decoding under a ten-second deadline.
 Typed private-bus tests cover success, denial, absence, malformed state, timeout,
 and late replies; read-only Fedora 44 probes also passed. No command, D-Bus
-mutation, or new protocol minor is enabled. The bounded locale catalog process,
-account/printer/source readers, lifecycle integration, and Settings controls
-remain outstanding.
+mutation, or new protocol minor is enabled. A separate fixed locale catalog
+collector now bounds output, process lifetime, signal cleanup, and reaping, with
+an independent timeout supervisor for abrupt collector death. It preserves exact
+installed identities and starts a new process for every read. Account/printer/source
+readers, lifecycle integration, and Settings controls remain outstanding.
 
 - [ ] Add date, time, timezone, and locale status plus safe common actions
   through stable platform services.

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -426,6 +426,21 @@ and malformed names make it unavailable with the corresponding
 `missing-provider`, `internal`, or `malformed` error. Readable locale1 state
 remains visible and the rest of the regional provider continues to work.
 
+The internal locale collector now executes only `/usr/bin/locale -a`, guarded
+by the existing Fedora coreutils `/usr/bin/timeout` supervisor. Its environment
+contains only a fixed system `PATH`, `LANG=C`, and `LC_ALL=C`; it does not inherit
+`LOCPATH`, loader overrides, or caller-selected commands. Stdout and stderr share
+the 2 MiB byte budget, and diagnostics are counted but never published. Every
+call starts a new process, requires complete stdout and successful exit, and
+validates the catalog before the three-second aggregate deadline. The independent
+supervisor also bounds the command if the collector is killed abruptly.
+Graceful `TERM`, `INT`, or `HUP` requests retain cleanup ownership before exit.
+The collector leaves its child waitable until the final group signal to prevent
+PID reuse, closes both pipes, and bounds reaping after `KILL` to one additional
+second. Cleanup failure cannot publish a successful catalog. This synchronous
+collector runs only on the provider's main thread with normal child-reaping
+semantics. It adds no CLI command, mutation, or snapshot minor by itself.
+
 ### Accounts, Printers, and Sources
 
 AccountsService supplies read-only account objects and properties. The provider

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -9,11 +9,14 @@ import fcntl
 import hashlib
 import os
 import re
+import selectors
 import shlex
 import signal
 import stat
 import struct
+import subprocess
 import sys
+import threading
 import time
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -537,6 +540,125 @@ class RegionalRead:
         if self.failure:
             raise self.failure
         return self.value
+
+
+def locale_process_status(process: subprocess.Popen):
+    # Leave the child waitable so its PID/process-group ID cannot be reused
+    # between observing exit and signaling any remaining group members.
+    return os.waitid(os.P_PID, process.pid, os.WEXITED | os.WNOHANG | os.WNOWAIT)
+
+
+def close_locale_process(process: subprocess.Popen) -> None:
+    """Stop only our still-owned group, reap its leader, and close both pipes."""
+    try:
+        status = locale_process_status(process)
+        if status is None:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGTERM)
+            deadline = time.monotonic() + 1
+            # Do not reap an early-exiting supervisor: a descendant may still
+            # resist TERM, and the retained PID protects the final group signal.
+            while time.monotonic() < deadline:
+                time.sleep(min(0.02, max(0, deadline - time.monotonic())))
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        # A separately bounded reap tolerates scheduler delay after KILL. A
+        # kernel-stuck process is a cleanup failure, never a successful catalog.
+        process.wait(timeout=1)
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise SnapshotFailure("timeout", "Locale process cleanup could not be confirmed",
+                              "unavailable") from error
+    finally:
+        for stream in (process.stdout, process.stderr):
+            if stream is not None:
+                stream.close()
+
+
+def read_locale_choices() -> tuple[str, ...]:
+    """Collect one fresh system locale catalog, never a caller-selected command."""
+    if (threading.current_thread() is not threading.main_thread()
+            or signal.getsignal(signal.SIGCHLD) != signal.SIG_DFL):
+        raise SnapshotFailure("internal", "Locale process ownership is unavailable", "unavailable")
+    process = None
+    handlers = {}
+    interrupted = 0
+
+    def terminate(number, _frame):
+        nonlocal interrupted
+        interrupted = interrupted or number
+
+    def check_deadline():
+        if interrupted:
+            raise SystemExit(128 + interrupted)
+        if time.monotonic() >= deadline:
+            raise SnapshotFailure("timeout", "Locale enumeration timed out", "unavailable")
+
+    try:
+        for number in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            handlers[number] = signal.signal(number, terminate)
+        deadline = time.monotonic() + 3
+        check_deadline()
+        try:
+            # The independent timeout also bounds the fixed command if this
+            # collector is killed before its finally block can execute. Avoid
+            # Python preexec_fn callbacks in a process that can also use GIO.
+            process = subprocess.Popen(["/usr/bin/timeout", "--signal=TERM",
+                "--kill-after=1", "3", "/usr/bin/locale", "-a"],
+                stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                start_new_session=True, env={"PATH": "/usr/bin:/bin", "LANG": "C", "LC_ALL": "C"})
+        except FileNotFoundError as error:
+            raise SnapshotFailure("missing-provider", "Locale enumeration command is unavailable",
+                                  "unavailable") from error
+        output = bytearray()
+        received = 0
+        with selectors.DefaultSelector() as selector:
+            for stream in (process.stdout, process.stderr):
+                os.set_blocking(stream.fileno(), False)
+                selector.register(stream, selectors.EVENT_READ)
+            while True:
+                check_deadline()
+                status = locale_process_status(process)
+                if status is not None and not selector.get_map():
+                    break
+                for key, _events in selector.select(min(0.05, max(0, deadline - time.monotonic()))):
+                    check_deadline()
+                    try:
+                        chunk = os.read(key.fd, min(65536, REGIONAL_LOCALE_OUTPUT_BYTES - received + 1))
+                    except BlockingIOError:
+                        continue
+                    if not chunk:
+                        selector.unregister(key.fileobj)
+                        continue
+                    received += len(chunk)
+                    if received > REGIONAL_LOCALE_OUTPUT_BYTES:
+                        raise SnapshotFailure("malformed", "Oversized locale enumeration output")
+                    if key.fileobj is process.stdout:
+                        output.extend(chunk)
+        exit_code = status.si_status if status.si_code == os.CLD_EXITED else -status.si_status
+        if exit_code in (124, 137, -signal.SIGKILL):
+            raise SnapshotFailure("timeout", "Locale enumeration timed out", "unavailable")
+        if exit_code == 127:
+            raise SnapshotFailure("missing-provider", "Locale enumeration command is unavailable", "unavailable")
+        if exit_code != 0:
+            raise SnapshotFailure("internal", "Locale enumeration failed", "unavailable")
+        try:
+            choices = validate_locale_choices(bytes(output))
+        except SnapshotFailure:
+            check_deadline()
+            raise
+        check_deadline()
+        return choices
+    except OSError as error:
+        raise SnapshotFailure("internal", "Locale enumeration failed", "unavailable") from error
+    finally:
+        try:
+            if process is not None:
+                close_locale_process(process)
+        finally:
+            for number, handler in handlers.items():
+                signal.signal(number, handler)
+        if interrupted:
+            raise SystemExit(128 + interrupted)
 
 
 class JournalFrameError(ValueError):

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -657,8 +657,10 @@ def read_locale_choices() -> tuple[str, ...]:
         finally:
             for number, handler in handlers.items():
                 signal.signal(number, handler)
-        if interrupted:
-            raise SystemExit(128 + interrupted)
+            # Termination must remain terminal even if group cleanup failed;
+            # otherwise callers could catch a read failure and keep running.
+            if interrupted:
+                raise SystemExit(128 + interrupted)
 
 
 class JournalFrameError(ValueError):

--- a/tests/fixtures/system-locale-process.py
+++ b/tests/fixtures/system-locale-process.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python3
+"""Finite and hostile locale catalog fixtures; never invokes host services."""
+
+import os
+import pathlib
+import signal
+import sys
+import time
+
+
+def write_pid(filename, pid):
+    destination = pathlib.Path(filename)
+    pending = destination.with_suffix(".pending")
+    pending.write_text(str(pid))
+    pending.replace(destination)
+
+
+mode = sys.argv[1]
+if mode == "collector":
+    import importlib.machinery
+    import importlib.util
+    import subprocess
+    from unittest import mock
+
+    sys.dont_write_bytecode = True
+    spec = importlib.util.spec_from_loader("locale_provider",
+        importlib.machinery.SourceFileLoader("locale_provider", sys.argv[2]))
+    provider = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = provider
+    spec.loader.exec_module(provider)
+    popen = subprocess.Popen
+
+    def launch(command, **options):
+        process = popen(command[:4] + ["/usr/bin/python3", __file__, "descendant", sys.argv[3]], **options)
+        write_pid(sys.argv[4], process.pid)
+        return process
+
+    with mock.patch.object(provider.subprocess, "Popen", side_effect=launch):
+        provider.read_locale_choices()
+elif mode == "success":
+    os.write(1, b"C\nC.utf8\nPOSIX\nen_US.utf8\n")
+elif mode == "empty":
+    pass
+elif mode == "exact-budget":
+    os.write(1, b"C\n")
+    sys.stderr.buffer.write(b"x" * (2 * 1024 * 1024 - 2))
+elif mode == "exit":
+    os.write(1, b"C\n")
+    os.write(2, b"private diagnostic must not reach the protocol\n")
+    sys.exit(int(sys.argv[2]))
+elif mode == "duplicate":
+    os.write(1, b"C\nC\n")
+elif mode == "nonascii":
+    os.write(1, b"C\n\xff\n")
+elif mode == "blank":
+    os.write(1, b"C\n\n")
+elif mode == "oversized-name":
+    os.write(1, b"x" * 129 + b"\n")
+elif mode == "too-many":
+    sys.stdout.write("".join(f"locale{index}\n" for index in range(4097)))
+elif mode in ("stdout-overflow", "stderr-overflow", "combined-overflow"):
+    streams = (1, 2) if mode == "combined-overflow" else ((1,) if mode == "stdout-overflow" else (2,))
+    for _ in range(257):
+        for stream in streams:
+            os.write(stream, b"x" * 8192)
+elif mode in ("closed-pipes", "descendant"):
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    if mode == "descendant":
+        child = os.fork()
+        if child:
+            write_pid(sys.argv[2], child)
+    else:
+        os.close(1)
+        os.close(2)
+    while True:
+        time.sleep(1)
+else:
+    raise RuntimeError("Unknown locale fixture")

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -618,6 +618,22 @@ class LocaleEnumerationTests(unittest.TestCase):
                 provider.read_locale_choices()
         self.assertEqual(caught.exception.code, "timeout")
 
+    def test_cleanup_failure_cannot_hide_pending_process_termination(self):
+        for number in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            for during_cleanup in (False, True):
+                handler = signal.getsignal(number)
+                def cleanup(_process):
+                    if during_cleanup:
+                        signal.raise_signal(number)
+                    raise provider.SnapshotFailure("timeout", "Fixture cleanup failure")
+                with self.subTest(number=number, during_cleanup=during_cleanup), \
+                        self.catalog(signal_number=None if during_cleanup else number), \
+                        mock.patch.object(provider, "close_locale_process", side_effect=cleanup):
+                    with self.assertRaises(SystemExit) as caught:
+                        provider.read_locale_choices()
+                    self.assertEqual(caught.exception.code, 128 + number)
+                self.assertEqual(signal.getsignal(number), handler)
+
     def test_lost_child_ownership_never_signals_a_possibly_reused_group(self):
         process = mock.Mock(pid=123)
         with mock.patch.object(provider, "locale_process_status", side_effect=ChildProcessError), \

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -11,6 +11,7 @@ import importlib.util
 import importlib.machinery
 import os
 import pathlib
+import signal
 import stat
 import subprocess
 import sys
@@ -452,6 +453,225 @@ class RegionalReadTests(unittest.TestCase):
                 with contextlib.suppress(ProcessLookupError):
                     os.killpg(process.pid, 9)
                 process.communicate(timeout=3)
+
+
+class LocaleEnumerationTests(unittest.TestCase):
+    @contextlib.contextmanager
+    def catalog(self, mode="success", *arguments, signal_number=None):
+        popen = subprocess.Popen
+        processes = []
+
+        def launch(command, **options):
+            self.assertEqual(command, ["/usr/bin/timeout", "--signal=TERM",
+                "--kill-after=1", "3", "/usr/bin/locale", "-a"])
+            self.assertEqual(options["env"], {"PATH": "/usr/bin:/bin", "LANG": "C", "LC_ALL": "C"})
+            self.assertTrue(options["start_new_session"])
+            self.assertNotIn("preexec_fn", options)
+            process = popen(command[:4] + ["/usr/bin/python3",
+                str(REPO / "tests/fixtures/system-locale-process.py"), mode, *arguments], **options)
+            processes.append(process)
+            if signal_number is not None:
+                signal.raise_signal(signal_number)
+            return process
+
+        try:
+            with mock.patch.object(provider.subprocess, "Popen", side_effect=launch):
+                yield processes
+        finally:
+            for process in processes:
+                if process.returncode is None:
+                    with contextlib.suppress(ProcessLookupError):
+                        os.killpg(process.pid, signal.SIGKILL)
+                    process.wait(timeout=2)
+                if process.stdout:
+                    process.stdout.close()
+                if process.stderr:
+                    process.stderr.close()
+
+    def failure(self, code, mode, *arguments):
+        with self.catalog(mode, *arguments) as processes:
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                provider.read_locale_choices()
+            self.assertEqual(caught.exception.code, code)
+            self.assertNotIn("private diagnostic", str(caught.exception))
+            self.assertTrue(all(p.returncode is not None for p in processes))
+
+    def test_fixed_catalog_is_fresh_and_preserves_exact_names(self):
+        handlers = {number: signal.getsignal(number)
+                    for number in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)}
+        with mock.patch.dict(os.environ, {"LOCPATH": "/untrusted", "LC_ALL": "invalid"}), \
+                self.catalog() as processes:
+            for _ in range(2):
+                self.assertEqual(provider.read_locale_choices(), ("C", "C.utf8", "POSIX", "en_US.utf8"))
+            self.assertEqual(len(processes), 2)
+            self.assertTrue(all(p.returncode == 0 and p.stdout.closed and p.stderr.closed for p in processes))
+        self.assertEqual(handlers, {number: signal.getsignal(number) for number in handlers})
+
+    def test_missing_supervisor_is_a_scoped_failure(self):
+        handlers = {number: signal.getsignal(number)
+                    for number in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)}
+        with mock.patch.object(provider.subprocess, "Popen", side_effect=FileNotFoundError):
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                provider.read_locale_choices()
+        self.assertEqual(caught.exception.code, "missing-provider")
+        self.assertEqual(handlers, {number: signal.getsignal(number) for number in handlers})
+
+    def test_exit_status_is_required_and_diagnostics_are_not_exposed(self):
+        for status, code in ((1, "internal"), (125, "internal"), (126, "internal"),
+                             (127, "missing-provider"), (124, "timeout"), (137, "timeout")):
+            with self.subTest(status=status):
+                self.failure(code, "exit", str(status))
+
+    def test_catalog_validates_complete_stdout(self):
+        for mode in ("duplicate", "nonascii", "blank", "oversized-name", "too-many"):
+            with self.subTest(mode=mode):
+                self.failure("malformed", mode)
+
+    def test_stdout_and_stderr_share_one_bounded_budget(self):
+        for mode in ("stdout-overflow", "stderr-overflow", "combined-overflow"):
+            with self.subTest(mode=mode):
+                self.failure("malformed", mode)
+
+    def test_exact_output_budget_and_empty_catalog_are_accepted(self):
+        with self.catalog("exact-budget"):
+            self.assertEqual(provider.read_locale_choices(), ("C",))
+        with self.catalog("empty"):
+            self.assertEqual(provider.read_locale_choices(), ())
+
+    def test_decoding_cannot_publish_success_or_malformed_after_deadline(self):
+        monotonic = time.monotonic
+        for malformed in (False, True):
+            offset = [0]
+            def decode(_output):
+                offset[0] = 4
+                if malformed:
+                    raise provider.SnapshotFailure("malformed", "Late parser failure")
+                return ("C",)
+            with self.subTest(malformed=malformed), self.catalog(), \
+                    mock.patch.object(provider.time, "monotonic", side_effect=lambda: monotonic() + offset[0]), \
+                    mock.patch.object(provider, "validate_locale_choices", side_effect=decode):
+                with self.assertRaises(provider.SnapshotFailure) as caught:
+                    provider.read_locale_choices()
+            self.assertEqual(caught.exception.code, "timeout")
+
+    def test_eof_without_process_exit_still_times_out(self):
+        started = time.monotonic()
+        self.failure("timeout", "closed-pipes")
+        self.assertLess(time.monotonic() - started, 5.5)
+
+    def test_timeout_kills_a_term_resistant_process_group(self):
+        with tempfile.TemporaryDirectory() as directory:
+            pid_file = str(pathlib.Path(directory) / "child-pid")
+            self.failure("timeout", "descendant", pid_file)
+            child = int(pathlib.Path(pid_file).read_text())
+            self.assert_process_stopped(child)
+
+    def assert_process_stopped(self, pid, *, seconds=2):
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            try:
+                state = pathlib.Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()[0]
+            except FileNotFoundError:
+                return
+            if state == "Z":
+                return
+            time.sleep(0.02)
+        self.fail(f"Owned locale fixture {pid} remained running")
+
+    def test_non_main_thread_cannot_install_process_signal_handlers(self):
+        errors = []
+        def run():
+            try:
+                provider.read_locale_choices()
+            except provider.SnapshotFailure as error:
+                errors.append(error.code)
+        with mock.patch.object(provider.subprocess, "Popen") as launch:
+            thread = threading.Thread(target=run)
+            thread.start()
+            thread.join(timeout=2)
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(errors, ["internal"])
+        launch.assert_not_called()
+
+    def test_auto_reaped_children_are_rejected_before_launch(self):
+        with mock.patch.object(provider.signal, "getsignal", return_value=signal.SIG_IGN), \
+                mock.patch.object(provider.subprocess, "Popen") as launch:
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                provider.read_locale_choices()
+        self.assertEqual(caught.exception.code, "internal")
+        launch.assert_not_called()
+
+    def test_termination_during_launch_cleans_up_before_exit_and_restores_handlers(self):
+        for number in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            handler = signal.getsignal(number)
+            with self.subTest(number=number), self.catalog("closed-pipes", signal_number=number) as processes:
+                with self.assertRaises(SystemExit) as caught:
+                    provider.read_locale_choices()
+                self.assertEqual(caught.exception.code, 128 + number)
+                self.assertTrue(all(p.returncode is not None for p in processes))
+            self.assertEqual(signal.getsignal(number), handler)
+
+    def test_cleanup_failure_cannot_publish_a_valid_catalog(self):
+        with self.catalog(), mock.patch.object(provider, "close_locale_process",
+                side_effect=provider.SnapshotFailure("timeout", "Fixture cleanup failure")):
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                provider.read_locale_choices()
+        self.assertEqual(caught.exception.code, "timeout")
+
+    def test_lost_child_ownership_never_signals_a_possibly_reused_group(self):
+        process = mock.Mock(pid=123)
+        with mock.patch.object(provider, "locale_process_status", side_effect=ChildProcessError), \
+                mock.patch.object(provider.os, "killpg") as kill:
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                provider.close_locale_process(process)
+        self.assertEqual(caught.exception.code, "timeout")
+        kill.assert_not_called()
+        process.stdout.close.assert_called_once()
+        process.stderr.close.assert_called_once()
+
+    def test_killed_collector_leaves_a_bounded_independent_supervisor(self):
+        self.interrupt_collector(signal.SIGKILL)
+
+    def test_terminated_collector_cleans_up_a_running_descendant_group(self):
+        self.interrupt_collector(signal.SIGTERM)
+
+    def interrupt_collector(self, number):
+        with tempfile.TemporaryDirectory() as directory:
+            pid_file = pathlib.Path(directory) / "child-pid"
+            supervisor_file = pathlib.Path(directory) / "supervisor-pid"
+            process = subprocess.Popen(["/usr/bin/python3",
+                str(REPO / "tests/fixtures/system-locale-process.py"), "collector",
+                str(PROVIDER_PATH), str(pid_file), str(supervisor_file)],
+                stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                start_new_session=True)
+            supervisor = None
+            try:
+                deadline = time.monotonic() + 3
+                while not pid_file.exists() and time.monotonic() < deadline:
+                    time.sleep(0.02)
+                self.assertTrue(pid_file.exists(), "Locale child did not become ready")
+                supervisor = int(supervisor_file.read_text())
+                child = int(pid_file.read_text())
+                process.send_signal(number)
+                process.communicate(timeout=3)
+                self.assertEqual(process.returncode, -signal.SIGKILL if number == signal.SIGKILL else 143)
+                self.assert_process_stopped(supervisor, seconds=5)
+                self.assert_process_stopped(child)
+            finally:
+                if process.poll() is None:
+                    process.kill()
+                process.communicate(timeout=2)
+                if supervisor is None and supervisor_file.exists():
+                    supervisor = int(supervisor_file.read_text())
+                if supervisor is not None:
+                    # Fixture-only cleanup if an assertion failed while the
+                    # known supervisor and its group are still running.
+                    try:
+                        command = pathlib.Path(f"/proc/{supervisor}/cmdline").read_bytes()
+                        if command.startswith(b"/usr/bin/timeout\0"):
+                            os.killpg(supervisor, signal.SIGKILL)
+                    except (FileNotFoundError, ProcessLookupError):
+                        pass
 
 
 class UpdateEventMonitorTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Add the internal, read-only installed-locale catalog needed for fresh regional confirmations. This boundary executes only `/usr/bin/locale -a` through a fixed GNU timeout supervisor; it adds no CLI command, snapshot minor, mutation, QML control, or idle poller.

- Bound collection and decoding to three monotonic seconds, cap combined stdout/stderr at 2 MiB, and reuse the exact-name/count validators.
- Use a dedicated process group with TERM/KILL cleanup, retained child identity until the final group signal, and separately bounded reaping. An independent supervisor still bounds the command after abrupt collector death.
- Use a fixed environment without inherited locale paths or loader overrides; start a fresh process on every read; require complete stdout and successful exit; never publish subprocess diagnostics.
- Preserve signal cleanup on pane/helper termination and reject unsafe child-reaping contexts. Missing commands, nonzero exits, malformed output, and timeout remain scoped failures.

## Validation

- Combined regional tests: 44 passed in 30.935s, including real isolated child groups, abrupt collector death, graceful termination, late decoding, exact output bounds, and missing/malformed inputs.
- Read-only Fedora 44 probe: 39 exact installed locale names in 0.051s; no host settings changed.
- Documentation: npm --prefix docs run build passed (15 files, zero diagnostics, 11 pages).
- `scripts/run-tests make clean all && scripts/run-tests`: passed, including 360 provider tests (50.316s), 1454 native assertions, QML/ShellCheck/shfmt gates, staged and repeated installation, LightDM configuration, and release-archive validation. Settings closed CPU: 0.100%; large surfaces closed CPU: 0.00%; power lifecycle delta: 0.033 percentage points. Both managed workspaces were removed.
- Independent CodeRabbit review: clean across all five changed files.
- Required post-full-gate Codex review: clean across all five changed files, with no additional edits or duplicate test runs.

## Scope and remaining work

This is an internal regional-reader boundary, not Phase 6 completion. Account/printer/source readers, regional/delegated lifecycle and CLI integration, Settings controls, system information/security, and combined installed-session qualification remain outstanding. No logout, desktop synchronization, package mutation, or Phase 7 work was performed.

## Hosted-review follow-up

CodeRabbit identified that cleanup failure could mask a pending TERM/INT/HUP request. The regression reproduced all three failures. The follow-up keeps termination dominant after cleanup and handler restoration, with six cases covering signals before and during cleanup; ordinary cleanup failures still remain failures. Follow-up commit `1f47670f5c1e903c9c0878c19de2691a285cc8dd` passed the full managed build/test gate and fresh CodeRabbit/Codex local reviews. The validation counts above describe this fixed version; exact-head hosted checks and reviews passed. Hosted CI ran 360 provider tests in 59.202s and 1454 native assertions; Settings and large surfaces both measured 0.00% closed CPU. CodeRabbit approved after withdrawing the inapplicable synchronous-callback advisory, and Codex code/security reviews completed with no findings. Both review threads are resolved.
