### PR TITLE
feat(system): add bounded repository reader

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -182,8 +182,15 @@ running service if the socket probe fails. Unit and private-bus tests cover
 status combinations, typed bounds, denial, absence, deadlines, and late replies.
 A read-only Fedora 44 probe returned running CUPS state in 0.030 seconds without
 errors or service changes. This reader adds no CLI command or protocol minor.
-Source readers, event subscriptions, lifecycle integration, and Settings controls
-remain outstanding.
+A separate PackageKit repository reader now collects enabled and disabled sources
+under one 30-second connection-to-completion deadline. It pins its exact service
+and transaction, observes acknowledged signals, requires both method and terminal
+success, and rejects duplicate or oversized complete results. Unit and private-bus
+tests cover bounds, denial, absence, replacement, timeout, and late replies. A
+read-only Fedora 44 probe returned 28 rows (15 enabled and 13 disabled) in 0.826
+seconds without requesting metadata refresh or repository changes. This reader
+adds no CLI command or protocol minor. Event subscriptions, lifecycle integration,
+delegated-tool availability, and Settings controls remain outstanding.
 
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -519,6 +519,22 @@ remain in the Fedora-packaged `dnfdragora` tool when present. Missing optional
 delegated tools are reported individually and never hide readable service
 state.
 
+The internal repository reader now bounds connection setup, optional activation
+of an absent PackageKit daemon, transaction setup, signals, and decoding under
+that one deadline. It pins the daemon's unique bus identity and new transaction,
+acknowledges its exact signal match before calling `GetRepoList`, uses fixed
+noninteractive background/cache hints, and requires both the method acknowledgment
+and successful `Finished` signal. A final owner lookup rejects daemon replacement.
+Each text field is limited to 512 UTF-8 bytes before copying; the complete result
+is limited to 512 unique rows and 384 KiB of canonical encoded rows including
+newlines. Any failure discards all rows; no partial list is presented as complete.
+Timeout cancels local requests and ignores late replies. On failure before
+`Finished`, it queues a best-effort noninteractive `Cancel` only for its own exact
+read transaction, without extending the deadline or claiming daemon cancellation.
+It removes its subscriptions and match rule without closing the shared bus.
+Private-bus fixtures exercise the real 30-second timeout and late completion.
+This reader adds no command, mutation, Settings control, or protocol minor.
+
 ### System Information and Filesystems
 
 The information snapshot uses only these fixed sources:

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -32,6 +32,9 @@ MAX_LIST_BYTES = 3 * 1024 * 1024
 READ_DEADLINE_SECONDS = 120
 REFRESH_AGE_DEADLINE_SECONDS = 10
 CANCEL_GRACE_SECONDS = 5
+REPOSITORY_READ_SECONDS = 30
+REPOSITORY_MAX_ROWS = 512
+REPOSITORY_MAX_BYTES = 384 * 1024
 MAX_OPERATION_PROGRESS_RECORDS = 252
 MAX_OPERATION_MISMATCH_SAMPLES = 128
 
@@ -539,6 +542,228 @@ class ServiceRead:
         if self.failure:
             raise self.failure
         return self.value
+
+
+@dataclass(frozen=True)
+class RepositoryRow:
+    repository_id: str
+    enabled: bool
+    description: str
+
+    def fields(self) -> tuple[str, ...]:
+        return ("repository", self.repository_id,
+                "enabled" if self.enabled else "disabled", self.description)
+
+
+def decode_repository_row(values: object) -> RepositoryRow:
+    """Bound serialized fields before copying a RepoDetail into Python."""
+    if values.get_type_string() != "(ssb)" or values.get_size() > 2 * MAX_TEXT_BYTES + 16:
+        raise SnapshotFailure("malformed", "Invalid PackageKit repository record")
+    for index in (0, 1):
+        if values.get_child_value(index).get_size() > MAX_TEXT_BYTES + 1:
+            raise SnapshotFailure("malformed", "Oversized PackageKit repository field")
+    repository_id, description, enabled = values.unpack()
+    return RepositoryRow(canonical_identity(repository_id), enabled,
+                         clean_text(description, truncate=False))
+
+
+class RepositoryRead(ServiceRead):
+    """Collect one complete fixed GetRepoList transaction, never a mutation."""
+
+    label = "Repository"
+    seconds = REPOSITORY_READ_SECONDS
+
+    def __init__(self, Gio=None, GLib=None) -> None:
+        super().__init__(Gio, GLib)
+        try:
+            import gi
+            gi.require_version("PackageKitGlib", "1.0")
+            from gi.repository import PackageKitGlib
+        except (ImportError, ValueError) as error:
+            raise SnapshotFailure("missing-provider", "PackageKit bindings are unavailable", "unavailable") from error
+        self.filter_none = PackageKitGlib.filter_bitfield_from_string("none")
+        self.stage = "connect"
+        self.owner = self.path = self.match_rule = ""
+        self.subscription = self.closed_handler = 0
+        self.fetch_sent = self.acknowledged = self.finished = False
+        self.rows: dict[str, RepositoryRow] = {}
+        self.row_bytes = 0
+
+    def request(self, stage, method, parameters=None, signature="()", *, bus=False, manager=False):
+        if not self.pending():
+            return
+        self.stage = stage
+        destination = "org.freedesktop.DBus" if bus else self.owner
+        path = "/org/freedesktop/DBus" if bus else PACKAGEKIT_PATH if manager else self.path
+        interface = "org.freedesktop.DBus" if bus else PACKAGEKIT_INTERFACE if manager else TRANSACTION_INTERFACE
+        self.connection.call(destination, path, interface, method, parameters,
+            self.GLib.VariantType.new(signature), self.Gio.DBusCallFlags.NONE,
+            max(1, min(int((self.deadline - time.monotonic()) * 1000), self.seconds * 1000)),
+            self.cancellable, self.replied, stage)
+
+    def connected(self, _source, result, _data):
+        if not self.pending() or self.stage != "connect":
+            return
+        try:
+            self.connection = self.Gio.bus_get_finish(result)
+            if not self.pending():
+                return
+            self.connection.set_exit_on_close(False)
+            self.closed_handler = self.connection.connect("closed", self.connection_closed)
+            self.request("owner", "GetNameOwner",
+                self.GLib.Variant("(s)", (PACKAGEKIT_NAME,)), "(s)", bus=True)
+        except self.GLib.Error as error:
+            self.fail(self.bus_failure(error))
+
+    def connection_closed(self, *_args):
+        if self.pending():
+            self.fail(SnapshotFailure("missing-provider", "Repository service bus disconnected", "unavailable"))
+
+    def bus_failure(self, error):
+        if time.monotonic() < self.deadline:
+            name = self.Gio.dbus_error_get_remote_error(error)
+            if name == "org.freedesktop.PackageKit.Transaction.RefusedByPolicy":
+                return SnapshotFailure("permission-denied", "PackageKit denied repository discovery", "restricted")
+            if name == "org.freedesktop.PackageKit.Transaction.NotSupported":
+                return SnapshotFailure("unsupported", "PackageKit cannot list repositories", "unsupported")
+        return super().bus_failure(error)
+
+    def replied(self, connection, result, stage):
+        if not self.pending() or stage != self.stage:
+            return
+        try:
+            reply = connection.call_finish(result)
+            if not self.pending():
+                return
+            signature = {"start": "(u)", "owner": "(s)", "owner-after-start": "(s)", "verify-owner": "(s)",
+                         "create": "(o)"}.get(stage, "()")
+            if reply.get_type_string() != signature or reply.get_size() > 256:
+                raise SnapshotFailure("malformed", "Invalid repository transaction reply")
+            if stage == "start":
+                if reply.unpack()[0] not in (1, 2):
+                    raise SnapshotFailure("malformed", "Invalid PackageKit activation reply")
+                self.request("owner-after-start", "GetNameOwner", self.GLib.Variant("(s)", (PACKAGEKIT_NAME,)), "(s)", bus=True)
+            elif stage in ("owner", "owner-after-start", "verify-owner"):
+                owner = reply.unpack()[0]
+                if re.fullmatch(r":[0-9]+\.[0-9]+", owner) is None:
+                    raise SnapshotFailure("malformed", "Invalid PackageKit service identity")
+                if stage != "verify-owner":
+                    self.owner = owner
+                    self.request("create", "CreateTransaction", signature="(o)", manager=True)
+                else:
+                    if owner != self.owner:
+                        raise SnapshotFailure("conflict", "PackageKit changed during repository discovery")
+                    rows = tuple(self.rows[key] for key in sorted(self.rows, key=lambda key: key.encode("utf-8")))
+                    if self.pending():
+                        self.finish(rows)
+            elif stage == "create":
+                path = reply.unpack()[0]
+                if JOURNAL_PACKAGEKIT_PATH_PATTERN.fullmatch(path) is None:
+                    raise SnapshotFailure("malformed", "Invalid repository transaction path")
+                self.path = path
+                self.subscription = connection.signal_subscribe(self.owner, TRANSACTION_INTERFACE,
+                    None, self.path, None, self.Gio.DBusSignalFlags.NO_MATCH_RULE, self.received, None)
+                self.match_rule = f"type='signal',sender='{self.owner}',interface='{TRANSACTION_INTERFACE}',path='{self.path}'"
+                # An explicit acknowledgment makes bus policy denial observable.
+                self.request("match", "AddMatch", self.GLib.Variant("(s)", (self.match_rule,)), bus=True)
+            elif stage == "match":
+                self.request("hints", "SetHints", self.GLib.Variant("(as)",
+                    (["background=true", "interactive=false", "cache-age=4294967295"],)))
+            elif stage == "hints":
+                self.fetch_sent = True
+                self.request("fetch", "GetRepoList", self.GLib.Variant("(t)", (self.filter_none,)))
+            elif stage == "fetch":
+                self.acknowledged = True
+                self.stage = "wait"
+                self.maybe_complete()
+        except self.GLib.Error as error:
+            if (stage == "owner" and self.pending()
+                    and self.Gio.dbus_error_get_remote_error(error) == "org.freedesktop.DBus.Error.NameHasNoOwner"):
+                # Activate only an absent daemon, once, within the same deadline.
+                try:
+                    self.request("start", "StartServiceByName",
+                        self.GLib.Variant("(su)", (PACKAGEKIT_NAME, 0)), "(u)", bus=True)
+                except self.GLib.Error as activation_error:
+                    self.fail(self.bus_failure(activation_error))
+                return
+            self.fail(self.bus_failure(error))
+        except (SnapshotFailure, TypeError, ValueError) as error:
+            if self.pending():
+                self.fail(error if isinstance(error, SnapshotFailure) else
+                          SnapshotFailure("malformed", "Malformed repository transaction reply"))
+
+    def maybe_complete(self):
+        if self.acknowledged and self.finished and self.stage == "wait":
+            self.request("verify-owner", "GetNameOwner",
+                self.GLib.Variant("(s)", (PACKAGEKIT_NAME,)), "(s)", bus=True)
+
+    def received(self, _connection, sender, path, interface, member, values, _data):
+        if (not self.pending() or sender != self.owner or path != self.path
+                or interface != TRANSACTION_INTERFACE or self.finished
+                or member not in ("RepoDetail", "ErrorCode", "Finished", "Destroy")):
+            return
+        try:
+            if self.stage not in ("fetch", "wait"):
+                raise SnapshotFailure("malformed", "Premature repository transaction signal")
+            if member == "RepoDetail":
+                if len(self.rows) >= REPOSITORY_MAX_ROWS:
+                    raise SnapshotFailure("malformed", "Too many PackageKit repositories")
+                row = decode_repository_row(values)
+                size = encoded_record_size(row.fields())
+                if row.repository_id in self.rows or self.row_bytes + size > REPOSITORY_MAX_BYTES:
+                    raise SnapshotFailure("malformed", "Duplicate or oversized repository result")
+                if self.pending():
+                    self.rows[row.repository_id] = row
+                    self.row_bytes += size
+            elif member == "ErrorCode":
+                if (values.get_type_string() != "(us)" or values.get_size() > MAX_TEXT_BYTES + 16
+                        or values.get_child_value(1).get_size() > MAX_TEXT_BYTES + 1):
+                    raise SnapshotFailure("malformed", "Invalid PackageKit repository error")
+                raise PackageKitBackend._transaction_failure(values.get_child_value(0).unpack(), "")
+            elif member == "Finished":
+                if values.get_type_string() != "(uu)" or values.get_size() != 8:
+                    raise SnapshotFailure("malformed", "Invalid repository completion signal")
+                self.finished = True
+                if values.unpack()[0] != EXIT_SUCCESS:
+                    raise SnapshotFailure("internal", "Repository transaction did not succeed")
+                self.maybe_complete()
+            else:
+                if values.get_type_string() != "()":
+                    raise SnapshotFailure("malformed", "Invalid repository destruction signal")
+                raise SnapshotFailure("missing-provider", "Repository transaction disappeared", "unavailable")
+        except (SnapshotFailure, TypeError, ValueError) as error:
+            if self.pending():
+                self.fail(error if isinstance(error, SnapshotFailure) else
+                          SnapshotFailure("malformed", "Malformed repository transaction signal"))
+        except self.GLib.Error as error:
+            self.fail(self.bus_failure(error))
+
+    def run(self):
+        try:
+            return super().run()
+        finally:
+            if self.connection is not None:
+                if self.subscription:
+                    self.connection.signal_unsubscribe(self.subscription)
+                    self.subscription = 0
+                if self.closed_handler:
+                    self.connection.disconnect(self.closed_handler)
+                    self.closed_handler = 0
+                if self.failure and self.fetch_sent and not self.finished:
+                    # Only this reader's exact transaction, never another owner's
+                    # work. Best effort is not a claim that the daemon canceled it.
+                    with contextlib.suppress(self.GLib.Error):
+                        self.connection.call(self.owner, self.path, TRANSACTION_INTERFACE, "Cancel",
+                            None, None, self.Gio.DBusCallFlags.NONE, 1000, None, None, None)
+                if self.match_rule:
+                    # Also remove a rule whose AddMatch reply was lost. These
+                    # asynchronous cleanup requests do not extend the deadline.
+                    with contextlib.suppress(self.GLib.Error):
+                        self.connection.call("org.freedesktop.DBus", "/org/freedesktop/DBus",
+                            "org.freedesktop.DBus", "RemoveMatch", self.GLib.Variant("(s)", (self.match_rule,)),
+                            None, self.Gio.DBusCallFlags.NONE, 1000, None, None, None)
+                    self.match_rule = ""
+            self.rows.clear()
 
 
 @dataclass(frozen=True)
@@ -6104,7 +6329,8 @@ class PackageKitBackend:
             if source:
                 self.GLib.source_remove(source)
 
-    def _transaction_failure(self, code: int, _detail: str) -> SnapshotFailure:
+    @staticmethod
+    def _transaction_failure(code: int, _detail: str) -> SnapshotFailure:
         if code == 2:
             return SnapshotFailure("network", "PackageKit could not reach the network")
         if code in {18, 19, 28, 33, 37, 43, 64}:

--- a/tests/fixtures/system-repository-read-bus.py
+++ b/tests/fixtures/system-repository-read-bus.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python3
+"""Exercise repository discovery on a private bus, never the host PackageKit."""
+
+import os
+import runpy
+import sys
+import time
+
+os.environ["DBUS_SYSTEM_BUS_ADDRESS"] = os.environ["DBUS_SESSION_BUS_ADDRESS"]
+from gi.repository import Gio, GLib
+
+provider = runpy.run_path(sys.argv[1], run_name="repository_read_fixture")
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+service = provider["PACKAGEKIT_NAME"]
+interface = provider["TRANSACTION_INTERFACE"]
+mode = "normal"
+registrations, calls, held = [], [], []
+manager = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.PackageKit">
+<method name="CreateTransaction"><arg type="o" direction="out"/></method>
+</interface></node>""").interfaces[0]
+transaction = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.PackageKit.Transaction">
+<method name="SetHints"><arg type="as" direction="in"/></method>
+<method name="GetRepoList"><arg type="t" direction="in"/></method>
+<method name="Cancel"/>
+</interface></node>""").interfaces[0]
+
+
+def name_call(method):
+    args = GLib.Variant("(su)", (service, 0)) if method == "RequestName" else GLib.Variant("(s)", (service,))
+    return bus.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus",
+        "org.freedesktop.DBus", method, args, GLib.VariantType.new("(u)"),
+        Gio.DBusCallFlags.NONE, 3000, None).unpack()[0]
+
+
+def emit(path, member, signature, values):
+    bus.emit_signal(None, path, interface, member, GLib.Variant(signature, values))
+
+
+def called(_bus, _sender, path, _interface, method, args, invocation):
+    calls.append((path, method))
+    if method == "CreateTransaction":
+        path = f"/{len(registrations)}_fixture"
+        registrations.append(bus.register_object(path, transaction, called, None, None))
+        invocation.return_value(GLib.Variant("(o)", (path,)))
+    elif method == "SetHints":
+        assert args.unpack() == (["background=true", "interactive=false", "cache-age=4294967295"],)
+        invocation.return_value(None)
+    elif method == "Cancel":
+        invocation.return_value(None)
+    else:
+        assert method == "GetRepoList" and args.unpack() == (2,)
+        if mode in ("denied", "unsupported"):
+            error = "RefusedByPolicy" if mode == "denied" else "NotSupported"
+            invocation.return_dbus_error(interface + "." + error, "fixture")
+            return
+        if mode != "empty":
+            emit(path, "RepoDetail", "(ssb)", ("z-disabled", "Disabled", False))
+            emit(path, "RepoDetail", "(ssb)", ("a-enabled", "Enabled", True))
+        if mode == "duplicate":
+            emit(path, "RepoDetail", "(ssb)", ("a-enabled", "Duplicate", True))
+        if mode == "error":
+            emit(path, "ErrorCode", "(us)", (18, "fixture repository error"))
+        if mode == "stall":
+            held.append((path, invocation))
+            return
+        emit(path, "Finished", "(uu)", (2 if mode == "error" else 1, 1))
+        if mode == "lost-owner":
+            assert name_call("ReleaseName") == 1
+        invocation.return_value(None)
+
+
+try:
+    assert name_call("RequestName") == 1
+    registrations.append(bus.register_object(provider["PACKAGEKIT_PATH"], manager, called, None, None))
+    for mode in ("normal", "empty", "denied", "unsupported", "duplicate", "error", "lost-owner"):
+        expected = {"denied": "permission-denied", "unsupported": "unsupported",
+                    "duplicate": "malformed", "error": "repository", "lost-owner": "missing-provider"}.get(mode)
+        current = provider["RepositoryRead"]()
+        try:
+            result = current.run()
+        except provider["SnapshotFailure"] as error:
+            assert expected == error.code, (mode, error.code, current.stage, calls)
+        else:
+            assert expected is None, mode
+            assert len(result) == (0 if mode == "empty" else 2), result
+            if result:
+                assert [row.enabled for row in result] == [True, False]
+        if mode == "lost-owner":
+            assert name_call("RequestName") == 1
+    mode = "stall"
+    reader = provider["RepositoryRead"]()
+    started = time.monotonic()
+    try:
+        reader.run()
+    except provider["SnapshotFailure"] as error:
+        assert error.code == "timeout", error.code
+    else:
+        raise AssertionError("stalled repository read succeeded")
+    elapsed = time.monotonic() - started
+    assert 29 <= elapsed < 36, elapsed
+    assert reader.value is None and reader.rows == {} and len(held) == 1
+    path, invocation = held.pop()
+    invocation.return_value(None)
+    emit(path, "Finished", "(uu)", (1, 30))
+    mode = "normal"
+    assert len(provider["RepositoryRead"]().run()) == 2
+    assert (path, "Cancel") in calls
+    assert reader.value is None and reader.failure.code == "timeout"
+    assert name_call("ReleaseName") == 1
+    try:
+        provider["RepositoryRead"]().run()
+    except provider["SnapshotFailure"] as error:
+        assert error.code == "missing-provider", error.code
+    else:
+        raise AssertionError("absent PackageKit succeeded")
+    assert set(method for _path, method in calls) == {"CreateTransaction", "SetHints", "GetRepoList", "Cancel"}
+    print("Private-bus repository reads: PASS (fixed filter, denial, absence, bounds, owner loss, 30-second deadline, late replies)")
+finally:
+    for registration in reversed(registrations):
+        bus.unregister_object(registration)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -84,6 +84,324 @@ def rows(lines, kind):
     return [line.split("\t") for line in lines if line.startswith(f"{kind}\t")]
 
 
+class RepositoryReadTests(unittest.TestCase):
+    def reader(self):
+        _unused, connection, gio, glib, variant = RegionalReadTests.reader(self)
+        return provider.RepositoryRead(gio, glib), connection, gio, glib, variant
+
+    def collect(self, *, records=None, overrides=None, stall=None, before_ack=False,
+                terminal=None, no_terminal=False, transform=None, remote_error=None, activate=False):
+        read, connection, gio, glib, variant = self.reader()
+        calls = []
+        connection.call.side_effect = lambda *args: calls.append(args)
+        gio.dbus_error_get_remote_error.return_value = remote_error
+        replies = {"start": variant.Variant("(u)", (2,)),
+                   "owner": variant.Variant("(s)", (":1.42",)),
+                   "owner-after-start": variant.Variant("(s)", (":1.42",)),
+                   "verify-owner": variant.Variant("(s)", (":1.42",)),
+                   "create": variant.Variant("(o)", ("/12_fixture",))}
+        replies.update(overrides or {})
+        if activate:
+            replies["owner"] = variant.Error("no owner")
+        def signals():
+            for record in records if records is not None else (
+                    variant.Variant("(ssb)", ("z-disabled", "Disabled", False)),
+                    variant.Variant("(ssb)", ("a-enabled", "Enabled", True))):
+                read.received(connection, read.owner, read.path, provider.TRANSACTION_INTERFACE,
+                              "RepoDetail", record, None)
+            if not no_terminal:
+                member, values = terminal or ("Finished", variant.Variant("(uu)", (1, 4)))
+                read.received(connection, read.owner, read.path, provider.TRANSACTION_INTERFACE,
+                              member, values, None)
+        def during_loop():
+            if stall == "connect":
+                read.expire()
+            read.connected(None, object(), None)
+            for call in calls:
+                stage = call[-1]
+                if stage is None:
+                    continue  # Best-effort cleanup does not own a new read.
+                if transform:
+                    transform(read, connection, stage)
+                if stage == "fetch" and before_ack:
+                    signals()
+                if stall == stage:
+                    read.expire()
+                reply = replies.get(stage, variant.Variant("()", ()))
+                gio.dbus_error_get_remote_error.return_value = (
+                    "org.freedesktop.DBus.Error.NameHasNoOwner" if activate and stage == "owner" else remote_error)
+                connection.call_finish.side_effect = reply if isinstance(reply, Exception) else None
+                connection.call_finish.return_value = reply
+                call[-2](connection, object(), stage)
+                call[-2](connection, object(), stage)  # Duplicate callbacks are inert.
+                if stage == "fetch" and not before_ack:
+                    signals()
+            if not read.done:
+                read.expire()
+        read.loop.run.side_effect = during_loop
+        failure = None
+        try:
+            value = read.run()
+        except provider.SnapshotFailure as error:
+            value, failure = None, error
+        return value, failure, read, connection, gio, glib, calls
+
+    def test_complete_enabled_disabled_rows_and_exact_fixed_calls(self):
+        for before_ack in (False, True):
+            value, failure, read, connection, gio, glib, calls = self.collect(before_ack=before_ack)
+            self.assertIsNone(failure)
+            self.assertEqual([row.fields() for row in value], [
+                ("repository", "a-enabled", "enabled", "Enabled"),
+                ("repository", "z-disabled", "disabled", "Disabled")])
+            self.assertEqual([call[3] for call in calls], ["GetNameOwner",
+                "CreateTransaction", "AddMatch", "SetHints", "GetRepoList", "GetNameOwner", "RemoveMatch"])
+            for call in calls:
+                self.assertEqual(call[6], gio.DBusCallFlags.NONE)
+                self.assertGreater(call[7], 0)
+                self.assertLessEqual(call[7], 30000)
+            fetch = next(call for call in calls if call[3] == "GetRepoList")
+            self.assertEqual(fetch[:4], (":1.42", "/12_fixture", provider.TRANSACTION_INTERFACE, "GetRepoList"))
+            self.assertEqual(fetch[4].get_type_string(), "(t)")
+            self.assertEqual(fetch[4].unpack(), (2,))
+            hints = next(call for call in calls if call[3] == "SetHints")
+            self.assertEqual(hints[4].unpack(), (["background=true", "interactive=false", "cache-age=4294967295"],))
+            self.assertEqual(connection.signal_subscribe.call_args.args[5], gio.DBusSignalFlags.NO_MATCH_RULE)
+            connection.signal_unsubscribe.assert_called_once()
+            connection.disconnect.assert_called_once()
+            connection.close_sync.assert_not_called()
+            glib.source_remove.assert_called_once_with(17)
+            self.assertTrue(read.cancellable.cancel.called)
+            self.assertEqual(read.rows, {})
+            with self.assertRaises(RuntimeError):
+                read.run()
+
+    def test_empty_success_requires_both_method_ack_and_finished(self):
+        value, failure, *_ = self.collect(records=[])
+        self.assertEqual(value, ())
+        self.assertIsNone(failure)
+        value, failure, *_ = self.collect(records=[], no_terminal=True)
+        self.assertIsNone(value)
+        self.assertEqual(failure.code, "timeout")
+        for before_ack in (False, True):
+            _read, _connection, _gio, _glib, variant = self.reader()
+            value, failure, *_ = self.collect(before_ack=before_ack,
+                overrides={"fetch": variant.Error("lost acknowledgment")})
+            self.assertIsNone(value)
+            self.assertEqual(failure.code, "internal")
+
+    def test_every_stage_timeout_discards_rows_and_late_callbacks(self):
+        for stage in ("connect", "start", "owner", "owner-after-start", "create", "match", "hints", "fetch", "verify-owner"):
+            value, failure, read, connection, gio, _glib, calls = self.collect(
+                stall=stage, activate=stage in ("start", "owner-after-start"))
+            self.assertIsNone(value, stage)
+            self.assertEqual(failure.code, "timeout", stage)
+            self.assertEqual(read.rows, {})
+            before = connection.call_finish.call_count
+            read.replied(connection, object(), stage)
+            read.connected(None, object(), None)
+            self.assertEqual(connection.call_finish.call_count, before)
+            if stage == "connect":
+                gio.bus_get_finish.assert_not_called()
+            canceled = [call for call in calls if call[3] == "Cancel"]
+            self.assertEqual(len(canceled), int(stage == "fetch"))
+            if canceled:
+                self.assertEqual(canceled[0][:4], (":1.42", "/12_fixture", provider.TRANSACTION_INTERFACE, "Cancel"))
+            self.assertEqual(sum(call[3] == "RemoveMatch" for call in calls),
+                             int(stage in ("match", "hints", "fetch", "verify-owner")))
+
+    def test_bus_failures_and_replacement_are_provider_scoped(self):
+        _read, _connection, _gio, _glib, variant = self.reader()
+        for stage, remote, code, status in (
+                ("owner", "org.freedesktop.DBus.Error.ServiceUnknown", "missing-provider", "unavailable"),
+                ("match", "org.freedesktop.DBus.Error.AccessDenied", "permission-denied", "restricted"),
+                ("fetch", "org.freedesktop.PackageKit.Transaction.RefusedByPolicy", "permission-denied", "restricted"),
+                ("fetch", "org.freedesktop.PackageKit.Transaction.NotSupported", "unsupported", "unsupported")):
+            value, failure, *_ = self.collect(overrides={stage: variant.Error("fixture")}, remote_error=remote)
+            self.assertIsNone(value)
+            self.assertEqual((failure.code, failure.status), (code, status))
+        value, failure, *_ = self.collect(overrides={"verify-owner": variant.Variant("(s)", (":1.43",))})
+        self.assertIsNone(value)
+        self.assertEqual(failure.code, "conflict")
+
+    def test_typed_reply_validation_rejects_invalid_setup(self):
+        _read, _connection, _gio, _glib, variant = self.reader()
+        for stage, reply in (("start", variant.Variant("(u)", (0,))),
+                ("owner", variant.Variant("(s)", ("org.freedesktop.PackageKit",))),
+                ("owner", variant.Variant("(s)", (":" + "1" * 255 + ".1",))),
+                ("create", variant.Variant("(o)", ("/unrelated",))),
+                ("match", variant.Variant("(b)", (True,))),
+                ("hints", variant.Variant("(s)", ("bad",))),
+                ("fetch", variant.Variant("(b)", (True,)))):
+            value, failure, *_ = self.collect(overrides={stage: reply}, activate=stage == "start")
+            self.assertIsNone(value)
+            self.assertEqual(failure.code, "malformed", stage)
+
+    def test_absent_daemon_activation_is_bounded_and_attempted_only_once(self):
+        value, failure, _read, _connection, _gio, _glib, calls = self.collect(activate=True)
+        self.assertIsNone(failure)
+        self.assertEqual(len(value), 2)
+        self.assertEqual([call[3] for call in calls[:3]], ["GetNameOwner", "StartServiceByName", "GetNameOwner"])
+        self.assertEqual(calls[1][4].unpack(), (provider.PACKAGEKIT_NAME, 0))
+        _read, _connection, _gio, _glib, variant = self.reader()
+        value, failure, *_rest, calls = self.collect(activate=True,
+            overrides={"owner-after-start": variant.Error("still absent")},
+            remote_error="org.freedesktop.DBus.Error.NameHasNoOwner")
+        self.assertIsNone(value)
+        self.assertEqual(failure.code, "missing-provider")
+        self.assertEqual(sum(call[3] == "StartServiceByName" for call in calls), 1)
+
+    def test_repository_fields_are_bounded_before_unpacking(self):
+        _read, _connection, _gio, _glib, variant = self.reader()
+        row = provider.decode_repository_row(variant.Variant("(ssb)", ("x" * 512, "é" * 256, True)))
+        self.assertEqual(len(row.repository_id), 512)
+        self.assertEqual(len(row.description.encode()), 512)
+        for record in (variant.Variant("(ssb)", ("", "description", True)),
+                       variant.Variant("(ssb)", ("bad\tid", "description", True)),
+                       variant.Variant("(ssb)", ("id", "é" * 257, True)),
+                       variant.Variant("(ssb)", ("x" * 513, "description", True)),
+                       variant.Variant("(sss)", ("id", "description", "true"))):
+            value, failure, *_ = self.collect(records=[record])
+            self.assertIsNone(value)
+            self.assertEqual(failure.code, "malformed")
+        oversized = mock.Mock()
+        oversized.get_type_string.return_value = "(ssb)"
+        oversized.get_size.return_value = 1000000
+        with self.assertRaises(provider.SnapshotFailure):
+            provider.decode_repository_row(oversized)
+        oversized.unpack.assert_not_called()
+        self.assertEqual(provider.decode_repository_row(variant.Variant("(ssb)",
+            ("id", "one\ntwo\tthree", False))).description, "one two three")
+
+    def test_duplicate_count_and_encoded_byte_overflow_discard_complete_result(self):
+        _read, _connection, _gio, _glib, variant = self.reader()
+        record = lambda index: variant.Variant("(ssb)", (f"repo-{index}", "description", True))
+        value, failure, *_ = self.collect(records=[record(index) for index in range(512)])
+        self.assertIsNone(failure)
+        self.assertEqual(len(value), 512)
+        for records in ([record(0), record(0)], [record(index) for index in range(513)]):
+            value, failure, read, *_ = self.collect(records=records)
+            self.assertIsNone(value)
+            self.assertEqual(failure.code, "malformed")
+            self.assertEqual(read.rows, {})
+        records = [variant.Variant("(ssb)", (f"{index:03d}" + "i" * 509, "d" * 512, True)) for index in range(512)]
+        value, failure, *_ = self.collect(records=records)
+        self.assertIsNone(value)
+        self.assertEqual(failure.code, "malformed")
+        size = provider.encoded_record_size(provider.decode_repository_row(record(0)).fields())
+        for limit, success in ((size, True), (size - 1, False)):
+            with mock.patch.object(provider, "REPOSITORY_MAX_BYTES", limit):
+                value, failure, *_ = self.collect(records=[record(0)])
+            self.assertEqual(failure is None, success)
+
+    def test_transaction_errors_and_malformed_terminal_signals_never_succeed(self):
+        _read, _connection, _gio, _glib, variant = self.reader()
+        for terminal, code in (
+                (("ErrorCode", variant.Variant("(us)", (18, "private details"))), "repository"),
+                (("ErrorCode", variant.Variant("(us)", (48, "private details"))), "permission-denied"),
+                (("ErrorCode", variant.Variant("(us)", (2, "private details"))), "network"),
+                (("ErrorCode", variant.Variant("(us)", (18, "x" * 513))), "malformed"),
+                (("Finished", variant.Variant("(uu)", (2, 4))), "internal"),
+                (("Finished", variant.Variant("(u)", (1,))), "malformed"),
+                (("Destroy", variant.Variant("()", ())), "missing-provider"),
+                (("Destroy", variant.Variant("(b)", (True,))), "malformed")):
+            value, failure, *_ = self.collect(terminal=terminal)
+            self.assertIsNone(value)
+            self.assertEqual(failure.code, code)
+            self.assertNotIn("private details", str(failure))
+
+    def test_wrong_peer_and_unrelated_signals_are_ignored_without_unpacking(self):
+        def unrelated(read, connection, stage):
+            if stage != "fetch":
+                return
+            values = mock.Mock()
+            for sender, path, interface, member in ((":1.99", read.path, provider.TRANSACTION_INTERFACE, "RepoDetail"),
+                    (read.owner, "/99_other", provider.TRANSACTION_INTERFACE, "Finished"),
+                    (read.owner, read.path, "other.Interface", "ErrorCode"),
+                    (read.owner, read.path, provider.TRANSACTION_INTERFACE, "Package")):
+                read.received(connection, sender, path, interface, member, values, None)
+            values.unpack.assert_not_called()
+            values.get_type_string.assert_not_called()
+        value, failure, *_ = self.collect(transform=unrelated)
+        self.assertIsNone(failure)
+        self.assertEqual(len(value), 2)
+
+    def test_premature_signal_and_unexpected_loop_exit_fail_closed(self):
+        _read, _connection, _gio, _glib, variant = self.reader()
+        def premature(read, connection, stage):
+            if stage == "match":
+                read.received(connection, read.owner, read.path, provider.TRANSACTION_INTERFACE,
+                    "Finished", variant.Variant("(uu)", (1, 0)), None)
+        value, failure, *_ = self.collect(transform=premature)
+        self.assertIsNone(value)
+        self.assertEqual(failure.code, "malformed")
+        read, *_ = self.reader()
+        with self.assertRaises(provider.SnapshotFailure) as caught:
+            read.run()
+        self.assertEqual(caught.exception.code, "internal")
+
+    def test_real_repository_reads_use_an_isolated_private_bus(self):
+        process = subprocess.Popen(["dbus-run-session", "--", "/usr/bin/python3",
+            str(REPO / "tests/fixtures/system-repository-read-bus.py"), str(PROVIDER_PATH)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True)
+        try:
+            output, error = process.communicate(timeout=50)
+        finally:
+            if process.poll() is None:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.communicate()
+        self.assertEqual(process.returncode, 0, error.decode(errors="replace"))
+        self.assertIn(b"Private-bus repository reads: PASS", output)
+
+    def test_expired_decoding_never_publishes_a_value_or_late_error(self):
+        for raises in (False, True):
+            def decode_late(_values):
+                current.deadline = 0
+                if raises:
+                    raise provider.SnapshotFailure("malformed", "late decoding error")
+                return provider.RepositoryRow("late", True, "Late")
+            def capture(read, _connection, _stage):
+                nonlocal current
+                current = read
+            current = None
+            with mock.patch.object(provider, "decode_repository_row", side_effect=decode_late):
+                value, failure, read, *_ = self.collect(transform=capture)
+            self.assertIsNone(value)
+            self.assertEqual(failure.code, "timeout")
+            self.assertEqual(read.rows, {})
+
+    def test_bus_close_is_bounded_and_cannot_override_terminal_evidence(self):
+        for expired in (False, True):
+            def close(read, _connection, stage):
+                if stage == "fetch":
+                    if expired:
+                        read.deadline = 0
+                    read.connection_closed()
+            value, failure, read, *_ = self.collect(transform=close)
+            self.assertIsNone(value)
+            self.assertEqual(failure.code, "timeout" if expired else "missing-provider")
+            read.connection_closed()
+            self.assertIs(read.failure, failure)
+        value, failure, read, *_ = self.collect()
+        read.connection_closed()
+        self.assertIs(read.value, value)
+        self.assertIsNone(read.failure)
+
+    def test_synchronous_dispatch_and_cleanup_failures_remain_bounded(self):
+        read, connection, _gio, _glib, variant = self.reader()
+        connection.call.side_effect = variant.Error("send failed")
+        read.loop.run.side_effect = lambda: read.connected(None, object(), None)
+        with self.assertRaises(provider.SnapshotFailure) as caught:
+            read.run()
+        self.assertEqual(caught.exception.code, "internal")
+        connection.close_sync.assert_not_called()
+        def reject_cleanup(_read, connection, stage):
+            if stage == "verify-owner":
+                connection.call.side_effect = variant.Error("cleanup failed")
+        value, failure, *_ = self.collect(transform=reject_cleanup)
+        self.assertIsNone(failure)
+        self.assertEqual(len(value), 2)
+
+
 class CupsReadTests(unittest.TestCase):
     def state(self, load="loaded", active="inactive", sub="dead"):
         return provider.UnitState("/org/freedesktop/systemd1/unit/fixture", load, active, sub)


### PR DESCRIPTION
## Summary

- Add an internal, single-use PackageKit `GetRepoList(NONE)` reader for enabled and disabled repositories, with one 30-second deadline covering bus connection, optional daemon activation, transaction setup, completion, and decoding.
- Pin the daemon and transaction, acknowledge the exact signal match, require both method and successful terminal evidence, and recheck daemon ownership before publishing.
- Reject duplicate, malformed, or oversized complete results (512 rows, 384 KiB encoded rows, 512-byte text fields). Clean up only the owned read transaction; never refresh metadata, edit repositories, or report best-effort cancellation as completed.
- Add unit and real private-bus coverage and update Phase 6 progress. No CLI command, protocol minor, QML control, or installation change is enabled.

## Validation

- `scripts/run-tests /usr/bin/python3 tests/test-system-management.py RepositoryReadTests`: 15 tests passed in 30.268 seconds, including the actual 30-second timeout and late completion on an isolated private bus.
- Fedora 44 / PackageKit 1.3.6 read-only probe: 28 repositories, 15 enabled and 13 disabled, in 0.826 seconds. No refresh or repository change requested.
- `npm --prefix docs run build`: passed, 15 files with zero diagnostics, 11 generated pages.
- `coderabbit review --agent -t uncommitted`: zero findings across all five files.
- `scripts/run-tests make clean all` and `scripts/run-tests`: passed on staged tree `bec54a30a6d041fa261d3ca8d2c9644254a592a6`; 405 provider tests passed in 104.006 seconds, plus native nested-X11 lifecycle, installer preservation, and release validation. Managed workspaces removed after completion. A second read-only Fedora probe on this exact tree returned the same 28 repositories in 0.510 seconds.
- `/usr/lib/chatgpt/resources/codex review --uncommitted`: passed after the complete local gate, no actionable findings.

## Scope and limitations

This PR is the repository-reader boundary following merged #247. Regional actions, delegated tool lifecycle, event subscriptions, Settings integration, information/security surfaces, and combined installed qualification remain outstanding. The reader is not yet exposed to Settings. No host settings, installed files, logout, or reboot were changed. Phase 6 is not complete; Phase 7 remains out of scope.