### PR TITLE
feat(system): retain native operation ownership leases

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -203,6 +203,13 @@ verification, and Settings confirmation integration are still required.
 Read-only Fedora 44 CLI probes passed for both catalogs and all three preview
 forms without changing system settings.
 
+An internal active-file lease now distinguishes a live native or delegated
+owner from an orphaned record. Recovery preserves live ownership without service
+inference, while owner exit leaves the existing interrupted recovery path intact.
+Focused tests cover competing descriptors, cleanup and path failures, and real
+process death. Native snapshot/watch integration, bounded service execution,
+and Settings actions remain disabled pending their next implementation boundary.
+
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit
 confirmation warning that a sent change cannot be canceled. Local cancellation

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -1300,6 +1300,21 @@ path, or elevation mechanism.
   long-running operation; descriptor checks remain mandatory because another
   same-user process can ignore advisory locks.
 
+  Regional and delegated-launch owners additionally retain an exclusive
+  `flock` lease on the existing `active` file. They admit the exact operation
+  and acquire this lease in the same short exclusive directory interval, before
+  dispatch. Lease acquisition and recovery probes are nonblocking; contention
+  never waits while holding the directory lock. The lease uses a separately
+  opened, validated, no-symlink, nonblocking, close-on-exec file description,
+  not `dup(active)`, so even a probe through the originating journal's retained
+  descriptor cannot release its own owner lock. The directory lock is then
+  released for bounded service work while the file lease remains held. Lease
+  release and descriptor closure run on every exit; process death also releases
+  the lease. A failed recovery probe preserves the active record as unresolved,
+  never as evidence that no owner exists. This adds no persistent path, journal
+  field, or authorization mechanism. A lease is liveness evidence only; it does
+  not authorize a new caller to repeat an existing operation.
+
   The absolute state path is opened component-by-component from a held root
   directory descriptor with directory-only, no-symlink semantics; a symlink or
   non-directory component fails closed. The provider retains each parent and
@@ -1604,7 +1619,7 @@ path, or elevation mechanism.
   full path chain, fixed files, and exact active operation identity, and only
   then commits recovered state. A mismatch discards the stale D-Bus result and
   changes no journal frame. No D-Bus method, signal wait, or bounded history
-  collection runs while either journal lock is held.
+  collection runs while a shared or exclusive directory lock is held.
 
   A negative bounded lookup is never evidence that PackageKit succeeded or
   failed. If exact adoption or the active transaction list confirms that the
@@ -1621,17 +1636,27 @@ path, or elevation mechanism.
   than describing the PackageKit transaction itself as failed. Recovery never
   expands to an unbounded history query. A regional operation recovers a
   terminal result only from a valid terminal journal record durably written
-  before interruption. Any nonterminal `timezone`, `ntp`, or `locale` record
-  encountered by snapshot recovery becomes `interrupted` regardless of the owning systemd
+  before interruption. Recovery first probes the exact nonterminal native
+  owner's file lease under the short directory lock. A held lease preserves
+  the validated active record without querying the service or writing a
+  terminal result. A nonterminal `timezone`, `ntp`, or `locale` record whose
+  lease is no longer held becomes `interrupted` regardless of the owning systemd
   service's current value, because the journal intentionally stores no target
   and current state cannot prove this operation caused it. Recovery publishes a
   fresh read-only regional snapshot and explains that the requested mutation's
   outcome is unknown; it never retries or audits it as successful. A delegated
   launch records its terminal `succeeded` result as soon as the trusted tool is
   accepted; the tool owns all later internal work. A nonterminal delegated
-  record encountered by snapshot recovery becomes `interrupted`, while a valid
+  record whose owner lease is no longer held becomes `interrupted`, while a valid
   durable terminal record replays its exact launch result. Settings never
   infers that the delegated tool's internal work succeeded.
+
+The internal native-owner lease and recovery guard are implemented independently
+of mutation commands. Tests cover all regional and delegated kinds, competing
+and originating descriptors, path replacement, lock and cleanup failures,
+normal process exit, abrupt process death, and durable terminal replay. Public
+native snapshot/watch integration and bounded service owners remain gated;
+this foundation enables no native command, Settings action, or snapshot minor.
 
 ## Event and Resource Contract
 

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -3673,6 +3673,83 @@ def load_writable_journal_state(journal: JournalDescriptorSet) -> JournalState:
     return state
 
 
+def _native_owner_descriptor(journal: JournalDescriptorSet, operation: JournalOperation) -> int:
+    _require_exclusive_journal(journal)
+    if (not isinstance(operation, JournalOperation)
+            or operation.kind not in {"timezone", "ntp", "locale", "delegate"}
+            or operation.state in JOURNAL_OPERATION_TERMINAL_STATES
+            or load_writable_journal_state(journal).active != operation):
+        raise JournalAdmissionError("native lease target is not the exact active operation")
+    return journal.descriptor("active")
+
+
+def _try_native_owner_lock(descriptor: int) -> bool:
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except OSError as error:
+        if error.errno in {errno.EACCES, errno.EAGAIN}:
+            return False
+        raise JournalLockError("native owner lease acquisition failed") from error
+
+
+def _unlock_native_owner(descriptor: int) -> None:
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+    except OSError as error:
+        raise JournalLockError("native owner lease release failed") from error
+
+
+@contextlib.contextmanager
+def retain_native_journal_owner(
+    journal: JournalDescriptorSet, operation: JournalOperation,
+) -> Iterator[None]:
+    """Enter beside admission under the directory lock; retain only a file lease.
+
+    Use an ExitStack to retain this context after the short directory interval
+    ends, and close it before closing the retained journal. This lease is local
+    operation liveness, not authorization or proof of a platform result.
+    """
+    _native_owner_descriptor(journal, operation)
+    try:
+        # A separate open file description is essential: flock on dup(active)
+        # would let a probe through active release the owner's own lock.
+        lease_descriptor = os.open("active",
+            os.O_RDWR | os.O_NONBLOCK | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=journal.chain.directory_descriptor)
+    except OSError as error:
+        raise JournalLockError("native owner lease descriptor open failed") from error
+    try:
+        _validate_journal_path_identity(journal.chain.directory_descriptor, "active",
+                                       lease_descriptor, JOURNAL_FILE_SIZE)
+        journal.validate()
+        if not _try_native_owner_lock(lease_descriptor):
+            journal.validate()
+            raise JournalAdmissionError("another live native owner holds the lease")
+        try:
+            journal.validate()
+            yield
+        finally:
+            _unlock_native_owner(lease_descriptor)
+    finally:
+        error = _close_descriptors((lease_descriptor,))
+        if error is not None:
+            raise JournalLockError("native owner lease descriptor close failed") from error
+
+
+def native_journal_owner_busy(journal: JournalDescriptorSet, operation: JournalOperation) -> bool:
+    """Probe nonblocking under the directory lock without releasing our own lease."""
+    descriptor = _native_owner_descriptor(journal, operation)
+    if not _try_native_owner_lock(descriptor):
+        journal.validate()
+        return True
+    try:
+        journal.validate()
+        return False
+    finally:
+        _unlock_native_owner(descriptor)
+
+
 def commit_writable_journal_path(
     journal: JournalDescriptorSet, name: str, payload: str
 ) -> tuple[int, JournalFrame]:
@@ -5079,6 +5156,9 @@ def recover_journal_active(
         if current.state in JOURNAL_OPERATION_TERMINAL_STATES:
             complete_journal_terminal(journal, boot_id=boot_id, session_started=session_started)
             return load_writable_journal_state(journal), None, None
+        if (current.kind not in {"update", "refresh"}
+                and native_journal_owner_busy(journal, current)):
+            return current_state, None, None
         if lookup_failure is not None and (lookup_failure.code == "malformed" or (
                 not history_used and (evidence is None or evidence.present))):
             return current_state, evidence, lookup_failure

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -11,6 +11,7 @@ import importlib.util
 import importlib.machinery
 import os
 import pathlib
+import select
 import signal
 import stat
 import subprocess
@@ -7064,6 +7065,278 @@ class SessionEvidenceTests(unittest.TestCase):
                 with self.assertRaises(provider.SnapshotFailure) as raised:
                     backend.session_started()
                 self.assertEqual(raised.exception.code, code)
+
+
+class NativeJournalOwnerTests(unittest.TestCase):
+    boot_id = JournalRetainedSessionTests.boot_id
+    session = JournalRetainedSessionTests.session
+
+    def begin(self, journal, action="timezone-set"):
+        return provider.begin_journal_operation(journal, action,
+            "2026-09-06T17:00:00Z", "Native ownership fixture")
+
+    @contextlib.contextmanager
+    def owner(self, journal, action="timezone-set"):
+        with contextlib.ExitStack() as retained:
+            with provider.lock_writable_journal(journal):
+                operation = self.begin(journal, action)
+                retained.enter_context(provider.retain_native_journal_owner(journal, operation))
+            yield operation
+
+    def recover(self, journal):
+        backend = mock.Mock()
+        result = provider.recover_journal_active(journal, backend, boot_id=self.boot_id)
+        self.assertEqual(backend.mock_calls, [])
+        return result
+
+    def test_every_native_kind_retains_live_state_without_backend_or_terminal_writes(self):
+        for action in ("timezone-set", "ntp-set", "locale-set", "accounts-open", "password-open",
+                       "printers-open", "sources-open"):
+            with self.subTest(action=action), self.session() as (path, chain, journal):
+                with self.owner(journal, action) as operation:
+                    before = {name: (path / name).read_bytes() for name in ("active", "cursor", "handoff")}
+                    # Required service work does not retain the directory lock.
+                    with provider._journal_lock(chain.directory_descriptor, exclusive=True):
+                        pass
+                    with provider.retain_writable_journal(chain) as observer:
+                        for _ in range(2):
+                            state, evidence, failure = self.recover(observer)
+                            self.assertEqual(state.active, operation)
+                            self.assertIsNone(state.handoff)
+                            self.assertTrue(all(item is None for item in state.terminals))
+                            self.assertIsNone(evidence)
+                            self.assertIsNone(failure)
+                    self.assertEqual(before,
+                        {name: (path / name).read_bytes() for name in before})
+                state, _, _ = self.recover(journal)
+                self.assertIsNone(state.active)
+                self.assertEqual(state.terminals[operation.slot].state, "interrupted")
+                self.assertEqual(state.handoff.operation_id, operation.operation_id)
+
+    def test_same_descriptor_set_probe_and_recovery_cannot_release_its_owner(self):
+        with self.session() as (_path, chain, journal), self.owner(journal) as operation:
+            for state_name in ("pending", "authorizing", "running"):
+                with provider.lock_writable_journal(journal):
+                    if operation.state != state_name:
+                        operation = provider.advance_journal_operation(journal, operation,
+                            replace(operation, state=state_name))
+                    self.assertTrue(provider.native_journal_owner_busy(journal, operation))
+                    with self.assertRaises(provider.JournalAdmissionError):
+                        with provider.retain_native_journal_owner(journal, operation):
+                            self.fail("nested owner stole the lease")
+                self.assertEqual(self.recover(journal)[0].active, operation)
+                with provider.retain_writable_journal(chain) as observer:
+                    with provider.lock_writable_journal(observer):
+                        self.assertTrue(provider.native_journal_owner_busy(observer, operation))
+                        with self.assertRaises(provider.JournalAdmissionError):
+                            with provider.retain_native_journal_owner(observer, operation):
+                                self.fail("a second descriptor set stole the lease")
+
+    def test_unlocked_stale_wrong_kind_and_terminal_targets_are_rejected(self):
+        with self.session() as (_path, _chain, journal):
+            with provider.lock_writable_journal(journal):
+                operation = self.begin(journal)
+            for function in (provider.native_journal_owner_busy, provider.retain_native_journal_owner):
+                with self.assertRaises(provider.JournalLockError):
+                    if function is provider.native_journal_owner_busy:
+                        function(journal, operation)
+                    else:
+                        with function(journal, operation):
+                            self.fail("unlocked lease was acquired")
+            with provider.lock_writable_journal(journal):
+                for invalid in (None, replace(operation, operation_id="op-" + "f" * 32),
+                                replace(operation, kind="update"), replace(operation, state="failed")):
+                    with self.assertRaises(provider.JournalAdmissionError):
+                        provider.native_journal_owner_busy(journal, invalid)
+                    with self.assertRaises(provider.JournalAdmissionError):
+                        with provider.retain_native_journal_owner(journal, invalid):
+                            self.fail("invalid lease was acquired")
+                self.assertFalse(provider.native_journal_owner_busy(journal, operation))
+            self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
+
+    def test_body_and_unlock_failures_release_the_independent_lease_descriptor(self):
+        original_close = provider._close_descriptors
+        def close_failure(descriptors):
+            return original_close(descriptors) or OSError("close fixture")
+        for failure in ("body", "unlock", "close"):
+            with self.subTest(failure=failure), self.session() as (_path, _chain, journal):
+                if failure == "unlock":
+                    patch = mock.patch.object(provider, "_unlock_native_owner",
+                        side_effect=provider.JournalLockError("unlock fixture"))
+                elif failure == "close":
+                    patch = mock.patch.object(provider, "_close_descriptors", side_effect=close_failure)
+                else:
+                    patch = contextlib.nullcontext()
+                with self.assertRaisesRegex(RuntimeError if failure == "body" else provider.JournalLockError,
+                                            "fixture" if failure != "close" else "descriptor close failed"):
+                    with patch:
+                        with self.owner(journal) as operation:
+                            if failure == "body":
+                                raise RuntimeError("body fixture")
+                # The dedicated file description must be closed even when
+                # the explicit unlock failed, leaving no inherited lease.
+                with provider.lock_writable_journal(journal):
+                    self.assertFalse(provider.native_journal_owner_busy(journal, operation))
+
+    def test_kernel_lock_errors_are_explicit_and_do_not_clear_the_active_record(self):
+        with self.session() as (path, _chain, journal):
+            with provider.lock_writable_journal(journal):
+                operation = self.begin(journal)
+                before = (path / "active").read_bytes()
+                for number, expected in ((errno.EAGAIN, True), (errno.EACCES, True)):
+                    with mock.patch.object(provider.fcntl, "flock", side_effect=OSError(number, "fixture")):
+                        self.assertEqual(provider.native_journal_owner_busy(journal, operation), expected)
+                with mock.patch.object(provider.fcntl, "flock", side_effect=OSError(errno.EIO, "fixture")):
+                    with self.assertRaises(provider.JournalLockError):
+                        provider.native_journal_owner_busy(journal, operation)
+                self.assertEqual((path / "active").read_bytes(), before)
+
+    def test_lease_handle_is_separate_nonblocking_close_on_exec_and_closed_on_failure(self):
+        for fail in (False, True):
+            with self.subTest(fail=fail), self.session() as (_path, chain, journal):
+                captured = []
+                original_open = os.open
+                def opened(name, flags, *args, **kwargs):
+                    descriptor = original_open(name, flags, *args, **kwargs)
+                    if name == "active" and kwargs.get("dir_fd") == chain.directory_descriptor:
+                        captured.append(descriptor)
+                        self.assertNotEqual(descriptor, journal.descriptor("active"))
+                        self.assertTrue(flags & os.O_NOFOLLOW)
+                        self.assertTrue(flags & os.O_NONBLOCK)
+                        self.assertTrue(flags & os.O_CLOEXEC)
+                        self.assertFalse(os.get_inheritable(descriptor))
+                    return descriptor
+                with provider.lock_writable_journal(journal):
+                    operation = self.begin(journal)
+                    with mock.patch.object(provider.os, "open", side_effect=opened):
+                        if fail:
+                            with mock.patch.object(provider, "_try_native_owner_lock",
+                                    side_effect=provider.JournalLockError("fixture")):
+                                with self.assertRaises(provider.JournalLockError):
+                                    with provider.retain_native_journal_owner(journal, operation):
+                                        self.fail("failed acquisition was accepted")
+                        else:
+                            with provider.retain_native_journal_owner(journal, operation):
+                                self.assertTrue(provider.native_journal_owner_busy(journal, operation))
+                    self.assertEqual(len(captured), 1)
+                    with self.assertRaises(OSError):
+                        os.fstat(captured[0])
+                    self.assertFalse(provider.native_journal_owner_busy(journal, operation))
+
+    def test_open_failure_is_explicit_and_preserves_active_state(self):
+        with self.session() as (path, _chain, journal):
+            with provider.lock_writable_journal(journal):
+                operation = self.begin(journal)
+                before = (path / "active").read_bytes()
+                with mock.patch.object(provider.os, "open", side_effect=OSError(errno.EACCES, "fixture")):
+                    with self.assertRaises(provider.JournalLockError):
+                        with provider.retain_native_journal_owner(journal, operation):
+                            self.fail("failed open was accepted")
+                self.assertEqual((path / "active").read_bytes(), before)
+                self.assertFalse(provider.native_journal_owner_busy(journal, operation))
+
+    def test_replaced_path_during_lease_open_is_rejected_and_handle_closed(self):
+        captured = []
+        with self.assertRaises(provider.JournalLayoutError):
+            with self.session() as (path, chain, journal):
+                with provider.lock_writable_journal(journal):
+                    operation = self.begin(journal)
+                    original_open = os.open
+                    def replaced(name, flags, *args, **kwargs):
+                        descriptor = original_open(name, flags, *args, **kwargs)
+                        if name == "active" and kwargs.get("dir_fd") == chain.directory_descriptor:
+                            captured.append(descriptor)
+                            active = path / "active"
+                            content = active.read_bytes()
+                            active.rename(path / "detached-active")
+                            active.write_bytes(content)
+                            active.chmod(0o600)
+                        return descriptor
+                    with mock.patch.object(provider.os, "open", side_effect=replaced):
+                        with provider.retain_native_journal_owner(journal, operation):
+                            self.fail("replaced lease path was accepted")
+        self.assertEqual(len(captured), 1)
+        with self.assertRaises(OSError):
+            os.fstat(captured[0])
+
+    def test_replaced_directory_during_owned_interval_is_rejected_before_recovery(self):
+        with self.assertRaises(provider.JournalLayoutError):
+            with self.session() as (path, _chain, journal), self.owner(journal):
+                before = (path / "active").read_bytes()
+                detached = path.with_name("detached-journal")
+                path.rename(detached)
+                path.mkdir(mode=0o700)
+                try:
+                    self.recover(journal)
+                    self.fail("detached journal was recovered")
+                finally:
+                    self.assertEqual((detached / "active").read_bytes(), before)
+
+    def test_recovery_probe_error_never_terminalizes_an_unknown_owner(self):
+        with self.session() as (path, _chain, journal):
+            with provider.lock_writable_journal(journal):
+                operation = self.begin(journal)
+            before = (path / "active").read_bytes()
+            backend = mock.Mock()
+            with mock.patch.object(provider, "_try_native_owner_lock",
+                    side_effect=provider.JournalLockError("probe fixture")):
+                with self.assertRaises(provider.JournalLockError):
+                    provider.recover_journal_active(journal, backend, boot_id=self.boot_id)
+            self.assertEqual(backend.mock_calls, [])
+            self.assertEqual((path / "active").read_bytes(), before)
+            self.assertEqual(provider.load_journal_state(journal.chain).active, operation)
+
+    def test_durable_terminal_recovery_does_not_wait_for_live_owner_release(self):
+        with self.session() as (_path, chain, journal), self.owner(journal) as operation:
+            with provider.lock_writable_journal(journal):
+                operation = provider.advance_journal_operation(journal, operation,
+                    replace(operation, state="running"))
+                terminal = provider.advance_journal_operation(journal, operation,
+                    replace(operation, state="succeeded", finished_at="2026-09-06T17:01:00Z"))
+            with provider.retain_writable_journal(chain) as observer:
+                state, evidence, failure = self.recover(observer)
+            self.assertIsNone(state.active)
+            self.assertEqual(state.terminals[operation.slot], terminal)
+            self.assertEqual(state.handoff.operation_id, operation.operation_id)
+            self.assertIsNone(evidence)
+            self.assertIsNone(failure)
+
+    def test_process_exit_and_sigkill_release_ownership_before_orphan_recovery(self):
+        program = """
+import contextlib, runpy, sys
+p = runpy.run_path(sys.argv[1])
+with p["open_journal_directory_chain"](sys.argv[2]) as chain:
+    with p["retain_writable_journal"](chain) as journal, contextlib.ExitStack() as owner:
+        with p["lock_writable_journal"](journal):
+            operation = p["load_writable_journal_state"](journal).active
+            owner.enter_context(p["retain_native_journal_owner"](journal, operation))
+        print("ready", flush=True)
+        sys.stdin.buffer.read(1)
+"""
+        for killed in (False, True):
+            with self.subTest(killed=killed), self.session() as (_path, chain, journal):
+                with provider.lock_writable_journal(journal):
+                    operation = self.begin(journal)
+                child = subprocess.Popen([sys.executable, "-c", program, str(PROVIDER_PATH), chain.path],
+                    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+                try:
+                    self.assertTrue(select.select([child.stdout], [], [], 3)[0], "owner did not become ready")
+                    self.assertEqual(child.stdout.readline(16), b"ready\n")
+                    self.assertEqual(self.recover(journal)[0].active, operation)
+                    if killed:
+                        child.kill()
+                    _stdout, stderr = child.communicate(input=None if killed else b"x", timeout=3)
+                    self.assertEqual(child.returncode, -signal.SIGKILL if killed else 0, stderr)
+                    self.assertEqual(stderr, b"")
+                finally:
+                    if child.poll() is None:
+                        child.kill()
+                    child.communicate(timeout=3)
+                state, evidence, failure = self.recover(journal)
+                self.assertIsNone(state.active)
+                self.assertIsNone(evidence)
+                self.assertIsNone(failure)
+                self.assertEqual(state.terminals[operation.slot].state, "interrupted")
 
 
 class OperationRecoveryTests(unittest.TestCase):


### PR DESCRIPTION
## Scope

Add the internal native-operation ownership lease needed before regional changes and delegated launches can run safely. A separate, validated active-file description holds a nonblocking flock lease across bounded owner work. Recovery preserves a live owner and only interrupts an orphan; lease errors never prove an owner is absent.

This is one preparatory Phase 6 boundary. Native commands, public native snapshot/watch support, Settings actions, and the protocol minor remain gated. Phase 6 is not complete.

## Validation

- Focused ownership/recovery/snapshot tests: 54 passed.
- Managed clean build and full suite: passed, including 430 provider tests, nested-X11 operation/lifecycle checks, staged installation, and repeat-install preservation.
- Settings closed CPU: 0.100%; large surfaces: 0.00%.
- Documentation build: 15 files, zero diagnostics, 11 pages.
- CodeRabbit local review and post-suite Codex review: no actionable findings.
- Real Linux process tests prove normal exit and SIGKILL release the independent lease; descriptor, lock, path-replacement, cleanup, and durable-terminal cases are covered.

No host settings were mutated. Actual native D-Bus execution and public native watch qualification belong to subsequent PRs. No installed synchronization, logout, reboot, or Phase 7 work is included.