### PR TITLE
feat(system): add bounded regional service client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versions from `config.mk`.
 
 ### Changed
 
+- Reject locale confirmations that the platform cannot apply while preserving
+  an explicit LANGUAGE override. Add a preparatory fixed regional service client
+  with fresh confirmation checks, authorization hooks, monitored conflicts, and
+  bounded verification. Native CLI and Settings origins remain disabled pending
+  durable owner integration and qualification; tests change only a private bus.
+
 - Restore exact regional and delegated operation observers from validated
   journal snapshots. Watch durable progress and owner exit without repeating
   the action; stalled or closed control-output consumers preserve recovery.

--- a/TASKS.md
+++ b/TASKS.md
@@ -216,7 +216,18 @@ boundedly on full or closed pipes while preserving active ownership and handoffs
 Operation and update-event writers never change inherited file-status flags;
 private stream handles and per-call socket writes preserve concurrent parent
 output, including after forced watcher termination.
-Bounded service execution and originating Settings actions remain disabled.
+An internal regional service client now pins a platform owner, acknowledges
+subscriptions before fresh confirmation reads, and restricts calls to the three
+fixed interactive methods. Required lifecycle hooks bracket dispatch and method
+success; one 60-second budget covers reply and verification. Conflicting events,
+replacement owners, invalidated state, and failed hooks suppress success without
+retrying. Unit/private-bus fixtures cover a real ambiguous timeout after the
+simulated service changed state. Known non-preserving LANGUAGE selections are
+rejected during preview. Known-invalid complete locale argument sets are rejected
+before admission without narrowing readable state or dropping overrides.
+No host setting was changed. Native journal integration,
+post-timeout display refresh, CLI origins, and originating Settings actions
+remain outstanding; the snapshot minor remains zero.
 
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -415,6 +415,50 @@ overrides, and explains that applications require a new login to consume the
 change. This effective-value comparison permits locale1 to omit a redundant
 `LC_*` assignment without producing a false conflict.
 
+A locale selection with an existing explicit `LANGUAGE` that is empty or
+identical to the new `LANG` is rejected before confirmation or dispatch.
+localed's fallback and simplification cannot preserve that assignment exactly.
+Read-only parsing still preserves its presence; the provider neither drops the
+override from its comparison nor sends a known non-preserving change. See the
+[systemd 259 simplification implementation](https://github.com/systemd/systemd/blob/v259/src/basic/locale-util.c).
+
+Mutation preflight also checks the complete prepared array against localed's
+write-value grammar before admission. Every value must be a nonempty locale
+name of fewer than 128 ASCII bytes using letters, digits, underscore, dot,
+hyphen, or `@`, excluding `.` and `..`. This excludes some readable override
+sets, including colon-separated LANGUAGE preference lists and empty LC values.
+They remain readable and generation-bound; the mutation reports `unsupported`
+instead of dropping an override or sending a known-invalid array. This grammar
+check does not normalize preserved aliases or claim they are installed; the
+platform remains responsible for accepting installed values. See the
+[systemd 259.8 SetLocale validation](https://github.com/systemd/systemd/blob/v259.8/src/locale/localed.c).
+
+The internal regional mutation client now validates Fedora identity and fresh
+catalog/configuration evidence, pins the unique platform-service owner, and
+requires acknowledged property and owner subscriptions before its final read.
+It calls only the three fixed methods with both interactive-authorization flags
+enabled. Required caller hooks reserve durable admission/authorization before
+dispatch and a running checkpoint only after a successful reply. The client
+drains at most 64 nonblocking event-loop iterations after synchronous admission
+work; a busy or changed configuration rejects the request. Relevant non-equivalent
+or invalidated notifications remain conflicts even if final state later matches.
+Synchronization-only NTP samples do not invalidate configuration. Completion
+requires a fresh typed read and a final owner check under the same 60-second
+budget as the mutating call. Local cancellation stops observation, not the
+platform action, and late callbacks cannot publish a result.
+
+Unit and private-bus fixtures cover fixed arguments, generation rejection,
+authorization denial, owner replacement, conflict retention, callback floods,
+failed lifecycle hooks, unsupported preserved locale values, cleanup, and a real
+60-second ambiguous timeout after the fixture service has changed state. Cleanup
+removes local subscriptions and acknowledged match rules without closing the shared bus or removing another
+client's rejected/unrequested rule. An unconfirmed rule whose acknowledgment
+cannot be recovered is ultimately removed when that bus connection exits.
+This client is preparatory: native journal-owner integration, terminal commit,
+post-timeout display refresh, CLI origins, and Settings controls remain disabled
+or outstanding. These fixtures do not change host settings or qualify graphical
+polkit authorization.
+
 Each regional mutation uses a 60-second monotonic aggregate deadline beginning
 immediately before the fixed mutating D-Bus method is sent and covering its
 reply plus the required verification read. The operation emits `authorizing`

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -175,6 +175,8 @@ TRANSACTION_INTERFACE = "org.freedesktop.PackageKit.Transaction"
 PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
 
 REGIONAL_READ_SECONDS = 10
+REGIONAL_MUTATION_SECONDS = 60
+REGIONAL_CALLBACK_LIMIT = 64
 REGIONAL_TIME_PROPERTY_COUNT = 64
 REGIONAL_READ_REQUESTS = {
     "time-state": ("org.freedesktop.timedate1", "/org/freedesktop/timedate1",
@@ -367,6 +369,11 @@ def prepare_locale_change(
     if locale not in choices:
         raise SnapshotFailure("conflict", "The selected locale is no longer available")
     current = parse_locale_configuration(values)
+    language = dict(value.split("=", 1) for value in current.assignments).get("LANGUAGE")
+    if language is not None and language in ("", locale):
+        # localed applies language fallback and simplifies every non-LANG key.
+        # Such an explicit LANGUAGE cannot survive SetLocale unchanged.
+        raise SnapshotFailure("conflict", "The locale service cannot preserve this explicit LANGUAGE override; review locale configuration before changing LANG")
     preserved = [value for value in current.assignments if not value.startswith("LANG=")]
     return parse_locale_configuration([f"LANG={locale}", *preserved])
 
@@ -387,6 +394,20 @@ def locale_change_matches(expected_values: object, observed_values: object) -> b
     return all((expected.get(key) or expected.get("LANG", ""))
                == (observed.get(key) or observed.get("LANG", ""))
                for key in REGIONAL_LOCALE_KEYS[2:])
+
+
+def require_locale_service_arguments(configuration: LocaleConfiguration) -> None:
+    """Keep broader readable state, but never send known-invalid localed values.
+
+    systemd 259 validates every SetLocale value, including LANGUAGE, as a locale
+    name. Do not omit an unsupported override to make an otherwise valid LANG
+    selection writable. Installed aliases remain the platform's responsibility.
+    """
+    for assignment in parse_locale_configuration(configuration.assignments).assignments:
+        value = assignment.split("=", 1)[1]
+        if (not 1 <= len(value) < 128 or value in {".", ".."}
+                or re.fullmatch(r"[A-Za-z0-9_.@-]+", value) is None):
+            raise SnapshotFailure("unsupported", "The locale service cannot accept the complete preserved assignment set; review locale configuration without dropping overrides", "unsupported")
 
 
 @dataclass(frozen=True)
@@ -1061,6 +1082,329 @@ class RegionalRead(ServiceRead):
         except SnapshotFailure as error:
             if self.pending():
                 self.finish(failure=error)
+
+
+class RegionalMutation(ServiceRead):
+    """Internal fixed service client; durable admission is a required caller hook.
+
+    No CLI or Settings origin uses this client yet. The caller must retain its
+    native journal lease, checkpoint authorizing in before_send, checkpoint
+    running in after_reply, and commit the result before releasing ownership.
+    A sent timeout is ambiguous, not proof of failure or service cancellation.
+    """
+
+    label = "Regional operation"
+
+    def __init__(self, action: str, argument: str, generation: str,
+                 before_send: Callable[[RegionalPreview], None],
+                 after_reply: Callable[[], None], Gio=None, GLib=None) -> None:
+        self.action = action
+        self.argument = validate_regional_argument(action, argument)
+        if not isinstance(generation, str) or JOURNAL_GENERATION_PATTERN.fullmatch(generation) is None:
+            raise SnapshotFailure("malformed", "Invalid regional confirmation generation")
+        if not callable(before_send) or not callable(after_reply):
+            raise ValueError("Regional operation requires durable lifecycle hooks")
+        self.generation = generation
+        self.before_send, self.after_reply = before_send, after_reply
+        self.kind = "locale-state" if action == "locale-set" else "time-state"
+        self.name, self.path = REGIONAL_READ_REQUESTS[self.kind][:2]
+        self.owner = ""
+        self.sent = self.acknowledged = False
+        self.dirty = False
+        self.observed = self.expected = self.preview = None
+        self.choices = ()
+        self.hook_error = None
+        self.subscriptions = []
+        self.rules = []
+        self.installed_rules = []
+        self.closed_handler = 0
+        super().__init__(Gio, GLib)
+
+    def timeout_failure(self) -> SnapshotFailure:
+        detail = ("Regional operation timed out after dispatch; the outcome is unknown. Refresh state before a new confirmation"
+                  if self.sent else "Regional operation preflight timed out; no change was sent")
+        return SnapshotFailure("timeout", detail, "unavailable")
+
+    def request(self, name, path, interface, method, parameters, reply_type, handler,
+                *, interactive=False, match_rule=None) -> None:
+        if not self.pending():
+            return
+
+        def replied(connection, result, _data):
+            if match_rule is None and not self.pending():
+                return
+            try:
+                reply = connection.call_finish(result)
+                if match_rule is not None:
+                    # Pair only a successful AddMatch with RemoveMatch. An
+                    # unrequested or rejected rule can belong to another user
+                    # of this shared connection. Late acknowledgments perform
+                    # cleanup only, never resume the operation.
+                    if self.done:
+                        self.remove_match(match_rule)
+                        return
+                    self.installed_rules.append(match_rule)
+                if not self.pending():
+                    return
+                if reply.get_type_string() != reply_type:
+                    raise SnapshotFailure("malformed", "Unexpected regional operation reply")
+                if self.pending():
+                    handler(reply)
+            except self.GLib.Error as error:
+                if self.pending():
+                    self.fail(self.bus_failure(error))
+            except SnapshotFailure as error:
+                if self.pending():
+                    self.fail(error)
+
+        flags = (self.Gio.DBusCallFlags.ALLOW_INTERACTIVE_AUTHORIZATION
+                 if interactive else self.Gio.DBusCallFlags.NONE)
+        try:
+            self.connection.call(name, path, interface, method, parameters,
+                self.GLib.VariantType.new(reply_type), flags,
+                max(1, int((self.deadline - time.monotonic()) * 1000)),
+                self.cancellable, replied, None)
+        except self.GLib.Error as error:
+            self.fail(self.bus_failure(error))
+
+    def bus_request(self, method, value, reply_type, handler):
+        self.request("org.freedesktop.DBus", "/org/freedesktop/DBus",
+            "org.freedesktop.DBus", method, self.GLib.Variant("(s)", (value,)),
+            reply_type, handler)
+
+    def bus_failure(self, error):
+        name = self.Gio.dbus_error_get_remote_error(error)
+        if (time.monotonic() < self.deadline
+                and name == "org.freedesktop.DBus.Error.InteractiveAuthorizationRequired"):
+            return SnapshotFailure("permission-denied", "Regional authorization was not granted", "restricted")
+        failure = super().bus_failure(error)
+        if failure.code == "timeout":
+            return self.timeout_failure()
+        if self.sent and name is None:
+            return SnapshotFailure("interrupted", "Regional transport failed after dispatch; the outcome is unknown. Refresh state before a new confirmation")
+        return failure
+
+    def remove_match(self, rule):
+        with contextlib.suppress(self.GLib.Error):
+            self.connection.call("org.freedesktop.DBus", "/org/freedesktop/DBus",
+                "org.freedesktop.DBus", "RemoveMatch", self.GLib.Variant("(s)", (rule,)),
+                None, self.Gio.DBusCallFlags.NONE, 1000, None, None, None)
+
+    def read_state(self, handler, *, activate=False):
+        _name, path, interface, method, signature, arguments, reply_type = REGIONAL_READ_REQUESTS[self.kind]
+        self.request(self.name if activate else self.owner, path, interface, method,
+            self.GLib.Variant(signature, arguments), reply_type, handler)
+
+    def connected(self, _source, result, _data) -> None:
+        if not self.pending():
+            return
+        try:
+            self.connection = self.Gio.bus_get_finish(result)
+            self.connection.set_exit_on_close(False)
+            self.closed_handler = self.connection.connect("closed", lambda *_args: self.fail(
+                SnapshotFailure("interrupted", "Regional service connection was lost; refresh state before retrying")))
+            # A fixed read may activate an idle platform service. Its result is
+            # not confirmation evidence; the pinned, subscribed read below is.
+            self.read_state(lambda _reply: self.resolve_owner(self.pinned), activate=True)
+        except self.GLib.Error as error:
+            self.fail(self.bus_failure(error))
+
+    def resolve_owner(self, handler):
+        self.bus_request("GetNameOwner", self.name, "(s)", handler)
+
+    def pinned(self, reply):
+        value = reply.get_child_value(0)
+        if value.get_size() > 256:
+            raise SnapshotFailure("malformed", "Invalid regional service owner")
+        owner = value.unpack()
+        if not self.Gio.dbus_is_unique_name(owner):
+            raise SnapshotFailure("malformed", "Invalid regional service owner")
+        self.owner = owner
+        specs = [
+            (None, PROPERTIES_INTERFACE, "PropertiesChanged", self.path, self.name,
+             self.properties_changed,
+             f"type='signal',sender='{owner}',interface='{PROPERTIES_INTERFACE}',member='PropertiesChanged',path='{self.path}',arg0='{self.name}'"),
+            ("org.freedesktop.DBus", "org.freedesktop.DBus", "NameOwnerChanged",
+             "/org/freedesktop/DBus", self.name, self.owner_changed,
+             f"type='signal',sender='org.freedesktop.DBus',interface='org.freedesktop.DBus',member='NameOwnerChanged',path='/org/freedesktop/DBus',arg0='{self.name}'"),
+        ]
+        for sender, interface, member, path, arg0, callback, rule in specs:
+            self.subscriptions.append(self.connection.signal_subscribe(sender, interface,
+                member, path, arg0, self.Gio.DBusSignalFlags.NO_MATCH_RULE, callback, None))
+            self.rules.append(rule)
+        self.add_match(0)
+
+    def add_match(self, index):
+        if index < len(self.rules):
+            rule = self.rules[index]
+            self.request("org.freedesktop.DBus", "/org/freedesktop/DBus",
+                "org.freedesktop.DBus", "AddMatch", self.GLib.Variant("(s)", (rule,)),
+                "()", lambda _reply: self.add_match(index + 1), match_rule=rule)
+        else:
+            self.resolve_owner(self.ready)
+
+    def require_owner(self, reply):
+        if reply.get_child_value(0).get_size() > 256 or reply.unpack()[0] != self.owner:
+            raise SnapshotFailure("conflict", "Regional service owner changed; refresh state before retrying")
+
+    def ready(self, reply):
+        self.require_owner(reply)
+        if self.action == "timezone-set":
+            self.request(self.owner, self.path, self.name, "ListTimezones", None,
+                "(as)", self.catalog_read)
+        else:
+            self.read_state(self.preflight_read)
+
+    def catalog_read(self, reply):
+        self.choices = decode_regional_reply("timezone-choices", reply)
+        self.read_state(self.preflight_read)
+
+    def drain(self) -> bool:
+        # Flush already queued notifications after synchronous journal work.
+        # Never turn a signal flood into an unbounded nested event loop.
+        context = self.loop.get_context()
+        for _ in range(REGIONAL_CALLBACK_LIMIT):
+            if not self.pending():
+                return False
+            if not context.pending():
+                return True
+            context.iteration(False)
+        if self.pending() and context.pending():
+            self.fail(SnapshotFailure("conflict", "Regional state notifications did not settle; refresh before retrying"))
+        return self.pending()
+
+    def hook(self, callback, *args) -> bool:
+        try:
+            callback(*args)
+        except Exception as error:
+            # A failed durable checkpoint must never escape a GLib callback
+            # and leave the loop able to send or publish a later success.
+            self.hook_error = error
+            self.fail(SnapshotFailure("interrupted", "Regional operation checkpoint failed; inspect recovery before retrying"))
+        return self.pending()
+
+    def preflight_read(self, reply):
+        state = decode_regional_reply(self.kind, reply)
+        self.preview = make_regional_preview(self.action, self.argument, state, self.choices)
+        require_regional_generation(self.preview, self.generation)
+        self.expected = (parse_locale_configuration((self.argument, *(value for value in state.assignments
+            if not value.startswith("LANG=")))) if self.action == "locale-set" else
+            replace(state, timezone=self.argument) if self.action == "timezone-set" else
+            replace(state, ntp_enabled=self.argument == "enabled"))
+        if self.action == "locale-set":
+            require_locale_service_arguments(self.expected)
+        if not self.drain():
+            return
+        if self.dirty:
+            raise SnapshotFailure("conflict", "Regional state changed before dispatch; review a fresh confirmation")
+        if not self.hook(self.before_send, self.preview) or not self.drain():
+            return
+        require_regional_generation(self.preview, self.generation)
+        if self.dirty:
+            raise SnapshotFailure("conflict", "Regional state changed before dispatch; review a fresh confirmation")
+        method, parameters = {
+            "timezone-set": ("SetTimezone", lambda: self.GLib.Variant("(sb)", (self.argument, True))),
+            "ntp-set": ("SetNTP", lambda: self.GLib.Variant("(bb)", (self.argument == "enabled", True))),
+            "locale-set": ("SetLocale", lambda: self.GLib.Variant("(asb)", (self.expected.assignments, True))),
+        }[self.action]
+        arguments = parameters()
+        self.GLib.source_remove(self.deadline_source)
+        self.deadline = time.monotonic() + REGIONAL_MUTATION_SECONDS
+        self.deadline_source = self.GLib.timeout_add(REGIONAL_MUTATION_SECONDS * 1000, self.expire)
+        self.sent = True
+        self.request(self.owner, self.path, self.name, method, arguments, "()",
+            self.method_replied, interactive=True)
+
+    def method_replied(self, _reply):
+        self.acknowledged = True
+        if self.hook(self.after_reply):
+            self.read_state(self.verified)
+
+    def matches(self, state):
+        if self.action == "locale-set":
+            return locale_change_matches(self.expected.assignments, state.assignments)
+        if self.action == "timezone-set":
+            return state.timezone == self.expected.timezone
+        return state.can_ntp and state.ntp_enabled == self.expected.ntp_enabled
+
+    def verified(self, reply):
+        self.observed = decode_regional_reply(self.kind, reply)
+        if not self.matches(self.observed):
+            self.dirty = True
+        self.resolve_owner(self.completed)
+
+    def completed(self, reply):
+        self.require_owner(reply)
+        if not self.drain():
+            return
+        if self.dirty:
+            raise SnapshotFailure("conflict", "Regional state differs from the confirmed result; a concurrent writer may have changed or been overwritten. Refresh state before retrying")
+        self.finish(value=self.observed)
+
+    def owner_changed(self, _connection, _sender, _path, _interface, _member, parameters, _data):
+        if self.pending():
+            self.fail(SnapshotFailure("interrupted" if self.sent else "conflict",
+                "Regional service owner changed; the result cannot be confirmed. Refresh state before retrying"))
+
+    def properties_changed(self, _connection, sender, _path, _interface, _member, parameters, _data):
+        if not self.pending() or sender != self.owner:
+            return
+        try:
+            if parameters.get_type_string() != "(sa{sv}as)" or parameters.get_size() > 16384:
+                raise SnapshotFailure("malformed", "Invalid regional notification")
+            if parameters.get_child_value(0).unpack() != self.name:
+                return
+            changed = parameters.get_child_value(1)
+            invalidated = regional_string_array(parameters.get_child_value(2),
+                REGIONAL_TIME_PROPERTY_COUNT, MAX_TEXT_BYTES, 8192)
+            if changed.n_children() > REGIONAL_TIME_PROPERTY_COUNT:
+                raise SnapshotFailure("malformed", "Oversized regional notification")
+            keys = set()
+            for index in range(changed.n_children()):
+                key = changed.get_child_value(index).get_child_value(0)
+                if key.get_size() > MAX_TEXT_BYTES + 1 or key.unpack() in keys:
+                    raise SnapshotFailure("malformed", "Invalid regional notification key")
+                keys.add(key.unpack())
+            relevant = ({"Locale"} if self.action == "locale-set" else
+                        {"Timezone"} if self.action == "timezone-set" else {"NTP", "CanNTP"})
+            if not relevant.intersection(keys.union(invalidated)):
+                return
+            if not self.sent or relevant.intersection(invalidated):
+                self.dirty = True
+                return
+            for key in relevant.intersection(keys):
+                value = changed.lookup_value(key, None)
+                if key == "Locale":
+                    state = parse_locale_configuration(regional_string_array(value,
+                        len(REGIONAL_LOCALE_KEYS), MAX_TEXT_BYTES, REGIONAL_LOCALE_ARRAY_BYTES, separators=True))
+                    equivalent = self.matches(state)
+                elif key == "Timezone":
+                    equivalent = (value.get_type_string() == "s" and value.get_size() <= REGIONAL_TIMEZONE_MAX + 1
+                                  and value.unpack() == self.expected.timezone)
+                else:
+                    equivalent = (value.get_type_string() == "b" and value.unpack()
+                                  == (True if key == "CanNTP" else self.expected.ntp_enabled))
+                if not equivalent:
+                    self.dirty = True
+        except SnapshotFailure:
+            self.dirty = True
+
+    def run(self):
+        if self.started:
+            raise RuntimeError("Regional operations are single-use")
+        read_fedora_identity()
+        if self.action == "locale-set":
+            self.choices = validate_locale_catalog(read_locale_choices())
+        try:
+            return super().run()
+        finally:
+            if self.connection is not None:
+                for subscription in self.subscriptions:
+                    self.connection.signal_unsubscribe(subscription)
+                if self.closed_handler:
+                    self.connection.disconnect(self.closed_handler)
+                for rule in self.installed_rules:
+                    self.remove_match(rule)
 
 
 @dataclass(frozen=True)

--- a/tests/fixtures/system-regional-mutation-bus.py
+++ b/tests/fixtures/system-regional-mutation-bus.py
@@ -1,0 +1,162 @@
+#!/usr/bin/python3
+"""Fixed regional writes on a private bus; never connect to host services."""
+
+import os
+import runpy
+import sys
+import time
+from unittest import mock
+
+os.environ["DBUS_SYSTEM_BUS_ADDRESS"] = os.environ["DBUS_SESSION_BUS_ADDRESS"]
+from gi.repository import Gio, GLib
+
+provider = runpy.run_path(sys.argv[1], run_name="regional_mutation_fixture")
+client_class = provider["RegionalMutation"]
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+mode = "normal"
+zone = "UTC"
+ntp = False
+locale = ["LANG=C", "LANGUAGE=C", "LC_TIME=C"]
+calls = []
+held = []
+registrations = []
+events = []
+properties = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.DBus.Properties">
+<method name="GetAll"><arg type="s" direction="in"/><arg type="a{sv}" direction="out"/></method>
+<method name="Get"><arg type="s" direction="in"/><arg type="s" direction="in"/><arg type="v" direction="out"/></method>
+</interface></node>""").interfaces[0]
+timedate = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.timedate1">
+<method name="ListTimezones"><arg type="as" direction="out"/></method>
+<method name="SetTimezone"><arg type="s" direction="in"/><arg type="b" direction="in"/></method>
+<method name="SetNTP"><arg type="b" direction="in"/><arg type="b" direction="in"/></method>
+</interface></node>""").interfaces[0]
+localed = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.locale1">
+<method name="SetLocale"><arg type="as" direction="in"/><arg type="b" direction="in"/></method>
+</interface></node>""").interfaces[0]
+
+
+def name_call(method, name):
+    args = GLib.Variant("(su)", (name, 0)) if method == "RequestName" else GLib.Variant("(s)", (name,))
+    return bus.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus",
+        "org.freedesktop.DBus", method, args, GLib.VariantType.new("(u)"),
+        Gio.DBusCallFlags.NONE, 3000, None).unpack()[0]
+
+
+def notify(path, interface, values):
+    bus.emit_signal(None, path, "org.freedesktop.DBus.Properties", "PropertiesChanged",
+                    GLib.Variant("(sa{sv}as)", (interface, values, [])))
+
+
+def called(_bus, _sender, path, interface, method, args, invocation):
+    global zone, ntp, locale
+    calls.append((path, interface, method, args.unpack()))
+    if method.startswith("Set"):
+        assert args.unpack()[-1] is True
+        assert invocation.get_message().get_flags() & Gio.DBusMessageFlags.ALLOW_INTERACTIVE_AUTHORIZATION
+        if mode == "denied":
+            invocation.return_dbus_error("org.freedesktop.DBus.Error.AccessDenied", "fixture denial")
+            return
+        if mode == "bad-arguments":
+            invocation.return_dbus_error("org.freedesktop.DBus.Error.InvalidArgs", "fixture rejection")
+            return
+        if mode == "owner-lost":
+            assert name_call("ReleaseName", interface) == 1
+            held.append(invocation)
+            return
+        if method == "SetTimezone":
+            zone = args.unpack()[0]
+            values = {"Timezone": GLib.Variant("s", zone)}
+        elif method == "SetNTP":
+            ntp = args.unpack()[0]
+            values = {"NTP": GLib.Variant("b", ntp)}
+        else:
+            locale = args.unpack()[0]
+            values = {"Locale": GLib.Variant("as", locale)}
+        if mode == "conflict":
+            notify(path, interface, {"Timezone": GLib.Variant("s", "Europe/London")})
+        notify(path, interface, values)
+        if mode == "stall":
+            held.append(invocation)
+        else:
+            invocation.return_value(GLib.Variant("()", ()))
+    elif method == "GetAll":
+        invocation.return_value(GLib.Variant("(a{sv})", ({
+            "Timezone": GLib.Variant("s", zone), "CanNTP": GLib.Variant("b", True),
+            "NTP": GLib.Variant("b", ntp), "NTPSynchronized": GLib.Variant("b", True)},)))
+    elif method == "Get":
+        invocation.return_value(GLib.Variant("(v)", (GLib.Variant("as", locale),)))
+    else:
+        invocation.return_value(GLib.Variant("(as)", (["UTC", "Etc/UTC"],)))
+
+
+def client(action="timezone-set", argument="Etc/UTC"):
+    state = (provider["parse_locale_configuration"](locale) if action == "locale-set" else
+             provider["RegionalTimeState"](zone, True, ntp, True))
+    choices = ["C", "en_US.utf8"] if action == "locale-set" else ["UTC", "Etc/UTC"]
+    preview = provider["make_regional_preview"](action, argument, state, choices)
+    return client_class(action, argument, preview.generation,
+        lambda current: events.append(("authorizing", current)), lambda: events.append(("running", None)))
+
+
+def fail(operation, code):
+    try:
+        operation.run()
+    except provider["SnapshotFailure"] as error:
+        assert error.code == code, (error.code, code)
+    else:
+        raise AssertionError("regional failure reported success")
+
+
+try:
+    for name in ("org.freedesktop.timedate1", "org.freedesktop.locale1"):
+        assert name_call("RequestName", name) == 1
+    for path, info in (("/org/freedesktop/timedate1", timedate),
+                       ("/org/freedesktop/timedate1", properties),
+                       ("/org/freedesktop/locale1", properties),
+                       ("/org/freedesktop/locale1", localed)):
+        registrations.append(bus.register_object(path, info, called, None, None))
+    with mock.patch.dict(client_class.run.__globals__,
+                         read_fedora_identity=lambda: {"ID": "fedora"},
+                         read_locale_choices=lambda: ("C", "en_US.utf8")):
+        assert client().run().timezone == "Etc/UTC"
+        assert client("ntp-set", "enabled").run().ntp_enabled
+        assert client("locale-set", "LANG=en_US.utf8").run().assignments == (
+            "LANG=en_US.utf8", "LANGUAGE=C", "LC_TIME=C")
+        assert [event[0] for event in events] == ["authorizing", "running"] * 3
+        stale = client()
+        zone = "UTC"
+        before = len([call for call in calls if call[2].startswith("Set")])
+        fail(stale, "conflict")
+        assert len([call for call in calls if call[2].startswith("Set")]) == before
+        for scenario, code in (("denied", "permission-denied"), ("bad-arguments", "malformed"),
+                               ("conflict", "conflict"), ("owner-lost", "interrupted")):
+            mode = scenario
+            operation = client()
+            fail(operation, code)
+            assert operation.sent
+            assert operation.acknowledged is (scenario == "conflict")
+        assert name_call("RequestName", "org.freedesktop.timedate1") == 1
+        for invocation in held:
+            invocation.return_value(GLib.Variant("()", ()))
+        held.clear()
+        mode = "stall"
+        operation = client("timezone-set", "UTC")
+        started = time.monotonic()
+        fail(operation, "timeout")
+        elapsed = time.monotonic() - started
+        assert 59.5 <= elapsed < 70, elapsed
+        assert operation.sent and not operation.acknowledged and operation.value is None
+        assert zone == "UTC"  # Timeout does not imply the platform did nothing.
+        assert len(held) == 1
+        held.pop().return_value(GLib.Variant("()", ()))
+        mode = "normal"
+        assert client().run().timezone == "Etc/UTC"
+        assert operation.value is None and operation.failure.code == "timeout"
+        assert all(call[2] in {"Get", "GetAll", "ListTimezones", "SetTimezone", "SetNTP", "SetLocale"} for call in calls)
+        print("Private-bus regional mutations: PASS (fixed calls, confirmation, signals, denial, owner loss, real 60-second timeout, late reply)")
+finally:
+    for registration in registrations:
+        bus.unregister_object(registration)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -123,16 +123,16 @@ class RegionalPreflightTests(unittest.TestCase):
         self.assertEqual(caught.exception.code, "unsupported")
 
     def test_locale_generation_preserves_key_presence_order_and_complete_overrides(self):
-        assignments = ["LANG=C", "LANGUAGE=", "LC_TIME=de_DE.utf8", "LC_NUMERIC=fr_FR.utf8"]
+        assignments = ["LANG=C", "LANGUAGE=de:en", "LC_TIME=de_DE.utf8", "LC_NUMERIC=fr_FR.utf8"]
         before = provider.parse_locale_configuration(assignments)
         preview = provider.make_regional_preview("locale-set", "LANG=en_US.utf8", before, ["C", "en_US.utf8"])
         self.assertEqual((preview.current, preview.target, preview.detail),
-                         ("C", "en_US.utf8", "LC_NUMERIC=fr_FR.utf8, LC_TIME=de_DE.utf8"))
+                         ("C", "en_US.utf8", "LANGUAGE=de:en, LC_NUMERIC=fr_FR.utf8, LC_TIME=de_DE.utf8"))
         reordered = provider.make_regional_preview("locale-set", "LANG=en_US.utf8",
             provider.parse_locale_configuration(list(reversed(assignments))), ["en_US.utf8", "C"])
         self.assertEqual(preview, reordered)
-        for changed in ([item for item in assignments if item != "LANGUAGE="],
-                        [item.replace("LANGUAGE=", "LANGUAGE=en") for item in assignments],
+        for changed in ([item for item in assignments if item != "LANGUAGE=de:en"],
+                        [item.replace("LANGUAGE=de:en", "LANGUAGE=en") for item in assignments],
                         [item.replace("LC_TIME=de_DE.utf8", "LC_TIME=C") for item in assignments]):
             other = provider.make_regional_preview("locale-set", "LANG=en_US.utf8",
                 provider.parse_locale_configuration(changed), ["C", "en_US.utf8"])
@@ -140,6 +140,10 @@ class RegionalPreflightTests(unittest.TestCase):
         forged = replace(before, lang="forged", detail="forged")
         self.assertEqual(provider.make_regional_preview("locale-set", "LANG=en_US.utf8",
             forged, ["C", "en_US.utf8"]), preview)
+        absent, empty = [provider.make_regional_preview("locale-set", "LANG=en_US.utf8",
+            provider.parse_locale_configuration(values), ["en_US.utf8"]).generation
+            for values in (["LANG=C"], ["LANG=C", "LC_TIME="])]
+        self.assertNotEqual(absent, empty)
 
     def test_invalid_selections_and_states_are_rejected_before_io(self):
         for action, argument in (("timezone-set", "../UTC"), ("ntp-set", "yes"),
@@ -1284,6 +1288,402 @@ class RegionalValidationTests(unittest.TestCase):
         self.assertFalse(provider.locale_change_matches(["LANG=C", "LANGUAGE="],
                                                         ["LANG=C"]))
         self.malformed(provider.locale_change_matches, ["LANG=C"], ["LC_ALL=C"])
+
+    def test_locale_confirmation_rejects_known_language_preservation_loss(self):
+        for language in ("", "C"):
+            before = provider.parse_locale_configuration(["LANG=en_US.utf8", "LANGUAGE=" + language])
+            self.assertIn("LANGUAGE=" + language, before.assignments)
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                provider.make_regional_preview("locale-set", "LANG=C", before, ["C"])
+            self.assertEqual(caught.exception.code, "conflict")
+            self.assertIn("cannot preserve", caught.exception.detail)
+        for values in (["LANG=en_US.utf8"], ["LANG=en_US.utf8", "LANGUAGE=de:en"]):
+            self.assertEqual(provider.make_regional_preview("locale-set", "LANG=C",
+                provider.parse_locale_configuration(values), ["C"]).target, "C")
+
+    def test_locale_service_grammar_does_not_narrow_readable_state_or_drop_overrides(self):
+        for value in ("C", "POSIX", "en_US.UTF-8", "sr_RS@latin", "x" * 127):
+            provider.require_locale_service_arguments(provider.parse_locale_configuration(["LANG=" + value]))
+        for key, value in (("LANGUAGE", "de:en"), ("LANGUAGE", "français"),
+                           ("LC_TIME", ""), ("LC_TIME", "."), ("LC_TIME", ".."),
+                           ("LC_TIME", "a/b"), ("LANG", "x" * 128), ("LC_NUMERIC", "C+")):
+            state = provider.parse_locale_configuration([key + "=" + value])
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                provider.require_locale_service_arguments(state)
+            self.assertEqual(caught.exception.code, "unsupported")
+            self.assertEqual(state.assignments, (key + "=" + value,))
+
+
+class RegionalMutationTests(unittest.TestCase):
+    def client(self, action="timezone-set", argument="Etc/UTC"):
+        from gi.repository import Gio, GLib
+        self.GLib = GLib
+        self.clock = 1.0
+        self.methods = []
+        self.events = []
+        self.owner = ":1.42"
+        self.time_state = provider.RegionalTimeState("UTC", True, False, True)
+        self.locale_state = provider.parse_locale_configuration(["LANG=C", "LANGUAGE=C", "LC_TIME=C"])
+        self.before_request = lambda _method: None
+        self.before_hook = lambda: None
+        self.after_hook = lambda: None
+        self.replies = {}
+        self.context = mock.Mock()
+        self.context.pending.return_value = False
+        loop = mock.Mock()
+        loop.get_context.return_value = self.context
+        glib = types.SimpleNamespace(Error=GLib.Error, Variant=GLib.Variant,
+            VariantType=GLib.VariantType, MainLoop=mock.Mock(return_value=loop),
+            timeout_add=mock.Mock(side_effect=range(17, 100)), source_remove=mock.Mock(), SOURCE_REMOVE=False)
+        gio = mock.Mock()
+        gio.BusType, gio.DBusCallFlags, gio.DBusSignalFlags = Gio.BusType, Gio.DBusCallFlags, Gio.DBusSignalFlags
+        gio.dbus_is_unique_name = Gio.dbus_is_unique_name
+        gio.dbus_error_get_remote_error = Gio.dbus_error_get_remote_error
+        gio.io_error_quark = Gio.io_error_quark
+        gio.IOErrorEnum = Gio.IOErrorEnum
+        self.connection = mock.Mock()
+        gio.bus_get_finish.return_value = self.connection
+        self.connection.signal_subscribe.side_effect = range(1, 10)
+        def finish(result):
+            if isinstance(result, Exception):
+                raise result
+            return result
+        self.connection.call_finish.side_effect = finish
+        state = self.locale_state if action == "locale-set" else self.time_state
+        choices = ("C", "en_US.utf8") if action == "locale-set" else ("UTC", "Etc/UTC")
+        preview = provider.make_regional_preview(action, argument, state, choices)
+
+        def before(preflight):
+            self.events.append(("authorizing", preflight))
+            self.before_hook()
+
+        def after():
+            self.events.append(("running", None))
+            self.after_hook()
+
+        client = provider.RegionalMutation(action, argument, preview.generation, before, after, gio, glib)
+        self.current = client
+
+        def call(name, path, interface, method, args, reply_type, flags, timeout, cancellable, callback, data):
+            self.methods.append((name, path, interface, method, None if args is None else args.unpack(), flags, timeout))
+            if method == "RemoveMatch":
+                return
+            self.before_request(method)
+            if method in self.replies:
+                result = self.replies[method]
+            elif method == "GetNameOwner":
+                result = GLib.Variant("(s)", (self.owner,))
+            elif method == "GetAll":
+                values = {"Timezone": GLib.Variant("s", self.time_state.timezone),
+                          "CanNTP": GLib.Variant("b", self.time_state.can_ntp),
+                          "NTP": GLib.Variant("b", self.time_state.ntp_enabled),
+                          "NTPSynchronized": GLib.Variant("b", self.time_state.ntp_synchronized)}
+                result = GLib.Variant("(a{sv})", (values,))
+            elif method == "Get":
+                result = GLib.Variant("(v)", (GLib.Variant("as", self.locale_state.assignments),))
+            elif method == "ListTimezones":
+                result = GLib.Variant("(as)", (["UTC", "Etc/UTC"],))
+            else:
+                if method == "SetTimezone":
+                    self.time_state = replace(self.time_state, timezone=args.unpack()[0])
+                elif method == "SetNTP":
+                    self.time_state = replace(self.time_state, ntp_enabled=args.unpack()[0])
+                elif method == "SetLocale":
+                    self.locale_state = provider.parse_locale_configuration(args.unpack()[0])
+                result = GLib.Variant("()", ())
+            if result is not None:
+                callback(self.connection, result, data)
+        self.connection.call.side_effect = call
+        gio.bus_get.side_effect = lambda *_args: client.connected(None, object(), None)
+        self.gio, self.glib = gio, glib
+        return client
+
+    def run_client(self, client):
+        with mock.patch.object(provider, "read_fedora_identity", return_value={"ID": "fedora"}), \
+                mock.patch.object(provider, "read_locale_choices", return_value=("C", "en_US.utf8")), \
+                mock.patch.object(provider.time, "monotonic", side_effect=lambda: self.clock):
+            return client.run()
+
+    def failure(self, client, code):
+        with self.assertRaises(provider.SnapshotFailure) as caught:
+            self.run_client(client)
+        self.assertEqual(caught.exception.code, code)
+        return caught.exception
+
+    def mutations(self):
+        return [method for method in self.methods if method[3].startswith("Set")]
+
+    def notify(self, values, invalidated=(), sender=":1.42"):
+        client = self.current
+        args = self.GLib.Variant("(sa{sv}as)", (client.name, values, invalidated))
+        client.properties_changed(None, sender, client.path, provider.PROPERTIES_INTERFACE,
+                                  "PropertiesChanged", args, None)
+
+    def test_fixed_methods_full_arguments_and_acknowledged_subscription_order(self):
+        for action, argument, method, signature_args in (
+            ("timezone-set", "Etc/UTC", "SetTimezone", ("Etc/UTC", True)),
+            ("ntp-set", "enabled", "SetNTP", (True, True)),
+            ("ntp-set", "disabled", "SetNTP", (False, True)),
+            ("locale-set", "LANG=en_US.utf8", "SetLocale",
+             (["LANG=en_US.utf8", "LANGUAGE=C", "LC_TIME=C"], True)),
+        ):
+            with self.subTest(action=action, argument=argument):
+                client = self.client(action, argument)
+                self.assertIsNotNone(self.run_client(client))
+                calls = self.mutations()
+                self.assertEqual(len(calls), 1)
+                self.assertEqual(calls[0][:6], (":1.42", client.path, client.name, method,
+                    signature_args, self.gio.DBusCallFlags.ALLOW_INTERACTIVE_AUTHORIZATION))
+                self.assertEqual(calls[0][6], 60000)
+                methods = [row[3] for row in self.methods]
+                final_read = methods.index("AddMatch") + 3
+                self.assertEqual(methods[final_read], "ListTimezones" if action == "timezone-set" else
+                                 "Get" if action == "locale-set" else "GetAll")
+                self.assertEqual([event[0] for event in self.events], ["authorizing", "running"])
+                self.assertTrue(client.sent and client.acknowledged and client.done)
+                self.assertEqual(len(client.subscriptions), 2)
+                self.assertEqual(self.connection.signal_unsubscribe.call_count, 2)
+                self.assertEqual(methods[-2:], ["RemoveMatch", "RemoveMatch"])
+                self.connection.close_sync.assert_not_called()
+                self.glib.timeout_add.assert_any_call(60000, client.expire)
+                self.assertEqual(provider.PROTOCOL_MINOR, 0)
+                with self.assertRaises(RuntimeError):
+                    self.run_client(client)
+
+    def test_validation_and_fedora_rejection_precede_connection_or_admission(self):
+        client = self.client()
+        for action, argument, generation in (("SetTime", "UTC", "a" * 64),
+                                            ("timezone-set", "../UTC", "a" * 64),
+                                            ("ntp-set", "true", "a" * 64),
+                                            ("locale-set", "LC_TIME=C", "a" * 64),
+                                            ("timezone-set", "UTC", "A" * 64)):
+            with self.assertRaises(provider.SnapshotFailure):
+                provider.RegionalMutation(action, argument, generation, mock.Mock(), mock.Mock(), self.gio, self.glib)
+        with mock.patch.object(provider, "read_fedora_identity", side_effect=provider.SnapshotFailure("unsupported", "Not Fedora")):
+            with self.assertRaises(provider.SnapshotFailure):
+                client.run()
+        self.gio.bus_get.assert_not_called()
+        self.assertEqual(self.events, [])
+
+    def test_fresh_state_and_catalog_reject_stale_generation_before_admission(self):
+        for change in ("state", "catalog", "language"):
+            client = self.client("locale-set", "LANG=en_US.utf8") if change == "language" else self.client()
+            if change == "state":
+                self.time_state = replace(self.time_state, timezone="Etc/UTC")
+            elif change == "catalog":
+                self.replies["ListTimezones"] = self.GLib.Variant("(as)", (["UTC"],))
+            else:
+                self.locale_state = provider.parse_locale_configuration(["LANG=C", "LANGUAGE="])
+            self.failure(client, "conflict")
+            self.assertFalse(client.sent)
+            self.assertEqual(self.events, [])
+            self.assertEqual(self.mutations(), [])
+
+    def test_pre_send_configuration_events_and_journal_delay_prevent_dispatch(self):
+        for scenario in ("changed", "invalidated", "deadline", "flood", "checkpoint"):
+            client = self.client()
+            def before():
+                if scenario == "changed":
+                    self.notify({"Timezone": self.GLib.Variant("s", "Etc/UTC")})
+                elif scenario == "invalidated":
+                    self.notify({}, ["Timezone"])
+                elif scenario == "deadline":
+                    self.clock = 12
+                elif scenario == "flood":
+                    self.context.pending.return_value = True
+                else:
+                    raise OSError("journal sync failed")
+            self.before_hook = before
+            self.failure(client, {"deadline": "timeout", "checkpoint": "interrupted"}.get(scenario, "conflict"))
+            self.assertEqual(self.mutations(), [])
+            self.assertFalse(client.sent)
+            self.assertLessEqual(self.context.iteration.call_count, provider.REGIONAL_CALLBACK_LIMIT)
+            if scenario == "checkpoint":
+                self.assertIsInstance(client.hook_error, OSError)
+
+    def test_matching_notifications_are_accepted_but_conflict_history_is_retained(self):
+        for conflict in (False, True):
+            client = self.client()
+            def after():
+                if conflict:
+                    self.notify({"Timezone": self.GLib.Variant("s", "UTC")})
+                self.notify({"Timezone": self.GLib.Variant("s", "Etc/UTC")})
+            self.after_hook = after
+            if conflict:
+                self.failure(client, "conflict")
+            else:
+                self.assertEqual(self.run_client(client).timezone, "Etc/UTC")
+            self.assertEqual(len(self.mutations()), 1)
+
+    def test_irrelevant_signals_do_not_invalidate_or_extend_the_deadline(self):
+        client = self.client("ntp-set", "enabled")
+        def before():
+            self.notify({"NTPSynchronized": self.GLib.Variant("b", False)})
+            self.notify({"NTP": self.GLib.Variant("b", True)}, sender=":1.99")
+        self.before_hook = before
+        self.after_hook = lambda: self.notify({"NTPSynchronized": self.GLib.Variant("b", True)})
+        self.assertTrue(self.run_client(client).ntp_enabled)
+        self.assertEqual(self.glib.timeout_add.call_count, 2)
+
+    def test_invalidated_malformed_and_mismatched_final_state_cannot_report_success(self):
+        for scenario in ("invalidated", "signature", "duplicate", "final"):
+            client = self.client()
+            def after():
+                if scenario == "invalidated":
+                    self.notify({}, ["Timezone"])
+                elif scenario == "signature":
+                    self.notify({"Timezone": self.GLib.Variant("b", True)})
+                elif scenario == "duplicate":
+                    value = self.GLib.Variant.parse(None,
+                        "('org.freedesktop.timedate1', {'Timezone': <'UTC'>, 'Timezone': <'Etc/UTC'>}, @as [])", None, None)
+                    client.properties_changed(None, client.owner, client.path, provider.PROPERTIES_INTERFACE,
+                        "PropertiesChanged", value, None)
+                else:
+                    self.time_state = replace(self.time_state, timezone="UTC")
+            self.after_hook = after
+            self.failure(client, "conflict")
+            self.assertTrue(client.sent and client.acknowledged)
+
+    def test_effective_locale_notifications_allow_lc_elision_but_not_language_loss(self):
+        for lost in (False, True):
+            client = self.client("locale-set", "LANG=en_US.utf8")
+            self.locale_state = provider.parse_locale_configuration(["LANG=C", "LANGUAGE=C", "LC_TIME=en_US.utf8"])
+            client.generation = provider.make_regional_preview(client.action, client.argument,
+                self.locale_state, ["en_US.utf8"]).generation
+            def after():
+                values = ["LANG=en_US.utf8"] + ([] if lost else ["LANGUAGE=C"])
+                self.locale_state = provider.parse_locale_configuration(values)
+                self.notify({"Locale": self.GLib.Variant("as", values)})
+            self.after_hook = after
+            if lost:
+                self.failure(client, "conflict")
+            else:
+                self.assertEqual(self.run_client(client).lang, "en_US.utf8")
+
+    def test_owner_changes_before_and_after_dispatch_never_retarget_or_retry(self):
+        for after_dispatch in (False, True):
+            client = self.client()
+            def changed():
+                client.owner_changed(None, "org.freedesktop.DBus", "/org/freedesktop/DBus",
+                    "org.freedesktop.DBus", "NameOwnerChanged", self.GLib.Variant("(sss)",
+                        (client.name, client.owner, ":1.99")), None)
+            if after_dispatch:
+                self.after_hook = changed
+            else:
+                self.before_hook = changed
+            self.failure(client, "interrupted" if after_dispatch else "conflict")
+            self.assertEqual(len(self.mutations()), int(after_dispatch))
+            self.assertTrue(all(row[0] == ":1.42" for row in self.mutations()))
+        client = self.client()
+        self.after_hook = lambda: setattr(self, "owner", ":1.99")
+        self.failure(client, "conflict")
+
+    def test_unsupported_preserved_locale_values_reject_before_admission(self):
+        for assignment in ("LANGUAGE=de:en", "LANGUAGE=français", "LC_TIME=", "LC_TIME=" + "x" * 128):
+            client = self.client("locale-set", "LANG=en_US.utf8")
+            self.locale_state = provider.parse_locale_configuration(["LANG=C", assignment])
+            client.generation = provider.make_regional_preview(client.action, client.argument,
+                self.locale_state, ["en_US.utf8"]).generation
+            before = self.locale_state.assignments
+            self.failure(client, "unsupported")
+            self.assertEqual(self.locale_state.assignments, before)
+            self.assertEqual(self.events, [])
+            self.assertEqual(self.mutations(), [])
+            self.assertFalse(client.sent)
+
+    def test_aggregate_deadline_covers_reply_verification_and_discards_late_callbacks(self):
+        for stage in ("reply", "verify", "final-owner"):
+            client = self.client()
+            def delay(method):
+                if ((stage == "reply" and method == "SetTimezone")
+                    or (stage == "verify" and method == "GetAll" and client.acknowledged)
+                    or (stage == "final-owner" and method == "GetNameOwner" and client.acknowledged)):
+                    self.clock = 61
+            self.before_request = delay
+            error = self.failure(client, "timeout")
+            self.assertIn("outcome is unknown", error.detail)
+            self.assertTrue(client.sent)
+            self.assertEqual(client.deadline, 61)
+            self.assertIsNone(client.value)
+            before = list(self.methods)
+            client.connected(None, object(), None)
+            client.properties_changed(None, client.owner, client.path, "", "", None, None)
+            self.assertEqual(before, self.methods)
+            self.assertEqual(len(self.mutations()), 1)
+
+    def test_post_reply_checkpoint_failure_cannot_publish_success(self):
+        client = self.client()
+        def fail():
+            raise OSError("journal storage unavailable")
+        self.after_hook = fail
+        self.failure(client, "interrupted")
+        self.assertTrue(client.sent and client.acknowledged)
+        self.assertIsInstance(client.hook_error, OSError)
+        self.assertIsNone(client.value)
+        self.assertEqual(len(self.mutations()), 1)
+
+    def test_rejected_matches_and_typed_method_errors_never_remove_unowned_rules(self):
+        from gi.repository import Gio
+        for method, remote, expected in (
+            ("AddMatch", "AccessDenied", "permission-denied"),
+            ("SetTimezone", "AccessDenied", "permission-denied"),
+            ("SetTimezone", "InteractiveAuthorizationRequired", "permission-denied"),
+            ("SetTimezone", "InvalidArgs", "malformed"),
+            ("SetTimezone", "NoReply", "timeout"),
+        ):
+            client = self.client()
+            self.replies[method] = Gio.DBusError.new_for_dbus_error(
+                "org.freedesktop.DBus.Error." + remote, "fixture error")
+            failure = self.failure(client, expected)
+            if remote == "NoReply":
+                self.assertIn("outcome is unknown", failure.detail)
+            self.assertEqual(len(self.mutations()), int(method.startswith("Set")))
+            self.assertFalse(client.acknowledged)
+            removed = [row for row in self.methods if row[3] == "RemoveMatch"]
+            self.assertEqual(len(removed), 0 if method == "AddMatch" else 2)
+
+    def test_late_match_acknowledgment_only_cleans_up_and_never_resumes(self):
+        client = self.client()
+        self.replies["AddMatch"] = None
+        client.loop.run.side_effect = client.expire
+        self.failure(client, "timeout")
+        call = [call for call in self.connection.call.call_args_list if call.args[3] == "AddMatch"][0]
+        self.assertEqual([row[3] for row in self.methods].count("RemoveMatch"), 0)
+        callback, data = call.args[-2:]
+        callback(self.connection, self.GLib.Variant("()", ()), data)
+        self.assertEqual([row[3] for row in self.methods].count("RemoveMatch"), 1)
+        self.assertEqual(self.events, [])
+        self.assertFalse(client.sent)
+        self.assertEqual(self.mutations(), [])
+
+    def test_local_transport_failure_after_dispatch_is_unknown_not_rejection(self):
+        from gi.repository import Gio, GLib
+        client = self.client()
+        self.replies["SetTimezone"] = GLib.Error.new_literal(
+            Gio.io_error_quark(), "fixture connection closed", Gio.IOErrorEnum.CLOSED)
+        failure = self.failure(client, "interrupted")
+        self.assertIn("outcome is unknown", failure.detail)
+        self.assertTrue(client.sent)
+        self.assertFalse(client.acknowledged)
+        self.assertEqual(len(self.mutations()), 1)
+
+    def test_queued_confirmation_change_is_drained_before_dispatch(self):
+        client = self.client()
+        def before():
+            self.context.pending.side_effect = [True, False]
+            self.context.iteration.side_effect = lambda _block: self.notify(
+                {"Timezone": self.GLib.Variant("s", "UTC")})
+        self.before_hook = before
+        self.failure(client, "conflict")
+        self.context.iteration.assert_called_once_with(False)
+        self.assertEqual(self.mutations(), [])
+
+    def test_private_bus_fixed_execution_and_failure_paths(self):
+        result = subprocess.run(["dbus-run-session", "--", "/usr/bin/python3",
+            str(REPO / "tests/fixtures/system-regional-mutation-bus.py"), str(PROVIDER_PATH)],
+            capture_output=True, text=True, timeout=90, check=False)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Private-bus regional mutations: PASS", result.stdout)
 
 
 class RegionalReadTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Continue Phase 6 after #251 with one preparatory boundary: an internal fixed regional service client. Native CLI commands, originating Settings actions, and the cumulative snapshot minor remain unchanged.

- Validate Fedora identity and fresh catalog/configuration evidence, pin the unique service owner, and require acknowledged subscriptions before the final confirmation read.
- Allow only SetTimezone, SetNTP, and SetLocale with explicit interactive authorization. Required lifecycle hooks bracket dispatch and a successful method reply.
- Bound reply plus verification to one 60-second deadline. Retain conflicting notifications, reject owner replacement, and distinguish explicit remote rejection from ambiguous timeout or local transport loss. Never retry, roll back, or claim service cancellation.
- Preserve complete locale state. Reject known non-preserving LANGUAGE selections and reject complete write arrays that systemd cannot accept before admission, without dropping overrides or narrowing readable state.

## Validation

- Focused regional tests: 43 passed in 60.530 seconds; the additional empty-LC generation assertion also passed.
- `scripts/run-tests make clean all` and `scripts/run-tests`: passed on the final staged tree, including 472 provider tests in 172.609 seconds, native X11 lifecycle/parser/owner tests, package resolution, staged installation, repeated-install preservation, and release packaging.
- Closed Settings CPU: 0.100%; power lifecycle baseline 0.167%, after 0.100%, delta 0.067 percentage points.
- `npm run check && npm run build` in docs: 15 files, no diagnostics, 11 pages built.
- Independent CodeRabbit review and required post-full-gate local Codex review: zero actionable findings on the final six-file tree.
- Private-bus fixtures exercise actual D-Bus calls and message flags, denial, stale confirmation, conflicting signals, owner loss, and a real 60-second timeout after the fixture service has changed state. Late replies cannot change that result.

## Limits and next boundary

No host settings or packages were mutated, and graphical polkit authorization was not exercised. The service client requires future durable native-owner integration; journal admission, terminal commit, timeout display refresh, CLI origins, and Settings controls are not enabled by this PR. An unconfirmed match rule whose acknowledgment is lost is removed when its shared bus connection exits; cleanup never removes another client's rejected or unrequested rule.

Phase 6 remains active. Installed synchronization and combined live-session qualification remain outstanding; no Phase 7 work, logout, or reboot is included.