### PR TITLE
feat(system): journal confirmed regional CLI operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,25 @@ versions from `config.mk`.
 
 ### Changed
 
+- Enable the three generation-confirmed regional CLI commands with durable
+  operation ownership, verified results, retained replay, and acknowledgment.
+  Preserve recovery after uncertain writes or lost output; ambiguous sent
+  changes are never retried or reclassified by later state. Settings origins
+  remain disabled pending their confirmation and display workflow. Tests use
+  private services and do not change host settings or log out the user.
+
 - Reject locale confirmations that the platform cannot apply while preserving
   an explicit LANGUAGE override. Add a preparatory fixed regional service client
   with fresh confirmation checks, authorization hooks, monitored conflicts, and
-  bounded verification. Native CLI and Settings origins remain disabled pending
-  durable owner integration and qualification; tests change only a private bus.
+  bounded verification. The fixed CLI now has durable owner integration;
+  Settings origins remain disabled. Tests change only a private bus.
 
 - Restore exact regional and delegated operation observers from validated
   journal snapshots. Watch durable progress and owner exit without repeating
   the action; stalled or closed control-output consumers preserve recovery.
   Isolate operation and update-event writers from inherited file-status flags,
   preserving concurrent parent output and behavior after forced termination.
-  Native mutation commands and Settings action entry points remain disabled.
+  Originating Settings action entry points remain disabled.
 
 - Preserve appearance inventory streams when a producer exits before the parent
   captures its identity. Keep buffered output and failure status instead of

--- a/TASKS.md
+++ b/TASKS.md
@@ -163,8 +163,8 @@ comparison accepts redundant LC-category elision while checking preserved values
 The validators perform no I/O. Separate fixed timedate1 and locale1 readers now
 bound connection setup, service replies, and decoding under a ten-second deadline.
 Typed private-bus tests cover success, denial, absence, malformed state, timeout,
-and late replies; read-only Fedora 44 probes also passed. No command, D-Bus
-mutation, or new protocol minor is enabled. A separate fixed locale catalog
+and late replies; read-only Fedora 44 probes also passed. Those readers add no
+mutation or new protocol minor. A separate fixed locale catalog
 collector now bounds output, process lifetime, signal cleanup, and reaping, with
 an independent timeout supervisor for abrupt collector death. It preserves exact
 installed identities and starts a new process for every read. A separate
@@ -198,8 +198,8 @@ selected value to current configuration with a generation token, preserve the
 complete locale override description, and require fresh reads for each request.
 Unit and private-bus tests cover stale state, key presence, strict output bounds,
 malformed selections, fixed read-only calls, and closed consumers. Native mutation
-commands remain disabled; their owner lifetime, platform authorization,
-verification, and Settings confirmation integration are still required.
+commands were initially disabled pending owner integration, described below.
+Settings confirmation integration remains required.
 Read-only Fedora 44 CLI probes passed for both catalogs and all three preview
 forms without changing system settings.
 
@@ -225,9 +225,20 @@ retrying. Unit/private-bus fixtures cover a real ambiguous timeout after the
 simulated service changed state. Known non-preserving LANGUAGE selections are
 rejected during preview. Known-invalid complete locale argument sets are rejected
 before admission without narrowing readable state or dropping overrides.
-No host setting was changed. Native journal integration,
-post-timeout display refresh, CLI origins, and originating Settings actions
-remain outstanding; the snapshot minor remains zero.
+No host setting was changed.
+The three generation-confirmed regional CLI commands now retain a native lease
+across unlocked service waits and commit every phase before output. Terminal
+handoffs are durable before completion; native records preserve the update
+restart aggregate. Output failure before dispatch aborts safely, while loss
+after dispatch keeps verification and durable recording alive. Uncertain
+admission or persistence produces no replacement result. An ambiguous sent
+outcome is durably interrupted before releasing the lease and attempting an
+independent fresh read, which cannot change that terminal result. Unit and
+actual CLI/private-bus fixtures cover all three actions, denial, stale
+confirmation, write failures, lost output, replay, and acknowledgment without
+repeating the action. Graphical polkit and host mutations are not qualified.
+Post-timeout Settings display refresh and originating Settings controls remain
+outstanding; the snapshot minor remains zero.
 
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -454,10 +454,31 @@ failed lifecycle hooks, unsupported preserved locale values, cleanup, and a real
 removes local subscriptions and acknowledged match rules without closing the shared bus or removing another
 client's rejected/unrequested rule. An unconfirmed rule whose acknowledgment
 cannot be recovered is ultimately removed when that bus connection exits.
-This client is preparatory: native journal-owner integration, terminal commit,
-post-timeout display refresh, CLI origins, and Settings controls remain disabled
-or outstanding. These fixtures do not change host settings or qualify graphical
-polkit authorization.
+The three fixed regional CLI origins now use a durable native journal owner.
+After fresh service preflight, admission and the active-file lease are acquired
+under one short directory lock; service waits retain the lease, not that lock.
+Every phase is committed before publication, and terminal retention/handoff is
+committed before a complete result is emitted. Native records do not modify the
+update restart aggregate. Locale success includes new-login guidance without
+logging out the user.
+
+Output loss before dispatch aborts the request; after dispatch it suppresses
+further output but keeps verification and durable terminal recording alive.
+Uncertain admission or checkpoint persistence never produces a replacement
+request or fabricated completion. Full, short, or closed CLI output fails
+without changing inherited file-status flags. Pre-admission rejections have a
+typed failed-request stream but create no journal transaction. Journal storage
+operations retain their existing bounded-lock contract, not a hard disk-I/O
+deadline.
+
+Actual CLI/private-bus fixtures cover all three fixed calls, live leases,
+durable handoffs, denial, stale generation, ambiguous replies, output loss after
+dispatch, retained replay, and acknowledgment without repeating the action.
+For an ambiguous sent result, a new independent read begins only after durable
+interruption and lease release; it cannot reclassify the terminal result.
+Settings still needs its own display refresh and confirmation/origin controls,
+and the cumulative snapshot remains minor zero. These fixtures do not change
+host settings or qualify graphical polkit authorization.
 
 Each regional mutation uses a 60-second monotonic aggregate deadline beginning
 immediately before the fixed mutating D-Bus method is sent and covering its
@@ -485,6 +506,9 @@ dwm-system-management password-open
 dwm-system-management printers-open
 dwm-system-management sources-open
 ```
+
+The first three confirmed regional forms are implemented. The four delegated
+launch forms remain planned and are not accepted by the CLI yet.
 
 `ZONE` is at most 255 ASCII bytes, contains no control characters, empty path
 components, `.` or `..` components, and must exactly match a value returned by
@@ -555,12 +579,13 @@ current timezone as its source field. NTP uses `yes|no` for `CanNTP` followed by
 configuration identity. Locale uses every current validated assignment in the
 fixed locale-key order, including explicit empty values and key presence.
 Unselected catalog entries do not affect this token; exact selected membership
-must still be freshly validated. Before any future mutating call, the provider
+must still be freshly validated. Before any mutating call, the provider
 must repeat the preflight and compare the confirmed 64-lowercase-hex generation.
 A mismatch requires new confirmation and sends no mutation. Visible confirmation
 and monitored invalidation remain mandatory; the token is a freshness guard,
-not an atomic service transaction or proof of human approval. The mutating
-forms above remain disabled until their lifecycle and Settings integration land.
+not an atomic service transaction or proof of human approval. The three fixed
+regional CLI forms now enforce this preflight and their durable lifecycle.
+Visible Settings origins remain disabled until confirmation integration lands.
 
 `health-open` is the sole action with no provider command: the root-scoped QML
 model invokes the fixed in-process `SystemHealthModel.openOnScreen` method with
@@ -1740,8 +1765,9 @@ of mutation commands. Tests cover all regional and delegated kinds, competing
 and originating descriptors, path replacement, lock and cleanup failures,
 normal process exit, abrupt process death, and durable terminal replay. Public
 native snapshot/watch integration now observes these owners without taking over
-service work. Bounded service origins remain gated; this enables no native
-mutation command, Settings action, or snapshot minor.
+service work. The fixed regional CLI origins now retain this lease throughout
+their service workflow. Delegated launch commands and originating Settings
+actions remain gated; the cumulative snapshot minor is unchanged.
 
 ## Event and Resource Contract
 

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -1087,9 +1087,10 @@ class RegionalRead(ServiceRead):
 class RegionalMutation(ServiceRead):
     """Internal fixed service client; durable admission is a required caller hook.
 
-    No CLI or Settings origin uses this client yet. The caller must retain its
-    native journal lease, checkpoint authorizing in before_send, checkpoint
-    running in after_reply, and commit the result before releasing ownership.
+    The fixed CLI owner uses this client; Settings origins remain gated. The
+    caller must retain its native journal lease, checkpoint authorizing in
+    before_send, checkpoint running in after_reply, and commit the result before
+    releasing ownership.
     A sent timeout is ambiguous, not proof of failure or service cancellation.
     """
 
@@ -4920,15 +4921,18 @@ class OperationStream:
 def reject_unadmitted_operation(operation_id: str, action_id: str, started_at: str,
                                failure: SnapshotFailure, write: Callable[[str], object]) -> None:
     """Report a rejected request without inventing a durable transaction or result."""
-    if (not isinstance(action_id, str) or action_id not in {"updates-refresh", "updates-install-all"}
+    if (not isinstance(action_id, str) or action_id not in {
+            "updates-refresh", "updates-install-all", "timezone-set", "ntp-set", "locale-set"}
             or not isinstance(failure, SnapshotFailure) or failure.code not in JOURNAL_ERROR_CODES):
-        raise OperationProtocolError("rejected update request is invalid")
+        raise OperationProtocolError("rejected operation request is invalid")
     _validate_journal_detail(failure.detail)
     finished_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    regional = action_id in {"timezone-set", "ntp-set", "locale-set"}
+    provider_id, mutation = ("regional", "regional") if regional else ("updates", "package")
     stream = OperationStream(operation_id, action_id, started_at,
-        "Request rejected before operation admission; no package mutation was dispatched", write)
+        f"Request rejected before operation admission; no {mutation} mutation was dispatched", write)
     stream._send([
-        f"error\tupdates\t{failure.code}\t{failure.detail}",
+        f"error\t{provider_id}\t{failure.code}\t{failure.detail}",
         stream._operation_line("failed", "unknown", False, failure.detail),
         "\t".join(("audit", operation_id, action_id, stream.kind, "failed", started_at, finished_at, failure.detail)),
         "complete\toperation",
@@ -5575,6 +5579,138 @@ def recover_journal_active(
         advance_journal_operation(journal, current, terminal, recovery_boot_id=recovery_boot)
         complete_journal_terminal(journal, boot_id=boot_id, session_started=session_started)
         return load_writable_journal_state(journal), None, lookup_failure
+
+
+class RegionalOperationOwner:
+    """Checkpoint one leased native owner before publishing its operation stream."""
+
+    def __init__(self, journal: JournalDescriptorSet, operation: JournalOperation,
+                 write: Callable[[str], object]) -> None:
+        self.journal, self.operation = journal, operation
+        self.stream = None
+        self.output_error = self.persistence_error = None
+        self.terminal = None
+        try:
+            self.stream = OperationStream(operation.operation_id, operation.action_id,
+                operation.started_at, operation.detail, write)
+        except Exception as error:
+            # Admission and its lease already exist. A partial first bundle
+            # cannot be retried or replaced with an unadmitted request.
+            self.output_error = error
+
+    def current(self):
+        current = load_writable_journal_state(self.journal).active
+        if current != self.operation or current.state in JOURNAL_OPERATION_TERMINAL_STATES:
+            raise JournalAdmissionError("Regional operation ownership changed")
+        return current
+
+    def output(self, callback):
+        if self.output_error is None:
+            try:
+                callback()
+            except Exception as error:
+                if self.stream is not None and not self.stream.faulted:
+                    raise
+                self.output_error = error
+
+    def checkpoint(self, state, detail):
+        if self.persistence_error is not None:
+            raise self.persistence_error
+        try:
+            with lock_writable_journal(self.journal):
+                current = self.current()
+                self.operation = advance_journal_operation(self.journal, current,
+                    replace(current, state=state, detail=detail))
+        except (OSError, JournalFrameError, JournalRecordError, JournalAdmissionError) as error:
+            self.persistence_error = error
+            raise
+        self.output(lambda: self.stream.transition(state, detail))
+
+    def finish(self, state, failure=None):
+        if self.persistence_error is not None:
+            raise self.persistence_error
+        detail = ("Regional change verified; sign out and back in for applications to use the locale"
+                  if failure is None and self.operation.kind == "locale" else
+                  "Regional change verified" if failure is None else failure.detail)
+        with lock_writable_journal(self.journal):
+            current = self.current()
+            terminal = replace(current, state=state,
+                finished_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                error_code=None if failure is None else failure.code, detail=detail)
+            advance_journal_operation(self.journal, current, terminal)
+            complete_journal_terminal(self.journal)
+        self.terminal = terminal
+        self.output(lambda: self.stream.finish(terminal))
+        return terminal
+
+
+def run_regional_mutation(
+    journal: JournalDescriptorSet, action: str, argument: str, generation: str,
+    write: Callable[[str], object], *, on_admission: Callable[[], None] | None = None,
+) -> JournalOperation:
+    """Own confirmed native execution, retaining liveness but not a service-wait lock."""
+    argument = validate_regional_argument(action, argument)
+    if not isinstance(generation, str) or JOURNAL_GENERATION_PATTERN.fullmatch(generation) is None:
+        raise SnapshotFailure("malformed", "Invalid regional confirmation generation")
+    if not callable(write):
+        raise ValueError("Regional operation requires an output writer")
+    with lock_writable_journal(journal):
+        prepare_journal_admission(journal)
+    owner = None
+    failure = None
+    with contextlib.ExitStack() as retained:
+        def before_send(preview):
+            nonlocal owner
+            # The service client has just checked fresh configuration, choices,
+            # compatibility and confirmation. Admission closes concurrent starts.
+            with lock_writable_journal(journal):
+                prepare_journal_admission(journal)
+                if on_admission is not None:
+                    on_admission()
+                operation = begin_journal_operation(journal, action,
+                    datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    f"Preparing {action}: {preview.target}")
+                retained.enter_context(retain_native_journal_owner(journal, operation))
+            owner = RegionalOperationOwner(journal, operation, write)
+            if owner.output_error is not None:
+                raise owner.output_error
+            owner.checkpoint("authorizing", "Regional authorization is pending; a sent change cannot be canceled")
+            if owner.output_error is not None:
+                raise owner.output_error
+
+        def after_reply():
+            owner.checkpoint("running", "Regional service accepted the change; verifying current state")
+
+        client = RegionalMutation(action, argument, generation, before_send, after_reply)
+        try:
+            client.run()
+        except SnapshotFailure as error:
+            if owner is None:
+                raise client.hook_error or error
+            if owner.persistence_error is not None:
+                raise owner.persistence_error
+            if client.hook_error is not None and client.hook_error is not owner.output_error:
+                raise client.hook_error
+            failure = (SnapshotFailure("internal", "Regional output was unavailable before dispatch; no change was sent")
+                       if not client.sent and owner.output_error is not None else error)
+        if owner is None:
+            raise SnapshotFailure("interrupted", "Regional execution ended without an admitted owner")
+        if failure is None and (not client.sent or not client.acknowledged or owner.operation.state != "running"):
+            failure = SnapshotFailure("interrupted", "Regional execution ended without verified service completion")
+        state = ("succeeded" if failure is None else
+                 "interrupted" if client.sent and failure.code in {"timeout", "interrupted"} else
+                 "permission-denied" if failure.code == "permission-denied" and owner.operation.state == "authorizing" else
+                 "failed")
+        terminal = owner.finish(state, failure)
+    if client.sent and failure is not None and failure.code in {"timeout", "interrupted"}:
+        # The terminal/handoff is durable and the native lease is released
+        # before this independent read. Its outcome cannot reclassify the call.
+        # Settings will publish its own fresh snapshot on origin completion.
+        with contextlib.suppress(SnapshotFailure):
+            RegionalRead(client.kind).run()
+    if owner.output_error is not None:
+        raise owner.output_error
+    return terminal
 
 
 class PackageKitMutation:
@@ -7273,6 +7409,76 @@ def run_operation_control(command: str, operation_id: str,
         return 3
 
 
+def regional_command(action: str, argument: str, generation: str) -> int:
+    """Expose only confirmed native origins with isolated nonblocking output."""
+    try:
+        with control_output_writers() as writers:
+            return run_regional_command(action, argument, generation, *writers)
+    except OSError:
+        return 1
+
+
+def run_regional_command(action: str, argument: str, generation: str,
+                         output_writer: Callable[[bytes], int] | None,
+                         error_writer: Callable[[bytes], int] | None) -> int:
+    admission_started = output_started = False
+
+    def admitted():
+        nonlocal admission_started
+        admission_started = True
+
+    def write(chunk):
+        nonlocal output_started
+        output_started = True
+        if output_writer is None:
+            sys.stdout.write(chunk)
+            sys.stdout.flush()
+        else:
+            payload = chunk.encode("utf-8")
+            if len(payload) > 4096 or output_writer(payload) != len(payload):
+                raise OSError("Incomplete regional operation output")
+
+    def diagnostic():
+        message = "regional result could not be confirmed; refresh state and observe the existing operation"
+        with contextlib.suppress(OSError):
+            if error_writer is None:
+                print(message, file=sys.stderr)
+            else:
+                error_writer((message + "\n").encode("ascii"))
+
+    try:
+        read_fedora_identity()
+        boot_id = read_boot_id()
+        with open_journal_directory() as chain:
+            initialize_journal_layout(chain.directory_descriptor, boot_id)
+            with retain_writable_journal(chain) as journal:
+                started_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                try:
+                    terminal = run_regional_mutation(journal, action, argument, generation,
+                                                     write, on_admission=admitted)
+                    return 0 if terminal.state == "succeeded" else 1
+                except (SnapshotFailure, JournalFrameError, JournalRecordError,
+                        JournalAdmissionError, OSError, OperationProtocolError) as error:
+                    if admission_started or output_started:
+                        raise
+                    with lock_writable_journal(journal):
+                        operation_id = generate_journal_operation_id(load_writable_journal_state(journal))
+                    if isinstance(error, SnapshotFailure):
+                        failure = error
+                    elif isinstance(error, (JournalAdmissionError, JournalLockError)):
+                        failure = SnapshotFailure("conflict", "Another operation or recovery state blocks this request; refresh state before retrying")
+                    elif isinstance(error, (JournalFrameError, JournalRecordError, OperationProtocolError)):
+                        failure = SnapshotFailure("malformed", "Regional preflight is malformed; refresh state and inspect recovery guidance")
+                    else:
+                        failure = SnapshotFailure("internal", "Regional preflight failed; check journal storage and refresh state before retrying")
+                    reject_unadmitted_operation(operation_id, action, started_at, failure, write)
+                    return 1
+    except (SnapshotFailure, JournalFrameError, JournalRecordError, JournalAdmissionError,
+            OSError, OperationProtocolError):
+        diagnostic()
+        return 1
+
+
 def update_command(action_id: str, generation: str | None = None) -> int:
     """Own an explicit CLI request; never replace a possibly admitted operation."""
     admission_started = False
@@ -7544,11 +7750,19 @@ def watch_update_events() -> int:
 
 
 def usage() -> int:
-    print(f"usage: {sys.argv[0]} snapshot | watch-updates | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE", file=sys.stderr)
+    print(f"usage: {sys.argv[0]} snapshot | watch-updates | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE | timezone-set ZONE GENERATION | ntp-set enabled|disabled GENERATION | locale-set LANG=LOCALE GENERATION", file=sys.stderr)
     return 2
 
 
 def main(argv: Sequence[str]) -> int:
+    if argv and argv[0] in {"timezone-set", "ntp-set", "locale-set"}:
+        if len(argv) != 3 or JOURNAL_GENERATION_PATTERN.fullmatch(argv[2]) is None:
+            return usage()
+        try:
+            validate_regional_argument(argv[0], argv[1])
+        except SnapshotFailure:
+            return usage()
+        return regional_command(*argv)
     if argv and argv[0] in {"regional-choices", "regional-preview"}:
         try:
             output, code = regional_preflight_output(argv[0], argv[1:])

--- a/tests/fixtures/system-regional-owner-bus.py
+++ b/tests/fixtures/system-regional-owner-bus.py
@@ -1,0 +1,202 @@
+#!/usr/bin/python3
+"""Exercise the real native CLI and journal using exclusively private bus services."""
+
+import os
+import pathlib
+import runpy
+import subprocess
+import sys
+import tempfile
+import time
+
+os.environ["DBUS_SYSTEM_BUS_ADDRESS"] = os.environ["DBUS_SESSION_BUS_ADDRESS"]
+from gi.repository import Gio, GLib
+
+provider_path = str(pathlib.Path(sys.argv[1]).resolve())
+p = runpy.run_path(provider_path, run_name="regional_owner_fixture")
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+registrations = []
+calls = []
+errors = []
+child = None
+mode = "success"
+zone, ntp, locale = "UTC", False, ["LANG=POSIX", "LC_TIME=POSIX"]
+journal_path = None
+fresh_reads = 0
+
+properties = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.DBus.Properties">
+<method name="GetAll"><arg type="s" direction="in"/><arg type="a{sv}" direction="out"/></method>
+<method name="Get"><arg type="s" direction="in"/><arg type="s" direction="in"/><arg type="v" direction="out"/></method>
+</interface></node>""").interfaces[0]
+timedate = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.timedate1">
+<method name="ListTimezones"><arg type="as" direction="out"/></method>
+<method name="SetTimezone"><arg type="s" direction="in"/><arg type="b" direction="in"/></method>
+<method name="SetNTP"><arg type="b" direction="in"/><arg type="b" direction="in"/></method>
+</interface></node>""").interfaces[0]
+localed = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.locale1">
+<method name="SetLocale"><arg type="as" direction="in"/><arg type="b" direction="in"/></method>
+</interface></node>""").interfaces[0]
+
+
+def journal_state():
+    """Read the fixture journal without sharing the child's descriptors or locks."""
+    with p["open_journal_directory_chain"](str(journal_path)) as chain:
+        return p["load_journal_state"](chain)
+
+
+def called(_bus, _sender, _path, _interface, method, args, invocation):
+    """Serve fixed test methods and surface callback assertions to the parent."""
+    global zone, ntp, locale, fresh_reads
+    try:
+        calls.append(method)
+        if method.startswith("Set"):
+            assert args.unpack()[-1] is True
+            assert invocation.get_message().get_flags() & Gio.DBusMessageFlags.ALLOW_INTERACTIVE_AUTHORIZATION
+            state = journal_state()
+            assert state.active.state == "authorizing" and state.handoff is None
+            descriptor = os.open(journal_path / "active", os.O_RDWR | os.O_CLOEXEC)
+            try:
+                assert not p["_try_native_owner_lock"](descriptor)
+            finally:
+                os.close(descriptor)
+            if mode == "denied":
+                invocation.return_dbus_error("org.freedesktop.DBus.Error.AccessDenied", "Fixture denial")
+                return
+            if method == "SetTimezone":
+                zone = args.unpack()[0]
+            elif method == "SetNTP":
+                ntp = args.unpack()[0]
+            else:
+                locale = args.unpack()[0]
+                assert locale == ["LANG=C", "LC_TIME=POSIX"]
+            if mode == "ambiguous":
+                invocation.return_dbus_error("org.freedesktop.DBus.Error.NoReply", "Fixture lost reply")
+                return
+            if mode == "lost-output":
+                child.stdout.close()
+            invocation.return_value(GLib.Variant("()", ()))
+        elif method == "GetAll":
+            if mode == "ambiguous" and "SetTimezone" in calls:
+                state = journal_state()
+                assert state.active is None
+                assert state.terminals[state.handoff.slot].state == "interrupted"
+                descriptor = os.open(journal_path / "active", os.O_RDWR | os.O_CLOEXEC)
+                try:
+                    assert p["_try_native_owner_lock"](descriptor)
+                    p["_unlock_native_owner"](descriptor)
+                finally:
+                    os.close(descriptor)
+                fresh_reads += 1
+            invocation.return_value(GLib.Variant("(a{sv})", ({
+                "Timezone": GLib.Variant("s", zone), "CanNTP": GLib.Variant("b", True),
+                "NTP": GLib.Variant("b", ntp), "NTPSynchronized": GLib.Variant("b", True)},)))
+        elif method == "Get":
+            invocation.return_value(GLib.Variant("(v)", (GLib.Variant("as", locale),)))
+        else:
+            assert method == "ListTimezones"
+            invocation.return_value(GLib.Variant("(as)", (["UTC", "Etc/UTC"],)))
+    except Exception as error:
+        errors.append(error)
+        invocation.return_dbus_error("org.freedesktop.DBus.Error.Failed", "Fixture assertion failed")
+
+
+def command(arguments, environment):
+    """Bound each real CLI child while keeping the private service loop responsive."""
+    global child
+    child = subprocess.Popen(["/usr/bin/python3", provider_path, *arguments],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=environment)
+    loop = GLib.MainLoop()
+    deadline = time.monotonic() + 10
+    expired = []
+
+    def poll():
+        if child.poll() is not None:
+            loop.quit()
+            return False
+        if time.monotonic() >= deadline:
+            expired.append(True)
+            loop.quit()
+            return False
+        return True
+
+    source = GLib.timeout_add(10, poll)
+    try:
+        loop.run()
+        assert not expired, "Fixture CLI exceeded ten seconds"
+        output = b"" if child.stdout.closed else child.stdout.read()
+        diagnostic = child.stderr.read()
+        assert not errors, errors
+        return child.returncode, output.decode(), diagnostic.decode()
+    finally:
+        if child.poll() is None:
+            child.terminate()
+            try:
+                child.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                child.kill()
+                child.wait(timeout=2)
+        if GLib.MainContext.default().find_source_by_id(source) is not None:
+            GLib.source_remove(source)
+        child.stdout.close()
+        child.stderr.close()
+        child = None
+
+
+try:
+    for name in ("org.freedesktop.timedate1", "org.freedesktop.locale1"):
+        reply = bus.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+            "RequestName", GLib.Variant("(su)", (name, 0)), GLib.VariantType.new("(u)"),
+            Gio.DBusCallFlags.NONE, 3000, None)
+        assert reply.unpack() == (1,)
+    for path, interface in (("/org/freedesktop/timedate1", timedate),
+                             ("/org/freedesktop/timedate1", properties),
+                             ("/org/freedesktop/locale1", localed),
+                             ("/org/freedesktop/locale1", properties)):
+        registrations.append(bus.register_object(path, interface, called, None, None))
+    for mode, action, argument in (("success", "timezone-set", "Etc/UTC"),
+            ("success", "ntp-set", "enabled"), ("success", "locale-set", "LANG=C"),
+            ("denied", "timezone-set", "Etc/UTC"), ("stale", "timezone-set", "Etc/UTC"),
+            ("ambiguous", "timezone-set", "Etc/UTC"), ("lost-output", "timezone-set", "Etc/UTC")):
+        with tempfile.TemporaryDirectory() as directory:
+            journal_path = pathlib.Path(directory) / "state/dwm-titus/system-management"
+            environment = dict(os.environ, XDG_STATE_HOME=str(pathlib.Path(directory) / "state"))
+            zone, ntp, locale = "UTC", False, ["LANG=POSIX", "LC_TIME=POSIX"]
+            calls.clear()
+            code, preview, diagnostic = command(["regional-preview", action, argument], environment)
+            assert code == 0 and not diagnostic, (code, preview, diagnostic)
+            state = p["parse_locale_configuration"](locale) if action == "locale-set" else p["RegionalTimeState"](zone, True, ntp, True)
+            generation = p["make_regional_preview"](action, argument, state,
+                ["C", "POSIX"] if action == "locale-set" else ["UTC", "Etc/UTC"]).generation
+            assert generation in preview
+            code, output, diagnostic = command([action, argument, "0" * 64 if mode == "stale" else generation], environment)
+            state = journal_state()
+            assert state.active is None
+            if mode == "stale":
+                assert state.handoff is None and not any(call.startswith("Set") for call in calls)
+                assert code == 1 and "no regional mutation was dispatched" in output
+                continue
+            terminal = state.terminals[state.handoff.slot]
+            expected = "permission-denied" if mode == "denied" else "interrupted" if mode == "ambiguous" else "succeeded"
+            assert terminal.state == expected, (mode, terminal, output, diagnostic)
+            assert code == (0 if mode == "success" else 1), (mode, code, output, diagnostic)
+            assert terminal.generation is None and terminal.boot_id is None
+            assert len([call for call in calls if call.startswith("Set")]) == 1
+            if mode == "lost-output":
+                assert diagnostic == "regional result could not be confirmed; refresh state and observe the existing operation\n"
+                assert calls[calls.index("SetTimezone") + 1:] == ["GetAll"]
+            else:
+                assert not diagnostic and output.endswith("complete\toperation\n")
+            before = list(calls)
+            code, replay, diagnostic = command(["watch-operation", terminal.operation_id], environment)
+            assert code == 0 and not diagnostic and replay.endswith("complete\toperation\n")
+            assert "\t" + expected + "\t" in replay and calls == before
+            assert command(["ack-operation", terminal.operation_id], environment) == (0, "", "")
+            assert journal_state().handoff is None and calls == before
+    assert fresh_reads == 1, fresh_reads
+    print("Private-bus regional owner: PASS (actual CLI, durable lease and handoff, denial, stale confirmation, ambiguous fresh read, lost output, replay, acknowledgment)")
+finally:
+    for registration in registrations:
+        bus.unregister_object(registration)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -283,12 +283,12 @@ raise SystemExit(main(["regional-choices", "locale"]))
                 self.assertEqual(result.returncode, 1, result.stderr)
                 self.assertEqual(result.stderr, b"")
 
-    def test_cli_grammar_and_native_mutations_remain_disabled(self):
+    def test_preflight_cli_grammar_and_invalid_native_requests(self):
         invalid = (["regional-choices"], ["regional-choices", "time"], ["regional-choices", "locale", "extra"],
                    ["regional-preview"], ["regional-preview", "ntp-set"],
                    ["regional-preview", "arbitrary", "value"], ["regional-preview", "ntp-set", "enabled", "extra"],
-                   ["timezone-set", "UTC", "a" * 64], ["ntp-set", "enabled", "a" * 64],
-                   ["locale-set", "LANG=C", "a" * 64])
+                   ["timezone-set", "UTC"], ["ntp-set", "enabled", "A" * 64],
+                   ["locale-set", "LC_TIME=C", "a" * 64])
         with mock.patch.object(provider, "RegionalRead") as reader, \
                 mock.patch.object(provider, "read_locale_choices") as locales, \
                 mock.patch.object(provider, "PackageKitBackend") as backend, \
@@ -9356,6 +9356,333 @@ class OperationWatchTests(unittest.TestCase):
             self.assertEqual(result.returncode, 1)
             self.assertEqual(result.stderr, b"operation observation was interrupted\n")
             self.assertEqual(provider.load_journal_state(journal.chain).handoff.operation_id, operation.operation_id)
+
+
+class RegionalOwnerTests(unittest.TestCase):
+    boot_id = JournalRetainedSessionTests.boot_id
+    session = JournalRetainedSessionTests.session
+
+    def setup_client(self, journal, mode="success", action="timezone-set", argument="Etc/UTC"):
+        state = (provider.parse_locale_configuration(["LANG=POSIX"]) if action == "locale-set" else
+                 provider.RegionalTimeState("UTC", True, False, True))
+        preview = provider.make_regional_preview(action, argument, state,
+            ["C", "POSIX"] if action == "locale-set" else ["UTC", "Etc/UTC"])
+        self.events = []
+        self.during = lambda: None
+        self.before_admission = lambda: None
+        self.client = None
+
+        def factory(received_action, received_argument, generation, before, after):
+            self.assertEqual((received_action, received_argument), (action, argument))
+            client = types.SimpleNamespace(sent=False, acknowledged=False, hook_error=None,
+                kind="locale-state" if action == "locale-set" else "time-state")
+            self.client = client
+
+            def hook(callback, *args):
+                try:
+                    callback(*args)
+                except Exception as error:
+                    client.hook_error = error
+                    raise provider.SnapshotFailure("interrupted", "Fixture checkpoint failed") from error
+
+            def run():
+                provider.require_regional_generation(preview, generation)
+                if mode == "preflight":
+                    raise provider.SnapshotFailure("missing-provider", "Fixture preflight unavailable")
+                self.before_admission()
+                hook(before, preview)
+                with provider.lock_writable_journal(journal):
+                    current = provider.load_writable_journal_state(journal).active
+                    self.assertEqual(current.state, "authorizing")
+                    self.assertTrue(provider.native_journal_owner_busy(journal, current))
+                # This interval is unlocked; only the active-file lease is held.
+                with provider._journal_lock(journal.chain.directory_descriptor, exclusive=True):
+                    pass
+                if mode == "stale-before-send":
+                    raise provider.SnapshotFailure("conflict", "Fixture confirmation changed")
+                client.sent = True
+                self.events.append("sent")
+                if mode in {"denied", "method-error", "timeout", "transport"}:
+                    code = {"denied": "permission-denied", "method-error": "internal",
+                            "timeout": "timeout", "transport": "interrupted"}[mode]
+                    raise provider.SnapshotFailure(code, "Fixture service outcome")
+                client.acknowledged = True
+                hook(after)
+                self.during()
+                self.events.append("verified")
+                if mode == "mismatch":
+                    raise provider.SnapshotFailure("conflict", "Fixture verification mismatch")
+                return state
+            client.run = run
+            return client
+        return factory, preview.generation
+
+    def invoke(self, journal, mode="success", action="timezone-set", argument="Etc/UTC", write=None,
+               on_admission=None, configure=None):
+        factory, generation = self.setup_client(journal, mode, action, argument)
+        if configure is not None:
+            configure()
+        output = []
+        with mock.patch.object(provider, "RegionalMutation", side_effect=factory) as client, \
+                mock.patch.object(provider, "RegionalRead") as fresh, \
+                mock.patch.object(provider, "PackageKitBackend") as packagekit:
+            terminal = provider.run_regional_mutation(journal, action, argument, generation,
+                output.append if write is None else write, on_admission=on_admission)
+            packagekit.assert_not_called()
+            client.assert_called_once()
+        return terminal, "".join(output), fresh
+
+    def test_successful_fixed_actions_have_durable_handoffs_and_no_update_restart_changes(self):
+        for action, argument in (("timezone-set", "Etc/UTC"), ("ntp-set", "enabled"), ("locale-set", "LANG=C")):
+            with self.subTest(action=action), self.session() as (path, _chain, journal):
+                with provider.lock_writable_journal(journal):
+                    previous = provider.begin_journal_operation(journal, "updates-install-all",
+                        "2026-09-06T21:00:00Z", "Earlier update", generation="a" * 64,
+                        transaction_path="/1_test", boot_id=self.boot_id)
+                    provider.advance_journal_operation(journal, previous, replace(previous, state="running"))
+                    previous = provider.load_writable_journal_state(journal).active
+                    provider.advance_journal_operation(journal, previous, replace(previous, state="succeeded",
+                        system_restart="system", session_restart="session", application_restart=True,
+                        finished_at="2026-09-06T21:01:00Z", terminal_monotonic=100))
+                    provider.complete_journal_terminal(journal, boot_id=self.boot_id)
+                    provider.acknowledge_journal_handoff(journal, previous.operation_id)
+                restart = (path / "restart").read_bytes()
+                terminal, output, fresh = self.invoke(journal, action=action, argument=argument)
+                self.assertEqual(self.events, ["sent", "verified"])
+                self.assertEqual(terminal.state, "succeeded")
+                self.assertIsNone(terminal.boot_id)
+                self.assertIsNone(terminal.generation)
+                self.assertIsNone(terminal.terminal_monotonic)
+                state = provider.load_journal_state(journal.chain)
+                self.assertIsNone(state.active)
+                self.assertEqual(state.handoff.operation_id, terminal.operation_id)
+                self.assertEqual(state.terminals[terminal.slot], terminal)
+                self.assertEqual((path / "restart").read_bytes(), restart)
+                self.assertEqual([row[4] for row in rows(output.splitlines(), "operation")],
+                    ["pending", "authorizing", "running", "succeeded"])
+                self.assertTrue(all(row[5:7] == ["unknown", "no"] for row in rows(output.splitlines(), "operation")))
+                self.assertEqual(output.splitlines()[-1], "complete\toperation")
+                fresh.assert_not_called()
+                if action == "locale-set":
+                    self.assertIn("sign out and back in", terminal.detail)
+
+    def test_denial_conflict_and_explicit_error_have_exact_typed_terminals(self):
+        for mode, state, code in (("denied", "permission-denied", "permission-denied"),
+                                  ("method-error", "failed", "internal"),
+                                  ("mismatch", "failed", "conflict"),
+                                  ("stale-before-send", "failed", "conflict")):
+            with self.subTest(mode=mode), self.session() as (_path, _chain, journal):
+                terminal, output, fresh = self.invoke(journal, mode)
+                self.assertEqual((terminal.state, terminal.error_code), (state, code))
+                self.assertEqual(rows(output.splitlines(), "error")[0][1:3], ["regional", code])
+                self.assertEqual(self.client.sent, mode != "stale-before-send")
+                fresh.assert_not_called()
+
+    def test_ambiguous_terminal_is_durable_and_lease_free_before_independent_read(self):
+        for mode in ("timeout", "transport"):
+            with self.subTest(mode=mode), self.session() as (_path, _chain, journal):
+                factory, generation = self.setup_client(journal, mode)
+                output = []
+                def reread():
+                    state = provider.load_journal_state(journal.chain)
+                    self.assertIsNone(state.active)
+                    self.assertEqual(state.terminals[state.handoff.slot].state, "interrupted")
+                    self.assertTrue(provider._try_native_owner_lock(journal.descriptor("active")))
+                    provider._unlock_native_owner(journal.descriptor("active"))
+                    self.assertTrue(output[-1].endswith("complete\toperation\n"))
+                    raise provider.SnapshotFailure("permission-denied", "Fresh read unavailable")
+                with mock.patch.object(provider, "RegionalMutation", side_effect=factory), \
+                        mock.patch.object(provider, "RegionalRead") as reader:
+                    reader.return_value.run.side_effect = reread
+                    terminal = provider.run_regional_mutation(journal, "timezone-set", "Etc/UTC",
+                        generation, output.append)
+                    reader.assert_called_once_with("time-state")
+                    reader.return_value.run.assert_called_once()
+                self.assertEqual(terminal.state, "interrupted")
+                self.assertEqual(terminal.error_code, "timeout" if mode == "timeout" else "interrupted")
+                self.assertEqual(self.events, ["sent"])
+
+    def test_preflight_failure_never_admits_or_emits_an_operation(self):
+        with self.session() as (_path, _chain, journal):
+            before = provider.load_journal_state(journal.chain)
+            output, admitted = [], mock.Mock()
+            with self.assertRaises(provider.SnapshotFailure):
+                self.invoke(journal, "preflight", write=output.append, on_admission=admitted)
+            self.assertEqual(output, [])
+            admitted.assert_not_called()
+            self.assertEqual(provider.load_journal_state(journal.chain), before)
+
+    def test_output_loss_before_dispatch_aborts_but_after_dispatch_keeps_verification(self):
+        for phase in ("pending", "authorizing", "running", "succeeded"):
+            with self.subTest(phase=phase), self.session() as (_path, _chain, journal):
+                output = []
+                def write(chunk):
+                    if "\t" + phase + "\t" in chunk:
+                        raise BrokenPipeError("Fixture output closed")
+                    output.append(chunk)
+                with self.assertRaises(BrokenPipeError):
+                    self.invoke(journal, write=write)
+                state = provider.load_journal_state(journal.chain)
+                self.assertIsNone(state.active)
+                terminal = state.terminals[state.handoff.slot]
+                sent = phase in {"running", "succeeded"}
+                self.assertEqual(self.client.sent, sent)
+                self.assertEqual(terminal.state, "succeeded" if sent else "failed")
+                self.assertEqual(self.events, ["sent", "verified"] if sent else [])
+                self.assertNotIn("complete\toperation", "".join(output))
+
+    def test_checkpoint_failures_suppress_terminal_success_and_release_the_lease(self):
+        for phase in ("authorizing", "running", "succeeded"):
+            for after_write in (False, True):
+                with self.subTest(phase=phase, after_write=after_write), self.session() as (_path, _chain, journal):
+                    output = []
+                    original = provider.advance_journal_operation
+                    def advance(current_journal, current, following, **kwargs):
+                        if following.state == phase:
+                            if after_write:
+                                original(current_journal, current, following, **kwargs)
+                            raise provider.JournalCommitError("Fixture sync failure")
+                        return original(current_journal, current, following, **kwargs)
+                    with mock.patch.object(provider, "advance_journal_operation", side_effect=advance), \
+                            self.assertRaises(provider.JournalCommitError):
+                        self.invoke(journal, write=output.append)
+                    self.assertNotIn("complete\toperation", "".join(output))
+                    state = provider.load_journal_state(journal.chain)
+                    self.assertIsNotNone(state.active)
+                    self.assertIsNone(state.handoff)
+                    self.assertTrue(provider._try_native_owner_lock(journal.descriptor("active")))
+                    provider._unlock_native_owner(journal.descriptor("active"))
+                    self.assertEqual(self.client.sent, phase != "authorizing")
+
+    def test_admission_race_does_not_replace_a_competing_owner(self):
+        with self.session() as (_path, _chain, journal):
+            admitted = mock.Mock()
+            def configure():
+                def competing():
+                    with provider.lock_writable_journal(journal):
+                        provider.begin_journal_operation(journal, "ntp-set", "2026-09-06T22:00:00Z", "Competing request")
+                self.before_admission = competing
+            with self.assertRaises(provider.JournalAdmissionError):
+                self.invoke(journal, on_admission=admitted, configure=configure)
+            admitted.assert_not_called()
+            self.assertEqual(provider.load_journal_state(journal.chain).active.action_id, "ntp-set")
+            self.assertFalse(self.client.sent)
+
+    def test_native_cli_routes_only_fixed_valid_arguments(self):
+        for args in (["timezone-set", "UTC", "a" * 64], ["ntp-set", "enabled", "b" * 64],
+                     ["locale-set", "LANG=C", "c" * 64]):
+            with mock.patch.object(provider, "regional_command", return_value=0) as command:
+                self.assertEqual(provider.main(args), 0)
+                command.assert_called_once_with(*args)
+        for args in (["timezone-set"], ["timezone-set", "../UTC", "a" * 64],
+                     ["ntp-set", "true", "a" * 64], ["locale-set", "LANG=C", "A" * 64],
+                     ["locale-set", "LANG=C", "a" * 64, "extra"]):
+            with mock.patch.object(provider, "regional_command") as command, \
+                    contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(provider.main(args), 2)
+                command.assert_not_called()
+
+
+class RegionalCommandTests(unittest.TestCase):
+    boot_id = RegionalOwnerTests.boot_id
+    session = RegionalOwnerTests.session
+    setup_client = RegionalOwnerTests.setup_client
+
+    def invoke(self, journal, mode="success", writer=None):
+        factory, generation = self.setup_client(journal, mode)
+        with mock.patch.dict(os.environ, {"XDG_STATE_HOME": str(pathlib.Path(journal.chain.path).parents[1])}), \
+                mock.patch.object(provider, "read_fedora_identity", return_value={"ID": "fedora"}), \
+                mock.patch.object(provider, "read_boot_id", return_value=self.boot_id), \
+                mock.patch.object(provider, "RegionalMutation", side_effect=factory), \
+                mock.patch.object(provider, "RegionalRead"), \
+                mock.patch.object(provider, "PackageKitBackend") as packagekit, \
+                contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(io.StringIO()) as stderr:
+            code = provider.run_regional_command("timezone-set", "Etc/UTC", generation, writer, None)
+            packagekit.assert_not_called()
+        return code, stdout.getvalue(), stderr.getvalue()
+
+    def test_confirmed_success_and_denial_have_durable_exact_results(self):
+        for mode, expected, code in (("success", "succeeded", 0), ("denied", "permission-denied", 1)):
+            with self.subTest(mode=mode), self.session() as (_path, _chain, journal):
+                result, output, diagnostic = self.invoke(journal, mode)
+                self.assertEqual((result, diagnostic), (code, ""))
+                state = provider.load_journal_state(journal.chain)
+                self.assertIsNone(state.active)
+                terminal = state.terminals[state.handoff.slot]
+                self.assertEqual(terminal.state, expected)
+                self.assertEqual(rows(output.splitlines(), "audit")[0][1:5],
+                    [terminal.operation_id, "timezone-set", "timezone", expected])
+                self.assertEqual(output.splitlines()[-1], "complete\toperation")
+
+    def test_preflight_rejection_and_overlap_do_not_change_the_journal(self):
+        for mode in ("preflight", "active", "handoff"):
+            with self.subTest(mode=mode), self.session() as (_path, _chain, journal):
+                if mode != "preflight":
+                    with provider.lock_writable_journal(journal):
+                        active = provider.begin_journal_operation(journal, "ntp-set", "2026-09-06T22:00:00Z", "Existing")
+                        if mode == "handoff":
+                            provider.advance_journal_operation(journal, active, replace(active, state="failed",
+                                error_code="internal", finished_at="2026-09-06T22:01:00Z"))
+                            provider.complete_journal_terminal(journal)
+                before = provider.load_journal_state(journal.chain)
+                code, output, diagnostic = self.invoke(journal, "preflight" if mode == "preflight" else "success")
+                self.assertEqual((code, diagnostic), (1, ""))
+                self.assertEqual(rows(output.splitlines(), "error")[0][1:3],
+                    ["regional", "missing-provider" if mode == "preflight" else "conflict"])
+                self.assertIn("no regional mutation was dispatched", output)
+                self.assertEqual(output.splitlines()[-1], "complete\toperation")
+                self.assertEqual(provider.load_journal_state(journal.chain), before)
+
+    def test_uncertain_admission_and_terminal_handoff_never_fabricate_completion(self):
+        for stage in ("admission", "handoff"):
+            for after in (False, True):
+                with self.subTest(stage=stage, after=after), self.session() as (_path, _chain, journal):
+                    name = "begin_journal_operation" if stage == "admission" else "complete_journal_terminal"
+                    original = getattr(provider, name)
+                    def fail(*args, **kwargs):
+                        if after:
+                            original(*args, **kwargs)
+                        raise provider.JournalCommitError("Fixture private detail")
+                    with mock.patch.object(provider, name, side_effect=fail):
+                        code, output, diagnostic = self.invoke(journal)
+                    self.assertEqual(code, 1)
+                    self.assertNotIn("complete\toperation", output)
+                    self.assertEqual(diagnostic,
+                        "regional result could not be confirmed; refresh state and observe the existing operation\n")
+                    self.assertEqual(self.client.sent, stage == "handoff")
+                    if stage == "admission":
+                        self.assertEqual(output, "")
+                    state = provider.load_journal_state(journal.chain)
+                    self.assertEqual(state.handoff is not None, stage == "handoff" and after)
+
+    def test_raw_short_full_and_closed_output_abort_before_dispatch(self):
+        for result in (0, BlockingIOError("Full"), BrokenPipeError("Closed")):
+            with self.subTest(result=result), self.session() as (_path, _chain, journal):
+                writer = mock.Mock(**({"side_effect": result} if isinstance(result, Exception) else {"return_value": result}))
+                code, output, diagnostic = self.invoke(journal, writer=writer)
+                self.assertEqual((code, output), (1, ""))
+                self.assertIn("observe the existing operation", diagnostic)
+                writer.assert_called_once()
+                self.assertFalse(self.client.sent)
+                state = provider.load_journal_state(journal.chain)
+                self.assertEqual(state.terminals[state.handoff.slot].state, "failed")
+
+    def test_non_fedora_rejects_before_opening_journal(self):
+        with mock.patch.object(provider, "read_fedora_identity", side_effect=provider.SnapshotFailure("unsupported", "Not Fedora")), \
+                mock.patch.object(provider, "open_journal_directory") as journal, \
+                mock.patch.object(provider, "RegionalMutation") as client, \
+                contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(provider.run_regional_command("timezone-set", "UTC", "a" * 64, None, None), 1)
+            journal.assert_not_called()
+            client.assert_not_called()
+            self.assertEqual(stdout.getvalue(), "")
+
+    def test_private_bus_actual_cli_journal_and_output_loss(self):
+        result = subprocess.run(["dbus-run-session", "--", "/usr/bin/python3",
+            str(REPO / "tests/fixtures/system-regional-owner-bus.py"), str(PROVIDER_PATH)],
+            capture_output=True, text=True, timeout=60, check=False)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Private-bus regional owner: PASS", result.stdout)
 
 
 class UpdateCommandTests(unittest.TestCase):


### PR DESCRIPTION
## Scope
Complete one Phase 6 review boundary: durable ownership and fixed CLI origins for timezone, NTP enablement, and system locale. Settings origins remain disabled and the cumulative snapshot stays minor 0. No Phase 7 work or live installation synchronization.

## Behavior
- Repeat service preflight and confirmed-generation checks before admission; acquire the exact native active-file lease beside admission, then release the directory lock during service waits.
- Commit pending/authorizing/running and terminal retention/handoff before publishing their corresponding stream records. Preserve existing update restart guidance.
- Abort on output loss before dispatch; after dispatch continue verification and durable recording without retrying output or the platform action.
- Preserve recovery after uncertain admission, persistence, or output. A sent timeout/transport ambiguity becomes interrupted before lease release and an independent fresh read; later state cannot reclassify the outcome.
- Expose only fixed timezone-set, ntp-set, and locale-set grammar. Existing services own polkit authorization; the unprivileged client adds no elevated helper or PackageKit gate.
- Locale success gives new-login guidance; it does not log out the user.

## Validation
Fedora 44 x86_64, systemd 259.8, Quickshell 0.2.1 / Qt 6.11.2.
- Focused owner/CLI tests: 14 tests, 5.668 seconds; combined owner/preflight/update CLI regression run: 40 tests, 6.994 seconds before strengthening the existing-update restart fixture.
- `scripts/run-tests make clean all && scripts/run-tests`: PASS. Full provider suite: 486 tests, 178.482 seconds.
- Actual CLI/private-bus fixture: all three actions, live lease, durable handoff, denial, stale confirmation, ambiguous reply followed by an independent read, broken output after dispatch, exact replay and acknowledgment without another service call.
- Full suite includes native Quickshell parser/owner/recovery, nested-X11 lifecycle, shell/QML checks, Fedora package resolution (66 packages), staged install, repeated-install preservation, Kickstart/ISO static checks, and release archive validation.
- Settings closed CPU 0.033%; power lifecycle baseline 0.100%, after 0.033%, delta 0.067 percentage points; large surfaces closed CPU 0.00%.
- Test workspaces were removed. One documentation-only stale sentence was corrected after the full run; runtime/test sources are unchanged and documentation gates were rerun.
- Final post-gate local Codex review: no actionable correctness/security findings. Fresh independent CodeRabbit review: 0 findings across all six changed files. Documentation: 15 files checked with 0 errors/warnings/hints; 11 pages built.

## Limits
No host timezone, NTP, locale, packages, or user settings changed by the new fixtures. Real graphical polkit authorization and installed Settings origins are not qualified by this PR. The prior service-client fixture supplies a real 60-second ambiguous timeout; the new owner fixture uses an immediate private-bus NoReply to check durable interruption/read ordering. Bounded journal locks and nonblocking stream output are not a hard storage-I/O deadline.

Regional/delegated event integration, delegated tools, cumulative minor 1 Settings controls, minor 2 information/security/storage, and combined Phase 6 qualification remain outstanding. No automatic retry, cancellation after dispatch, rollback, logout, or reboot.