### PR TITLE
docs(system): approve narrow regional cancellation contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -363,7 +363,12 @@ without turning Quickshell into an unrestricted administration console.
 
 ### Exit Criteria
 
-- Every privileged action is allowlisted, confirmed, auditable, and cancelable.
+- Every privileged action is allowlisted, confirmed, auditable, and cancelable
+  within the platform's safe cancellation window. The sole regional exception
+  is the fixed timezone, NTP enablement, and system locale actions defined in
+  `SPEC.md`: confirmation is cancelable, but sent changes are not. Their
+  confirmation explains that limit and ambiguous results retain recovery
+  guidance instead of reporting success or cancellation.
 - Read-only status remains available when authorization is denied.
 - Interrupted updates and failed delegated tools produce actionable recovery
   guidance rather than ambiguous success.

--- a/SPEC.md
+++ b/SPEC.md
@@ -464,6 +464,18 @@ must not prevent other sections from opening. Risky changes must provide
 preview, confirmation, rollback, or recovery behavior appropriate to their
 impact.
 
+Phase 6 permits a narrow cancellation exception for the fixed system timezone,
+NTP enablement, and system locale actions. Users can cancel their confirmation
+without issuing a service call. The confirmation must clearly state that a
+change cannot be canceled after dispatch to timedate1 or locale1; local request
+cancellation does not undo a system change. These actions still require fixed
+allowlisted arguments, explicit confirmation, platform authorization, audit
+evidence, and bounded verification. An ambiguous post-dispatch timeout is
+`interrupted`, never success or cancellation, and must trigger a fresh bounded
+read without automatically retrying or rolling back the mutation. Any later
+corrective change requires new confirmation. This exception does not change
+the cancellation requirements of other privileged actions.
+
 The planned Settings surface covers:
 
 - Displays and monitor profiles.

--- a/TASKS.md
+++ b/TASKS.md
@@ -185,6 +185,13 @@ errors or service changes. This reader adds no CLI command or protocol minor.
 Source readers, event subscriptions, lifecycle integration, and Settings controls
 remain outstanding.
 
+The user approved the narrow regional cancellation exception on 2026-09-06.
+Keep native timezone, NTP enablement, and system locale actions, with an explicit
+confirmation warning that a sent change cannot be canceled. Local cancellation
+is not rollback; ambiguous post-dispatch timeouts remain interrupted and require
+fresh state without automatic retry. This approval changes the contract, not
+implementation or qualification status.
+
 - [ ] Add date, time, timezone, and locale status plus safe common actions
   through stable platform services.
 - [ ] Add user-account, printer, and software-source entry points through trusted
@@ -225,9 +232,12 @@ Acceptance:
 - [ ] Run focused provider, parser, privilege, cancellation, lifecycle, failure,
   recovery, QML, and nested-X11 tests for every Phase 6 workflow.
 - [ ] Prove every privileged action is allowlisted, explicitly confirmed,
-  auditable, cancelable, and unavailable from repository- or user-writable
-  helper copies. Exclude or delegate any operation that cannot meet that
-  contract.
+  auditable, and unavailable from repository- or user-writable helper copies.
+  Require cancellation within the platform's safe window, except for the three
+  fixed regional actions permitted by `SPEC.md`. For those actions, verify the
+  cancellation-limit warning, no post-dispatch cancellation claim, bounded
+  verification, interrupted recovery, and fresh confirmation for any correction.
+  Exclude or delegate any other operation that cannot meet the contract.
 - [ ] Exercise authorization denial, interrupted updates, failed delegated tools,
   missing services, and recovery without hiding readable status or reporting
   false success.

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -310,6 +310,17 @@ interactive-authorization argument remains enabled so systemd and polkit own
 the decision. Arbitrary environment variables, keymaps, NTP servers, RTC mode,
 or manual timestamps are not accepted.
 
+The user-approved 2026-09-06 regional exception in `SPEC.md` applies only to
+these three fixed mutations. Before dispatch, the visible confirmation can be
+canceled without a service call. It must explicitly warn that a sent change
+cannot be canceled. After dispatch, the operation reports `cancelable=no` and
+does not offer a cancellation control; canceling a local D-Bus request never
+means that the service mutation was canceled or undone. Closing Settings must
+not stop the required operation owner or verification. The bounded timeout and
+fresh-state recovery below remain mandatory, and any later corrective mutation
+requires a new confirmation. This exception does not permit arbitrary system
+administration or weaken update cancellation.
+
 The internal read-only regional reader now has three fixed requests: timedate1
 `GetAll`, locale1 `Get(Locale)`, and timedate1 `ListTimezones`. Each single-use
 reader bounds asynchronous bus connection, method reply, and decoding under one


### PR DESCRIPTION
## Summary

- Record the user's 2026-09-06 approval of the narrow cancellation exception for fixed timezone, NTP enablement, and system locale changes.
- Require a cancelable confirmation with a clear post-dispatch warning, installed-helper trust checks, platform authorization, audit evidence, bounded verification, and conservative interrupted recovery.
- Preserve cancellation requirements for every other privileged action. This four-document PR adds no runtime commands, service mutations, protocol minor, or completion claims.

## Scope and follow-up

This is the contract-only prerequisite for the remaining Phase 6 regional implementation. Source readers, lifecycle integration, Settings controls, information/security surfaces, and combined qualification remain outstanding. Phase 7 is out of scope.

The user also approved backup-preserving installed synchronization after the remaining implementation is validated. This PR performs no installed synchronization, logout, or reboot.

## Validation

- `npm --prefix docs run build`: passed (15 files, zero diagnostics, 11 pages).
- `scripts/run-tests make clean all`: passed.
- `scripts/run-tests`: passed, including 390 system-management tests, native nested-X11 lifecycle tests, staged installation, repeated-install preservation, Kickstart/package-map checks, and release archive validation.
- Both managed workspaces were removed after completion; staged tree remained `3bab19247974a5ed8230429ab8475381a5aa9337` throughout validation.
- `coderabbit review --agent -t uncommitted`: passed, zero findings across all four documents.
- `/usr/lib/chatgpt/resources/codex review --uncommitted`: passed after the full gate, no actionable findings.
- Hosted checks, independent reviews, and unresolved-thread verification will be completed against the published exact head before merge.

No new runtime behavior is claimed. Existing Phase 6 graphical authorization, live installation, and hardware limitations remain explicit in the planning documents.