### PR TITLE
feat(system): add bounded printer service reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ versions from `config.mk`.
 
 ### Changed
 
+- Preserve appearance inventory streams when a producer exits before the parent
+  captures its identity. Keep buffered output and failure status instead of
+  crashing the asset watcher and leaving wallpaper preview state stale.
+
 - Offer confirmed update actions only after complete idle recovery and the
   PackageKit security check. Installation also requires a supported dependency
   preview; failures preserve readable inventory and explicit refresh guidance.

--- a/TASKS.md
+++ b/TASKS.md
@@ -175,8 +175,15 @@ tests cover filtering, malformed and missing properties, overflow, denial,
 absence, timeout, and late replies. A read-only Fedora 44 probe returned the
 current account in 0.042 seconds. These readers share a single-use cancellable
 service lifetime; none adds account mutations, CLI exposure, or a protocol minor.
-Printer/source readers, event subscriptions, lifecycle integration, and Settings
-controls remain outstanding.
+A separate printer reader now queries only the fixed CUPS service and socket,
+without D-Bus auto-start, under one ten-second deadline. It distinguishes running,
+socket-ready, stopped, absent, and incomplete state while preserving a validated
+running service if the socket probe fails. Unit and private-bus tests cover
+status combinations, typed bounds, denial, absence, deadlines, and late replies.
+A read-only Fedora 44 probe returned running CUPS state in 0.030 seconds without
+errors or service changes. This reader adds no CLI command or protocol minor.
+Source readers, event subscriptions, lifecycle integration, and Settings controls
+remain outstanding.
 
 - [ ] Add date, time, timezone, and locale status plus safe common actions
   through stable platform services.

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -479,8 +479,8 @@ including a present socket with an absent service, malformed or transitional
 state, a failed service, or a failed socket when the service is not running, is
 `partial`/`unknown`. This distinguishes Fedora's healthy idle socket-activated
 scheduler and valid service-only configurations from a missing scheduler.
-One ten-second monotonic aggregate deadline covers resolving both fixed unit
-objects and reading their required properties. On expiry the provider cancels
+One ten-second monotonic aggregate deadline covers bus connection, both fixed
+unit-state requests, and reply decoding. On expiry the provider cancels
 each unfinished local D-Bus request and discards late replies. If the service
 was already validated active, `cups-service` remains `available`/`running`
 because socket state cannot affect that result; the provider may still emit the

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -489,6 +489,13 @@ state emits `cups-service` as `unavailable`/`unknown` with that error. The finit
 snapshot continues without degrading unrelated providers. A validated systemd
 no-such-unit reply remains absence evidence under the status mapping above
 rather than a timeout.
+The internal reader uses one fixed `ListUnitsByNames` request per unit, with
+D-Bus auto-start disabled. Each typed reply supplies the resolved object and
+load/active/substate together; it does not start CUPS or rely on a later property
+read of an unloaded object. Replies are bounded to one row and 64 KiB before
+decoding. Canonical aliases returned by systemd do not change the fixed requested
+unit's identity. Private-bus fixtures stall each unit reply under the shared
+deadline and verify both late-reply rejection and the running-service exception.
 Phase 6 reports service/tool availability and opens Fedora's
 `system-config-printer`; it does not reproduce printer discovery, driver,
 queue, job, or authentication policy.
@@ -1844,8 +1851,8 @@ A pre-handoff conflict fixture proves a terminal stream with no durable handoff
 does not invoke acknowledgment. Hostname fixtures stall each property before
 and after the other property succeeds and prove the ten-second monotonic
 aggregate deadline discards late replies, degrades only unfinished states, and
-does not block other information records. CUPS fixtures stall unit resolution
-and each property read, prove late replies are discarded, and verify the timeout
+does not block other information records. CUPS fixtures stall each fixed
+unit-state reply, prove late replies are discarded, and verify the timeout
 degrades only `cups-service`; a socket timeout after the service is validated
 active must preserve `available`/`running`. Accounts initialization fixtures
 inject manager and candidate changes after subscription attachment but during

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -681,12 +681,13 @@ personalization_candidate_safe() {
 
 start_inventory_stream() {
 	stop_inventory_stream cancel
-	coproc DWM_INVENTORY_STREAM {
+	# Own the read descriptor even if the producer exits before this shell
+	# resumes. Bash can unset a completed named coprocess's PID and fd array.
+	exec {inventory_stream_fd}< <(
 		exec timeout --signal=TERM --kill-after=1 \
-			"$max_inventory_scan_seconds" "$@" 2>/dev/null
-	}
-	inventory_stream_pid=$DWM_INVENTORY_STREAM_PID
-	exec {inventory_stream_fd}<&"${DWM_INVENTORY_STREAM[0]}"
+			"$max_inventory_scan_seconds" "$@" </dev/null 2>/dev/null
+	)
+	inventory_stream_pid=$!
 }
 
 stop_inventory_stream() {

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -188,6 +188,15 @@ ACCOUNT_LIST_BYTES = 256 * 1024
 ACCOUNT_PROPERTY_CONCURRENCY = 8
 DBUS_OBJECT_PATH = re.compile(r"/(?:[A-Za-z0-9_]+(?:/[A-Za-z0-9_]+)*)?")
 
+SYSTEMD_NAME = "org.freedesktop.systemd1"
+SYSTEMD_PATH = "/org/freedesktop/systemd1"
+SYSTEMD_MANAGER = "org.freedesktop.systemd1.Manager"
+CUPS_UNITS = ("cups.service", "cups.socket")
+CUPS_READ_SECONDS = 10
+UNIT_REPLY_TYPE = "(a(ssssssouso))"
+UNIT_REPLY_BYTES = 64 * 1024
+UNIT_STATE_TOKEN = re.compile(r"[a-z][a-z-]{0,63}")
+
 ROLE_REFRESH_CACHE = 13
 EXIT_SUCCESS = 1
 G_MAXUINT = (1 << 32) - 1
@@ -530,6 +539,134 @@ class ServiceRead:
         if self.failure:
             raise self.failure
         return self.value
+
+
+@dataclass(frozen=True)
+class UnitState:
+    path: str
+    load: str
+    active: str
+    sub: str
+
+
+def decode_unit_state(reply: object) -> UnitState:
+    """Decode the single fixed-name query before exposing any unit state."""
+    if (reply.get_type_string() != UNIT_REPLY_TYPE or reply.get_size() > UNIT_REPLY_BYTES
+            or reply.get_child_value(0).n_children() != 1):
+        raise SnapshotFailure("malformed", "Invalid systemd unit reply")
+    row = reply.get_child_value(0).get_child_value(0)
+    # ListUnitsByNames can return a canonical alias name. The fixed request,
+    # not a guessed object-path encoding or canonical name, identifies the unit.
+    values = []
+    for index in (2, 3, 4, 6):
+        child = row.get_child_value(index)
+        if child.get_size() > MAX_TEXT_BYTES + 1:
+            raise SnapshotFailure("malformed", "Oversized systemd unit state")
+        values.append(child.unpack())
+    load, active, sub, path = values
+    if (any(UNIT_STATE_TOKEN.fullmatch(value) is None for value in (load, active, sub))
+            or not path.startswith(SYSTEMD_PATH + "/unit/")
+            or DBUS_OBJECT_PATH.fullmatch(path) is None):
+        raise SnapshotFailure("malformed", "Malformed systemd unit state")
+    return UnitState(path, load, active, sub)
+
+
+@dataclass(frozen=True)
+class CupsState:
+    status: str
+    value: str
+    units: tuple[tuple[str, UnitState], ...]
+    errors: tuple[SnapshotFailure, ...]
+
+
+def classify_cups(units: Mapping[str, UnitState], errors=()) -> CupsState:
+    """Keep a validated running scheduler independent of the socket probe."""
+    service, socket = (units.get(name) for name in CUPS_UNITS)
+    status, value = "partial", "unknown"
+    if service and service.load == "loaded" and service.active == "active":
+        status, value = "available", "running"
+    elif errors or len(units) != 2:
+        status = "partial" if errors and all(error.code == "malformed" for error in errors) else "unavailable"
+    else:
+        service_absent = (service.load, service.active, service.sub) == ("not-found", "inactive", "dead")
+        socket_absent = (socket.load, socket.active, socket.sub) == ("not-found", "inactive", "dead")
+        if service_absent and socket_absent:
+            status = "unsupported"
+        elif service.load == "loaded" and service.active == "inactive":
+            if socket.load == "loaded" and (socket.active, socket.sub) == ("active", "listening"):
+                status, value = "available", "socket-ready"
+            elif socket_absent or (socket.load == "loaded" and socket.active == "inactive"):
+                status, value = "available", "stopped"
+    return CupsState(status, value, tuple((name, units[name]) for name in CUPS_UNITS if name in units),
+                     tuple(errors))
+
+
+class CupsRead(ServiceRead):
+    """Read two fixed CUPS units under one connection-to-decoding deadline."""
+
+    label = "Printer"
+    seconds = CUPS_READ_SECONDS
+
+    def __init__(self, Gio=None, GLib=None) -> None:
+        super().__init__(Gio, GLib)
+        self.units = {}
+        self.errors = []
+        self.waiting = set(CUPS_UNITS)
+
+    def fail(self, failure: SnapshotFailure) -> None:
+        if not self.done:
+            self.errors.append(failure)
+            self.finish(value=classify_cups(self.units, self.errors))
+
+    def connected(self, _source, result, _data) -> None:
+        if not self.pending():
+            return
+        try:
+            self.connection = self.Gio.bus_get_finish(result)
+            self.connection.set_exit_on_close(False)
+        except self.GLib.Error as error:
+            self.fail(self.bus_failure(error))
+            return
+        for unit in CUPS_UNITS:
+            if not self.pending():
+                return
+            try:
+                self.connection.call(SYSTEMD_NAME, SYSTEMD_PATH, SYSTEMD_MANAGER,
+                    "ListUnitsByNames", self.GLib.Variant("(as)", ([unit],)),
+                    self.GLib.VariantType.new(UNIT_REPLY_TYPE), self.Gio.DBusCallFlags.NO_AUTO_START,
+                    max(1, int((self.deadline - time.monotonic()) * 1000)),
+                    self.cancellable, self.replied, unit)
+            except self.GLib.Error as error:
+                self.unit_failed(unit, error)
+
+    def unit_failed(self, unit: str, error: Exception) -> None:
+        if not self.pending():
+            return
+        if self.Gio.dbus_error_get_remote_error(error) == "org.freedesktop.systemd1.NoSuchUnit":
+            self.completed_unit(unit, state=UnitState("", "not-found", "inactive", "dead"))
+        else:
+            self.completed_unit(unit, failure=self.bus_failure(error))
+
+    def completed_unit(self, unit: str, state=None, failure=None) -> None:
+        if not self.pending() or unit not in self.waiting:
+            return
+        self.waiting.remove(unit)
+        if failure is not None:
+            self.errors.append(failure)
+        else:
+            self.units[unit] = state
+        if not self.waiting:
+            self.finish(value=classify_cups(self.units, self.errors))
+
+    def replied(self, connection, result, unit) -> None:
+        if not self.pending() or unit not in self.waiting:
+            return
+        try:
+            self.completed_unit(unit, state=decode_unit_state(connection.call_finish(result)))
+        except self.GLib.Error as error:
+            self.unit_failed(unit, error)
+        except SnapshotFailure as error:
+            self.completed_unit(unit, failure=error)
 
 
 class RegionalRead(ServiceRead):

--- a/tests/fixtures/system-cups-read-bus.py
+++ b/tests/fixtures/system-cups-read-bus.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python3
+"""Qualify fixed printer unit reads without touching the host system bus."""
+
+import os
+import runpy
+import sys
+import time
+
+os.environ["DBUS_SYSTEM_BUS_ADDRESS"] = os.environ["DBUS_SESSION_BUS_ADDRESS"]
+from gi.repository import Gio, GLib
+
+provider = runpy.run_path(sys.argv[1], run_name="cups_read_fixture")
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+service = provider["SYSTEMD_NAME"]
+mode = "normal"
+calls, held = [], []
+manager = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.systemd1.Manager">
+<method name="ListUnitsByNames"><arg type="as" direction="in"/>
+<arg type="a(ssssssouso)" direction="out"/></method>
+</interface></node>""").interfaces[0]
+
+
+def name_call(method):
+    args = GLib.Variant("(su)", (service, 0)) if method == "RequestName" else GLib.Variant("(s)", (service,))
+    return bus.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus",
+        "org.freedesktop.DBus", method, args, GLib.VariantType.new("(u)"),
+        Gio.DBusCallFlags.NONE, 3000, None).unpack()[0]
+
+
+def called(_bus, _sender, path, interface, method, args, invocation):
+    assert (path, interface, method) == (provider["SYSTEMD_PATH"], provider["SYSTEMD_MANAGER"], "ListUnitsByNames")
+    names = args.unpack()[0]
+    assert len(names) == 1 and names[0] in provider["CUPS_UNITS"]
+    unit = names[0]
+    calls.append(unit)
+    if mode == "denied":
+        invocation.return_dbus_error("org.freedesktop.DBus.Error.AccessDenied", "fixture denial")
+    elif mode == "absent":
+        invocation.return_dbus_error("org.freedesktop.systemd1.NoSuchUnit", "fixture absence")
+    elif mode == "stall-" + unit.split(".")[1]:
+        held.append(invocation)
+    else:
+        load, active, sub = "loaded", "active", "running" if unit.endswith("service") else "listening"
+        if unit.endswith("service") and mode in ("socket-ready", "stopped"):
+            active, sub = "inactive", "dead"
+        if unit.endswith("socket") and mode == "stopped":
+            load, active, sub = "not-found", "inactive", "dead"
+        if mode == "malformed":
+            active = "bad\nstate"
+        row = (unit, "Fixture", load, active, sub, "", provider["SYSTEMD_PATH"] + "/unit/fixture", 0, "", "/")
+        invocation.return_value(GLib.Variant(provider["UNIT_REPLY_TYPE"], ([row],)))
+
+
+registration = None
+try:
+    assert name_call("RequestName") == 1
+    registration = bus.register_object(provider["SYSTEMD_PATH"], manager, called, None, None)
+    for mode, expected in (("normal", ("available", "running")),
+                           ("socket-ready", ("available", "socket-ready")),
+                           ("stopped", ("available", "stopped")),
+                           ("absent", ("unsupported", "unknown")),
+                           ("denied", ("unavailable", "unknown")),
+                           ("malformed", ("partial", "unknown"))):
+        result = provider["CupsRead"]().run()
+        assert (result.status, result.value) == expected, result
+    for mode in ("stall-service", "stall-socket"):
+        held.clear()
+        started = time.monotonic()
+        reader = provider["CupsRead"]()
+        result = reader.run()
+        elapsed = time.monotonic() - started
+        assert 9 <= elapsed < 15, elapsed
+        expected = ("available", "running") if mode == "stall-socket" else ("unavailable", "unknown")
+        assert (result.status, result.value) == expected, result
+        assert [error.code for error in result.errors] == ["timeout"]
+        assert len(held) == 1
+        held[0].return_dbus_error("org.freedesktop.DBus.Error.Failed", "late reply")
+        mode = "normal"
+        assert provider["CupsRead"]().run().value == "running"
+        assert reader.value is result
+    assert name_call("ReleaseName") == 1
+    result = provider["CupsRead"]().run()
+    assert (result.status, result.value) == ("unavailable", "unknown")
+    assert all(error.code == "missing-provider" for error in result.errors)
+    assert set(calls) == set(provider["CUPS_UNITS"])
+    print("Private-bus printer reads: PASS (typed states, denial, absence, aggregate deadlines, late replies)")
+finally:
+    if registration is not None:
+        bus.unregister_object(registration)

--- a/tests/test-dwm-settings-appearance-inventory.sh
+++ b/tests/test-dwm-settings-appearance-inventory.sh
@@ -131,6 +131,30 @@ inventory=$(HOME=$home PATH=$bin_dir XDG_CONFIG_HOME=$config_home \
 	DWM_APPEARANCE_WALLPAPER_DIR=$wallpaper_dir QT_QPA_PLATFORMTHEME=qt6ct \
 	"$helper" inventory)
 
+# Force every small fixture producer to exit before the parent captures its
+# identity. Bash removes a completed named coprocess's PID and descriptor array;
+# an explicitly owned process-substitution pipe must retain its buffered data.
+race_env=$work/stream-race.env
+race_marker=$work/stream-race.marker
+cat >"$race_env" <<'EOF'
+set -T
+trap 'case $BASH_COMMAND in inventory_stream_pid=\$*) wait "$!" || :; printf "reaped\n" >>"$DWM_TEST_STREAM_RACE_MARKER" ;; esac' DEBUG
+EOF
+race_inventory=$(HOME=$home PATH=$bin_dir XDG_CONFIG_HOME=$config_home \
+	XDG_DATA_HOME=$data_root DWM_APPEARANCE_DATA_DIRS=$data_root \
+	DWM_APPEARANCE_WALLPAPER_DIR=$wallpaper_dir QT_QPA_PLATFORMTHEME=qt6ct \
+	BASH_ENV=$race_env DWM_TEST_STREAM_RACE_MARKER=$race_marker "$helper" inventory)
+[[ -s $race_marker && $race_inventory == "$inventory" ]] || {
+	printf 'Fast inventory producer lost its stream or bypassed the startup race fixture\n' >&2
+	exit 1
+}
+HOME=$home PATH=$bin_dir XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
+	DWM_APPEARANCE_DATA_DIRS=$data_root DWM_APPEARANCE_WALLPAPER_DIR=$wallpaper_dir \
+	BASH_ENV=$race_env DWM_TEST_STREAM_RACE_MARKER=$race_marker \
+	DWM_TEST_INOTIFY_ARGS=$work/race-watch.args "$helper" watch-inventory >"$work/race-watch.out"
+grep -Fqx $'ready\tinventory' "$work/race-watch.out"
+grep -Fqx $'changed\tCREATE\t'"$wallpaper_dir/new.png" "$work/race-watch.out"
+
 if grep -Eq $'^candidate\t(cursor|icon|gtk)\tavailable\tunknown\t' <<<"$inventory"; then
 	printf 'Reserved unknown sentinel was emitted as an applicable candidate\n' >&2
 	exit 1
@@ -813,6 +837,7 @@ chmod +x "$failing_inventory_bin/find" "$failing_inventory_bin/fc-list"
 failed_inventory=$(HOME=$home PATH=$failing_inventory_bin XDG_CONFIG_HOME=$config_home \
 	XDG_DATA_HOME=$data_root DWM_APPEARANCE_DATA_DIRS=$data_root \
 	DWM_APPEARANCE_WALLPAPER_DIR=$wallpaper_dir DWM_TEST_REAL_FIND=$real_find \
+	BASH_ENV=$race_env DWM_TEST_STREAM_RACE_MARKER=$race_marker \
 	QT_QPA_PLATFORMTHEME=qt6ct "$helper" inventory)
 grep -Fqx $'selection\twallpaper\tpartial\t\tfill\tWallpaper candidate discovery did not complete' \
 	<<<"$failed_inventory"

--- a/tests/test-dwm-settings-appearance-inventory.sh
+++ b/tests/test-dwm-settings-appearance-inventory.sh
@@ -138,20 +138,22 @@ race_env=$work/stream-race.env
 race_marker=$work/stream-race.marker
 cat >"$race_env" <<'EOF'
 set -T
-trap 'case $BASH_COMMAND in inventory_stream_pid=\$*) wait "$!" || :; printf "reaped\n" >>"$DWM_TEST_STREAM_RACE_MARKER" ;; esac' DEBUG
+trap 'case $BASH_COMMAND in inventory_stream_pid=\$*) stream_wait_status=0; wait "$!" || stream_wait_status=$?; printf "%s\n" "$stream_wait_status" >>"$DWM_TEST_STREAM_RACE_MARKER" ;; esac' DEBUG
 EOF
 race_inventory=$(HOME=$home PATH=$bin_dir XDG_CONFIG_HOME=$config_home \
 	XDG_DATA_HOME=$data_root DWM_APPEARANCE_DATA_DIRS=$data_root \
 	DWM_APPEARANCE_WALLPAPER_DIR=$wallpaper_dir QT_QPA_PLATFORMTHEME=qt6ct \
 	BASH_ENV=$race_env DWM_TEST_STREAM_RACE_MARKER=$race_marker "$helper" inventory)
-[[ -s $race_marker && $race_inventory == "$inventory" ]] || {
+[[ -s $race_marker && $(sort -u "$race_marker") == 0 && $race_inventory == "$inventory" ]] || {
 	printf 'Fast inventory producer lost its stream or bypassed the startup race fixture\n' >&2
 	exit 1
 }
+: >"$race_marker"
 HOME=$home PATH=$bin_dir XDG_CONFIG_HOME=$config_home XDG_DATA_HOME=$data_root \
 	DWM_APPEARANCE_DATA_DIRS=$data_root DWM_APPEARANCE_WALLPAPER_DIR=$wallpaper_dir \
 	BASH_ENV=$race_env DWM_TEST_STREAM_RACE_MARKER=$race_marker \
 	DWM_TEST_INOTIFY_ARGS=$work/race-watch.args "$helper" watch-inventory >"$work/race-watch.out"
+[[ -s $race_marker && $(sort -u "$race_marker") == 0 ]]
 grep -Fqx $'ready\tinventory' "$work/race-watch.out"
 grep -Fqx $'changed\tCREATE\t'"$wallpaper_dir/new.png" "$work/race-watch.out"
 
@@ -834,11 +836,14 @@ cat >"$failing_inventory_bin/fc-list" <<'EOF'
 exit 9
 EOF
 chmod +x "$failing_inventory_bin/find" "$failing_inventory_bin/fc-list"
+: >"$race_marker"
 failed_inventory=$(HOME=$home PATH=$failing_inventory_bin XDG_CONFIG_HOME=$config_home \
 	XDG_DATA_HOME=$data_root DWM_APPEARANCE_DATA_DIRS=$data_root \
 	DWM_APPEARANCE_WALLPAPER_DIR=$wallpaper_dir DWM_TEST_REAL_FIND=$real_find \
 	BASH_ENV=$race_env DWM_TEST_STREAM_RACE_MARKER=$race_marker \
 	QT_QPA_PLATFORMTHEME=qt6ct "$helper" inventory)
+# A collected failing child returns its actual status, not wait's non-child 127.
+[[ -s $race_marker && $(sort -u "$race_marker") == $'0\n7\n9' ]]
 grep -Fqx $'selection\twallpaper\tpartial\t\tfill\tWallpaper candidate discovery did not complete' \
 	<<<"$failed_inventory"
 grep -Fqx $'selection\tfont\tunavailable\tNoto Sans\tNoto Sans 11\tFontconfig candidate discovery did not complete' \

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -84,6 +84,260 @@ def rows(lines, kind):
     return [line.split("\t") for line in lines if line.startswith(f"{kind}\t")]
 
 
+class CupsReadTests(unittest.TestCase):
+    def state(self, load="loaded", active="inactive", sub="dead"):
+        return provider.UnitState("/org/freedesktop/systemd1/unit/fixture", load, active, sub)
+
+    def reply(self, variant, state=None, **overrides):
+        state = self.state() if state is None else state
+        row = ["cups.service", "Fixture", state.load, state.active, state.sub, "", state.path, 0, "", "/"]
+        for index, value in overrides.items():
+            row[int(index)] = value
+        return variant.Variant(provider.UNIT_REPLY_TYPE, ([tuple(row)],))
+
+    def reader(self):
+        _unused, connection, gio, glib, variant = RegionalReadTests.reader(self)
+        return provider.CupsRead(gio, glib), connection, gio, glib, variant
+
+    def collect(self, replies=None, *, mode="normal", remote_error=None, transform=None):
+        read, connection, gio, glib, variant = self.reader()
+        gio.dbus_error_get_remote_error.return_value = remote_error
+        calls = []
+        connection.call.side_effect = lambda *args: calls.append(args)
+        def during_loop():
+            if mode == "connection-timeout":
+                read.expire()
+                return
+            if mode == "connection-error":
+                gio.bus_get_finish.side_effect = variant.Error("fixture")
+            read.connected(None, object(), None)
+            if mode == "method-timeout":
+                read.expire()
+            for call in calls:
+                unit = call[-1]
+                if mode == "socket-timeout" and unit == "cups.socket":
+                    read.expire()
+                reply = (replies or {}).get(unit, self.reply(variant))
+                if isinstance(reply, Exception):
+                    connection.call_finish.side_effect = reply
+                else:
+                    connection.call_finish.side_effect = None
+                    connection.call_finish.return_value = reply
+                if transform:
+                    transform(read, connection, unit)
+                read.replied(connection, object(), unit)
+        read.loop.run.side_effect = during_loop
+        result = read.run()
+        return result, read, connection, gio, glib, calls
+
+    def test_cups_status_matrix_preserves_running_service_and_socket_activation(self):
+        absent = self.state("not-found")
+        stopped = self.state()
+        running = self.state(active="active", sub="running")
+        listening = self.state(active="active", sub="listening")
+        failed = self.state(active="failed", sub="failed")
+        cases = [(running, listening, "available", "running"),
+                 (running, absent, "available", "running"),
+                 (running, failed, "available", "running"),
+                 (stopped, listening, "available", "socket-ready"),
+                 (stopped, absent, "available", "stopped"),
+                 (stopped, stopped, "available", "stopped"),
+                 (absent, absent, "unsupported", "unknown"),
+                 (absent, listening, "partial", "unknown"),
+                 (failed, listening, "partial", "unknown"),
+                 (stopped, failed, "partial", "unknown"),
+                 (stopped, self.state(active="active", sub="running"), "partial", "unknown"),
+                 (self.state(active="activating", sub="start"), listening, "partial", "unknown"),
+                 (stopped, self.state(active="deactivating", sub="stop-pre"), "partial", "unknown"),
+                 (self.state("masked"), listening, "partial", "unknown")]
+        for service, socket, status, value in cases:
+            with self.subTest(service=service, socket=socket):
+                result = provider.classify_cups(dict(zip(provider.CUPS_UNITS, (service, socket))))
+                self.assertEqual((result.status, result.value), (status, value))
+
+    def test_only_fixed_read_queries_are_sent_with_one_aggregate_lifetime(self):
+        result, read, connection, gio, glib, calls = self.collect()
+        self.assertEqual((result.status, result.value), ("available", "stopped"))
+        self.assertEqual(len(calls), 2)
+        for call, unit in zip(calls, provider.CUPS_UNITS):
+            self.assertEqual(call[:4], (provider.SYSTEMD_NAME, provider.SYSTEMD_PATH,
+                             provider.SYSTEMD_MANAGER, "ListUnitsByNames"))
+            self.assertEqual(call[4].unpack(), ([unit],))
+            self.assertEqual(call[5].dup_string(), provider.UNIT_REPLY_TYPE)
+            self.assertEqual(call[6], gio.DBusCallFlags.NO_AUTO_START)
+            self.assertGreater(call[7], 0)
+            self.assertLessEqual(call[7], 10000)
+            self.assertIs(call[8], read.cancellable)
+        glib.timeout_add.assert_called_once_with(10000, read.expire)
+        glib.source_remove.assert_called_once_with(17)
+        connection.close_sync.assert_not_called()
+        self.assertTrue(read.cancellable.cancel.called)
+        with self.assertRaises(RuntimeError):
+            read.run()
+
+    def test_decoder_checks_structure_and_bounds_before_unpacking(self):
+        _read, _connection, _gio, _glib, variant = self.reader()
+        for reply in (variant.Variant("(s)", ("bad",)),
+                      variant.Variant(provider.UNIT_REPLY_TYPE, ([],)),
+                      variant.Variant(provider.UNIT_REPLY_TYPE, ([self.reply(variant).unpack()[0][0]] * 2,)),
+                      self.reply(variant, **{"1": "x" * provider.UNIT_REPLY_BYTES}),
+                      self.reply(variant, **{"2": "x" * 513}),
+                      self.reply(variant, **{"3": "active\n"}),
+                      self.reply(variant, **{"4": ""}),
+                      self.reply(variant, **{"6": "/wrong/unit"})):
+            with self.subTest(reply_type=reply.get_type_string()):
+                with self.assertRaises(provider.SnapshotFailure) as caught:
+                    provider.decode_unit_state(reply)
+                self.assertEqual(caught.exception.code, "malformed")
+        oversized = mock.Mock()
+        oversized.get_type_string.return_value = provider.UNIT_REPLY_TYPE
+        oversized.get_size.return_value = provider.UNIT_REPLY_BYTES + 1
+        with self.assertRaises(provider.SnapshotFailure):
+            provider.decode_unit_state(oversized)
+        oversized.get_child_value.assert_not_called()
+        # Canonical aliases need not equal the fixed query name or a guessed path.
+        self.assertEqual(provider.decode_unit_state(self.reply(variant, **{"0": "org.cups.cupsd.service"})),
+                         self.state())
+
+    def test_connection_and_method_deadlines_cancel_and_ignore_late_replies(self):
+        for mode in ("connection-timeout", "method-timeout"):
+            result, read, connection, gio, glib, _calls = self.collect(mode=mode)
+            self.assertEqual((result.status, result.value), ("unavailable", "unknown"))
+            self.assertEqual([error.code for error in result.errors], ["timeout"])
+            self.assertTrue(read.cancellable.cancel.called)
+            glib.source_remove.assert_not_called()
+            connection.call_finish.assert_not_called()
+            before = tuple(result.units)
+            read.connected(None, object(), None)
+            read.replied(connection, object(), "cups.service")
+            self.assertEqual(result.units, before)
+            if mode == "connection-timeout":
+                gio.bus_get_finish.assert_not_called()
+
+    def test_active_service_survives_socket_timeout_but_inactive_does_not(self):
+        _read, _connection, _gio, _glib, variant = self.reader()
+        for active in (False, True):
+            state = self.state(active="active", sub="running") if active else self.state()
+            result, read, _connection, _gio, _glib, _calls = self.collect(
+                {"cups.service": self.reply(variant, state)}, mode="socket-timeout")
+            self.assertEqual((result.status, result.value),
+                             ("available", "running") if active else ("unavailable", "unknown"))
+            self.assertEqual([error.code for error in result.errors], ["timeout"])
+            self.assertEqual(result.units, (("cups.service", state),))
+            self.assertIs(read.value, result)
+
+    def test_error_and_malformed_socket_cannot_downgrade_running_service(self):
+        _read, _connection, _gio, _glib, variant = self.reader()
+        for bad in (variant.Error("fixture"), variant.Variant("(s)", ("bad",))):
+            result, *_ = self.collect({"cups.service": self.reply(variant, self.state(active="active")),
+                                      "cups.socket": bad}, remote_error="org.freedesktop.DBus.Error.AccessDenied")
+            self.assertEqual((result.status, result.value), ("available", "running"))
+            self.assertEqual(len(result.errors), 1)
+
+    def test_denial_absence_and_malformed_states_are_distinct(self):
+        _read, _connection, _gio, _glib, variant = self.reader()
+        for remote, code in (("org.freedesktop.DBus.Error.AccessDenied", "permission-denied"),
+                             ("org.freedesktop.DBus.Error.ServiceUnknown", "missing-provider")):
+            result, *_ = self.collect(mode="connection-error", remote_error=remote)
+            self.assertEqual((result.status, result.value), ("unavailable", "unknown"))
+            self.assertEqual([error.code for error in result.errors], [code])
+        result, *_ = self.collect({unit: variant.Error("fixture") for unit in provider.CUPS_UNITS},
+                                 remote_error="org.freedesktop.systemd1.NoSuchUnit")
+        self.assertEqual((result.status, result.value, result.errors), ("unsupported", "unknown", ()))
+        for remote in ("org.freedesktop.DBus.Error.UnknownObject", "org.freedesktop.DBus.Error.UnknownMethod"):
+            result, *_ = self.collect({unit: variant.Error("fixture") for unit in provider.CUPS_UNITS},
+                                     remote_error=remote)
+            self.assertEqual(result.status, "unavailable")
+        result, *_ = self.collect({"cups.service": variant.Variant("(s)", ("bad",))})
+        self.assertEqual((result.status, result.value), ("partial", "unknown"))
+
+    def test_decoder_result_or_error_after_deadline_is_discarded(self):
+        for raises in (False, True):
+            read, connection, _gio, _glib, variant = self.reader()
+            read.deadline = 10
+            state = self.state(active="active")
+            def late(_reply):
+                read.deadline = 1
+                if raises:
+                    raise provider.SnapshotFailure("malformed", "late")
+                return state
+            with mock.patch.object(provider.time, "monotonic", return_value=2), \
+                    mock.patch.object(provider, "decode_unit_state", side_effect=late):
+                read.replied(connection, object(), "cups.service")
+            self.assertEqual(read.value.units, ())
+            self.assertEqual([error.code for error in read.value.errors], ["timeout"])
+            read.unit_failed("cups.socket", variant.Error("late"))
+            self.assertEqual(len(read.value.errors), 1)
+
+    def test_unexpected_loop_exit_and_duplicate_callbacks_do_not_fake_success(self):
+        read, connection, _gio, _glib, _variant = self.reader()
+        result = read.run()
+        self.assertEqual((result.status, result.value), ("unavailable", "unknown"))
+        self.assertEqual([error.code for error in result.errors], ["internal"])
+        result, read, connection, *_ = self.collect()
+        calls = connection.call_finish.call_count
+        read.replied(connection, object(), "cups.service")
+        self.assertEqual(connection.call_finish.call_count, calls)
+        self.assertIs(result, read.value)
+
+    def test_reversed_replies_and_synchronous_dispatch_errors_keep_both_units_bounded(self):
+        for reverse, synchronous_error in ((True, False), (False, True)):
+            read, connection, gio, _glib, variant = self.reader()
+            calls = []
+            def sent(*args):
+                calls.append(args)
+                if synchronous_error:
+                    raise variant.Error("dispatch failure")
+            connection.call.side_effect = sent
+            gio.dbus_error_get_remote_error.return_value = "org.freedesktop.systemd1.NoSuchUnit"
+            def during_loop():
+                read.connected(None, object(), None)
+                if not synchronous_error:
+                    for call in reversed(calls) if reverse else calls:
+                        connection.call_finish.return_value = self.reply(variant)
+                        read.replied(connection, object(), call[-1])
+                        read.replied(connection, object(), call[-1])
+            read.loop.run.side_effect = during_loop
+            result = read.run()
+            self.assertEqual(len(calls), 2)
+            self.assertEqual(result.status, "unsupported" if synchronous_error else "available")
+            self.assertEqual(result.errors, ())
+            self.assertEqual(len(result.units), 2)
+            self.assertEqual(connection.call_finish.call_count, 0 if synchronous_error else 2)
+
+    def test_elapsed_deadline_prevents_dispatch_and_normalizes_late_bus_failure(self):
+        for during_finish in (False, True):
+            read, connection, gio, _glib, variant = self.reader()
+            read.deadline = 10 if during_finish else 1
+            def late(_result):
+                read.deadline = 1
+                raise variant.Error("late failure")
+            connection.call_finish.side_effect = late
+            with mock.patch.object(provider.time, "monotonic", return_value=2):
+                if during_finish:
+                    read.replied(connection, object(), "cups.service")
+                else:
+                    read.connected(None, object(), None)
+                    gio.bus_get_finish.assert_not_called()
+            self.assertEqual(read.value.units, ())
+            self.assertEqual([error.code for error in read.value.errors], ["timeout"])
+            connection.call.assert_not_called()
+
+    def test_real_cups_reads_use_an_isolated_private_bus(self):
+        process = subprocess.Popen(["dbus-run-session", "--", "/usr/bin/python3",
+            str(REPO / "tests/fixtures/system-cups-read-bus.py"), str(PROVIDER_PATH)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True)
+        try:
+            stdout, stderr = process.communicate(timeout=35)
+            self.assertEqual(process.returncode, 0, stderr.decode("utf-8", "replace"))
+            self.assertIn(b"Private-bus printer reads: PASS", stdout)
+        finally:
+            if process.poll() is None:
+                with contextlib.suppress(ProcessLookupError):
+                    os.killpg(process.pid, 9)
+                process.communicate(timeout=3)
+
+
 class AccountReadTests(unittest.TestCase):
     current_path = "/org/freedesktop/Accounts/Current"
 


### PR DESCRIPTION
## Summary
- Add an internal read-only CUPS reader. Query only the fixed cups.service and cups.socket units with D-Bus auto-start disabled, typed reply bounds, and one ten-second connection-to-decoding deadline.
- Distinguish running, socket-ready, stopped, absent, malformed, and unavailable state. Preserve a validated running service when the socket probe fails. No CLI exposure, protocol-minor change, printer administration, or service mutation is enabled.
- Fix the appearance inventory race exposed by the first CI run: Bash can remove a completed named coprocess's PID and descriptor array before the parent captures them. An explicitly owned process-substitution pipe preserves buffered output, child identity, and failure status.
- Add printer unit/private-bus coverage and a deterministic appearance race fixture. Review follow-ups align the deadline documentation and require fresh per-invocation wait-status evidence.

## Local qualification
Final head: e9b0c96bde15379fdcd3fe7b417135176dae2a42; tree: 011e298bc3f1b5e5b31bd7dd3abe5158b87e7f12.
- Focused printer/account/regional readers: 46 tests passed. Read-only Fedora 44 CUPS probe: running, no errors, 0.030s.
- The appearance race fixture reproduced the original unbound PID failure, then passed with the fix. The final fixture verifies wait status 0 for success and the expected 0/7/9 set for intentional failures, rejecting stale markers and non-child status 127.
- ShellCheck, shfmt, clean build, and full managed suite passed: 390 provider tests in 73.529s and 1,454 native assertions in this run.
- Fedora 44 nested X11: closed Settings 0.067% CPU; closed large surfaces 0.00%; power lifecycle 0.167% to 0.067%.
- Configured QML lint, staged install, repeated-install preservation, package map, Kickstarts, and release archive checks passed. Documentation build: 15 files, zero diagnostics, 11 pages.
- Final local CodeRabbit and post-gate Codex reviews: no actionable findings. Managed test workspaces were removed.

## Hosted qualification
The preceding runtime-fix commit passed Fedora CI run 34033173171, including privileged-helper security and nested X11. Final-head CodeRabbit approved and Codex code/security reviews found no issues. Final-head CI run 34034370242 passed, including the full suite, privileged-helper trust/authorization denial, and nested X11 runtime. Hosted results: 390 provider tests in 80.694s; closed Settings 0.033% CPU; closed large surfaces 0.00%. Documentation, configured QML lint, and CodeQL passed. Both review threads are resolved; final state is APPROVED, CLEAN, and MERGEABLE.

## Remaining Phase 6 work
Source/tool readers, subscriptions, regional/delegated action lifecycle, cumulative protocol and Settings integration, information/security/storage, and combined installed qualification remain outstanding. The regional cancellation contract requires reconciliation before mutations are implemented.

The read-only installed parity check fails: the installed system-management helper is missing and the installed binary, some helpers, and managed QML differ. No live installation synchronization or session restart was performed. This PR does not complete Phase 6 or begin Phase 7.