### PR TITLE
feat(system): add read-only regional preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ versions from `config.mk`.
 
 ### Added
 
+- Add bounded read-only regional choice and confirmation-preview commands.
+  Bind selected timezone, NTP, or locale values to fresh configuration with a
+  generation token and preserve complete locale override details. Regional
+  mutation commands and Settings controls remain disabled pending lifecycle
+  integration.
+
 - Monitor update changes while the System Settings section is open. Coalesce
   bursts into an initial read plus at most one settling read, preserve readable
   status with reload guidance when state keeps changing or monitoring fails,

--- a/TASKS.md
+++ b/TASKS.md
@@ -192,6 +192,17 @@ seconds without requesting metadata refresh or repository changes. This reader
 adds no CLI command or protocol minor. Event subscriptions, lifecycle integration,
 delegated-tool availability, and Settings controls remain outstanding.
 
+Read-only regional choices and preview commands now expose separately bounded
+streams without changing the cumulative snapshot minor. Previews bind the exact
+selected value to current configuration with a generation token, preserve the
+complete locale override description, and require fresh reads for each request.
+Unit and private-bus tests cover stale state, key presence, strict output bounds,
+malformed selections, fixed read-only calls, and closed consumers. Native mutation
+commands remain disabled; their owner lifetime, platform authorization,
+verification, and Settings confirmation integration are still required.
+Read-only Fedora 44 CLI probes passed for both catalogs and all three preview
+forms without changing system settings.
+
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit
 confirmation warning that a sent change cannot be canceled. Local cancellation

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -349,7 +349,7 @@ field limit of 512 bytes, the provider never truncates it: locale becomes
 `partial`/`unknown`, `locale-set` becomes unavailable, and the detail reports
 that the override set is too large to confirm safely. Immediately before
 confirmation and again before the D-Bus call,
-`locale-set LANG=LOCALE` rereads locale1's complete `Locale` array, validates
+`locale-set LANG=LOCALE GENERATION` rereads locale1's complete `Locale` array, validates
 the allowlist and bounds above, replaces only `LANG`, preserves every validated
 `LANGUAGE` and `LC_*` assignment, sorts the complete set in the fixed order
 above, recomputes the complete display detail, and revalidates every bound
@@ -365,8 +365,13 @@ notification for this call and is ignored; any non-equivalent notification or
 final effective-value mismatch reports `conflict`, refreshes visible state, and
 warns that a concurrent writer may have won or been overwritten.
 
-locale1 replaces the full assignment array and exposes no lock or compare-and-
-set argument, so no client can make this cross-client read-modify-write fully
+locale1 merges omitted keys from its current configuration and simplifies
+redundant values; it does not simply replace the whole assignment array.
+It also applies its own language fallback policy. See the
+[systemd 259 SetLocale implementation](https://github.com/systemd/systemd/blob/v259/src/locale/localed.c).
+The provider still supplies the complete validated preserved set and verifies
+the required effective values. locale1 exposes no lock or compare-and-set
+argument, so no client can make this cross-client read-modify-write fully
 atomic. An external writer in the final read-to-method interval can therefore
 still be overwritten even though the provider detects its notification when
 available. The confirmation states this limitation, shows the preserved
@@ -392,9 +397,9 @@ post-dispatch mutation automatically.
 Provider-backed regional and delegated actions use this exact command grammar:
 
 ```text
-dwm-system-management timezone-set ZONE
-dwm-system-management ntp-set enabled|disabled
-dwm-system-management locale-set LANG=LOCALE
+dwm-system-management timezone-set ZONE GENERATION
+dwm-system-management ntp-set enabled|disabled GENERATION
+dwm-system-management locale-set LANG=LOCALE GENERATION
 dwm-system-management accounts-open
 dwm-system-management password-open
 dwm-system-management printers-open
@@ -420,6 +425,62 @@ immediately before `SetLocale`; it never reuses the first allowlist. Arguments
 are validated at both points. The four no-argument forms reject every positional or
 option argument. No other option, key, D-Bus argument, or trailing argument is
 accepted by any form.
+
+#### Read-only Regional Confirmation Preflight
+
+The separate read-only commands are:
+
+```text
+dwm-system-management regional-choices timezone|locale
+dwm-system-management regional-preview timezone-set ZONE
+dwm-system-management regional-preview ntp-set enabled|disabled
+dwm-system-management regional-preview locale-set LANG=LOCALE
+```
+
+These commands never authorize or mutate system state and do not advertise a
+snapshot action or change the cumulative snapshot minor. Unknown forms or arity
+return usage with exit 2 before I/O. A recognized request with an invalid selected
+value or unavailable read returns a complete typed error stream with exit 1.
+
+Choice streams begin with
+`regional-choices-protocol<TAB>1<TAB>0<TAB>timezone|locale`, contain only
+`choice<TAB>exact-id` rows, and end with `complete<TAB>regional-choices`.
+Success requires exit 0, a valid header, unique ascending ASCII identities, and
+completion. The existing catalog validation limits remain in force; the entire
+encoded stream, including every newline, is additionally limited to 512 KiB for
+timezones or 1 MiB for locales. Failed reads emit no choice rows, only the header,
+one `error<TAB>regional<TAB>code<TAB>detail`, and completion. Results are fully
+buffered and validated before any output; an oversized result is not truncated.
+
+Preview streams begin with `regional-preview-protocol<TAB>1<TAB>0`, contain one
+`preview<TAB>action<TAB>argument<TAB>generation<TAB>current<TAB>target<TAB>detail`,
+and end with `complete<TAB>regional-preview`. Success requires exit 0 and all
+three records. Every text field is at most 512 UTF-8 bytes and the whole stream
+is at most 8 KiB including newlines. A failure replaces the preview with one
+typed regional error and exits 1. Locale detail is the complete preserved
+override description, not a truncated summary. Preflight is not authorization
+or proof that a future mutation is available.
+
+Each preview makes fresh fixed reads: timezone state and timezone choices, NTP
+state, or locale state and installed locale choices. Service reads retain their
+ten-second aggregate bounds; the locale collector retains its three-second
+collection and bounded cleanup. No PackageKit read, journal access, arbitrary
+command, or user-selected service is involved.
+
+The generation is SHA-256 over the ASCII prefix `dwm-titus-regional-preview-v1`
+followed by action, selected argument, and source fields, each encoded as an
+eight-byte big-endian UTF-8 byte length followed by its bytes. Timezone uses the
+current timezone as its source field. NTP uses `yes|no` for `CanNTP` followed by
+`enabled|disabled` for its current setting; synchronization samples are not
+configuration identity. Locale uses every current validated assignment in the
+fixed locale-key order, including explicit empty values and key presence.
+Unselected catalog entries do not affect this token; exact selected membership
+must still be freshly validated. Before any future mutating call, the provider
+must repeat the preflight and compare the confirmed 64-lowercase-hex generation.
+A mismatch requires new confirmation and sends no mutation. Visible confirmation
+and monitored invalidation remain mandatory; the token is a freshness guard,
+not an atomic service transaction or proof of human approval. The mutating
+forms above remain disabled until their lifecycle and Settings integration land.
 
 `health-open` is the sole action with no provider command: the root-scoped QML
 model invokes the fixed in-process `SystemHealthModel.openOnScreen` method with

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -45,6 +45,8 @@ REGIONAL_LOCALE_MAX = 128
 REGIONAL_LOCALE_COUNT = 4096
 REGIONAL_LOCALE_OUTPUT_BYTES = 2 * 1024 * 1024
 REGIONAL_LOCALE_ARRAY_BYTES = 8192
+REGIONAL_CHOICE_STREAM_BYTES = {"timezone": 512 * 1024, "locale": 1024 * 1024}
+REGIONAL_PREVIEW_STREAM_BYTES = 8192
 REGIONAL_LOCALE_KEYS = (
     "LANG", "LANGUAGE", "LC_CTYPE", "LC_NUMERIC", "LC_TIME", "LC_COLLATE",
     "LC_MONETARY", "LC_MESSAGES", "LC_PAPER", "LC_NAME", "LC_ADDRESS",
@@ -298,7 +300,14 @@ def validate_locale_choices(output: object) -> tuple[str, ...]:
     lines = text.removesuffix("\n").split("\n", REGIONAL_LOCALE_COUNT)
     if len(lines) > REGIONAL_LOCALE_COUNT:
         raise SnapshotFailure("malformed", "Too many regional locale choices")
-    result = tuple(validate_locale_name(line) for line in lines)
+    return validate_locale_catalog(lines)
+
+
+def validate_locale_catalog(values: object) -> tuple[str, ...]:
+    """Validate already decoded identities without rebuilding unbounded stdout."""
+    if not isinstance(values, (list, tuple)) or len(values) > REGIONAL_LOCALE_COUNT:
+        raise SnapshotFailure("malformed", "Invalid regional locale catalog")
+    result = tuple(validate_locale_name(value) for value in values)
     if len(set(result)) != len(result):
         raise SnapshotFailure("malformed", "Duplicate regional locale choices")
     return result
@@ -436,6 +445,120 @@ def decode_regional_reply(kind: str, reply: object) -> object:
             raise SnapshotFailure("malformed", "Missing or malformed timedate1 property")
         values.append(value.unpack())
     return RegionalTimeState(validate_timezone_name(values[0]), *values[1:])
+
+
+@dataclass(frozen=True)
+class RegionalPreview:
+    action: str
+    argument: str
+    generation: str
+    current: str
+    target: str
+    detail: str
+
+    def fields(self) -> tuple[str, ...]:
+        return ("preview", self.action, self.argument, self.generation,
+                self.current, self.target, self.detail)
+
+
+def validate_regional_argument(action: str, argument: object) -> str:
+    """Validate one fixed action's selection before starting any preflight I/O."""
+    if action == "timezone-set":
+        return validate_timezone_name(argument)
+    if action == "ntp-set" and isinstance(argument, str) and argument in ("enabled", "disabled"):
+        return argument
+    if action == "locale-set" and isinstance(argument, str) and argument.startswith("LANG="):
+        return "LANG=" + validate_locale_name(argument[5:])
+    raise SnapshotFailure("malformed", "Invalid regional action or selected value")
+
+
+def make_regional_preview(action: str, argument: object, state: object, choices=()) -> RegionalPreview:
+    """Bind a selection to complete validated current state, without I/O."""
+    argument = validate_regional_argument(action, argument)
+    if action == "locale-set":
+        if not isinstance(state, LocaleConfiguration):
+            raise SnapshotFailure("malformed", "Invalid regional locale state")
+        current = parse_locale_configuration(state.assignments)
+        catalog = validate_locale_catalog(choices)
+        expected = prepare_locale_change(current.assignments, argument,
+                                         ("\n".join(catalog) + ("\n" if catalog else "")).encode("ascii"))
+        current_value, target, detail = current.lang, expected.lang, expected.detail
+        source_fields = current.assignments
+    else:
+        if (not isinstance(state, RegionalTimeState)
+                or any(type(value) is not bool for value in
+                       (state.can_ntp, state.ntp_enabled, state.ntp_synchronized))):
+            raise SnapshotFailure("malformed", "Invalid regional time state")
+        validate_timezone_name(state.timezone)
+        if action == "timezone-set":
+            target = prepare_timezone_change(argument, choices)
+            current_value, detail = state.timezone, "System timezone"
+            source_fields = (state.timezone,)
+        else:
+            if not state.can_ntp:
+                raise SnapshotFailure("unsupported", "No supported network time service is available", "unsupported")
+            current_value = "enabled" if state.ntp_enabled else "disabled"
+            target, detail = argument, "Network time synchronization setting"
+            source_fields = ("yes", current_value)
+    digest = hashlib.sha256(b"dwm-titus-regional-preview-v1")
+    for field in (action, argument, *source_fields):
+        encoded = field.encode("utf-8")
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+    return RegionalPreview(action, argument, digest.hexdigest(), current_value, target, detail)
+
+
+def require_regional_generation(preview: RegionalPreview, confirmed: object) -> None:
+    """Future owners must call this with freshly collected preflight evidence."""
+    if not isinstance(confirmed, str) or JOURNAL_GENERATION_PATTERN.fullmatch(confirmed) is None:
+        raise SnapshotFailure("malformed", "Invalid regional confirmation generation")
+    if confirmed != preview.generation:
+        raise SnapshotFailure("conflict", "Regional state changed; review a fresh confirmation")
+
+
+def regional_choices(kind: str) -> tuple[str, ...]:
+    if kind == "timezone":
+        return validate_timezone_choices(RegionalRead("timezone-choices").run())
+    if kind == "locale":
+        return validate_locale_catalog(read_locale_choices())
+    raise SnapshotFailure("malformed", "Unknown regional choice catalog")
+
+
+def read_regional_preview(action: str, argument: object) -> RegionalPreview:
+    argument = validate_regional_argument(action, argument)
+    state = RegionalRead("locale-state" if action == "locale-set" else "time-state").run()
+    choices = regional_choices("locale" if action == "locale-set" else "timezone") if action != "ntp-set" else ()
+    return make_regional_preview(action, argument, state, choices)
+
+
+def regional_preflight_output(command: str, arguments: Sequence[str]) -> tuple[str, int]:
+    """Fully buffer a bounded read-only stream; failures never leak partial rows."""
+    choices = command == "regional-choices"
+    if (choices and (len(arguments) != 1 or arguments[0] not in REGIONAL_CHOICE_STREAM_BYTES)
+            or not choices and (command != "regional-preview" or len(arguments) != 2
+                or arguments[0] not in {"timezone-set", "ntp-set", "locale-set"})):
+        raise ValueError("invalid regional preflight command")
+    header = f"{command}-protocol\t1\t0" + ("\t" + arguments[0] if choices else "")
+    completion = "complete\t" + command
+    limit = REGIONAL_CHOICE_STREAM_BYTES[arguments[0]] if choices else REGIONAL_PREVIEW_STREAM_BYTES
+    try:
+        if choices:
+            records = [("choice", value) for value in sorted(regional_choices(arguments[0]))]
+        else:
+            records = [read_regional_preview(*arguments).fields()]
+        for record in records:
+            if any(not isinstance(field, str) or len(field.encode("utf-8")) > MAX_TEXT_BYTES
+                   or field and not field.isprintable() for field in record):
+                raise SnapshotFailure("malformed", "Undisplayable regional preflight field")
+        output = "\n".join((header, *("\t".join(record) for record in records), completion)) + "\n"
+        if len(output.encode("utf-8")) > limit:
+            raise SnapshotFailure("malformed", "Regional preflight stream is too large")
+        return output, 0
+    except (SnapshotFailure, UnicodeError) as error:
+        failure = error if isinstance(error, SnapshotFailure) else SnapshotFailure("malformed", "Non-UTF-8 regional preflight field")
+        code = failure.code if failure.code in JOURNAL_ERROR_CODES else "internal"
+        detail = "".join(char if char.isprintable() else " " for char in failure.detail)
+        return "\n".join((header, f"error\tregional\t{code}\t{detail}", completion)) + "\n", 1
 
 
 class ServiceRead:
@@ -6806,11 +6929,26 @@ def watch_update_events() -> int:
 
 
 def usage() -> int:
-    print(f"usage: {sys.argv[0]} snapshot | watch-updates | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID", file=sys.stderr)
+    print(f"usage: {sys.argv[0]} snapshot | watch-updates | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE", file=sys.stderr)
     return 2
 
 
 def main(argv: Sequence[str]) -> int:
+    if argv and argv[0] in {"regional-choices", "regional-preview"}:
+        try:
+            output, code = regional_preflight_output(argv[0], argv[1:])
+        except ValueError:
+            return usage()
+        try:
+            sys.stdout.write(output)
+            sys.stdout.flush()
+        except BrokenPipeError:
+            # Prevent the shutdown flush from replacing the controlled status
+            # or emitting an unraisable-exception diagnostic for a closed pane.
+            with open(os.devnull, "w") as sink:
+                os.dup2(sink.fileno(), sys.stdout.fileno())
+            return 1
+        return code
     if list(argv) == ["watch-updates"]:
         return watch_update_events()
     if list(argv) == ["updates-refresh"]:

--- a/tests/fixtures/system-regional-read-bus.py
+++ b/tests/fixtures/system-regional-read-bus.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python3
 """Qualify regional reads on a private bus with no host-service access."""
 
+import contextlib
+import io
 import os
 import runpy
 import sys
@@ -72,8 +74,20 @@ try:
     assert [call[2:] for call in calls] == [
         ("GetAll", ("org.freedesktop.timedate1",)),
         ("Get", ("org.freedesktop.locale1", "Locale")), ("ListTimezones", ())]
+    for arguments in (["regional-choices", "timezone"],
+                      ["regional-preview", "timezone-set", "Etc/UTC"],
+                      ["regional-preview", "ntp-set", "enabled"],
+                      ["regional-preview", "locale-set", "LANG=C"]):
+        with contextlib.redirect_stdout(io.StringIO()) as output:
+            assert provider["main"](arguments) == 0, arguments
+        assert output.getvalue().startswith(arguments[0] + "-protocol\t1\t0")
+        assert output.getvalue().endswith("complete\t" + arguments[0] + "\n")
     mode = "malformed"
     failure("time-state", "malformed")
+    with contextlib.redirect_stdout(io.StringIO()) as output:
+        assert provider["main"](["regional-preview", "ntp-set", "enabled"]) == 1
+    assert "error\tregional\tmalformed\t" in output.getvalue()
+    assert "\npreview\t" not in output.getvalue()
     mode = "denied"
     failure("locale-state", "permission-denied")
     mode = "normal"
@@ -89,7 +103,7 @@ try:
     mode = "normal"
     assert provider["RegionalRead"]("timezone-choices").run() == ("UTC", "Etc/UTC")
     assert all(call[2] in {"Get", "GetAll", "ListTimezones"} for call in calls)
-    print("Private-bus regional reads: PASS (typed replies, denial, absence, deadline, late reply)")
+    print("Private-bus regional reads: PASS (typed replies, readonly preflight, denial, absence, deadline, late reply)")
 finally:
     for registration in registrations:
         bus.unregister_object(registration)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -84,6 +84,230 @@ def rows(lines, kind):
     return [line.split("\t") for line in lines if line.startswith(f"{kind}\t")]
 
 
+class RegionalPreflightTests(unittest.TestCase):
+    def time_state(self, **changes):
+        return replace(provider.RegionalTimeState("UTC", True, False, True), **changes)
+
+    def test_timezone_preview_requires_membership_and_binds_current_and_target(self):
+        preview = provider.make_regional_preview("timezone-set", "Etc/UTC", self.time_state(), ["UTC", "Etc/UTC"])
+        self.assertEqual(preview.fields()[:3], ("preview", "timezone-set", "Etc/UTC"))
+        self.assertEqual((preview.current, preview.target), ("UTC", "Etc/UTC"))
+        provider.require_regional_generation(preview, preview.generation)
+        for current, target in (("Etc/UTC", "Etc/UTC"), ("UTC", "UTC")):
+            changed = provider.make_regional_preview("timezone-set", target,
+                self.time_state(timezone=current), ["UTC", "Etc/UTC"])
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                provider.require_regional_generation(changed, preview.generation)
+            self.assertEqual(caught.exception.code, "conflict")
+        with self.assertRaises(provider.SnapshotFailure):
+            provider.make_regional_preview("timezone-set", "Etc/UTC", self.time_state(), ["UTC"])
+        same = provider.make_regional_preview("timezone-set", "Etc/UTC",
+            self.time_state(ntp_enabled=True), ["Etc/UTC", "UTC", "Europe/London"])
+        self.assertEqual(same.generation, preview.generation)
+
+    def test_ntp_generation_has_exact_framing_and_ignores_synchronization_samples(self):
+        preview = provider.make_regional_preview("ntp-set", "enabled", self.time_state())
+        framed = b"dwm-titus-regional-preview-v1"
+        for value in (b"ntp-set", b"enabled", b"yes", b"disabled"):
+            framed += len(value).to_bytes(8, "big") + value
+        self.assertEqual(preview.generation, hashlib.sha256(framed).hexdigest())
+        self.assertEqual(provider.make_regional_preview("ntp-set", "enabled",
+            self.time_state(ntp_synchronized=False)).generation, preview.generation)
+        self.assertNotEqual(provider.make_regional_preview("ntp-set", "enabled",
+            self.time_state(ntp_enabled=True)).generation, preview.generation)
+        with self.assertRaises(provider.SnapshotFailure) as caught:
+            provider.make_regional_preview("ntp-set", "enabled", self.time_state(can_ntp=False))
+        self.assertEqual(caught.exception.code, "unsupported")
+
+    def test_locale_generation_preserves_key_presence_order_and_complete_overrides(self):
+        assignments = ["LANG=C", "LANGUAGE=", "LC_TIME=de_DE.utf8", "LC_NUMERIC=fr_FR.utf8"]
+        before = provider.parse_locale_configuration(assignments)
+        preview = provider.make_regional_preview("locale-set", "LANG=en_US.utf8", before, ["C", "en_US.utf8"])
+        self.assertEqual((preview.current, preview.target, preview.detail),
+                         ("C", "en_US.utf8", "LC_NUMERIC=fr_FR.utf8, LC_TIME=de_DE.utf8"))
+        reordered = provider.make_regional_preview("locale-set", "LANG=en_US.utf8",
+            provider.parse_locale_configuration(list(reversed(assignments))), ["en_US.utf8", "C"])
+        self.assertEqual(preview, reordered)
+        for changed in ([item for item in assignments if item != "LANGUAGE="],
+                        [item.replace("LANGUAGE=", "LANGUAGE=en") for item in assignments],
+                        [item.replace("LC_TIME=de_DE.utf8", "LC_TIME=C") for item in assignments]):
+            other = provider.make_regional_preview("locale-set", "LANG=en_US.utf8",
+                provider.parse_locale_configuration(changed), ["C", "en_US.utf8"])
+            self.assertNotEqual(other.generation, preview.generation)
+        forged = replace(before, lang="forged", detail="forged")
+        self.assertEqual(provider.make_regional_preview("locale-set", "LANG=en_US.utf8",
+            forged, ["C", "en_US.utf8"]), preview)
+
+    def test_invalid_selections_and_states_are_rejected_before_io(self):
+        for action, argument in (("timezone-set", "../UTC"), ("ntp-set", "yes"),
+                                 ("locale-set", "LC_TIME=C"), ("locale-set", "LANG=C\n"),
+                                 ("arbitrary", "command")):
+            with mock.patch.object(provider, "RegionalRead") as reader, \
+                    mock.patch.object(provider, "read_locale_choices") as locales:
+                with self.assertRaises(provider.SnapshotFailure):
+                    provider.read_regional_preview(action, argument)
+                reader.assert_not_called()
+                locales.assert_not_called()
+        for state in (None, self.time_state(can_ntp=1), self.time_state(timezone="../UTC")):
+            with self.assertRaises(provider.SnapshotFailure):
+                provider.make_regional_preview("ntp-set", "enabled", state)
+        for value in (None, "", "A" * 64, "a" * 63, "a" * 65):
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                provider.require_regional_generation(
+                    provider.make_regional_preview("ntp-set", "enabled", self.time_state()), value)
+            self.assertEqual(caught.exception.code, "malformed")
+
+    def test_locale_generation_counts_utf8_bytes_in_each_length_prefix(self):
+        preview = provider.make_regional_preview("locale-set", "LANG=en_US.utf8",
+            provider.parse_locale_configuration(["LANGUAGE=français", "LANG=C"]), ["en_US.utf8"])
+        self.assertEqual(preview.generation, "09ff64d6ea53aa4d497cec2d722b95701f913c40576c7024dfdc6377e9b8fd83")
+
+    def test_preflight_uses_only_fresh_fixed_readers(self):
+        states = {"time-state": self.time_state(), "timezone-choices": ("UTC", "Etc/UTC"),
+                  "locale-state": provider.parse_locale_configuration(["LANG=C"])}
+        with mock.patch.object(provider, "RegionalRead", side_effect=lambda kind: mock.Mock(
+                run=mock.Mock(return_value=states[kind]))) as reader, \
+                mock.patch.object(provider, "read_locale_choices", return_value=("C", "en_US.utf8")) as locales, \
+                mock.patch.object(provider, "PackageKitBackend") as backend, \
+                mock.patch.object(provider, "open_journal_directory") as journal:
+            for _ in range(2):
+                provider.read_regional_preview("timezone-set", "Etc/UTC")
+                provider.read_regional_preview("ntp-set", "enabled")
+                provider.read_regional_preview("locale-set", "LANG=en_US.utf8")
+            self.assertEqual([call.args[0] for call in reader.call_args_list],
+                ["time-state", "timezone-choices", "time-state", "locale-state"] * 2)
+            self.assertEqual(locales.call_count, 2)
+            backend.assert_not_called()
+            journal.assert_not_called()
+
+    def test_choice_streams_are_sorted_complete_and_independently_versioned(self):
+        for kind in ("timezone", "locale"):
+            with mock.patch.object(provider, "regional_choices", return_value=("UTC", "C")):
+                output, code = provider.regional_preflight_output("regional-choices", [kind])
+            self.assertEqual(code, 0)
+            self.assertEqual(output.splitlines(), [f"regional-choices-protocol\t1\t0\t{kind}",
+                "choice\tC", "choice\tUTC", "complete\tregional-choices"])
+            self.assertLessEqual(len(output.encode()), provider.REGIONAL_CHOICE_STREAM_BYTES[kind])
+        self.assertEqual(provider.PROTOCOL_MINOR, 0)
+
+    def test_choice_catalog_limits_and_duplicates_are_rejected(self):
+        for values in (("C", "C"), ("bad\nlocale",), ("x" * 129,), tuple(f"x{i}" for i in range(4097))):
+            with self.assertRaises(provider.SnapshotFailure):
+                provider.validate_locale_catalog(values)
+        maximum = tuple(f"x{i}" for i in range(4096))
+        self.assertEqual(provider.validate_locale_catalog(maximum), maximum)
+        for kind, patch, value in (("locale", "read_locale_choices", ("C", "C")),
+                                   ("timezone", "RegionalRead", mock.Mock(run=mock.Mock(return_value=("UTC", "UTC"))))):
+            with mock.patch.object(provider, patch, return_value=value):
+                output, code = provider.regional_preflight_output("regional-choices", [kind])
+            self.assertEqual(code, 1)
+            self.assertIn("error\tregional\tmalformed\t", output)
+            self.assertNotIn("\nchoice\t", output)
+
+    def test_preview_stream_and_errors_never_publish_partial_evidence(self):
+        preview = provider.make_regional_preview("ntp-set", "enabled", self.time_state())
+        with mock.patch.object(provider, "read_regional_preview", return_value=preview):
+            output, code = provider.regional_preflight_output("regional-preview", ["ntp-set", "enabled"])
+        self.assertEqual((code, output.splitlines()), (0, ["regional-preview-protocol\t1\t0",
+            "\t".join(preview.fields()), "complete\tregional-preview"]))
+        for command, args, helper in (("regional-preview", ["ntp-set", "enabled"], "read_regional_preview"),
+                                     ("regional-choices", ["locale"], "regional_choices")):
+            for code in ("timeout", "permission-denied", "missing-provider", "malformed"):
+                with mock.patch.object(provider, helper, side_effect=provider.SnapshotFailure(code, "Fixture failure")):
+                    output, status = provider.regional_preflight_output(command, args)
+                self.assertEqual(status, 1)
+                self.assertEqual(len(output.splitlines()), 3)
+                self.assertEqual(output.splitlines()[1], f"error\tregional\t{code}\tFixture failure")
+                self.assertNotIn("\npreview\t", output)
+                self.assertNotIn("\nchoice\t", output)
+
+    def test_full_encoded_stream_limits_include_newlines(self):
+        preview = provider.make_regional_preview("ntp-set", "enabled", self.time_state())
+        with mock.patch.object(provider, "read_regional_preview", return_value=preview):
+            output, _ = provider.regional_preflight_output("regional-preview", ["ntp-set", "enabled"])
+            for limit, expected in ((len(output.encode()), 0), (len(output.encode()) - 1, 1)):
+                with mock.patch.object(provider, "REGIONAL_PREVIEW_STREAM_BYTES", limit):
+                    bounded, code = provider.regional_preflight_output("regional-preview", ["ntp-set", "enabled"])
+                self.assertEqual(code, expected)
+                if code:
+                    self.assertNotIn("\npreview\t", bounded)
+        with mock.patch.object(provider, "regional_choices", return_value=("UTC",)):
+            output, _ = provider.regional_preflight_output("regional-choices", ["timezone"])
+            for limit, expected in ((len(output.encode()), 0), (len(output.encode()) - 1, 1)):
+                with mock.patch.dict(provider.REGIONAL_CHOICE_STREAM_BYTES, timezone=limit):
+                    bounded, code = provider.regional_preflight_output("regional-choices", ["timezone"])
+                self.assertEqual(code, expected)
+                if code:
+                    self.assertNotIn("\nchoice\t", bounded)
+
+    def test_non_utf8_or_oversized_preview_fields_are_not_emitted(self):
+        preview = provider.make_regional_preview("ntp-set", "enabled", self.time_state())
+        for detail in ("x" * 513, "é" * 257, "bad\nfield", "bad\0field", "bad\ud800field", "bad\x1bfield", None):
+            with mock.patch.object(provider, "read_regional_preview", return_value=replace(preview, detail=detail)):
+                output, code = provider.regional_preflight_output("regional-preview", ["ntp-set", "enabled"])
+            self.assertEqual(code, 1)
+            self.assertNotIn("\npreview\t", output)
+        with mock.patch.object(provider, "read_regional_preview", side_effect=provider.SnapshotFailure(
+                "unrecognized\ncode", "bad\ud800\0detail")):
+            output, code = provider.regional_preflight_output("regional-preview", ["ntp-set", "enabled"])
+        self.assertEqual(code, 1)
+        self.assertEqual(output.splitlines()[1], "error\tregional\tinternal\tbad  detail")
+        output.encode("utf-8")
+
+    def test_closed_preflight_consumer_exits_without_traceback_or_shutdown_flush(self):
+        program = """
+import io, runpy, sys
+if int(sys.argv[2]) > 8192:
+    sys.stdout = io.TextIOWrapper(io.FileIO(sys.stdout.fileno(), "w", closefd=False),
+                                encoding="utf-8", write_through=True)
+main = runpy.run_path(sys.argv[1])["main"]
+main.__globals__["regional_preflight_output"] = lambda *_: ("x" * int(sys.argv[2]), 0)
+raise SystemExit(main(["regional-choices", "locale"]))
+"""
+        for size in (32, 65536):
+            with self.subTest(size=size):
+                read_fd, write_fd = os.pipe()
+                os.close(read_fd)
+                try:
+                    result = subprocess.run([sys.executable, "-c", program, str(PROVIDER_PATH), str(size)],
+                        stdin=subprocess.DEVNULL, stdout=write_fd, stderr=subprocess.PIPE, timeout=5)
+                finally:
+                    os.close(write_fd)
+                self.assertEqual(result.returncode, 1, result.stderr)
+                self.assertEqual(result.stderr, b"")
+
+    def test_cli_grammar_and_native_mutations_remain_disabled(self):
+        invalid = (["regional-choices"], ["regional-choices", "time"], ["regional-choices", "locale", "extra"],
+                   ["regional-preview"], ["regional-preview", "ntp-set"],
+                   ["regional-preview", "arbitrary", "value"], ["regional-preview", "ntp-set", "enabled", "extra"],
+                   ["timezone-set", "UTC", "a" * 64], ["ntp-set", "enabled", "a" * 64],
+                   ["locale-set", "LANG=C", "a" * 64])
+        with mock.patch.object(provider, "RegionalRead") as reader, \
+                mock.patch.object(provider, "read_locale_choices") as locales, \
+                mock.patch.object(provider, "PackageKitBackend") as backend, \
+                mock.patch.object(provider, "open_journal_directory") as journal, \
+                contextlib.redirect_stdout(io.StringIO()) as output, contextlib.redirect_stderr(io.StringIO()):
+            for args in invalid:
+                self.assertEqual(provider.main(args), 2, args)
+            self.assertEqual(output.getvalue(), "")
+            for mocked in (reader, locales, backend, journal):
+                mocked.assert_not_called()
+            for args in (["regional-preview", "timezone-set", "../UTC"],
+                         ["regional-preview", "ntp-set", "yes"],
+                         ["regional-preview", "locale-set", "LC_TIME=C"]):
+                output.seek(0)
+                output.truncate(0)
+                self.assertEqual(provider.main(args), 1, args)
+                self.assertEqual(len(output.getvalue().splitlines()), 3)
+                self.assertIn("error\tregional\tmalformed\t", output.getvalue())
+            for mocked in (reader, locales, backend, journal):
+                mocked.assert_not_called()
+        with mock.patch.object(provider, "regional_choices", return_value=("C",)), \
+                contextlib.redirect_stdout(io.StringIO()) as output:
+            self.assertEqual(provider.main(["regional-choices", "locale"]), 0)
+            self.assertIn("choice\tC\n", output.getvalue())
+
+
 class RepositoryReadTests(unittest.TestCase):
     def reader(self):
         _unused, connection, gio, glib, variant = RegionalReadTests.reader(self)


### PR DESCRIPTION
## Scope

A small Phase 6 preparation boundary for fresh regional confirmations. Adds only read-only `regional-choices timezone|locale` and fixed `regional-preview` commands. Native timezone, NTP, and locale mutations remain disabled; no Settings controls or cumulative snapshot-minor change is included.

- Bound complete catalog/preview streams, typed errors, exact identities, and UTF-8 fields before output.
- Bind the selected value to fresh current configuration using a deterministic generation; preserve the complete locale override set and key presence.
- Reuse the fixed bounded service/catalog readers without PackageKit discovery or journal access.
- Handle closed consumers without a traceback or shutdown-flush exit-status replacement.
- Document the preflight protocol, future generation check, and systemd's locale merge/simplification behavior.

## Validation

- `scripts/run-tests /usr/bin/python3 tests/test-system-management.py RegionalPreflightTests RegionalReadTests`: 29 tests passed.
- `scripts/run-tests make clean all && scripts/run-tests`: passed, including 418 provider tests (104.528 seconds), QML checks, native operation parser/owner/recovery fixtures, nested-X11 lifecycle, staged installation, repeated-install preservation, and release checks.
- Closed Settings CPU: 0.033%; closed large surfaces: 0.00%.
- `npm --prefix docs run build`: passed; 15 checked files, zero errors/warnings/hints, 11 pages built.
- Local CodeRabbit review: zero findings after fixing and regression-testing its closed-pipe finding.
- Required post-gate Codex review: no actionable findings.
- Final source/test tree is exactly the full-suite version; only a TASKS wording correction aligning platform authorization and adding the closed-consumer test note followed that run. Documentation build and both reviews were repeated after that wording correction.
- Managed test workspaces were removed.

Read-only Fedora 44 CLI probes passed: 598 timezone choices, 39 installed locale choices, and timezone UTC, NTP enabled, and LANG=C previews. These probes changed no system settings. Private-bus fixtures cover fixed read calls, denial, absence, malformed replies, deadlines, and late completion.

## Remaining work / limitations

This is not Phase 6 completion. Native operation ownership, platform authorization and verification, event-driven regional integration, delegated entry points, Settings integration, information/security/recovery surfaces, and combined installed-runtime qualification remain. A preflight generation is neither human authorization nor an atomic service transaction. No installed synchronization, logout, or reboot is performed by this PR.

Base: main after #248.