### PR TITLE
feat(system): observe native operation journal lifecycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ versions from `config.mk`.
 - Restore exact regional and delegated operation observers from validated
   journal snapshots. Watch durable progress and owner exit without repeating
   the action; stalled or closed control-output consumers preserve recovery.
+  Isolate operation and update-event writers from inherited file-status flags,
+  preserving concurrent parent output and behavior after forced termination.
   Native mutation commands and Settings action entry points remain disabled.
 
 - Preserve appearance inventory streams when a producer exits before the parent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ versions from `config.mk`.
 
 ### Changed
 
+- Restore exact regional and delegated operation observers from validated
+  journal snapshots. Watch durable progress and owner exit without repeating
+  the action; stalled or closed control-output consumers preserve recovery.
+  Native mutation commands and Settings action entry points remain disabled.
+
 - Preserve appearance inventory streams when a producer exits before the parent
   captures its identity. Keep buffered output and failure status instead of
   crashing the asset watcher and leaving wallpaper preview state stale.

--- a/TASKS.md
+++ b/TASKS.md
@@ -207,8 +207,13 @@ An internal active-file lease now distinguishes a live native or delegated
 owner from an orphaned record. Recovery preserves live ownership without service
 inference, while owner exit leaves the existing interrupted recovery path intact.
 Focused tests cover competing descriptors, cleanup and path failures, and real
-process death. Native snapshot/watch integration, bounded service execution,
-and Settings actions remain disabled pending their next implementation boundary.
+process death. Exact-ID native watches now observe durable checkpoints through
+inode events without reopening a service, reissuing an action, or canceling an
+owner. A fixed observation budget ends with a fresh lease check, including the
+close-before-unlock race. Snapshots retain native identities, and Settings can
+restore their observer and acknowledge verified results. Control output fails
+boundedly on full or closed pipes while preserving active ownership and handoffs.
+Bounded service execution and originating Settings actions remain disabled.
 
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit

--- a/TASKS.md
+++ b/TASKS.md
@@ -213,6 +213,9 @@ owner. A fixed observation budget ends with a fresh lease check, including the
 close-before-unlock race. Snapshots retain native identities, and Settings can
 restore their observer and acknowledge verified results. Control output fails
 boundedly on full or closed pipes while preserving active ownership and handoffs.
+Operation and update-event writers never change inherited file-status flags;
+private stream handles and per-call socket writes preserve concurrent parent
+output, including after forced watcher termination.
 Bounded service execution and originating Settings actions remain disabled.
 
 The user approved the narrow regional cancellation exception on 2026-09-06.

--- a/config/quickshell/systemmanagement/SystemManagementModel.qml
+++ b/config/quickshell/systemmanagement/SystemManagementModel.qml
@@ -456,11 +456,12 @@ Scope {
                     break;
                 }
                 if (!root.fieldsFit(fields, 8) || !root.validOperationId(fields[1])
-                        || root.updateActionKind(fields[2]).length === 0
-                        || root.updateActionKind(fields[2]) !== fields[3]
+                        || root.operationActionKind(fields[2]).length === 0
+                        || root.operationActionKind(fields[2]) !== fields[3]
                         || !root.validOperationState(fields[4])
                         || !root.validPercent(fields[5])
-                        || (fields[6] !== "yes" && fields[6] !== "no")) {
+                        || (fields[6] !== "yes" && fields[6] !== "no")
+                        || (root.updateActionKind(fields[2]).length === 0 && fields[6] !== "no")) {
                     fatal = "System management provider returned an invalid active operation";
                     break;
                 }

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -193,16 +193,17 @@ idempotent recovery sequence for any terminalized active payload, including its
 terminal-slot, cursor, handoff, and empty-active commits. A terminalized update
 also completes its restart-record commit; no other operation kind reads or
 writes that record. The command then requires that
-the ID match either the current validated nonterminal PackageKit refresh or
-update payload or, when the active payload is empty, exactly one validated
+the ID match either the current validated nonterminal operation
+payload or, when the active payload is empty, exactly one validated
 terminal record with that ID among the 32 fixed ring slots. Operation IDs are
 collision-checked against every retained slot when created, so more than one
 matching slot is malformed recovery state. The matching terminal record is
 accepted regardless of its position relative to the cursor, but only when its
 validated kind is any operation kind in the closed protocol enum. Active
-adoption remains limited to PackageKit `refresh` and `update`; a retained
-regional or delegated terminal record is replay-only and opens no service or
-program. The command uses only the transaction path bound inside a matching
+service adoption remains limited to PackageKit `refresh` and `update`. Native
+and delegated owners are observed through their journal lease and checkpoints,
+never by reopening a service or program. A retained terminal record is replay-only.
+The command uses only the transaction path bound inside a matching
 active PackageKit record. It may
 recover or replay bounded terminal evidence when the exact transaction finished
 after the snapshot, but never accepts an arbitrary transaction path, an
@@ -214,10 +215,39 @@ only the fixed diagnostic `watch target is unavailable` to standard error. The
 root model maps that status to `conflict` and immediately requests a fresh
 snapshot as the next recovery attempt.
 
-`watch-operation` adopts a nonterminal operation only for PackageKit `refresh`
-and `update`. Regional and delegated operations remain owned by their finite
-originating stream while active, but an exact retained terminal record for any
-valid kind can be replayed without reissuing its external action.
+For regional and delegated operations, `watch-operation` establishes an inotify
+watch on the retained `active` inode before its first recovery read. One bounded
+event batch triggers one exact-ID journal recheck; unchanged progress is coalesced.
+The originating process retains the lease and owns all service work. The observer
+never invokes a service, infers a target from current settings, requests native
+cancellation, or repeats an action. Lost/overflowed notifications and changed
+file or operation identities fail observation without claiming a terminal result.
+Recovery compares the original ID and every immutable action field before any
+service access or journal write, including a same-ID replacement or terminal.
+Every journal access still validates the complete retained path chain.
+
+Native observation has a fixed 120-second event-wait budget, followed by one
+final fresh recovery read through the existing bounded journal-lock intervals.
+Events never extend that deadline. The final read matters because Linux can
+deliver a close notification before releasing its file lock; a dying owner
+must not strand a watcher awaiting another event. If ownership is then free,
+normal orphan recovery records `interrupted`; a still-held lease instead ends
+only observation with timeout guidance and leaves the active owner intact.
+There is no recurring idle poller, auxiliary waiter process, or service lookup.
+Closing the observer releases its event descriptor and all associated watches.
+An exact durable terminal record for any valid kind replays without reissuing
+its external action.
+
+Operation controls write fixed formatter bundles directly through nonblocking
+stdout. Each bundle fits Linux `PIPE_BUF`; a full pipe or short write fails the
+observer without a backlog or a shutdown-buffer retry. Failure diagnostics are
+nonblocking and best-effort, including when stderr shares the full output pipe.
+Both original descriptor modes are captured before either changes and restored
+on normal, error, and handled TERM/INT/HUP exits, preserving writers retained
+by the calling shell. The previous signal handlers are restored too; forced
+SIGKILL cannot run userspace cleanup. Control exit status
+remains authoritative when diagnostics cannot be delivered. Output failure does
+not cancel the operation owner or acknowledge its handoff.
 The public cancel control pins PackageKit's unique D-Bus peer and uses one
 ten-second aggregate deadline for owner lookup, exact-object validation, and
 the `Cancel` request. It checks the transaction's exact role and invoking UID,
@@ -855,18 +885,20 @@ The initial vocabulary is closed for known record fields:
   operation record must use `cancelable=no`. Audit result uses only the
   terminal operation states.
 - An `active-operation` row is snapshot-only and has the same closed fields as
-  an operation row. It represents the one validated nonterminal PackageKit
-  `refresh` or `update` journal record after recovery. Its ID must have the
+  an operation row. It represents the one validated nonterminal
+  journal record after recovery. Its ID must have the
   required `op-` shape, its action and kind must match the fixed mapping, and
   its state must be nonterminal. A snapshot contains at most one such row. The
-  row is omitted when no PackageKit operation remains active; it is never
+  row is omitted when no operation remains active; it is never
   synthesized from an unsafe or malformed journal record. `cancelable=yes` is
   emitted only while the exact adopted transaction reports `AllowCancel=true`.
   This bounded row lets the root model restore the visible operation identity
-  and pass that exact ID to `updates-cancel` after Settings or the provider
-  restarts. Regional and delegated work remains visible through its originating
-  operation stream and the kind-specific recovery rules below, never through an
-  `active-operation` row.
+  and pass that exact ID to `watch-operation` after Settings or the provider
+  restarts. Only PackageKit actions may advertise cancellation or use
+  `updates-cancel`. Regional and delegated rows always use `cancelable=no`;
+  their live lease and durable checkpoints, not service-value inference, govern
+  recovery. The 1.0 snapshot can identify these existing journal owners without
+  advertising native mutation actions or advancing the cumulative minor.
 - A `terminal-handoff` row is snapshot-only and identifies exactly one durable
   terminal result not yet acknowledged by the root model. Its ID, action, and
   kind must exactly match the validated terminal slot named by the handoff
@@ -980,8 +1012,8 @@ or authorizes handoff acknowledgment. This parser does not start processes,
 own a journal, or enable Settings mutation controls.
 The minor's active-ID table governs snapshot capability advertisement, not the
 closed journal action-to-kind mapping: as specified for `watch-operation`, a
-1.0 stream can replay an exact retained regional or delegated result without
-advertising or invoking that action.
+1.0 stream can observe an exact regional or delegated journal owner and replay
+its retained result without advertising or invoking that action.
 
 Allowed operation transitions are:
 
@@ -1655,8 +1687,9 @@ The internal native-owner lease and recovery guard are implemented independently
 of mutation commands. Tests cover all regional and delegated kinds, competing
 and originating descriptors, path replacement, lock and cleanup failures,
 normal process exit, abrupt process death, and durable terminal replay. Public
-native snapshot/watch integration and bounded service owners remain gated;
-this foundation enables no native command, Settings action, or snapshot minor.
+native snapshot/watch integration now observes these owners without taking over
+service work. Bounded service origins remain gated; this enables no native
+mutation command, Settings action, or snapshot minor.
 
 ## Event and Resource Contract
 

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -238,14 +238,20 @@ Closing the observer releases its event descriptor and all associated watches.
 An exact durable terminal record for any valid kind replays without reissuing
 its external action.
 
-Operation controls write fixed formatter bundles directly through nonblocking
-stdout. Each bundle fits Linux `PIPE_BUF`; a full pipe or short write fails the
+Operation controls write fixed formatter bundles through isolated stream
+writers. Each bundle fits Linux `PIPE_BUF`; a full pipe or short write fails the
 observer without a backlog or a shutdown-buffer retry. Failure diagnostics are
 nonblocking and best-effort, including when stderr shares the full output pipe.
-Both original descriptor modes are captured before either changes and restored
-on normal, error, and handled TERM/INT/HUP exits, preserving writers retained
-by the calling shell. The previous signal handlers are restored too; forced
-SIGKILL cannot run userspace cleanup. Control exit status
+Pipes and character devices are reopened through their retained `/proc/self/fd`
+identity with nonblocking, close-on-exec, and no-controlling-terminal flags.
+These handles have independent open-file descriptions, not `dup`-shared flags;
+packet pipes retain packet mode. Sockets use per-call `MSG_DONTWAIT` output.
+Inherited file-status flags never change, including during observation and after
+forced SIGKILL, so concurrent parent writers retain their behavior. Regular-file
+output retains its shared offset and append semantics; bounded record sizes do
+not impose a hard storage-I/O deadline. Private handles close on normal/error
+exit and handled TERM/INT/HUP, with prior signal handlers restored; the kernel
+closes them after SIGKILL too. Control exit status
 remains authoritative when diagnostics cannot be delivered. Output failure does
 not cancel the operation owner or acknowledge its handoff.
 The public cancel control pins PackageKit's unique D-Bus peer and uses one
@@ -1718,11 +1724,11 @@ Writes are nonblocking and each fixed row fits `PIPE_BUF`; a full output pipe
 or short write stops monitoring with the same failure instead of queuing events
 or blocking signal handling. Consumers must treat any unexpected exit as lost
 monitoring and invalidate their preview. There is no userspace output backlog.
-The command restores stdout's original blocking mode on exit, preserving a
-writer retained by a calling shell group. Failure diagnostics are nonblocking
-and best-effort too, including when stderr shares a full stdout pipe; their
-original descriptor mode is restored. Exit status is authoritative when the
-diagnostic cannot be delivered.
+The command uses the same isolated output strategy as operation controls,
+without changing inherited file-status flags while live or on exit. Failure
+diagnostics are nonblocking and best-effort too, including when stderr shares
+a full stdout pipe. Exit status is authoritative when the diagnostic cannot be
+delivered.
 SIGTERM, SIGINT, or SIGHUP stop the subscriptions and exit 0. A missing PackageKit
 owner does not prevent readiness: the monitor waits for owner changes without
 activating the service, while finite discovery reports availability separately.

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -1166,31 +1166,33 @@ path, or elevation mechanism.
   PackageKit transaction nor the root-scoped `watch-operation` process. While a
   regional or delegated originating stream is nonterminal, the root model
   defers finite snapshot requests until that stream terminates; event-driven
-  read-state refreshes remain coalesced. Thus snapshot recovery terminalizes a
-  stranded non-PackageKit journal record under the kind-specific rules below
-  before producing output and never emits it as `active-operation`. Under the
-  same exclusive-lock path, it also completes any terminalized PackageKit
-  active payload before selecting snapshot records. This is journal-only
-  completion of an already durable result; it performs no PackageKit lookup,
-  history query, or signal wait while holding the lock. An incomplete recovery
-  is a recovery error, never a nonterminal row. A
-  finite `snapshot` always ends at `complete<TAB>snapshot`; when it contains an
-  `active-operation`, its kind is necessarily PackageKit `refresh` or `update`.
+  read-state refreshes remain coalesced. Snapshot recovery distinguishes a live
+  native owner from an orphan through its exact file lease. A held lease
+  preserves the validated regional or delegated record as `active-operation`;
+  an unheld lease permits conservative interrupted recovery under the
+  kind-specific rules below. Under the short exclusive-lock path, recovery also
+  completes any already terminalized active payload before selecting snapshot
+  records. This is journal-only completion of an already durable result; it
+  performs no service lookup, history query, or signal wait while holding the
+  lock. Recovery errors never synthesize a row from unsafe or malformed state.
+  A finite `snapshot` always ends at `complete<TAB>snapshot`; its optional
+  `active-operation` can have any supported closed operation kind.
   The root model first compares its ID with the one live provider stream it
-  already owns. A matching originating refresh or install stream remains the
+  already owns. A matching live operation stream remains the
   sole observer and no watcher is started. Otherwise the root model immediately
   starts exactly one
   `dwm-system-management watch-operation OPERATION_ID` process, and records it
   as that operation's sole live stream before accepting another snapshot. That
   process revalidates one of the two permitted journal identities above. For a
-  nonterminal record it adopts only its exact PackageKit object, emits `pending`,
-  then `authorizing` when the adopted transaction is known to have reached
-  authorization. It emits `running` only after the journal or adopted
-  transaction proves that state was reached, followed when applicable by
-  `cancel-requested`. Thus an authorization still in progress remains in
-  `authorizing` and may terminate directly as `permission-denied`. It emits each
-  known reached lifecycle state once and remains subscribed until it emits the
-  terminal operation, audit, and `complete<TAB>operation` records.
+  nonterminal PackageKit record it adopts only its exact recorded object. For a
+  native record it observes only the retained inode and durable checkpoints,
+  with the bounded event wait and final lease probe described above. Both paths
+  emit `pending` and subsequently observed lifecycle states only when supported
+  by the journal or, for PackageKit, exact adopted transaction evidence. An
+  observed authorization remains `authorizing` and may terminate directly as
+  `permission-denied`; only PackageKit offers cancellation. A verified durable
+  result emits the terminal operation, audit, and `complete<TAB>operation`
+  records. Lost or expired observation retains recovery guidance, not success.
 
   When a snapshot instead contains `terminal-handoff`, the root model first
   compares it with the one validated terminal stream it already owns. An exact

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -1951,9 +1951,10 @@ and proves a possibly running `Finished` yields the conservative unknown tuple
 without clearing seeded lower-scope contributions, while a provably pre-running
 denial or cancellation remains all-clear. A
 previous-boot adoption and history fixture proves every result remains all-clear.
-Watch fixtures reject active regional or delegated operation IDs with status 3
-and no stream, but replay their exact retained terminal records without
-reissuing an action. They prove that a requested PackageKit terminal record
+Watch fixtures reject stale active IDs with status 3 and no stream. Exact
+regional and delegated IDs observe durable checkpoints through completion, or
+replay their retained terminal records, without reissuing an action. They prove
+that a requested PackageKit terminal record
 replays by its exact retained ID even when one or more newer terminal slots
 exist, while a missing ID, duplicate retained ID, malformed slot, or unrelated
 transaction path fails closed. A root-restart fixture terminates after `active`

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -15,6 +15,7 @@ import re
 import selectors
 import shlex
 import signal
+import socket
 import stat
 import struct
 import subprocess
@@ -6799,57 +6800,79 @@ def cancel_journal_operation(journal: JournalDescriptorSet, operation_id: str, *
                 detail="Cancellation requested; waiting for PackageKit completion"))
 
 
+def control_output_writer(output, resources: contextlib.ExitStack) -> Callable[[bytes], int] | None:
+    """Never set file-status flags on an inherited open-file description."""
+    try:
+        descriptor = output.fileno()
+    except io.UnsupportedOperation:
+        return None  # In-memory test consumers have no kernel writer.
+    original = os.fstat(descriptor)
+    flags = fcntl.fcntl(descriptor, fcntl.F_GETFL)
+    if (flags & os.O_ACCMODE) not in (os.O_WRONLY, os.O_RDWR):
+        raise OSError("Operation output is not writable")
+    if stat.S_ISFIFO(original.st_mode) or stat.S_ISCHR(original.st_mode):
+        # dup would still share O_NONBLOCK with the parent. Opening the retained
+        # proc descriptor gives pipes/terminals a separate open-file description.
+        descriptor = os.open(f"/proc/self/fd/{descriptor}",
+            os.O_WRONLY | os.O_NONBLOCK | os.O_CLOEXEC | os.O_NOCTTY)
+        resources.callback(os.close, descriptor)
+        if stat.S_ISFIFO(original.st_mode) and flags & os.O_DIRECT:
+            # Packet mode is set after opening a pipe, on this private OFD only.
+            fcntl.fcntl(descriptor, fcntl.F_SETFL, fcntl.fcntl(descriptor, fcntl.F_GETFL) | os.O_DIRECT)
+        current = os.fstat(descriptor)
+        identity = lambda value: (value.st_dev, value.st_ino, value.st_mode, value.st_rdev)
+        if identity(current) != identity(original):
+            raise OSError("Operation output identity changed")
+    elif stat.S_ISSOCK(original.st_mode):
+        # Sockets cannot be reopened through proc. MSG_DONTWAIT is per-call,
+        # unlike O_NONBLOCK, and does not affect another holder of this socket.
+        libc = ctypes.CDLL(None, use_errno=True)
+        libc.send.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_size_t, ctypes.c_int]
+        libc.send.restype = ctypes.c_ssize_t
+
+        def send(payload):
+            count = libc.send(descriptor, payload, len(payload), socket.MSG_DONTWAIT | socket.MSG_NOSIGNAL)
+            if count < 0:
+                raise OSError(ctypes.get_errno(), "Operation socket output failed")
+            return count
+
+        return send
+    elif not stat.S_ISREG(original.st_mode):
+        raise OSError("Unsupported operation output type")
+    # Regular files retain their original shared offset and append semantics.
+    # O_NONBLOCK cannot impose a storage-I/O deadline on a regular file.
+    return lambda payload: os.write(descriptor, payload)
+
+
 @contextlib.contextmanager
-def control_output_descriptors() -> Iterator[tuple[int | None, int | None]]:
-    """Bound control output without changing a calling shell's retained writers."""
-    descriptors = []
-    modes = {}
+def control_output_writers() -> Iterator[tuple[Callable[[bytes], int] | None, Callable[[bytes], int] | None]]:
+    """Retain isolated writers and close them even on handled interruption."""
     handlers = {}
 
     def interrupted(_signum, _frame):
         raise InterruptedError("Operation control was interrupted")
 
-    for output in (sys.stdout, sys.stderr):
-        try:
-            descriptor = output.fileno()
-        except io.UnsupportedOperation:
-            descriptor = None  # In-memory test consumers have no kernel writer.
-        descriptors.append(descriptor)
-        if descriptor is not None:
-            modes[descriptor] = os.get_blocking(descriptor)
-    # Capture both original modes before changing either: stderr can share
-    # stdout's open file description, including a completely full pipe.
     try:
         for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
             handlers[signum] = signal.signal(signum, interrupted)
-        for descriptor in modes:
-            os.set_blocking(descriptor, False)
-        yield tuple(descriptors)
+        with contextlib.ExitStack() as resources:
+            yield tuple(control_output_writer(output, resources) for output in (sys.stdout, sys.stderr))
     finally:
-        failure = None
-        try:
-            for descriptor, blocking in modes.items():
-                try:
-                    os.set_blocking(descriptor, blocking)
-                except OSError as error:
-                    failure = error
-        finally:
-            for signum, handler in handlers.items():
-                signal.signal(signum, handler)
-        if failure is not None:
-            raise failure
+        for signum, handler in handlers.items():
+            signal.signal(signum, handler)
 
 
 def operation_control(command: str, operation_id: str) -> int:
     try:
-        with control_output_descriptors() as descriptors:
-            return run_operation_control(command, operation_id, *descriptors)
+        with control_output_writers() as writers:
+            return run_operation_control(command, operation_id, *writers)
     except OSError:
         return 1  # Output setup/cleanup failed; no trustworthy completion.
 
 
 def run_operation_control(command: str, operation_id: str,
-                          output_descriptor: int | None, error_descriptor: int | None) -> int:
+                          output_writer: Callable[[bytes], int] | None,
+                          error_writer: Callable[[bytes], int] | None) -> int:
     """Keep stale control rejection stream-free and watch failure distinct."""
     started = False
     cancel_dispatched = False
@@ -6861,22 +6884,22 @@ def run_operation_control(command: str, operation_id: str,
     def write(chunk):
         nonlocal started
         started = True
-        if output_descriptor is None:
+        if output_writer is None:
             sys.stdout.write(chunk)
             sys.stdout.flush()
             return
         payload = chunk.encode("utf-8")
         # Each formatter bundle fits Linux PIPE_BUF. A slow consumer must not
         # block observation, hold locks, or create an unbounded output backlog.
-        if len(payload) > 4096 or os.write(output_descriptor, payload) != len(payload):
+        if len(payload) > 4096 or output_writer(payload) != len(payload):
             raise OSError("Incomplete operation control output")
 
     def diagnostic(message):
         with contextlib.suppress(OSError):
-            if error_descriptor is None:
+            if error_writer is None:
                 print(message, file=sys.stderr)
             else:
-                os.write(error_descriptor, (message + "\n").encode("ascii"))
+                error_writer((message + "\n").encode("ascii"))
 
     try:
         boot_id = read_boot_id()
@@ -7139,15 +7162,14 @@ class UpdateEventMonitor:
 
 
 def watch_update_events() -> int:
-    output_descriptor = None
-    original_blocking = None
+    output_writer = None
 
     def emit(record: str) -> None:
         payload = (record + "\n").encode("ascii")
         # Each fixed row fits PIPE_BUF. Never block GLib callbacks behind a
         # stalled reader or queue unbounded notifications. Overflow is an
         # explicit monitoring failure; the consumer must refresh finite state.
-        if os.write(output_descriptor, payload) != len(payload):
+        if output_writer(payload) != len(payload):
             raise OSError("Incomplete event output")
 
     try:
@@ -7157,36 +7179,23 @@ def watch_update_events() -> int:
         gi.require_version("GLibUnix", "2.0")
         from gi.repository import Gio, GLib, GLibUnix
 
-        output_descriptor = sys.stdout.fileno()
-        original_blocking = os.get_blocking(output_descriptor)
-        os.set_blocking(output_descriptor, False)
-        code = UpdateEventMonitor(Gio, GLib, GLibUnix, emit).run()
+        with contextlib.ExitStack() as resources:
+            output_writer = control_output_writer(sys.stdout, resources)
+            if output_writer is None:
+                raise OSError("Event output requires a file descriptor")
+            code = UpdateEventMonitor(Gio, GLib, GLibUnix, emit).run()
     except (ImportError, ValueError, OSError):
         code = 1
-    finally:
-        if output_descriptor is not None and original_blocking is not None:
-            try:
-                # File status flags belong to the shared open-file description.
-                # A shell group may retain this writer for its next command.
-                os.set_blocking(output_descriptor, original_blocking)
-            except OSError:
-                code = 1
     if code:
-        error_descriptor = None
-        error_blocking = None
         try:
-            error_descriptor = sys.stderr.fileno()
-            error_blocking = os.get_blocking(error_descriptor)
-            os.set_blocking(error_descriptor, False)
-            os.write(error_descriptor, b"PackageKit live change monitoring is unavailable; reload status explicitly\n")
+            with contextlib.ExitStack() as resources:
+                error_writer = control_output_writer(sys.stderr, resources)
+                if error_writer is not None:
+                    error_writer(b"PackageKit live change monitoring is unavailable; reload status explicitly\n")
         except (OSError, ValueError):
             # Exit status remains authoritative when even diagnostics cannot
             # be delivered (including stderr sharing the full stdout pipe).
             pass
-        finally:
-            if error_descriptor is not None and error_blocking is not None:
-                with contextlib.suppress(OSError):
-                    os.set_blocking(error_descriptor, error_blocking)
     return code
 
 

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 import bisect
 import contextlib
+import ctypes
 import errno
 import fcntl
 import hashlib
+import io
 import os
 import re
 import selectors
@@ -37,6 +39,7 @@ REPOSITORY_MAX_ROWS = 512
 REPOSITORY_MAX_BYTES = 384 * 1024
 MAX_OPERATION_PROGRESS_RECORDS = 252
 MAX_OPERATION_MISMATCH_SAMPLES = 128
+NATIVE_WATCH_SECONDS = 120
 
 REGIONAL_TIMEZONE_MAX = 255
 REGIONAL_TIMEZONE_COUNT = 2048
@@ -4763,8 +4766,6 @@ def read_recovery_snapshot(backend: PackageKitBackend) -> RecoverySnapshot:
                         current = load_writable_journal_state(journal)
                     if current.active != state.active:
                         evidence = None
-                    if current.active is not None and current.active.kind not in {"update", "refresh"}:
-                        raise JournalAdmissionError("Another regional or delegated owner appeared during recovery")
                     return RecoverySnapshot(current, evidence, prior_restart, tuple(failures))
     except (SnapshotFailure, JournalFrameError, JournalRecordError, JournalAdmissionError, OSError) as error:
         if isinstance(error, SnapshotFailure):
@@ -5062,6 +5063,7 @@ def recover_journal_active(
     journal: JournalDescriptorSet, backend: PackageKitBackend, *,
     boot_id: str, session_started: int | None = None,
     watch: bool = False, expected_operation_id: str | None = None,
+    expected_operation: JournalOperation | None = None,
     on_progress: Callable[[RecoveryEvidence], object] | None = None,
     session_reader: Callable[[], int | None] | None = None,
 ) -> tuple[JournalState, RecoveryEvidence | None, SnapshotFailure | None]:
@@ -5070,12 +5072,24 @@ def recover_journal_active(
         raise JournalRecordError("recovery boot identity is invalid")
     if session_started is not None:
         _encode_journal_uint64(session_started, "session start")
+    identity = ("operation_id", "action_id", "started_at", "kind", "generation", "transaction_path", "boot_id", "slot")
+    if expected_operation is not None:
+        if (not isinstance(expected_operation, JournalOperation)
+                or expected_operation_id not in {None, expected_operation.operation_id}):
+            raise JournalAdmissionError("recovery expected identity is invalid")
+        expected_operation_id = expected_operation.operation_id
     original = load_journal_state(journal.chain).active
+    if expected_operation is not None and original is not None and any(
+            getattr(original, field) != getattr(expected_operation, field) for field in identity):
+        raise JournalAdmissionError("recovery owner identity changed")
     if expected_operation_id is not None and original is None:
         # Completion can race the watcher's initial target selection. Validate
         # the exact retained result without following a replacement owner.
         with lock_writable_journal(journal):
-            retained_journal_operation(journal, expected_operation_id)
+            terminal = retained_journal_operation(journal, expected_operation_id)
+            if expected_operation is not None and any(
+                    getattr(terminal, field) != getattr(expected_operation, field) for field in identity):
+                raise JournalAdmissionError("recovery terminal identity changed")
             return load_writable_journal_state(journal), None, None
     if expected_operation_id is not None and (original is None or original.operation_id != expected_operation_id):
         raise JournalAdmissionError("recovery target changed")
@@ -5087,8 +5101,6 @@ def recover_journal_active(
     lookup_failure = None
     history_match = None
     history_used = False
-    identity = ("operation_id", "action_id", "started_at", "kind", "generation", "transaction_path", "boot_id", "slot")
-
     def checkpoint_running():
         with lock_writable_journal(journal):
             current = load_writable_journal_state(journal).active
@@ -6597,9 +6609,116 @@ def control_journal_target(journal: JournalDescriptorSet, operation_id: str, boo
             state = load_writable_journal_state(journal)
         if state.active is None:
             return retained_journal_operation(journal, operation_id)
-        if state.active.operation_id != operation_id or state.active.kind not in {"refresh", "update"}:
+        if state.active.operation_id != operation_id:
             raise JournalAdmissionError("journal control target is unavailable")
         return state.active
+
+
+class NativeJournalEvents:
+    """One inode watch, retained before recovery; notifications are hints only."""
+
+    # IN_MODIFY | IN_ATTRIB | IN_CLOSE_WRITE | IN_DELETE_SELF | IN_MOVE_SELF.
+    mask = 0x0002 | 0x0004 | 0x0008 | 0x0400 | 0x0800
+
+    def __init__(self, journal: JournalDescriptorSet) -> None:
+        self.journal = journal
+        self.descriptor = None
+        self.selector = None
+
+    def __enter__(self):
+        try:
+            self.journal.validate()
+            libc = ctypes.CDLL(None, use_errno=True)
+            libc.inotify_init1.argtypes = [ctypes.c_int]
+            libc.inotify_init1.restype = ctypes.c_int
+            libc.inotify_add_watch.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_uint32]
+            libc.inotify_add_watch.restype = ctypes.c_int
+            descriptor = libc.inotify_init1(os.O_NONBLOCK | os.O_CLOEXEC)
+            if descriptor < 0:
+                raise OSError(ctypes.get_errno(), "native journal event setup failed")
+            self.descriptor = descriptor
+            path = f"/proc/self/fd/{self.journal.descriptor('active')}".encode("ascii")
+            self.watch = libc.inotify_add_watch(descriptor, path, self.mask)
+            if self.watch < 0:
+                raise OSError(ctypes.get_errno(), "native journal inode watch failed")
+            self.selector = selectors.DefaultSelector()
+            self.selector.register(descriptor, selectors.EVENT_READ)
+            self.journal.validate()
+            return self
+        except BaseException:
+            self.__exit__(None, None, None)
+            raise
+
+    def __exit__(self, *_args):
+        try:
+            if self.selector is not None:
+                self.selector.close()
+        finally:
+            if self.descriptor is not None:
+                descriptor, self.descriptor = self.descriptor, None
+                os.close(descriptor)  # Also frees the instance's inode watch.
+
+    def wait(self, deadline: float) -> None:
+        while time.monotonic() < deadline:
+            if not self.selector.select(max(0, deadline - time.monotonic())):
+                continue
+            try:
+                data = os.read(self.descriptor, 65536)
+            except BlockingIOError:
+                continue
+            # A file-only watch has fixed 16-byte events and no filename.
+            # Overflow, unmount, lost watches, and malformed events fail closed.
+            if not data or len(data) % 16:
+                raise SnapshotFailure("interrupted", "Native journal notifications are incomplete")
+            for offset in range(0, len(data), 16):
+                watch, mask, cookie, length = struct.unpack_from("=iIII", data, offset)
+                if watch != self.watch or not mask or mask & ~self.mask or cookie or length:
+                    raise SnapshotFailure("interrupted", "Native journal monitoring was lost")
+            return  # Coalesce one bounded batch into one validated recovery read.
+
+
+def watch_native_journal_operation(
+    journal: JournalDescriptorSet, original: JournalOperation,
+    write: Callable[[str], object], *, boot_id: str,
+) -> None:
+    """Observe durable native checkpoints, never the service or its target value."""
+    deadline = time.monotonic() + NATIVE_WATCH_SECONDS
+    identity = ("operation_id", "action_id", "started_at", "kind", "generation",
+                "transaction_path", "boot_id", "slot")
+    with NativeJournalEvents(journal) as events:
+        stream = OperationStream(original.operation_id, original.action_id,
+                                 original.started_at, original.detail, write)
+        while True:
+            # Also run after the deadline: Linux can notify close before freeing
+            # flock. A final fresh probe bounds recovery of that last-event race.
+            state, _evidence, failure = recover_journal_active(journal, None,
+                boot_id=boot_id, expected_operation=original)
+            if failure is not None:
+                raise failure
+            current = state.active
+            if current is None:
+                current = next((item for item in state.terminals
+                    if item is not None and item.operation_id == original.operation_id), None)
+            if current is None or any(getattr(current, key) != getattr(original, key) for key in identity):
+                raise JournalAdmissionError("native journal watch owner changed")
+            if current.state in JOURNAL_OPERATION_TERMINAL_STATES:
+                if current.state == "succeeded" and stream.state in {"pending", "authorizing"}:
+                    stream.transition("running", current.detail)
+                elif current.state == "permission-denied" and stream.state == "pending":
+                    stream.transition("authorizing", current.detail)
+                elif current.state == "canceled" and stream.state == "running":
+                    stream.transition("cancel-requested", current.detail)
+                stream.finish(current)
+                return
+            if current.state == "cancel-requested" and stream.state in {"pending", "authorizing"}:
+                stream.transition("running", current.detail)
+            if current.state != stream.state:
+                stream.transition(current.state, current.detail)
+            else:
+                stream.progress(current.detail)
+            if time.monotonic() >= deadline:
+                raise SnapshotFailure("timeout", "Native owner remains active; refresh and observe its result")
+            events.wait(deadline)
 
 
 def watch_journal_operation(
@@ -6610,6 +6729,9 @@ def watch_journal_operation(
     original = control_journal_target(journal, operation_id, boot_id)
     if original.state in JOURNAL_OPERATION_TERMINAL_STATES:
         replay_terminal_operation(original, write)
+        return
+    if original.kind not in {"update", "refresh"}:
+        watch_native_journal_operation(journal, original, write, boot_id=boot_id)
         return
     detail = "Observing recovered PackageKit operation; package comparison is unavailable"
     stream = OperationStream(original.operation_id, original.action_id, original.started_at, detail, write)
@@ -6677,7 +6799,57 @@ def cancel_journal_operation(journal: JournalDescriptorSet, operation_id: str, *
                 detail="Cancellation requested; waiting for PackageKit completion"))
 
 
+@contextlib.contextmanager
+def control_output_descriptors() -> Iterator[tuple[int | None, int | None]]:
+    """Bound control output without changing a calling shell's retained writers."""
+    descriptors = []
+    modes = {}
+    handlers = {}
+
+    def interrupted(_signum, _frame):
+        raise InterruptedError("Operation control was interrupted")
+
+    for output in (sys.stdout, sys.stderr):
+        try:
+            descriptor = output.fileno()
+        except io.UnsupportedOperation:
+            descriptor = None  # In-memory test consumers have no kernel writer.
+        descriptors.append(descriptor)
+        if descriptor is not None:
+            modes[descriptor] = os.get_blocking(descriptor)
+    # Capture both original modes before changing either: stderr can share
+    # stdout's open file description, including a completely full pipe.
+    try:
+        for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            handlers[signum] = signal.signal(signum, interrupted)
+        for descriptor in modes:
+            os.set_blocking(descriptor, False)
+        yield tuple(descriptors)
+    finally:
+        failure = None
+        try:
+            for descriptor, blocking in modes.items():
+                try:
+                    os.set_blocking(descriptor, blocking)
+                except OSError as error:
+                    failure = error
+        finally:
+            for signum, handler in handlers.items():
+                signal.signal(signum, handler)
+        if failure is not None:
+            raise failure
+
+
 def operation_control(command: str, operation_id: str) -> int:
+    try:
+        with control_output_descriptors() as descriptors:
+            return run_operation_control(command, operation_id, *descriptors)
+    except OSError:
+        return 1  # Output setup/cleanup failed; no trustworthy completion.
+
+
+def run_operation_control(command: str, operation_id: str,
+                          output_descriptor: int | None, error_descriptor: int | None) -> int:
     """Keep stale control rejection stream-free and watch failure distinct."""
     started = False
     cancel_dispatched = False
@@ -6689,8 +6861,22 @@ def operation_control(command: str, operation_id: str) -> int:
     def write(chunk):
         nonlocal started
         started = True
-        sys.stdout.write(chunk)
-        sys.stdout.flush()
+        if output_descriptor is None:
+            sys.stdout.write(chunk)
+            sys.stdout.flush()
+            return
+        payload = chunk.encode("utf-8")
+        # Each formatter bundle fits Linux PIPE_BUF. A slow consumer must not
+        # block observation, hold locks, or create an unbounded output backlog.
+        if len(payload) > 4096 or os.write(output_descriptor, payload) != len(payload):
+            raise OSError("Incomplete operation control output")
+
+    def diagnostic(message):
+        with contextlib.suppress(OSError):
+            if error_descriptor is None:
+                print(message, file=sys.stderr)
+            else:
+                os.write(error_descriptor, (message + "\n").encode("ascii"))
 
     try:
         boot_id = read_boot_id()
@@ -6708,19 +6894,15 @@ def operation_control(command: str, operation_id: str) -> int:
     except (SnapshotFailure, JournalFrameError, JournalRecordError, JournalAdmissionError, OSError, OperationProtocolError) as error:
         if command == "updates-cancel":
             if cancel_dispatched and not isinstance(error, CancelTargetUnavailable):
-                print("cancellation request could not be confirmed; observe the existing operation", file=sys.stderr)
+                diagnostic("cancellation request could not be confirmed; observe the existing operation")
                 return 1
-            print("cancel target is unavailable", file=sys.stderr)
+            diagnostic("cancel target is unavailable")
             return 3
         if started:
-            if isinstance(error, BrokenPipeError):
-                # Avoid a second buffered flush at interpreter shutdown changing
-                # the exit status or writing an unraisable-exception diagnostic.
-                with open(os.devnull, "w") as sink:
-                    os.dup2(sink.fileno(), sys.stdout.fileno())
-            print("operation observation was interrupted", file=sys.stderr)
+            # Raw descriptor writes leave no buffered shutdown flush to retry.
+            diagnostic("operation observation was interrupted")
             return 1
-        print("watch target is unavailable" if command == "watch-operation" else "ack target is unavailable", file=sys.stderr)
+        diagnostic("watch target is unavailable" if command == "watch-operation" else "ack target is unavailable")
         return 3
 
 

--- a/tests/fixtures/system-update-events-bus.py
+++ b/tests/fixtures/system-update-events-bus.py
@@ -101,10 +101,12 @@ try:
     error = broken.stderr.read()
     assert b"reload status explicitly" in error and b"Traceback" not in error
 
-    # Shell groups can retain the same write-side open-file description for
-    # later commands. Restore its original mode on both clean and failed exits.
-    for originally_blocking, overflow, merged in ((True, False, False), (False, False, False),
-            (True, True, False), (True, True, True)):
+    # Shell groups can retain this writer during monitoring and after a forced
+    # exit. Never change its mode, even temporarily, or disrupt parent output.
+    for originally_blocking, overflow, merged, killed in (
+            (True, False, False, False), (False, False, False, False),
+            (True, True, False, False), (True, True, True, False),
+            (True, False, True, True), (False, False, True, True)):
         reader, writer = os.pipe()
         retained_writers.append(writer)
         os.set_blocking(writer, originally_blocking)
@@ -114,15 +116,18 @@ try:
         inherited.stdout = os.fdopen(reader, "rb", buffering=0)
         fcntl.fcntl(writer, fcntl.F_SETPIPE_SZ, 4096)
         assert line(inherited) == b"update-event\tready\n"
+        assert os.get_blocking(writer) == originally_blocking, "Live monitor changed inherited stdout mode"
+        os.write(writer, b"parent output\n")
+        assert line(inherited) == b"parent output\n"
         if overflow:
             for _ in range(1000):
                 emit("UpdatesChanged")
                 if inherited.poll() is not None:
                     break
         else:
-            inherited.send_signal(signal.SIGTERM)
-        assert inherited.wait(timeout=3) == int(overflow)
-        assert os.get_blocking(writer) == originally_blocking, "Inherited stdout mode was not restored"
+            inherited.send_signal(signal.SIGKILL if killed else signal.SIGTERM)
+        assert inherited.wait(timeout=3) == (-signal.SIGKILL if killed else int(overflow))
+        assert os.get_blocking(writer) == originally_blocking, "Inherited stdout mode changed"
 
     # A reader that remains open but stops draining cannot pin the GLib loop
     # and its subscriptions. Overflow exits explicitly, with no event queue.

--- a/tests/test-quickshell-system-management-xvfb.sh
+++ b/tests/test-quickshell-system-management-xvfb.sh
@@ -109,6 +109,8 @@ watch-operation | ack-operation)
 	case ${2:-} in
 	op-11111111111111111111111111111111) action=timezone-set; kind=timezone ;;
 	op-22222222222222222222222222222222) action=updates-refresh; kind=refresh ;;
+	op-33333333333333333333333333333333) action=locale-set; kind=locale ;;
+	op-44444444444444444444444444444444) action=printers-open; kind=delegate ;;
 	*) exit 3 ;;
 	esac
 	if [ "$1" = ack-operation ]; then
@@ -180,6 +182,27 @@ regional-handoff)
 	else
 		snapshot | sed '/^complete\t/i\terminal-handoff\top-11111111111111111111111111111111\ttimezone-set\ttimezone'
 	fi
+	;;
+regional-active | delegate-active)
+	if [ "$mode" = regional-active ]; then
+		operation=op-33333333333333333333333333333333
+		action=locale-set
+		kind=locale
+	else
+		operation=op-44444444444444444444444444444444
+		action=printers-open
+		kind=delegate
+	fi
+	if [ -f "$fixture/ack-$operation" ]; then
+		snapshot
+	elif [ -f "$fixture/finished-$operation" ]; then
+		snapshot | sed "/^complete\t/i\terminal-handoff\t$operation\t$action\t$kind"
+	else
+		snapshot | sed "/^complete\t/i\active-operation\t$operation\t$action\t$kind\trunning\tunknown\tno\tNative fixture"
+	fi
+	;;
+invalid-native-cancel)
+	snapshot | sed '/^complete\t/i\active-operation\top-55555555555555555555555555555555\ttimezone-set\ttimezone\trunning\tunknown\tyes\tInvalid cancellation'
 	;;
 invalid-handoff)
 	snapshot | sed '/^complete\t/i\terminal-handoff\top-11111111111111111111111111111111\ttimezone-set\tdelegate'
@@ -710,6 +733,33 @@ while [ "$i" -lt 100 ]; do
 	sleep 0.05
 done
 [ -f "$fixture/ack-op-22222222222222222222222222222222" ]
+
+for native_mode in regional-active delegate-active; do
+	if [ "$native_mode" = regional-active ]; then
+		native_id=op-33333333333333333333333333333333
+		native_result=locale-set:succeeded
+	else
+		native_id=op-44444444444444444444444444444444
+		native_result=printers-open:succeeded
+	fi
+	printf '%s\n' "$native_mode" >"$fixture/mode"
+	ipc refresh >/dev/null
+	wait_state ready
+	[ "$(ipc systemManagementUpdateCount)" -eq 1 ]
+	i=0
+	while [ "$i" -lt 100 ]; do
+		[ -f "$fixture/ack-$native_id" ] && break
+		i=$((i + 1))
+		sleep 0.05
+	done
+	[ -f "$fixture/ack-$native_id" ]
+	[ "$(ipc systemManagementOperationResult)" = "$native_result" ]
+done
+
+printf 'invalid-native-cancel\n' >"$fixture/mode"
+ipc refresh >/dev/null
+wait_state failure
+[ "$(ipc systemManagementUpdateCount)" -eq 0 ]
 
 printf 'invalid-handoff\n' >"$fixture/mode"
 ipc refresh >/dev/null

--- a/tests/test-quickshell-system-management.sh
+++ b/tests/test-quickshell-system-management.sh
@@ -74,8 +74,8 @@ grep -Fq 'property var recoveryProvider: root.recoveryFallback(' "$model"
 grep -Fq '"providerClass": "user-session"' "$model"
 grep -Fq "Number(states[\"\$update-summary\"].value) !== parsedUpdates.length" "$model"
 grep -Fq 'parsedActive !== null || parsedHandoff !== null' "$model"
-[ "$(grep -Fc 'root.updateActionKind(fields[2]).length === 0' "$model")" -eq 1 ]
-grep -Fq 'root.operationActionKind(fields[2]).length === 0' "$model"
+[ "$(grep -Fc 'root.operationActionKind(fields[2]).length === 0' "$model")" -eq 2 ]
+grep -Fq 'root.updateActionKind(fields[2]).length === 0 && fields[6] !== "no"' "$model"
 grep -Fq 'responseGeneration !== root.requestGeneration' "$model"
 grep -Fq 'if (root.snapshotOwned)' "$model"
 grep -Fq 'root.requiredPending = root.requiredPending || required;' "$model"

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -7339,6 +7339,425 @@ with p["open_journal_directory_chain"](sys.argv[2]) as chain:
                 self.assertEqual(state.terminals[operation.slot].state, "interrupted")
 
 
+class NativeJournalWatchTests(unittest.TestCase):
+    boot_id = NativeJournalOwnerTests.boot_id
+    session = NativeJournalOwnerTests.session
+    begin = NativeJournalOwnerTests.begin
+    owner = NativeJournalOwnerTests.owner
+
+    def checkpoint(self, journal, state, *, complete=True):
+        with provider.lock_writable_journal(journal):
+            current = provider.load_writable_journal_state(journal).active
+            if state == "succeeded" and current.state in {"pending", "authorizing"}:
+                current = provider.advance_journal_operation(journal, current, replace(current, state="running"))
+            if state == "permission-denied" and current.state == "pending":
+                current = provider.advance_journal_operation(journal, current, replace(current, state="authorizing"))
+            changes = dict(state=state, detail=f"Native fixture {state}")
+            if state in provider.JOURNAL_OPERATION_TERMINAL_STATES:
+                changes["finished_at"] = "2026-09-06T17:01:00Z"
+                if state == "failed":
+                    changes["error_code"] = "conflict"
+            current = provider.advance_journal_operation(journal, current, replace(current, **changes))
+            if complete and state in provider.JOURNAL_OPERATION_TERMINAL_STATES:
+                provider.complete_journal_terminal(journal, boot_id=self.boot_id)
+            return current
+
+    def watch(self, journal, operation, write):
+        backend = mock.Mock(side_effect=AssertionError("native watch opened PackageKit"))
+        provider.watch_journal_operation(journal, operation.operation_id, write,
+            boot_id=self.boot_id, backend_factory=backend)
+        backend.assert_not_called()
+
+    @contextlib.contextmanager
+    def events(self, callback):
+        waiter = types.SimpleNamespace(wait=callback)
+        with mock.patch.object(provider, "NativeJournalEvents",
+                return_value=contextlib.nullcontext(waiter)):
+            yield
+
+    def test_each_kind_replays_exact_durable_result_without_backend_or_cancelability(self):
+        for action in ("timezone-set", "ntp-set", "locale-set", "accounts-open", "password-open",
+                       "printers-open", "sources-open"):
+            for result in ("succeeded", "permission-denied", "canceled", "failed", "interrupted"):
+                with self.subTest(action=action, result=result), self.session() as (_path, _chain, journal), \
+                        self.owner(journal, action) as operation:
+                    chunks = []
+                    def finish(_deadline):
+                        self.assertFalse(journal._exclusive)
+                        self.checkpoint(journal, result, complete=False)
+                    def write(chunk):
+                        if "complete\toperation" in chunk:
+                            state = provider.load_journal_state(journal.chain)
+                            self.assertIsNone(state.active)
+                            self.assertEqual(state.handoff.operation_id, operation.operation_id)
+                        chunks.append(chunk)
+                    with self.events(finish):
+                        self.watch(journal, operation, write)
+                    operations = rows("".join(chunks).splitlines(), "operation")
+                    self.assertEqual(operations[0][4], "pending")
+                    self.assertEqual(operations[-1][1:5],
+                        [operation.operation_id, action, operation.kind, result])
+                    self.assertTrue(all(row[5:7] == ["unknown", "no"] for row in operations))
+                    self.assertEqual(len(rows("".join(chunks).splitlines(), "audit")), 1)
+
+    def test_progress_coalesces_without_writing_and_deadline_does_not_extend(self):
+        with self.session() as (_path, _chain, journal), self.owner(journal) as operation:
+            chunks, deadlines = [], []
+            steps = iter(("pending", "authorizing", "authorizing", "running", "succeeded"))
+            def changed(deadline):
+                deadlines.append(deadline)
+                state = next(steps)
+                if state == provider.load_journal_state(journal.chain).active.state:
+                    return
+                self.checkpoint(journal, state)
+            with self.events(changed):
+                self.watch(journal, operation, chunks.append)
+            self.assertEqual(len(set(deadlines)), 1)
+            self.assertEqual([row[4] for row in rows("".join(chunks).splitlines(), "operation")],
+                ["pending", "authorizing", "running", "succeeded"])
+            self.assertEqual(provider.load_journal_state(journal.chain).handoff.operation_id, operation.operation_id)
+
+    def test_orphan_recovery_and_completion_during_watch_setup_are_exact(self):
+        for completed in (False, True):
+            with self.subTest(completed=completed), self.session() as (_path, _chain, journal):
+                with provider.lock_writable_journal(journal):
+                    operation = self.begin(journal)
+                @contextlib.contextmanager
+                def events(_journal):
+                    if completed:
+                        self.checkpoint(journal, "succeeded")
+                    yield types.SimpleNamespace(wait=mock.Mock(side_effect=AssertionError("unneeded wait")))
+                chunks = []
+                with mock.patch.object(provider, "NativeJournalEvents", side_effect=events):
+                    self.watch(journal, operation, chunks.append)
+                self.assertEqual(rows("".join(chunks).splitlines(), "operation")[-1][4],
+                    "succeeded" if completed else "interrupted")
+
+    def test_final_deadline_probe_recovers_close_before_unlock_race(self):
+        with self.session() as (_path, _chain, journal), contextlib.ExitStack() as owner:
+            with provider.lock_writable_journal(journal):
+                operation = self.begin(journal)
+                owner.enter_context(provider.retain_native_journal_owner(journal, operation))
+            clock, waits, chunks = [10], [], []
+            def wait(deadline):
+                waits.append(deadline)
+                if len(waits) == 1:
+                    return  # CLOSE_WRITE arrived while the lease was still busy.
+                owner.close()
+                clock[0] = deadline  # No further filesystem event followed.
+            with self.events(wait), mock.patch.object(provider.time, "monotonic", side_effect=lambda: clock[0]):
+                self.watch(journal, operation, chunks.append)
+            self.assertEqual(len(waits), 2)
+            self.assertEqual(rows("".join(chunks).splitlines(), "operation")[-1][4], "interrupted")
+
+    def test_timeout_or_output_loss_preserves_the_live_owner_and_has_no_terminal(self):
+        for fault in ("timeout", "output", "events"):
+            with self.subTest(fault=fault), self.session() as (path, _chain, journal), self.owner(journal) as operation:
+                before = (path / "active").read_bytes()
+                clock, chunks = [10], []
+                def wait(deadline):
+                    if fault == "events":
+                        raise provider.SnapshotFailure("interrupted", "events fixture")
+                    clock[0] = deadline
+                def write(chunk):
+                    chunks.append(chunk)
+                    if fault == "output":
+                        raise BrokenPipeError("output fixture")
+                with self.events(wait), mock.patch.object(provider.time, "monotonic", side_effect=lambda: clock[0]):
+                    with self.assertRaises(BrokenPipeError if fault == "output" else provider.SnapshotFailure):
+                        self.watch(journal, operation, write)
+                self.assertNotIn("complete\toperation", "".join(chunks))
+                self.assertEqual((path / "active").read_bytes(), before)
+                with provider.lock_writable_journal(journal):
+                    self.assertTrue(provider.native_journal_owner_busy(journal, operation))
+
+    def test_replacement_owner_is_never_followed(self):
+        with self.session() as (_path, _chain, journal), self.owner(journal) as operation:
+            following, chunks = [], []
+            def replace_owner(_deadline):
+                self.checkpoint(journal, "succeeded")
+                with provider.lock_writable_journal(journal):
+                    provider.acknowledge_journal_handoff(journal, operation.operation_id)
+                    following.append(self.begin(journal, "ntp-set"))
+            with self.events(replace_owner), self.assertRaises(provider.JournalAdmissionError):
+                self.watch(journal, operation, chunks.append)
+            self.assertNotIn("complete\toperation", "".join(chunks))
+            self.assertEqual(provider.load_journal_state(journal.chain).active, following[0])
+
+    def test_same_id_changed_immutable_fields_are_rejected_before_recovery_writes(self):
+        for changes in (dict(action_id="ntp-set", kind="ntp"),
+                        dict(action_id="updates-refresh", kind="refresh", transaction_path="/1_test"),
+                        dict(started_at="2026-09-06T16:00:00Z")):
+            with self.subTest(changes=changes), self.session() as (path, _chain, journal):
+                with provider.lock_writable_journal(journal):
+                    operation = self.begin(journal)
+                changed, before, chunks = replace(operation, **changes), {}, []
+                @contextlib.contextmanager
+                def events(_journal):
+                    with provider.lock_writable_journal(journal):
+                        provider.commit_writable_journal_path(journal, "active",
+                            provider.encode_journal_operation(changed))
+                    before.update({name: (path / name).read_bytes() for name in provider.JOURNAL_NAMES})
+                    yield types.SimpleNamespace(wait=mock.Mock(side_effect=AssertionError("unneeded wait")))
+                with mock.patch.object(provider, "NativeJournalEvents", side_effect=events):
+                    with self.assertRaises(provider.JournalAdmissionError):
+                        self.watch(journal, operation, chunks.append)
+                for name, content in before.items():
+                    self.assertTrue((path / name).read_bytes() == content, f"Recovery changed {name}")
+                self.assertNotIn("complete\toperation", "".join(chunks))
+
+    def test_same_id_changed_terminal_is_rejected_without_rewriting_any_record(self):
+        with self.session() as (path, _chain, journal):
+            with provider.lock_writable_journal(journal):
+                operation = self.begin(journal)
+            before, chunks = {}, []
+            @contextlib.contextmanager
+            def events(_journal):
+                with provider.lock_writable_journal(journal):
+                    provider.commit_writable_journal_path(journal, "active",
+                        provider.encode_journal_operation(replace(operation, action_id="ntp-set", kind="ntp")))
+                self.checkpoint(journal, "succeeded")
+                before.update({name: (path / name).read_bytes() for name in provider.JOURNAL_NAMES})
+                yield types.SimpleNamespace(wait=mock.Mock(side_effect=AssertionError("unneeded wait")))
+            with mock.patch.object(provider, "NativeJournalEvents", side_effect=events):
+                with self.assertRaises(provider.JournalAdmissionError):
+                    self.watch(journal, operation, chunks.append)
+            for name, content in before.items():
+                self.assertTrue((path / name).read_bytes() == content, f"Recovery changed {name}")
+            self.assertNotIn("complete\toperation", "".join(chunks))
+
+    def test_real_inode_events_and_descriptor_cleanup(self):
+        with self.session() as (_path, _chain, journal):
+            with provider.NativeJournalEvents(journal) as events:
+                descriptor = events.descriptor
+                self.assertFalse(os.get_blocking(descriptor))
+                self.assertFalse(os.get_inheritable(descriptor))
+                with provider.lock_writable_journal(journal):
+                    self.begin(journal)
+                started = time.monotonic()
+                events.wait(started + 1)
+                self.assertLess(time.monotonic() - started, 0.5)
+            with self.assertRaises(OSError):
+                os.fstat(descriptor)
+
+    def test_overflow_lost_malformed_and_empty_notifications_fail_closed(self):
+        for fault in ("overflow", "ignored", "short", "name", "empty", "cookie", "unknown"):
+            with self.subTest(fault=fault), self.session() as (_path, _chain, journal), \
+                    provider.NativeJournalEvents(journal) as events:
+                data = provider.struct.pack("=iIII", events.watch, 2, 0, 0)
+                if fault == "overflow": data = provider.struct.pack("=iIII", -1, 0x4000, 0, 0)
+                elif fault == "ignored": data = provider.struct.pack("=iIII", events.watch, 0x8000, 0, 0)
+                elif fault == "short": data = data[:-1]
+                elif fault == "empty": data = b""
+                elif fault == "name": data = provider.struct.pack("=iIII", events.watch, 2, 0, 16)
+                elif fault == "cookie": data = provider.struct.pack("=iIII", events.watch, 2, 1, 0)
+                elif fault == "unknown": data = provider.struct.pack("=iIII", events.watch + 1, 2, 0, 0)
+                with mock.patch.object(events.selector, "select", return_value=[True]), \
+                        mock.patch.object(provider.os, "read", return_value=data):
+                    with self.assertRaises(provider.SnapshotFailure):
+                        events.wait(time.monotonic() + 1)
+
+    def test_setup_failure_closes_created_event_descriptor(self):
+        with self.session() as (_path, _chain, journal):
+            events = provider.NativeJournalEvents(journal)
+            captured = []
+            original_close = os.close
+            def close(descriptor):
+                captured.append(descriptor)
+                return original_close(descriptor)
+            with mock.patch.object(provider.selectors, "DefaultSelector", side_effect=OSError("selector fixture")), \
+                    mock.patch.object(provider.os, "close", side_effect=close):
+                with self.assertRaises(OSError):
+                    with events:
+                        self.fail("failed setup entered")
+            self.assertEqual(len(captured), 1)
+            self.assertIsNone(events.descriptor)
+            with self.assertRaises(OSError):
+                os.fstat(captured[0])
+
+    def test_live_snapshot_exposes_native_identity_without_enabling_origins(self):
+        for action in ("timezone-set", "ntp-set", "locale-set", "accounts-open", "password-open",
+                       "printers-open", "sources-open"):
+            with self.subTest(action=action), self.session() as (_path, _chain, journal), \
+                    self.owner(journal, action) as operation:
+                fixture = RecoverySnapshotTests()
+                backend = fixture.backend()
+                output = fixture.snapshot(journal, backend)
+                self.assertEqual(rows(output, "active-operation")[0][1:7],
+                    [operation.operation_id, action, operation.kind, "pending", "unknown", "no"])
+                self.assertEqual([row[2] for row in rows(output, "action")], ["unavailable"] * 3)
+                self.assertEqual(rows(output, "terminal-handoff"), [])
+                backend.probe_operation.assert_not_called()
+                backend.operation_history.assert_not_called()
+
+    def test_real_cli_watch_observes_completion_and_owner_sigkill(self):
+        owner_program = """
+import contextlib, dataclasses, runpy, sys
+p = runpy.run_path(sys.argv[1])
+with p["open_journal_directory_chain"](sys.argv[2]) as chain:
+    with p["retain_writable_journal"](chain) as journal, contextlib.ExitStack() as owner:
+        with p["lock_writable_journal"](journal):
+            operation = p["load_writable_journal_state"](journal).active
+            owner.enter_context(p["retain_native_journal_owner"](journal, operation))
+        print("ready", flush=True)
+        sys.stdin.buffer.read(1)
+        with p["lock_writable_journal"](journal):
+            running = p["advance_journal_operation"](journal, operation,
+                dataclasses.replace(operation, state="running"))
+            p["advance_journal_operation"](journal, running, dataclasses.replace(running,
+                state="succeeded", finished_at="2026-09-06T17:01:00Z"))
+            p["complete_journal_terminal"](journal)
+"""
+        watch_program = """
+import runpy, sys
+p = runpy.run_path(sys.argv[1])
+p["main"].__globals__["NATIVE_WATCH_SECONDS"] = 1
+def unexpected(*args, **kwargs):
+    raise AssertionError("Native watch must not open PackageKit")
+p["PackageKitBackend"].__init__ = unexpected
+raise SystemExit(p["main"](sys.argv[2:]))
+"""
+        for killed in (False, True):
+            with self.subTest(killed=killed), self.session() as (_path, chain, journal):
+                with provider.lock_writable_journal(journal):
+                    operation = self.begin(journal)
+                processes = []
+                try:
+                    owner = subprocess.Popen([sys.executable, "-c", owner_program, str(PROVIDER_PATH), chain.path],
+                        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0, close_fds=True)
+                    processes.append(owner)
+                    self.assertTrue(select.select([owner.stdout], [], [], 3)[0])
+                    self.assertEqual(owner.stdout.readline(16), b"ready\n")
+                    environment = dict(os.environ, XDG_STATE_HOME=str(pathlib.Path(chain.path).parents[1]))
+                    watcher = subprocess.Popen([sys.executable, "-c", watch_program, str(PROVIDER_PATH),
+                        "watch-operation", operation.operation_id], stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE, env=environment, bufsize=0, close_fds=True)
+                    processes.append(watcher)
+                    prefix = b""
+                    for _ in range(2):
+                        self.assertTrue(select.select([watcher.stdout], [], [], 3)[0])
+                        prefix += watcher.stdout.readline(1024)
+                    self.assertIn(b"\tpending\t", prefix)
+                    if killed:
+                        owner.kill()
+                    _output, diagnostic = owner.communicate(input=None if killed else b"x", timeout=3)
+                    self.assertEqual((owner.returncode, diagnostic), (-signal.SIGKILL if killed else 0, b""))
+                    output, diagnostic = watcher.communicate(timeout=4)
+                    self.assertEqual((watcher.returncode, diagnostic), (0, b""))
+                    records = (prefix + output).decode().splitlines()
+                    self.assertEqual(rows(records, "operation")[-1][4], "interrupted" if killed else "succeeded")
+                    self.assertEqual(records[-1], "complete\toperation")
+                    self.assertEqual(provider.load_journal_state(chain).handoff.operation_id, operation.operation_id)
+                finally:
+                    for process in processes:
+                        if process.poll() is None:
+                            process.kill()
+                        process.communicate(timeout=3)
+
+    def test_full_control_output_and_shared_diagnostics_detach_and_restore_writer_modes(self):
+        for terminal in (False, True):
+            for shared in (False, True):
+                for blocking in (False, True):
+                    with self.subTest(terminal=terminal, shared=shared, blocking=blocking), \
+                            self.session() as (path, chain, journal), self.owner(journal) as operation:
+                        if terminal:
+                            self.checkpoint(journal, "succeeded")
+                        before = {name: (path / name).read_bytes() for name in ("active", "handoff")}
+                        reader, writer = os.pipe()
+                        child = None
+                        try:
+                            os.set_blocking(writer, False)
+                            with self.assertRaises(BlockingIOError):
+                                while True:
+                                    os.write(writer, b"x" * 4096)
+                            os.set_blocking(writer, blocking)
+                            environment = dict(os.environ, XDG_STATE_HOME=str(pathlib.Path(chain.path).parents[1]))
+                            child = subprocess.Popen([sys.executable, str(PROVIDER_PATH), "watch-operation",
+                                operation.operation_id], stdout=writer, stderr=writer if shared else subprocess.PIPE,
+                                env=environment, close_fds=True)
+                            _output, diagnostic = child.communicate(timeout=3)
+                            self.assertEqual(child.returncode, 1)
+                            if not shared:
+                                self.assertEqual(diagnostic, b"operation observation was interrupted\n")
+                            self.assertEqual(os.get_blocking(writer), blocking)
+                            self.assertEqual(before, {name: (path / name).read_bytes() for name in before})
+                        finally:
+                            if child is not None:
+                                if child.poll() is None:
+                                    child.kill()
+                                child.communicate(timeout=3)
+                            os.close(reader)
+                            os.close(writer)
+
+    def test_short_output_is_failure_without_terminalizing_the_live_owner(self):
+        with self.session() as (path, chain, journal), self.owner(journal) as operation:
+            before = (path / "active").read_bytes()
+            state_home = str(pathlib.Path(chain.path).parents[1])
+            with mock.patch.dict(os.environ, {"XDG_STATE_HOME": state_home}), \
+                    mock.patch.object(provider, "read_boot_id", return_value=self.boot_id), \
+                    mock.patch.object(provider.os, "write", return_value=1) as output, \
+                    contextlib.redirect_stderr(io.StringIO()) as diagnostic:
+                code = provider.run_operation_control("watch-operation", operation.operation_id, 123, None)
+            self.assertEqual(code, 1)
+            self.assertEqual(diagnostic.getvalue(), "operation observation was interrupted\n")
+            output.assert_called_once()
+            self.assertEqual((path / "active").read_bytes(), before)
+
+    def test_control_signals_restore_retained_pipe_modes_and_preserve_ownership(self):
+        for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            for blocking in (False, True):
+                with self.subTest(signum=signum, blocking=blocking), self.session() as (path, chain, journal), \
+                        self.owner(journal) as operation:
+                    before = (path / "active").read_bytes()
+                    reader, writer = os.pipe()
+                    child = None
+                    try:
+                        os.set_blocking(writer, blocking)
+                        environment = dict(os.environ, XDG_STATE_HOME=str(pathlib.Path(chain.path).parents[1]))
+                        child = subprocess.Popen([sys.executable, str(PROVIDER_PATH), "watch-operation",
+                            operation.operation_id], stdout=writer, stderr=writer, env=environment, close_fds=True)
+                        self.assertTrue(select.select([reader], [], [], 3)[0])
+                        self.assertIn(b"\tpending\t", os.read(reader, 4096))
+                        child.send_signal(signum)
+                        child.communicate(timeout=3)
+                        self.assertEqual(child.returncode, 1)
+                        self.assertEqual(os.get_blocking(writer), blocking)
+                        self.assertEqual((path / "active").read_bytes(), before)
+                    finally:
+                        if child is not None:
+                            if child.poll() is None:
+                                child.kill()
+                            child.communicate(timeout=3)
+                        os.close(reader)
+                        os.close(writer)
+
+    def test_control_output_context_restores_existing_signal_handlers(self):
+        original = {signum: signal.getsignal(signum)
+            for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)}
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaisesRegex(OSError, "fixture"):
+                with provider.control_output_descriptors():
+                    for signum, handler in original.items():
+                        self.assertIsNot(signal.getsignal(signum), handler)
+                    raise OSError("output fixture")
+        for signum, handler in original.items():
+            self.assertIs(signal.getsignal(signum), handler)
+
+    def test_path_replacement_during_watch_never_publishes_completion(self):
+        chunks = []
+        with self.assertRaises(provider.JournalLayoutError):
+            with self.session() as (path, _chain, journal), self.owner(journal) as operation:
+                def replace_path(_deadline):
+                    active = path / "active"
+                    content = active.read_bytes()
+                    active.rename(path / "detached-active")
+                    active.write_bytes(content)
+                    active.chmod(0o600)
+                with self.events(replace_path):
+                    self.watch(journal, operation, chunks.append)
+        self.assertNotIn("complete\toperation", "".join(chunks))
+
+
 class OperationRecoveryTests(unittest.TestCase):
     boot_id = PackageKitExecutionTests.boot_id
     journal = PackageKitExecutionTests.journal
@@ -8297,11 +8716,11 @@ class OperationWatchTests(unittest.TestCase):
                     provider.acknowledge_journal_handoff(journal, operation.operation_id)
                     self.assertEqual(provider.retained_journal_operation(journal, operation.operation_id), terminal)
 
-    def test_stale_id_and_active_regional_emit_no_stream(self):
+    def test_stale_id_emits_no_stream_for_packagekit_and_native_owners(self):
         for kind in ("refresh", "timezone"):
             with self.subTest(kind=kind), self.journal() as journal:
                 operation = self.begin(journal, kind)
-                requested = "op-" + "0" * 32 if kind == "refresh" else operation.operation_id
+                requested = "op-" + "0" * 32
                 chunks = []
                 backend = mock.Mock()
                 with self.assertRaises(provider.JournalAdmissionError):

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -11,8 +11,10 @@ import importlib.util
 import importlib.machinery
 import os
 import pathlib
+import pty
 import select
 import signal
+import socket
 import stat
 import subprocess
 import sys
@@ -7695,16 +7697,16 @@ raise SystemExit(p["main"](sys.argv[2:]))
             state_home = str(pathlib.Path(chain.path).parents[1])
             with mock.patch.dict(os.environ, {"XDG_STATE_HOME": state_home}), \
                     mock.patch.object(provider, "read_boot_id", return_value=self.boot_id), \
-                    mock.patch.object(provider.os, "write", return_value=1) as output, \
                     contextlib.redirect_stderr(io.StringIO()) as diagnostic:
-                code = provider.run_operation_control("watch-operation", operation.operation_id, 123, None)
+                output = mock.Mock(return_value=1)
+                code = provider.run_operation_control("watch-operation", operation.operation_id, output, None)
             self.assertEqual(code, 1)
             self.assertEqual(diagnostic.getvalue(), "operation observation was interrupted\n")
             output.assert_called_once()
             self.assertEqual((path / "active").read_bytes(), before)
 
-    def test_control_signals_restore_retained_pipe_modes_and_preserve_ownership(self):
-        for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+    def test_control_signals_never_change_retained_pipe_modes_or_ownership(self):
+        for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGKILL):
             for blocking in (False, True):
                 with self.subTest(signum=signum, blocking=blocking), self.session() as (path, chain, journal), \
                         self.owner(journal) as operation:
@@ -7718,9 +7720,13 @@ raise SystemExit(p["main"](sys.argv[2:]))
                             operation.operation_id], stdout=writer, stderr=writer, env=environment, close_fds=True)
                         self.assertTrue(select.select([reader], [], [], 3)[0])
                         self.assertIn(b"\tpending\t", os.read(reader, 4096))
+                        self.assertEqual(os.get_blocking(writer), blocking)
+                        os.write(writer, b"parent output\n")
+                        self.assertTrue(select.select([reader], [], [], 3)[0])
+                        self.assertEqual(os.read(reader, 4096), b"parent output\n")
                         child.send_signal(signum)
                         child.communicate(timeout=3)
-                        self.assertEqual(child.returncode, 1)
+                        self.assertEqual(child.returncode, -signal.SIGKILL if signum == signal.SIGKILL else 1)
                         self.assertEqual(os.get_blocking(writer), blocking)
                         self.assertEqual((path / "active").read_bytes(), before)
                     finally:
@@ -7736,12 +7742,131 @@ raise SystemExit(p["main"](sys.argv[2:]))
             for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)}
         with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
             with self.assertRaisesRegex(OSError, "fixture"):
-                with provider.control_output_descriptors():
+                with provider.control_output_writers():
                     for signum, handler in original.items():
                         self.assertIsNot(signal.getsignal(signum), handler)
                     raise OSError("output fixture")
         for signum, handler in original.items():
             self.assertIs(signal.getsignal(signum), handler)
+
+    def test_isolated_pipe_and_terminal_writers_preserve_flags_and_close(self):
+        for terminal in (False, True):
+            for blocking in (False, True):
+                with self.subTest(terminal=terminal, blocking=blocking):
+                    reader, writer = pty.openpty() if terminal else os.pipe()
+                    opened = []
+                    real_open = os.open
+                    def capture(*args):
+                        descriptor = real_open(*args)
+                        opened.append(descriptor)
+                        return descriptor
+                    try:
+                        os.set_blocking(writer, blocking)
+                        original = provider.fcntl.fcntl(writer, provider.fcntl.F_GETFL)
+                        output = types.SimpleNamespace(fileno=lambda: writer)
+                        with contextlib.ExitStack() as resources, \
+                                mock.patch.object(provider.os, "open", side_effect=capture):
+                            send = provider.control_output_writer(output, resources)
+                            self.assertEqual(len(opened), 1)
+                            self.assertNotEqual(opened[0], writer)
+                            self.assertFalse(os.get_blocking(opened[0]))
+                            self.assertFalse(os.get_inheritable(opened[0]))
+                            self.assertEqual(send(b"watch"), 5)
+                            self.assertTrue(select.select([reader], [], [], 1)[0])
+                            self.assertEqual(os.read(reader, 4096), b"watch")
+                            os.write(writer, b"parent")
+                            self.assertTrue(select.select([reader], [], [], 1)[0])
+                            self.assertEqual(os.read(reader, 4096), b"parent")
+                            with self.assertRaises(BlockingIOError):
+                                for _ in range(256):
+                                    send(b"x" * 4096)
+                            self.assertEqual(provider.fcntl.fcntl(writer, provider.fcntl.F_GETFL), original)
+                        with self.assertRaises(OSError):
+                            os.fstat(opened[0])
+                        self.assertEqual(provider.fcntl.fcntl(writer, provider.fcntl.F_GETFL), original)
+                    finally:
+                        os.close(reader)
+                        os.close(writer)
+
+    def test_packet_pipe_writer_retains_packet_boundaries(self):
+        reader, writer = os.pipe2(os.O_DIRECT)
+        try:
+            with contextlib.ExitStack() as resources:
+                send = provider.control_output_writer(types.SimpleNamespace(fileno=lambda: writer), resources)
+                send(b"first")
+                send(b"second")
+                self.assertTrue(select.select([reader], [], [], 1)[0])
+                self.assertEqual(os.read(reader, 4096), b"first")
+                self.assertTrue(select.select([reader], [], [], 1)[0])
+                self.assertEqual(os.read(reader, 4096), b"second")
+                self.assertTrue(os.get_blocking(writer))
+        finally:
+            os.close(reader)
+            os.close(writer)
+
+    def test_socket_output_is_nonblocking_per_call_without_changing_flags(self):
+        for blocking in (False, True):
+            with self.subTest(blocking=blocking):
+                sender, reader = socket.socketpair()
+                with sender, reader, contextlib.ExitStack() as resources:
+                    sender.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 4096)
+                    sender.setblocking(blocking)
+                    send = provider.control_output_writer(sender, resources)
+                    self.assertEqual(send(b"watch"), 5)
+                    self.assertEqual(reader.recv(4096), b"watch")
+                    with self.assertRaises(BlockingIOError):
+                        for _ in range(64):
+                            send(b"x" * 4096)
+                    self.assertEqual(os.get_blocking(sender.fileno()), blocking)
+                    reader.close()
+                    with self.assertRaises(OSError):
+                        send(b"closed")
+                    self.assertEqual(os.get_blocking(sender.fileno()), blocking)
+
+    def test_regular_output_preserves_shared_offset_and_append_semantics(self):
+        for append in (False, True):
+            with self.subTest(append=append), tempfile.TemporaryFile() as output:
+                output.write(b"prefix")
+                output.flush()
+                flags = provider.fcntl.fcntl(output.fileno(), provider.fcntl.F_GETFL)
+                if append:
+                    flags |= os.O_APPEND
+                    provider.fcntl.fcntl(output.fileno(), provider.fcntl.F_SETFL, flags)
+                    output.seek(0)
+                with contextlib.ExitStack() as resources:
+                    send = provider.control_output_writer(output, resources)
+                    self.assertEqual(send(b"watch"), 5)
+                    os.write(output.fileno(), b"parent")
+                    self.assertEqual(provider.fcntl.fcntl(output.fileno(), provider.fcntl.F_GETFL), flags)
+                output.seek(0)
+                self.assertEqual(output.read(), b"prefixwatchparent")
+
+    def test_pipe_reopen_rejects_readonly_and_mismatched_output(self):
+        reader, writer = os.pipe()
+        closed = []
+        real_close = os.close
+        try:
+            with contextlib.ExitStack() as resources, mock.patch.object(provider.os, "open") as opened:
+                with self.assertRaisesRegex(OSError, "not writable"):
+                    provider.control_output_writer(types.SimpleNamespace(fileno=lambda: reader), resources)
+                opened.assert_not_called()
+            original = os.fstat(writer)
+            changed = types.SimpleNamespace(st_dev=original.st_dev, st_ino=original.st_ino + 1,
+                st_mode=original.st_mode, st_rdev=original.st_rdev)
+            def close(descriptor):
+                closed.append(descriptor)
+                real_close(descriptor)
+            with self.assertRaisesRegex(OSError, "identity changed"), contextlib.ExitStack() as resources, \
+                    mock.patch.object(provider.os, "fstat", side_effect=[original, changed]), \
+                    mock.patch.object(provider.os, "close", side_effect=close):
+                provider.control_output_writer(types.SimpleNamespace(fileno=lambda: writer), resources)
+            self.assertEqual(len(closed), 1)
+            with self.assertRaises(OSError):
+                os.fstat(closed[0])
+            self.assertTrue(os.get_blocking(writer))
+        finally:
+            os.close(reader)
+            os.close(writer)
 
     def test_path_replacement_during_watch_never_publishes_completion(self):
         chunks = []


### PR DESCRIPTION
## Scope

Complete one Phase 6 boundary: exact-ID observation and recovery of already-journaled native/delegated operations, with isolated bounded stream output. Native originating service calls and Settings actions remain disabled. Protocol minor remains 0; no privileged helper, installer, package, C core, or command-grammar changes.

## Implementation

- Observe the retained active inode using inotify and the existing owner lease. Never reissue native work, infer a result from target state, or call PackageKit for native recovery.
- Verify full immutable identity before recovery I/O and at terminal handoff. Bound event waiting to 120 seconds, then make a final fresh lease probe for Linux's close-before-unlock notification race.
- Isolate pipe/terminal output using independent open-file descriptions, preserve packet-pipe mode, and use per-call nonblocking socket writes. Never change inherited status flags, even while alive or after SIGKILL. Regular files retain shared offsets and append semantics; record bounds do not promise a hard storage-I/O deadline.
- Apply that writer to operation controls and the existing update-event monitor. Full/shared pipes, short writes and lost output fail without an unbounded queue, owner cancellation, or premature handoff acknowledgment.
- Let snapshots and the root Settings owner restore validated native identities and acknowledge verified results; native cancellation stays unavailable.
- Cover all seven native/delegated actions, immutable identity replacement, malformed/lost events, real process death, parent-output isolation, descriptor cleanup, and nested-X11 restoration. Reconcile the old documentation paragraphs with this behavior.

## Final local validation

Passed on tree `e0a09eb2ca80c62d9d4eb550462d79d9b0092310`, commit `23d0d889117753dc48979daeb4a4d33d5fe67b9d`:

- Focused selection: 120 tests, 16.203 seconds, plus the real private-bus update monitor fixture.
- `scripts/run-tests make clean all` followed by `scripts/run-tests`: full pass, including 453 provider tests (112.218 seconds), configured QML validation, nested-X11 lifecycle, staged/repeated installation, and release checks.
- Earlier changed-shell gates: `shellcheck install.sh scripts/*.sh tests/*.sh` and `shfmt -d install.sh scripts/*.sh tests/*.sh`; those shell files are unchanged by the output fix.
- Quickshell skill lint helper with explicit Qt/Quickshell imports: exit 0; existing packaged-type warnings remain documented.
- `npm --prefix docs run build`: 15 checked files, zero diagnostics, 11 pages.
- Independent local CodeRabbit and required post-full-gate Codex review: no actionable findings, including the final six-file review fix.
- `git diff --check`; managed test workspaces removed.

Fedora 44 nested-X11 evidence: restored locale and delegated active records reached verified terminal handoff/acknowledgment; invalid native cancellation was rejected. Closed Settings CPU: 0.067%; large surfaces: 0.00%; power baseline 0.100%, after 0.067%. Fixtures did not mutate host regional settings or launch administration tools. Real-process tests exercised owner/watchers, abrupt death, concurrent parent output, full pipes/sockets, terminals, packet pipes, and regular-file offset/append behavior.

The hosted Codex P2 shared-file-flags finding was reproduced before the fix and regression-tested afterward. The same reproduced pattern in the update-event monitor now uses the shared isolated writer. Hosted exact-head results will be recorded before merge.

## Remaining Phase 6 work

Regional execution/authorization/verification, delegated launch origins, event-driven cumulative discovery and Settings controls, information/recovery surfaces, and combined installed-X11 qualification are not complete. No installed synchronization, logout, or reboot occurs in this PR.