### PR TITLE
feat(system): add bounded AccountsService reader

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -167,8 +167,16 @@ and late replies; read-only Fedora 44 probes also passed. No command, D-Bus
 mutation, or new protocol minor is enabled. A separate fixed locale catalog
 collector now bounds output, process lifetime, signal cleanup, and reaping, with
 an independent timeout supervisor for abrupt collector death. It preserves exact
-installed identities and starts a new process for every read. Account/printer/source
-readers, lifecycle integration, and Settings controls remain outstanding.
+installed identities and starts a new process for every read. A separate
+AccountsService reader now reserves the current user's row, bounds candidate
+selection and encoded rows, reads only four allowlisted properties, and keeps
+validated partial results under one three-second deadline. Unit and private-bus
+tests cover filtering, malformed and missing properties, overflow, denial,
+absence, timeout, and late replies. A read-only Fedora 44 probe returned the
+current account in 0.042 seconds. These readers share a single-use cancellable
+service lifetime; none adds account mutations, CLI exposure, or a protocol minor.
+Printer/source readers, event subscriptions, lifecycle integration, and Settings
+controls remain outstanding.
 
 - [ ] Add date, time, timezone, and locale status plus safe common actions
   through stable platform services.

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -786,6 +786,14 @@ ShellRoot {
             return appearanceModel.inventoryWatchState;
         }
 
+        function appearanceInventoryWatchDetail(): string {
+            return appearanceModel.inventoryWatchDetail;
+        }
+
+        function appearanceInventoryProviderDetail(): string {
+            return appearanceModel.inventoryProviderDetail;
+        }
+
         function appearanceInventoryCandidateState(capability: string, token: string): string {
             const match = appearanceModel.inventoryCandidates.find(function(item) {
                 return item.id === capability && item.token === token;

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import bisect
 import contextlib
 import errno
 import fcntl
@@ -177,6 +178,15 @@ REGIONAL_READ_REQUESTS = {
                          "org.freedesktop.timedate1", "ListTimezones", None,
                          None, "(as)"),
 }
+
+ACCOUNTS_NAME = "org.freedesktop.Accounts"
+ACCOUNTS_PATH = "/org/freedesktop/Accounts"
+ACCOUNT_INTERFACE = "org.freedesktop.Accounts.User"
+ACCOUNT_PROPERTIES = {"UserName": "s", "RealName": "s", "SystemAccount": "b", "LocalAccount": "b"}
+ACCOUNT_LIMIT = 256
+ACCOUNT_LIST_BYTES = 256 * 1024
+ACCOUNT_PROPERTY_CONCURRENCY = 8
+DBUS_OBJECT_PATH = re.compile(r"/(?:[A-Za-z0-9_]+(?:/[A-Za-z0-9_]+)*)?")
 
 ROLE_REFRESH_CACHE = 13
 EXIT_SUCCESS = 1
@@ -416,12 +426,13 @@ def decode_regional_reply(kind: str, reply: object) -> object:
     return RegionalTimeState(validate_timezone_name(values[0]), *values[1:])
 
 
-class RegionalRead:
-    """One fixed read with an aggregate connection, reply, and decoding deadline."""
+class ServiceRead:
+    """Shared single-use lifetime for bounded, asynchronous service readers."""
 
-    def __init__(self, kind: str, Gio=None, GLib=None) -> None:
-        if not isinstance(kind, str) or kind not in REGIONAL_READ_REQUESTS:
-            raise SnapshotFailure("malformed", "Unknown regional read")
+    label = "Service"
+    seconds = REGIONAL_READ_SECONDS
+
+    def __init__(self, Gio=None, GLib=None) -> None:
         if Gio is None or GLib is None:
             try:
                 import gi
@@ -430,7 +441,7 @@ class RegionalRead:
             except (ImportError, ValueError) as error:
                 raise SnapshotFailure("missing-provider", "System Python GObject bindings are unavailable",
                                       "unavailable") from error
-        self.kind, self.Gio, self.GLib = kind, Gio, GLib
+        self.Gio, self.GLib = Gio, GLib
         self.loop = GLib.MainLoop()
         self.cancellable = Gio.Cancellable()
         self.connection = None
@@ -449,22 +460,28 @@ class RegionalRead:
         self.cancellable.cancel()
         self.loop.quit()
 
+    def fail(self, failure: SnapshotFailure) -> None:
+        self.finish(failure=failure)
+
+    def timeout_failure(self) -> SnapshotFailure:
+        return SnapshotFailure("timeout", f"{self.label} read timed out", "unavailable")
+
     def expire(self) -> bool:
         self.deadline_source = 0
-        self.finish(failure=SnapshotFailure("timeout", "Regional read timed out", "unavailable"))
+        self.fail(self.timeout_failure())
         return self.GLib.SOURCE_REMOVE
 
     def pending(self) -> bool:
         if self.done:
             return False
         if time.monotonic() >= self.deadline:
-            self.finish(failure=SnapshotFailure("timeout", "Regional read timed out", "unavailable"))
+            self.fail(self.timeout_failure())
             return False
         return True
 
     def bus_failure(self, error: Exception) -> SnapshotFailure:
         if time.monotonic() >= self.deadline:
-            return SnapshotFailure("timeout", "Regional read timed out", "unavailable")
+            return self.timeout_failure()
         name = self.Gio.dbus_error_get_remote_error(error)
         code, status = {
             "org.freedesktop.DBus.Error.ServiceUnknown": ("missing-provider", "unavailable"),
@@ -483,7 +500,48 @@ class RegionalRead:
         if (name is None and error.matches(self.Gio.io_error_quark(),
                                           self.Gio.IOErrorEnum.TIMED_OUT)):
             code, status = "timeout", "unavailable"
-        return SnapshotFailure(code, "Regional service read failed", status)
+        return SnapshotFailure(code, f"{self.label} service read failed", status)
+
+    def connected(self, _source, result, _data) -> None:
+        raise NotImplementedError
+
+    def run(self) -> object:
+        if self.started:
+            raise RuntimeError(f"{self.label} reads are single-use")
+        self.started = True
+        self.deadline = time.monotonic() + self.seconds
+        try:
+            self.deadline_source = self.GLib.timeout_add(self.seconds * 1000, self.expire)
+            self.Gio.bus_get(self.Gio.BusType.SYSTEM, self.cancellable, self.connected, None)
+            if not self.done:
+                self.loop.run()
+            if not self.done:
+                self.fail(SnapshotFailure("internal", f"{self.label} read ended without a reply", "unavailable"))
+        except self.GLib.Error as error:
+            self.fail(self.bus_failure(error))
+        finally:
+            self.done = True
+            self.cancellable.cancel()
+            self.loop.quit()
+            if self.deadline_source:
+                self.GLib.source_remove(self.deadline_source)
+                self.deadline_source = 0
+            # bus_get returns a shared connection; never close another reader's bus.
+        if self.failure:
+            raise self.failure
+        return self.value
+
+
+class RegionalRead(ServiceRead):
+    """One fixed read with an aggregate connection, reply, and decoding deadline."""
+
+    label = "Regional"
+
+    def __init__(self, kind: str, Gio=None, GLib=None) -> None:
+        if not isinstance(kind, str) or kind not in REGIONAL_READ_REQUESTS:
+            raise SnapshotFailure("malformed", "Unknown regional read")
+        self.kind = kind
+        super().__init__(Gio, GLib)
 
     def connected(self, _source, result, _data) -> None:
         if not self.pending():
@@ -515,31 +573,247 @@ class RegionalRead:
             if self.pending():
                 self.finish(failure=error)
 
-    def run(self) -> object:
-        if self.started:
-            raise RuntimeError("Regional reads are single-use")
-        self.started = True
-        self.deadline = time.monotonic() + REGIONAL_READ_SECONDS
+
+@dataclass(frozen=True)
+class AccountRecord:
+    path: str
+    scope: str
+    display_name: str
+    login_name: str
+    local_account: bool
+
+    def fields(self) -> tuple[str, ...]:
+        return "account", self.path, self.scope, self.display_name, self.login_name
+
+
+@dataclass(frozen=True)
+class AccountInventory:
+    records: tuple[AccountRecord, ...]
+    candidates: tuple[str, ...]
+    current_path: str | None
+    status: str
+    errors: tuple[SnapshotFailure, ...]
+
+
+def account_object_path(value: object) -> str:
+    if value.get_type_string() != "o" or value.get_size() > MAX_TEXT_BYTES + 1:
+        raise SnapshotFailure("malformed", "Invalid AccountsService object path")
+    path = value.unpack()
+    if not isinstance(path, str) or DBUS_OBJECT_PATH.fullmatch(path) is None:
+        raise SnapshotFailure("malformed", "Invalid AccountsService object path")
+    return path
+
+
+class AccountRead(ServiceRead):
+    """Bounded account discovery; neither publishes a protocol nor changes users."""
+
+    label = "Account"
+    seconds = 3
+
+    def __init__(self, Gio=None, GLib=None) -> None:
+        super().__init__(Gio, GLib)
+        self.enumerated = False
+        self.selected: list[str] = []
+        self.seen: set[str] = set()
+        self.current_path = None
+        self.candidates: tuple[str, ...] = ()
+        self.errors: dict[str, SnapshotFailure] = {}
+        self.values: dict[str, dict[str, object]] = {}
+        self.records: dict[str, AccountRecord] = {}
+        self.invalid: set[str] = set()
+        self.queue: tuple[tuple[str, str], ...] = ()
+        self.offset = 0
+        self.outstanding = 0
+        self.draining = False
+
+    def note(self, error: SnapshotFailure) -> None:
+        # One diagnostic per closed error code, not one per failed property.
+        self.errors.setdefault(error.code, error)
+
+    def inventory(self) -> AccountInventory:
+        records = tuple(self.records[path] for path in self.candidates if path in self.records)
+        errors = dict(self.errors)
+        if (len(records) > ACCOUNT_LIMIT
+                or sum(encoded_record_size(row.fields()) for row in records) > ACCOUNT_LIST_BYTES):
+            records = ()
+            errors["malformed"] = SnapshotFailure("malformed", "Account rows exceeded the protocol budget")
+        status = "available"
+        if errors:
+            status = "partial" if self.enumerated or records or "timeout" in errors else next(iter(errors.values())).status
+        return AccountInventory(records, self.candidates, self.current_path, status, tuple(errors.values()))
+
+    def fail(self, failure: SnapshotFailure) -> None:
+        if not self.done:
+            self.note(failure)
+            self.finish(value=self.inventory())
+
+    def request(self, path, interface, method, parameters, reply_type, callback, data=None):
+        if self.pending():
+            self.connection.call(ACCOUNTS_NAME, path, interface, method, parameters,
+                self.GLib.VariantType.new(reply_type), self.Gio.DBusCallFlags.NONE,
+                max(1, int((self.deadline - time.monotonic()) * 1000)),
+                self.cancellable, callback, data)
+
+    def connected(self, _source, result, _data) -> None:
+        if not self.pending():
+            return
         try:
-            self.deadline_source = self.GLib.timeout_add(REGIONAL_READ_SECONDS * 1000, self.expire)
-            self.Gio.bus_get(self.Gio.BusType.SYSTEM, self.cancellable, self.connected, None)
-            if not self.done:
-                self.loop.run()
-            if not self.done:
-                self.finish(failure=SnapshotFailure("internal", "Regional read ended without a reply", "unavailable"))
+            self.connection = self.Gio.bus_get_finish(result)
+            self.connection.set_exit_on_close(False)
+            self.request(ACCOUNTS_PATH, ACCOUNTS_NAME, "ListCachedUsers", None, "(ao)", self.cached)
         except self.GLib.Error as error:
-            self.finish(failure=self.bus_failure(error))
+            self.fail(self.bus_failure(error))
+
+    def cached(self, connection, result, _data) -> None:
+        if not self.pending():
+            return
+        try:
+            reply = connection.call_finish(result)
+            if reply.get_type_string() != "(ao)":
+                raise SnapshotFailure("malformed", "Invalid cached account list")
+            self.enumerated = True
+            paths = reply.get_child_value(0)
+            # Never unpack or sort an unbounded reply. Retain at most 257
+            # unique identities for overflow evidence and the lowest 256 paths.
+            for index in range(paths.n_children()):
+                if not self.pending():
+                    return
+                try:
+                    path = account_object_path(paths.get_child_value(index))
+                except SnapshotFailure as error:
+                    if not self.pending():
+                        return
+                    self.note(error)
+                    continue
+                if not self.pending():
+                    return
+                if len(self.seen) <= ACCOUNT_LIMIT:
+                    self.seen.add(path)
+                if len(self.seen) > ACCOUNT_LIMIT:
+                    self.note(SnapshotFailure("malformed", "Too many AccountsService candidates"))
+                if path not in self.selected and (len(self.selected) < ACCOUNT_LIMIT or path < self.selected[-1]):
+                    bisect.insort(self.selected, path)
+                    if len(self.selected) > ACCOUNT_LIMIT:
+                        self.selected.pop()
+        except self.GLib.Error as error:
+            if not self.pending():
+                return
+            self.note(self.bus_failure(error))
+        except SnapshotFailure as error:
+            if not self.pending():
+                return
+            self.note(error)
+        if self.pending():
+            try:
+                self.request(ACCOUNTS_PATH, ACCOUNTS_NAME, "FindUserById",
+                    self.GLib.Variant("(x)", (os.getuid(),)), "(o)", self.current)
+            except self.GLib.Error as error:
+                self.note(self.bus_failure(error))
+                self.start_properties()
+
+    def current(self, connection, result, _data) -> None:
+        if not self.pending():
+            return
+        try:
+            reply = connection.call_finish(result)
+            if reply.get_type_string() != "(o)":
+                raise SnapshotFailure("malformed", "Invalid current account reply")
+            current = account_object_path(reply.get_child_value(0))
+            if not self.pending():
+                return
+            if len(self.seen) >= ACCOUNT_LIMIT and current not in self.seen:
+                self.note(SnapshotFailure("malformed", "Too many AccountsService candidates"))
+            if self.pending():
+                self.current_path = current
+        except self.GLib.Error as error:
+            if not self.pending():
+                return
+            self.note(self.bus_failure(error))
+        except SnapshotFailure as error:
+            if not self.pending():
+                return
+            self.note(error)
+        self.start_properties()
+
+    def start_properties(self) -> None:
+        if not self.pending():
+            return
+        others = [path for path in self.selected if path != self.current_path][:ACCOUNT_LIMIT - 1]
+        self.candidates = ((self.current_path,) if self.current_path is not None else ()) + tuple(others)
+        self.values = {path: {} for path in self.candidates}
+        self.queue = tuple((path, name) for path in self.candidates for name in ACCOUNT_PROPERTIES)
+        self.pump()
+
+    def pump(self) -> None:
+        if self.draining or not self.pending():
+            return
+        self.draining = True
+        try:
+            while self.pending() and self.outstanding < ACCOUNT_PROPERTY_CONCURRENCY and self.offset < len(self.queue):
+                path, name = self.queue[self.offset]
+                self.offset += 1
+                if path in self.invalid:
+                    continue
+                self.outstanding += 1
+                try:
+                    self.request(path, PROPERTIES_INTERFACE, "Get",
+                        self.GLib.Variant("(ss)", (ACCOUNT_INTERFACE, name)), "(v)", self.property_reply, (path, name))
+                except self.GLib.Error as error:
+                    self.outstanding -= 1
+                    self.invalid.add(path)
+                    self.note(self.bus_failure(error))
+            if not self.outstanding and self.offset == len(self.queue):
+                value = self.inventory()
+                if self.pending():
+                    self.finish(value=value)
         finally:
-            self.done = True
-            self.cancellable.cancel()
-            self.loop.quit()
-            if self.deadline_source:
-                self.GLib.source_remove(self.deadline_source)
-                self.deadline_source = 0
-            # bus_get returns a shared connection; never close another reader's bus.
-        if self.failure:
-            raise self.failure
-        return self.value
+            self.draining = False
+
+    def property_reply(self, connection, result, data) -> None:
+        if not self.pending():
+            return
+        path, name = data
+        self.outstanding -= 1
+        try:
+            reply = connection.call_finish(result)
+            if reply.get_type_string() != "(v)":
+                raise SnapshotFailure("malformed", "Invalid account property reply")
+            value = reply.get_child_value(0).get_variant()
+            signature = ACCOUNT_PROPERTIES[name]
+            if (value.get_type_string() != signature
+                    or (signature == "s" and value.get_size() > MAX_TEXT_BYTES + 1)):
+                raise SnapshotFailure("malformed", "Invalid account property type or size")
+            decoded = value.unpack()
+            if name == "UserName" and not decoded:
+                raise SnapshotFailure("malformed", "Account has no login name")
+            if not self.pending():
+                return
+            if path not in self.invalid:
+                self.values[path][name] = decoded
+                fields = self.values[path]
+                if len(fields) == len(ACCOUNT_PROPERTIES):
+                    scope = "current" if path == self.current_path else "other"
+                    if scope == "current" or not fields["SystemAccount"]:
+                        record = AccountRecord(path, scope,
+                            clean_text(fields["RealName"] or fields["UserName"]),
+                            clean_text(fields["UserName"]), fields["LocalAccount"])
+                        if not self.pending():
+                            return
+                        self.records[path] = record
+        except self.GLib.Error as error:
+            if not self.pending():
+                return
+            self.invalid.add(path)
+            if self.Gio.dbus_error_get_remote_error(error) == "org.freedesktop.DBus.Error.UnknownProperty":
+                self.note(SnapshotFailure("malformed", "Missing account property"))
+            else:
+                self.note(self.bus_failure(error))
+        except SnapshotFailure as error:
+            if not self.pending():
+                return
+            self.invalid.add(path)
+            self.note(error)
+        self.pump()
 
 
 def locale_process_status(process: subprocess.Popen):

--- a/tests/fixtures/system-account-read-bus.py
+++ b/tests/fixtures/system-account-read-bus.py
@@ -1,0 +1,106 @@
+#!/usr/bin/python3
+"""Qualify fixed AccountsService reads without accessing the host system bus."""
+
+import os
+import runpy
+import sys
+import time
+
+os.environ["DBUS_SYSTEM_BUS_ADDRESS"] = os.environ["DBUS_SESSION_BUS_ADDRESS"]
+from gi.repository import Gio, GLib
+
+provider = runpy.run_path(sys.argv[1], run_name="account_read_fixture")
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+service = provider["ACCOUNTS_NAME"]
+current = "/users/Current"
+others = ("/users/Other", "/users/System")
+mode = "normal"
+calls, held, registrations = [], [], []
+manager = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.Accounts">
+<method name="ListCachedUsers"><arg type="ao" direction="out"/></method>
+<method name="FindUserById"><arg type="x" direction="in"/><arg type="o" direction="out"/></method>
+</interface></node>""").interfaces[0]
+properties = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.DBus.Properties">
+<method name="Get"><arg type="s" direction="in"/><arg type="s" direction="in"/><arg type="v" direction="out"/></method>
+</interface></node>""").interfaces[0]
+
+
+def name_call(method):
+    args = GLib.Variant("(su)", (service, 0)) if method == "RequestName" else GLib.Variant("(s)", (service,))
+    return bus.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus",
+        "org.freedesktop.DBus", method, args, GLib.VariantType.new("(u)"),
+        Gio.DBusCallFlags.NONE, 3000, None).unpack()[0]
+
+
+def called(_bus, _sender, path, interface, method, args, invocation):
+    calls.append((path, interface, method, args.unpack()))
+    if mode == "denied":
+        invocation.return_dbus_error("org.freedesktop.DBus.Error.AccessDenied", "fixture denial")
+    elif method == "ListCachedUsers":
+        invocation.return_value(GLib.Variant("(ao)", ([others[1], others[0], others[0]],)))
+    elif method == "FindUserById":
+        assert args.unpack() == (os.getuid(),)
+        invocation.return_value(GLib.Variant("(o)", (current,)))
+    elif mode == "stall" and path != current:
+        held.append(invocation)
+    else:
+        account_interface, name = args.unpack()
+        assert account_interface == provider["ACCOUNT_INTERFACE"]
+        values = {"UserName": GLib.Variant("s", "fixture"),
+            "RealName": GLib.Variant("s", "Fixture User"),
+            "SystemAccount": GLib.Variant("b", path != others[0]),
+            "LocalAccount": GLib.Variant("b", path != others[0])}
+        assert name in values
+        if mode == "missing" and path == others[0] and name == "UserName":
+            invocation.return_dbus_error("org.freedesktop.DBus.Error.UnknownProperty", "fixture missing")
+        else:
+            value = GLib.Variant("u", 0) if mode == "malformed" and path == others[0] else values[name]
+            invocation.return_value(GLib.Variant("(v)", (value,)))
+
+
+try:
+    assert name_call("RequestName") == 1
+    registrations.append(bus.register_object(provider["ACCOUNTS_PATH"], manager, called, None, None))
+    for path in (current, *others):
+        registrations.append(bus.register_object(path, properties, called, None, None))
+    result = provider["AccountRead"]().run()
+    assert result.status == "available", result.errors
+    assert [row.path for row in result.records] == [current, others[0]]
+    assert [row.scope for row in result.records] == ["current", "other"]
+    assert not result.records[1].local_account
+    assert len(calls) == 14
+    for mode in ("malformed", "missing"):
+        result = provider["AccountRead"]().run()
+        assert result.status == "partial"
+        assert [row.path for row in result.records] == [current]
+        assert {error.code for error in result.errors} == {"malformed"}
+    mode = "denied"
+    result = provider["AccountRead"]().run()
+    assert result.status == "restricted", result.status
+    assert {error.code for error in result.errors} == {"permission-denied"}
+    mode = "stall"
+    started = time.monotonic()
+    reader = provider["AccountRead"]()
+    result = reader.run()
+    elapsed = time.monotonic() - started
+    assert 2.5 <= elapsed < 8, elapsed
+    assert result.status == "partial"
+    assert [row.path for row in result.records] == [current]
+    assert {error.code for error in result.errors} == {"timeout"}
+    assert held and len(held) <= 8
+    for invocation in held:
+        invocation.return_dbus_error("org.freedesktop.DBus.Error.Failed", "late fixture reply")
+    mode = "normal"
+    assert provider["AccountRead"]().run().status == "available"
+    assert reader.value is result
+    assert name_call("ReleaseName") == 1
+    result = provider["AccountRead"]().run()
+    assert result.status == "unavailable"
+    assert {error.code for error in result.errors} == {"missing-provider"}
+    assert all(call[2] in {"ListCachedUsers", "FindUserById", "Get"} for call in calls)
+    print("Private-bus account reads: PASS (typed rows, filtering, denial, absence, deadline, late replies)")
+finally:
+    for registration in registrations:
+        bus.unregister_object(registration)

--- a/tests/test-quickshell-settings-xvfb.sh
+++ b/tests/test-quickshell-settings-xvfb.sh
@@ -2224,6 +2224,9 @@ if [ "$wallpaper_preview" != active ]; then
 	printf 'Wallpaper watcher: %s; status busy: %s\n' \
 		"$(settings_ipc_retry appearanceInventoryWatchState)" \
 		"$(settings_ipc_retry appearanceWallpaperStatusBusy)" >&2
+	printf 'Inventory provider detail: %s; watcher detail: %s\n' \
+		"$(settings_ipc_retry appearanceInventoryProviderDetail)" \
+		"$(settings_ipc_retry appearanceInventoryWatchDetail)" >&2
 	DISPLAY=$display HOME=$home XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_home \
 		XDG_RUNTIME_DIR=$runtime DWM_APPEARANCE_WALLPAPER_DIR=$home/Pictures/backgrounds \
 		"$data_home/dwm-titus/scripts/dwm-settings-wallpaper" status --read-only >&2 || true

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -84,6 +84,278 @@ def rows(lines, kind):
     return [line.split("\t") for line in lines if line.startswith(f"{kind}\t")]
 
 
+class AccountReadTests(unittest.TestCase):
+    current_path = "/org/freedesktop/Accounts/Current"
+
+    def collect(self, paths=(), *, current=None, values=None, transform=None,
+                stop_when=None, remote_error=None, connection_error=False):
+        _unused, connection, gio, glib, variant = RegionalReadTests.reader(self)
+        read = provider.AccountRead(gio, glib)
+        current = self.current_path if current is None else current
+        calls, queued = [], []
+        peaks = []
+        gio.dbus_error_get_remote_error.return_value = remote_error
+        error = variant.Error("fixture service error")
+        if connection_error:
+            gio.bus_get_finish.side_effect = error
+
+        def sent(*args):
+            self.assertEqual(args[0], provider.ACCOUNTS_NAME)
+            self.assertEqual(args[6], gio.DBusCallFlags.NONE)
+            self.assertGreater(args[7], 0)
+            self.assertLessEqual(args[7], 3000)
+            self.assertIn(args[3], ("ListCachedUsers", "FindUserById", "Get"))
+            if args[3] == "Get":
+                self.assertEqual(args[2], provider.PROPERTIES_INTERFACE)
+                interface, name = args[4].unpack()
+                self.assertEqual(interface, provider.ACCOUNT_INTERFACE)
+                self.assertIn(name, provider.ACCOUNT_PROPERTIES)
+                self.assertLessEqual(read.outstanding, 8)
+            else:
+                self.assertEqual(args[1:3], (provider.ACCOUNTS_PATH, provider.ACCOUNTS_NAME))
+                if args[3] == "FindUserById":
+                    self.assertEqual(args[4].unpack(), (os.getuid(),))
+                    self.assertEqual(args[4].get_type_string(), "(x)")
+            calls.append(args)
+            queued.append(args)
+            peaks.append(len(queued))
+
+        def finish(reply):
+            if isinstance(reply, variant.Error):
+                raise reply
+            return reply
+
+        def reply_for(args):
+            method = args[3]
+            if method == "ListCachedUsers":
+                reply = variant.Variant("(ao)", (list(paths),))
+            elif method == "FindUserById":
+                reply = variant.Variant("(o)", (current,))
+            else:
+                name = args[4].unpack()[1]
+                default = {"UserName": "login", "RealName": "", "SystemAccount": False, "LocalAccount": True}[name]
+                field = (values or {}).get(args[1], {}).get(name, default)
+                inner = field if isinstance(field, variant.Variant) else variant.Variant(provider.ACCOUNT_PROPERTIES[name], field)
+                reply = variant.Variant("(v)", (inner,))
+            return transform(args, reply, variant, error) if transform else reply
+
+        def drive():
+            read.connected(None, object(), None)
+            while queued and not read.done:
+                args = queued.pop(0)
+                args[9](connection, reply_for(args), args[10])
+                if stop_when and stop_when(read):
+                    read.expire()
+
+        connection.call.side_effect = sent
+        connection.call_finish.side_effect = finish
+        read.loop.run.side_effect = drive
+        result = read.run()
+        self.assertTrue(read.cancellable.cancel.called)
+        connection.close_sync.assert_not_called()
+        return result, read, calls, queued, connection, max(peaks, default=0)
+
+    def codes(self, result):
+        return {error.code for error in result.errors}
+
+    def test_fixed_reads_reserve_current_user_and_cap_concurrency(self):
+        result, read, calls, _queued, _connection, peak = self.collect(
+            ["/users/z", self.current_path, "/users/a", "/users/a"])
+        self.assertEqual(result.status, "available")
+        self.assertEqual(result.candidates, (self.current_path, "/users/a", "/users/z"))
+        self.assertEqual([row.scope for row in result.records], ["current", "other", "other"])
+        self.assertEqual(result.current_path, self.current_path)
+        self.assertEqual((len(calls), peak), (14, 8))
+        self.assertEqual(read.outstanding, 0)
+        self.assertEqual(result.records[0].display_name, "login")
+        with self.assertRaises(RuntimeError):
+            read.run()
+
+    def test_filtering_preserves_current_system_account_and_remote_accounts(self):
+        result, *_ = self.collect(["/system", "/remote"], values={
+            self.current_path: {"SystemAccount": True, "RealName": "Current User"},
+            "/system": {"SystemAccount": True}, "/remote": {"LocalAccount": False}})
+        self.assertEqual(result.status, "available")
+        self.assertEqual([row.path for row in result.records], [self.current_path, "/remote"])
+        self.assertEqual(result.records[0].display_name, "Current User")
+        self.assertFalse(result.records[1].local_account)
+        self.assertIn("/system", result.candidates)
+
+    def test_overflow_keeps_current_and_lowest_255_other_paths(self):
+        paths = [f"/users/u{index:04}" for index in range(300, -1, -1)]
+        result, read, *_ = self.collect(paths)
+        self.assertEqual((result.status, len(result.records)), ("partial", 256))
+        self.assertEqual(result.candidates, (self.current_path, *sorted(paths)[:255]))
+        self.assertEqual(self.codes(result), {"malformed"})
+        self.assertLessEqual(len(read.seen), 257)
+        self.assertLessEqual(len(read.selected), 256)
+
+    def test_256_including_current_is_complete_but_256_plus_current_is_partial(self):
+        others = [f"/users/u{index:04}" for index in range(256)]
+        result, *_ = self.collect([*others[:255], self.current_path])
+        self.assertEqual((result.status, len(result.records)), ("available", 256))
+        result, *_ = self.collect(others)
+        self.assertEqual((result.status, len(result.records)), ("partial", 256))
+
+    def test_repeated_paths_do_not_create_false_overflow(self):
+        result, *_ = self.collect(["/same"] * 300)
+        self.assertEqual((result.status, len(result.records)), ("available", 2))
+
+    def test_bad_account_properties_do_not_hide_valid_rows(self):
+        from gi.repository import GLib
+        for fields in ({"UserName": ""}, {"RealName": "x" * 513},
+                       {"SystemAccount": GLib.Variant("u", 0)}, {"LocalAccount": GLib.Variant("s", "yes")}):
+            with self.subTest(fields=fields):
+                result, *_ = self.collect(["/bad", "/good"], values={"/bad": fields})
+                self.assertEqual(result.status, "partial")
+                self.assertEqual([row.path for row in result.records], [self.current_path, "/good"])
+                self.assertEqual(self.codes(result), {"malformed"})
+
+    def test_field_bounds_are_utf8_and_do_not_truncate_display_text(self):
+        result, *_ = self.collect(values={self.current_path: {"RealName": "é" * 256, "UserName": "a\tb\nc"}})
+        self.assertEqual(result.records[0].display_name, "é" * 256)
+        self.assertEqual(result.records[0].login_name, "a b c")
+        result, *_ = self.collect(values={self.current_path: {"RealName": "é" * 257}})
+        self.assertEqual(result.records, ())
+        self.assertEqual(self.codes(result), {"malformed"})
+
+    def test_oversized_encoded_list_discards_all_rows(self):
+        paths = [f"/users/u{index:04}" for index in range(255)]
+        values = {path: {"RealName": "x" * 512, "UserName": "y" * 512}
+                  for path in [self.current_path, *paths]}
+        result, *_ = self.collect(paths, values=values)
+        self.assertEqual((result.status, result.records), ("partial", ()))
+        self.assertEqual(self.codes(result), {"malformed"})
+
+    def test_oversized_object_path_is_rejected_before_unpacking(self):
+        value = mock.Mock()
+        value.get_type_string.return_value = "o"
+        value.get_size.return_value = 514
+        with self.assertRaises(provider.SnapshotFailure):
+            provider.account_object_path(value)
+        value.unpack.assert_not_called()
+        result, *_ = self.collect(["/" + "x" * 512, "/good"])
+        self.assertEqual([row.path for row in result.records], [self.current_path, "/good"])
+        self.assertEqual(self.codes(result), {"malformed"})
+
+    def test_bad_list_still_allows_a_valid_current_user_lookup(self):
+        def corrupt(args, reply, variant, _error):
+            return variant.Variant("(s)", ("bad",)) if args[3] == "ListCachedUsers" else reply
+        result, *_ = self.collect(transform=corrupt)
+        self.assertEqual((result.status, len(result.records)), ("partial", 1))
+        self.assertEqual(result.records[0].scope, "current")
+
+    def test_failed_current_lookup_never_infers_current_scope_from_a_path(self):
+        def fail(args, reply, _variant, error):
+            return error if args[3] == "FindUserById" else reply
+        result, *_ = self.collect([self.current_path], transform=fail)
+        self.assertIsNone(result.current_path)
+        self.assertEqual(result.records[0].scope, "other")
+        self.assertEqual(result.status, "partial")
+
+    def test_connection_denial_or_missing_service_is_scoped(self):
+        for name, code, status in (("AccessDenied", "permission-denied", "restricted"),
+                                   ("ServiceUnknown", "missing-provider", "unavailable")):
+            with self.subTest(name=name):
+                result, _read, calls, *_ = self.collect(connection_error=True,
+                    remote_error=f"org.freedesktop.DBus.Error.{name}")
+                self.assertEqual((result.status, result.records, calls), (status, (), []))
+                self.assertEqual(self.codes(result), {code})
+
+    def test_deadline_preserves_completed_rows_and_ignores_late_replies(self):
+        result, read, calls, queued, connection, _peak = self.collect(
+            ["/users/a", "/users/b"], stop_when=lambda reader: len(reader.records) == 1)
+        self.assertEqual((result.status, len(result.records)), ("partial", 1))
+        self.assertEqual(self.codes(result), {"timeout"})
+        self.assertTrue(queued)
+        count = len(calls)
+        for args in queued[:]:
+            args[9](connection, object(), args[10])
+        self.assertIs(read.value, result)
+        self.assertEqual(len(calls), count)
+
+    def test_missing_property_excludes_only_its_account(self):
+        def missing(args, reply, _variant, error):
+            return error if args[1] == "/bad" and args[3] == "Get" else reply
+        result, *_ = self.collect(["/bad", "/good"], transform=missing,
+            remote_error="org.freedesktop.DBus.Error.UnknownProperty")
+        self.assertEqual([row.path for row in result.records], [self.current_path, "/good"])
+        self.assertEqual((result.status, self.codes(result)), ("partial", {"malformed"}))
+
+    def test_late_path_decoding_and_errors_cannot_publish_state(self):
+        original = provider.account_object_path
+        for late_call in (1, 2):
+            for malformed in (False, True):
+                with self.subTest(late_call=late_call, malformed=malformed):
+                    count = 0
+                    with mock.patch.object(provider.time, "monotonic", return_value=0) as clock:
+                        def decode(value):
+                            nonlocal count
+                            count += 1
+                            if count == late_call:
+                                clock.return_value = 4
+                                if malformed:
+                                    raise provider.SnapshotFailure("malformed", "late decode")
+                            return original(value)
+                        with mock.patch.object(provider, "account_object_path", side_effect=decode):
+                            result, read, calls, *_ = self.collect(["/cached"])
+                    self.assertEqual((result.status, self.codes(result)), ("partial", {"timeout"}))
+                    self.assertEqual(result.records, ())
+                    self.assertIsNone(result.current_path)
+                    self.assertLessEqual(len(calls), 2)
+                    self.assertEqual(len(read.selected), late_call - 1)
+
+    def test_late_property_decoding_and_errors_cannot_publish_a_row(self):
+        for malformed in (False, True):
+            with self.subTest(malformed=malformed):
+                with mock.patch.object(provider.time, "monotonic", return_value=0) as clock:
+                    def late(args, reply, _variant, _error):
+                        if args[3] != "Get":
+                            return reply
+                        wrapped = mock.Mock(wraps=reply)
+                        inner = mock.Mock(wraps=reply.get_child_value(0).get_variant())
+                        child = mock.Mock()
+                        child.get_variant.return_value = inner
+                        wrapped.get_child_value.return_value = child
+                        def unpack():
+                            clock.return_value = 4
+                            if malformed:
+                                raise provider.SnapshotFailure("malformed", "late property")
+                            return "login"
+                        inner.unpack.side_effect = unpack
+                        return wrapped
+                    result, *_ = self.collect(transform=late)
+                self.assertEqual((result.records, self.codes(result)), ((), {"timeout"}))
+
+    def test_connection_deadline_and_unexpected_loop_exit_do_not_fake_success(self):
+        for expires in (False, True):
+            with self.subTest(expires=expires):
+                _unused, connection, gio, glib, _variant = RegionalReadTests.reader(self)
+                read = provider.AccountRead(gio, glib)
+                if expires:
+                    read.loop.run.side_effect = read.expire
+                result = read.run()
+                self.assertEqual(result.records, ())
+                self.assertEqual(self.codes(result), {"timeout" if expires else "internal"})
+                self.assertEqual(result.status, "partial" if expires else "unavailable")
+                connection.call.assert_not_called()
+                self.assertTrue(read.cancellable.cancel.called)
+
+    def test_real_account_reads_use_an_isolated_private_bus(self):
+        process = subprocess.Popen(["dbus-run-session", "--", "/usr/bin/python3",
+            str(REPO / "tests/fixtures/system-account-read-bus.py"), str(PROVIDER_PATH)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True)
+        try:
+            stdout, stderr = process.communicate(timeout=20)
+            self.assertEqual(process.returncode, 0, stderr.decode("utf-8", "replace"))
+            self.assertIn(b"Private-bus account reads: PASS", stdout)
+        finally:
+            if process.poll() is None:
+                with contextlib.suppress(ProcessLookupError):
+                    os.killpg(process.pid, 9)
+                process.communicate(timeout=3)
+
+
 class RegionalValidationTests(unittest.TestCase):
     def malformed(self, function, *args):
         with self.assertRaises(provider.SnapshotFailure) as caught:


### PR DESCRIPTION
## Summary
- Add an internal, read-only AccountsService reader for the Phase 6 account summary; no new CLI command, protocol minor, mutation, tool launch, or UI exposure.
- Share the regional reader's single-use asynchronous service lifetime. Reserve the valid current-user object, select at most 255 other sorted paths, issue only the four fixed property reads, and cap outstanding calls at eight.
- Bound the entire read to three seconds; preserve validated rows on timeout, cancel local work, reject late decoding and replies, and enforce per-field and encoded-list budgets without false complete truncation.
- Add unit and real private-bus coverage for filtering, current identity, overflow, malformed/missing properties, denial, absence, deadlines, and late replies. Update active Phase 6 progress without marking the broader entry-point task complete.

## Validation
- `scripts/run-tests make clean all` and `scripts/run-tests`: PASS, including 378 provider tests (53.803s), 1,454 native assertions, configured QML lint, shell gates, staged installation/preservation, Kickstarts, and release archive validation. Both managed workspaces were removed.
- Nested Fedora 44 X11: Settings closed-idle 0.067% CPU, large surfaces 0.00%, power lifecycle 0.133% to 0.067% (delta 0.066 points).
- Focused account/regional suite: 34 tests passed in 13.568s. Read-only Fedora 44 AccountsService probe: available, one current account, 0.042s, no errors. No account or host configuration changes. Documentation build: 15 files, zero diagnostics, 11 pages.
- Independent CodeRabbit review completed for all four files. Its only minor suggestion (allow 256 other rows when current lookup fails) conflicts with the accepted explicit maximum of 255 other objects in `docs/P6-SYSTEM-MANAGEMENT.md`; retained the documented limit. No actionable findings.
- Post-gate Codex review: PASS, no actionable defects; independently confirmed the documented account-limit behavior.

## Remaining Phase 6 scope
Event subscriptions, printer/source readers, regional actions and lifecycle, fixed delegated tools, cumulative protocol/UI integration, information/security/storage, and combined installed qualification remain separate PR boundaries.