### PR TITLE
feat(system): journal fixed delegated administration launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ versions from `config.mk`.
 
 ### Changed
 
+- Add fixed account, password, printer, and software-source CLI entry points.
+  Resolve trusted tools, keep password handling in the configured supported
+  terminal, and record only accepted launches with durable recovery. Missing
+  tools and unsupported terminal forms remain capability-local. Launched tools
+  cannot inherit the operation journal or output; Settings origins remain
+  disabled pending discovery and confirmation integration.
+
 - Enable the three generation-confirmed regional CLI commands with durable
   operation ownership, verified results, retained replay, and acknowledgment.
   Preserve recovery after uncertain writes or lost output; ambiguous sent

--- a/TASKS.md
+++ b/TASKS.md
@@ -189,8 +189,9 @@ success, and rejects duplicate or oversized complete results. Unit and private-b
 tests cover bounds, denial, absence, replacement, timeout, and late replies. A
 read-only Fedora 44 probe returned 28 rows (15 enabled and 13 disabled) in 0.826
 seconds without requesting metadata refresh or repository changes. This reader
-adds no CLI command or protocol minor. Event subscriptions, lifecycle integration,
-delegated-tool availability, and Settings controls remain outstanding.
+adds no CLI command or protocol minor. Event subscriptions and cumulative
+Settings integration remain outstanding; delegated entry points are described
+below.
 
 Read-only regional choices and preview commands now expose separately bounded
 streams without changing the cumulative snapshot minor. Previews bind the exact
@@ -239,6 +240,22 @@ confirmation, write failures, lost output, replay, and acknowledgment without
 repeating the action. Graphical polkit and host mutations are not qualified.
 Post-timeout Settings display refresh and originating Settings controls remain
 outstanding; the snapshot minor remains zero.
+
+The four fixed delegated CLI origins now resolve trusted administration tools,
+preserve configured terminal selection for the fixed password command, and
+record only accepted launches. The terminal selector has a three-second
+supervised lifetime and one 4096-byte output budget; unsupported terminal forms
+degrade only the password action. Launched tools receive a new session, null
+stdio, and no inherited journal descriptors. Native admission, checkpoints,
+terminal retention, and replay preserve ownership without tracking the tools'
+internal administration. Unit and real private-child fixtures cover trust,
+selection, denial/failure, lost output, child isolation, and later tool failure
+without falsely reporting its work as completed. No real administration tool or
+password prompt was opened. Settings origins and cumulative minor 1 discovery
+remain outstanding.
+A read-only Fedora 44 probe resolved the password command through Alacritty in
+0.056 seconds and found the printer tool available. Account and source tools
+were absent and returned their scoped missing-provider results; none was opened.
 
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -718,7 +718,12 @@ active-file lease precede output, `running` is committed before the single exec,
 and terminal retention/handoff is committed before completion. The child starts
 in its own session with stdin/stdout/stderr on `/dev/null` and every descriptor
 above 2 closed, so an open tool cannot retain the journal lease or operation
-stream. No shell interprets the launch argv. A successful exec is only an
+stream. This isolated launch requires Python 3.13 or newer with
+[`os.POSIX_SPAWN_CLOSEFROM`](https://docs.python.org/3/library/os.html#os.POSIX_SPAWN_CLOSEFROM)
+support in `/usr/bin/python3`; the supported Fedora 44 runtime supplies it.
+The launcher returns a scoped `unsupported` result when that primitive is
+unavailable, without an unsafe fallback. No shell
+interprets the launch argv. A successful exec is only an
 accepted launch; the tool owns its subsequent UI, authorization, changes, and
 cancellation. The provider neither waits for that internal work nor reports it
 as completed. Output loss before launch prevents exec; loss after accepted exec

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -507,8 +507,8 @@ dwm-system-management printers-open
 dwm-system-management sources-open
 ```
 
-The first three confirmed regional forms are implemented. The four delegated
-launch forms remain planned and are not accepted by the CLI yet.
+All seven forms are implemented as fixed CLI origins. Originating Settings
+controls remain disabled until their confirmation and discovery integration.
 
 `ZONE` is at most 255 ASCII bytes, contains no control characters, empty path
 components, `.` or `..` components, and must exactly match a value returned by
@@ -684,6 +684,53 @@ rows; timeout or excess results are provider-scoped errors. Repository changes
 remain in the Fedora-packaged `dnfdragora` tool when present. Missing optional
 delegated tools are reported individually and never hide readable service
 state.
+
+The four no-argument administration CLI origins are now implemented. Accounts,
+printers, and sources resolve only `/usr/bin/lxqt-admin-user`,
+`/usr/bin/system-config-printer`, and `/usr/bin/dnfdragora`, respectively.
+Resolution uses the canonical executable path and requires the file and every
+resolved parent directory to be root-owned and not group/other-writable. A
+missing, non-executable, or unsupported target fails only that launch. These
+checks select trusted unprivileged launch targets; they do not elevate a
+repository helper or authorize changes inside the tools.
+
+The password entry uses the existing managed `dwm-terminal --print-command`
+selection contract, including the invoking user's configured terminal and
+fallback order. The selected helper must be root-controlled. A fixed
+`/usr/bin/bash` interpreter prevents the helper's env shebang from resolving a
+user-supplied Bash. Only PATH, HOME, XDG_CONFIG_HOME, DWM_TERMINAL, and fixed C
+locale values enter this read-only selector; shell startup and loader overrides
+are excluded. A separate timeout supervisor bounds collection to three seconds,
+stdout and stderr share a 4096-byte budget, and complete UTF-8 output must contain
+exactly one nonempty printable command identity and one final newline. Cleanup
+retains the owned process group through TERM, KILL, and bounded reaping, including
+signal interruption; incomplete cleanup cannot produce a usable selection.
+
+Password launch supports Alacritty, st, and xterm with the fixed `-e` argument,
+and Kitty with its positional-program form. The sole program argument is the
+root-controlled `/usr/bin/passwd`; no username or password is accepted by QML or
+the provider. Other terminal forms, including Warp, leave the password entry
+unsupported with guidance to run `passwd` directly. The provider does not change
+the terminal preference or substitute another command for an unsupported form.
+
+Every delegated launch uses the shared durable native owner: admission and its
+active-file lease precede output, `running` is committed before the single exec,
+and terminal retention/handoff is committed before completion. The child starts
+in its own session with stdin/stdout/stderr on `/dev/null` and every descriptor
+above 2 closed, so an open tool cannot retain the journal lease or operation
+stream. No shell interprets the launch argv. A successful exec is only an
+accepted launch; the tool owns its subsequent UI, authorization, changes, and
+cancellation. The provider neither waits for that internal work nor reports it
+as completed. Output loss before launch prevents exec; loss after accepted exec
+preserves the durable launch result. Ambiguous launch observation is interrupted
+without retry, and replay/acknowledgment never launches another tool. Local
+filesystem/exec operations do not claim a hard kernel-I/O deadline.
+
+Unit and real private-child fixtures cover fixed argv, trust failures, bounded
+selection, launch errors, lost output, descriptor/session isolation, handoff
+replay, and a tool exiting unsuccessfully after its launch was accepted.
+Originating Settings controls and cumulative minor 1 discovery remain
+outstanding; the cumulative snapshot remains minor zero.
 
 The internal repository reader now bounds connection setup, optional activation
 of an absent PackageKit daemon, transaction setup, signals, and decoding under
@@ -1765,9 +1812,10 @@ of mutation commands. Tests cover all regional and delegated kinds, competing
 and originating descriptors, path replacement, lock and cleanup failures,
 normal process exit, abrupt process death, and durable terminal replay. Public
 native snapshot/watch integration now observes these owners without taking over
-service work. The fixed regional CLI origins now retain this lease throughout
-their service workflow. Delegated launch commands and originating Settings
-actions remain gated; the cumulative snapshot minor is unchanged.
+service work. Fixed regional CLI origins retain this lease throughout their
+service workflow; fixed delegated origins retain it through accepted launch and
+durable handoff. Originating Settings actions remain gated; the cumulative
+snapshot minor is unchanged.
 
 ## Event and Resource Contract
 

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -14,6 +14,7 @@ import os
 import re
 import selectors
 import shlex
+import shutil
 import signal
 import socket
 import stat
@@ -41,6 +42,13 @@ REPOSITORY_MAX_BYTES = 384 * 1024
 MAX_OPERATION_PROGRESS_RECORDS = 252
 MAX_OPERATION_MISMATCH_SAMPLES = 128
 NATIVE_WATCH_SECONDS = 120
+DELEGATED_TOOLS = {
+    "accounts-open": ("/usr/bin/lxqt-admin-user", "User accounts"),
+    "printers-open": ("/usr/bin/system-config-printer", "Printers"),
+    "sources-open": ("/usr/bin/dnfdragora", "Software sources"),
+}
+PASSWORD_TERMINALS = {"alacritty": ("-e",), "kitty": (), "st": ("-e",), "xterm": ("-e",)}
+DELEGATED_ACTIONS = frozenset((*DELEGATED_TOOLS, "password-open"))
 
 REGIONAL_TIMEZONE_MAX = 255
 REGIONAL_TIMEZONE_COUNT = 2048
@@ -1769,6 +1777,182 @@ def read_locale_choices() -> tuple[str, ...]:
             # otherwise callers could catch a read failure and keep running.
             if interrupted:
                 raise SystemExit(128 + interrupted)
+
+
+def trusted_delegated_executable(path: str, basename: str) -> str:
+    """Resolve an unprivileged launch target into a root-controlled executable path."""
+    try:
+        resolved = os.path.realpath(path, strict=True)
+        if os.path.basename(resolved) != basename:
+            raise SnapshotFailure("unsupported", "The configured administration command has an unsupported identity")
+        current = resolved
+        while True:
+            value = os.stat(current, follow_symlinks=False)
+            expected_type = stat.S_ISREG if current == resolved else stat.S_ISDIR
+            if not expected_type(value.st_mode) or value.st_uid != 0 or value.st_mode & 0o022:
+                raise SnapshotFailure("unsupported", "The administration command is not in a root-controlled executable path")
+            if current == "/":
+                break
+            current = os.path.dirname(current)
+        if not os.access(resolved, os.X_OK):
+            raise SnapshotFailure("permission-denied", "The administration command is not executable")
+        return resolved
+    except FileNotFoundError as error:
+        raise SnapshotFailure("missing-provider", "The required administration command is not installed") from error
+    except OSError as error:
+        raise SnapshotFailure("internal", "The administration command could not be inspected") from error
+
+
+def terminal_selection_environment() -> dict[str, str]:
+    """Preserve only terminal-selection inputs, never shell startup or loader overrides."""
+    result = {"PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"), "LANG": "C", "LC_ALL": "C"}
+    for name in ("HOME", "XDG_CONFIG_HOME", "DWM_TERMINAL"):
+        if name in os.environ:
+            result[name] = os.environ[name]
+    try:
+        invalid = any(len(value.encode("utf-8")) > 4096 or "\0" in value for value in result.values())
+    except UnicodeError:
+        invalid = True
+    if not result.get("HOME", "").startswith("/") or invalid:
+        raise SnapshotFailure("malformed", "Terminal selection environment is unavailable or oversized")
+    return result
+
+
+def read_terminal_selection(helper: str, environment: Mapping[str, str]) -> str:
+    """Bound the managed helper's read-only terminal selection without capturing passwords."""
+    if (threading.current_thread() is not threading.main_thread()
+            or signal.getsignal(signal.SIGCHLD) != signal.SIG_DFL):
+        raise SnapshotFailure("internal", "Terminal selection process ownership is unavailable")
+    process, handlers, interrupted = None, {}, 0
+
+    def terminate(number, _frame):
+        nonlocal interrupted
+        interrupted = interrupted or number
+
+    def check_deadline():
+        if interrupted:
+            raise SystemExit(128 + interrupted)
+        if time.monotonic() >= deadline:
+            raise SnapshotFailure("timeout", "Terminal selection timed out")
+
+    try:
+        for number in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            handlers[number] = signal.signal(number, terminate)
+        deadline = time.monotonic() + 3
+        # A fixed interpreter avoids resolving the helper's env shebang through
+        # the user's PATH. The helper only prints its selected command identity.
+        check_deadline()
+        process = subprocess.Popen(["/usr/bin/timeout", "--signal=TERM", "--kill-after=1", "3",
+            "/usr/bin/bash", helper, "--print-command"], stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True, env=dict(environment))
+        output, received = bytearray(), 0
+        with selectors.DefaultSelector() as selector:
+            for stream in (process.stdout, process.stderr):
+                os.set_blocking(stream.fileno(), False)
+                selector.register(stream, selectors.EVENT_READ)
+            while True:
+                check_deadline()
+                status = locale_process_status(process)
+                if status is not None and not selector.get_map():
+                    break
+                for key, _events in selector.select(min(0.05, max(0, deadline - time.monotonic()))):
+                    check_deadline()
+                    try:
+                        chunk = os.read(key.fd, min(4096, 4096 - received + 1))
+                    except BlockingIOError:
+                        continue
+                    if not chunk:
+                        selector.unregister(key.fileobj)
+                        continue
+                    received += len(chunk)
+                    if received > 4096:
+                        raise SnapshotFailure("malformed", "Terminal selection output is oversized")
+                    if key.fileobj is process.stdout:
+                        output.extend(chunk)
+        check_deadline()
+        code = status.si_status if status.si_code == os.CLD_EXITED else -status.si_status
+        if code in (124, 137, -signal.SIGKILL):
+            raise SnapshotFailure("timeout", "Terminal selection timed out")
+        if code != 0:
+            raise SnapshotFailure("missing-provider" if code == 127 else "internal", "Terminal selection failed")
+        try:
+            value = bytes(output).decode("utf-8")
+        except UnicodeDecodeError as error:
+            check_deadline()
+            raise SnapshotFailure("malformed", "Terminal selection is not UTF-8") from error
+        valid = value.endswith("\n") and bool(value[:-1]) and value[:-1].isprintable()
+        check_deadline()
+        if not valid:
+            raise SnapshotFailure("malformed", "Terminal selection is not one command identity")
+        return value[:-1]
+    except FileNotFoundError as error:
+        raise SnapshotFailure("missing-provider", "Terminal selection helper is unavailable") from error
+    except OSError as error:
+        raise SnapshotFailure("internal", "Terminal selection failed") from error
+    finally:
+        try:
+            if process is not None:
+                try:
+                    close_locale_process(process)
+                except SnapshotFailure as error:
+                    raise SnapshotFailure("timeout", "Terminal selection cleanup could not be confirmed") from error
+        finally:
+            for number, handler in handlers.items():
+                signal.signal(number, handler)
+            if interrupted:
+                raise SystemExit(128 + interrupted)
+
+
+def delegated_command(action: str) -> tuple[tuple[str, ...], str]:
+    """Resolve only fixed administration entries; unavailable tools are capability-local."""
+    if not isinstance(action, str) or action not in DELEGATED_ACTIONS:
+        raise SnapshotFailure("malformed", "Unknown delegated administration action")
+    if action in DELEGATED_TOOLS:
+        path, label = DELEGATED_TOOLS[action]
+        return (trusted_delegated_executable(path, os.path.basename(path)),), label
+    passwd = trusted_delegated_executable("/usr/bin/passwd", "passwd")
+    environment = terminal_selection_environment()
+    helper = shutil.which("dwm-terminal", path=environment["PATH"])
+    if helper is None:
+        raise SnapshotFailure("missing-provider", "The managed terminal selector is not installed")
+    helper = trusted_delegated_executable(helper, "dwm-terminal")
+    selected = read_terminal_selection(helper, environment)
+    name = os.path.basename(selected)
+    if name not in PASSWORD_TERMINALS:
+        raise SnapshotFailure("unsupported", "The configured terminal has no supported password-launch form; run passwd in your terminal")
+    terminal = shutil.which(selected, path=environment["PATH"])
+    if terminal is None:
+        raise SnapshotFailure("missing-provider", "The selected terminal is no longer installed")
+    terminal = trusted_delegated_executable(terminal, name)
+    return (terminal, *PASSWORD_TERMINALS[name], passwd), "Change your password"
+
+
+def launch_delegated_tool(command: tuple[str, ...]) -> None:
+    """Accept a resolved fixed exec without waiting for the tool's internal administration."""
+    if not hasattr(os, "POSIX_SPAWN_CLOSEFROM"):
+        raise SnapshotFailure("unsupported", "Isolated administration launches are unavailable")
+    accepted = False
+    try:
+        null = os.open("/dev/null", os.O_RDWR | os.O_CLOEXEC)
+        try:
+            actions = [(os.POSIX_SPAWN_DUP2, null, descriptor) for descriptor in (0, 1, 2)]
+            actions.append((os.POSIX_SPAWN_CLOSEFROM, 3))
+            os.posix_spawn(command[0], command, dict(os.environ), file_actions=actions,
+                setsid=True, setsigmask=(),
+                setsigdef=(signal.SIGPIPE, signal.SIGINT, signal.SIGTERM, signal.SIGHUP))
+            accepted = True
+        finally:
+            os.close(null)
+    except FileNotFoundError as error:
+        raise SnapshotFailure("missing-provider", "The administration tool is no longer installed") from error
+    except PermissionError as error:
+        raise SnapshotFailure("permission-denied", "The administration tool could not be launched") from error
+    except NotImplementedError as error:
+        raise SnapshotFailure("unsupported", "Isolated administration launches are unavailable") from error
+    except OSError as error:
+        if accepted or isinstance(error, InterruptedError):
+            raise SnapshotFailure("interrupted", "Administration launch observation was interrupted; the tool may already be open") from error
+        raise SnapshotFailure("internal", "The administration tool could not be launched") from error
 
 
 class JournalFrameError(ValueError):
@@ -4922,15 +5106,20 @@ def reject_unadmitted_operation(operation_id: str, action_id: str, started_at: s
                                failure: SnapshotFailure, write: Callable[[str], object]) -> None:
     """Report a rejected request without inventing a durable transaction or result."""
     if (not isinstance(action_id, str) or action_id not in {
-            "updates-refresh", "updates-install-all", "timezone-set", "ntp-set", "locale-set"}
+            "updates-refresh", "updates-install-all", "timezone-set", "ntp-set", "locale-set", *DELEGATED_ACTIONS}
             or not isinstance(failure, SnapshotFailure) or failure.code not in JOURNAL_ERROR_CODES):
         raise OperationProtocolError("rejected operation request is invalid")
     _validate_journal_detail(failure.detail)
     finished_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     regional = action_id in {"timezone-set", "ntp-set", "locale-set"}
     provider_id, mutation = ("regional", "regional") if regional else ("updates", "package")
+    detail = f"Request rejected before operation admission; no {mutation} mutation was dispatched"
+    if action_id in DELEGATED_ACTIONS:
+        provider_id = {"accounts-open": "accounts", "password-open": "accounts",
+                       "printers-open": "printers", "sources-open": "sources"}[action_id]
+        detail = "Request rejected before operation admission; no administration tool was launched"
     stream = OperationStream(operation_id, action_id, started_at,
-        f"Request rejected before operation admission; no {mutation} mutation was dispatched", write)
+        detail, write)
     stream._send([
         f"error\t{provider_id}\t{failure.code}\t{failure.detail}",
         stream._operation_line("failed", "unknown", False, failure.detail),
@@ -5581,7 +5770,7 @@ def recover_journal_active(
         return load_writable_journal_state(journal), None, lookup_failure
 
 
-class RegionalOperationOwner:
+class NativeOperationOwner:
     """Checkpoint one leased native owner before publishing its operation stream."""
 
     def __init__(self, journal: JournalDescriptorSet, operation: JournalOperation,
@@ -5601,7 +5790,7 @@ class RegionalOperationOwner:
     def current(self):
         current = load_writable_journal_state(self.journal).active
         if current != self.operation or current.state in JOURNAL_OPERATION_TERMINAL_STATES:
-            raise JournalAdmissionError("Regional operation ownership changed")
+            raise JournalAdmissionError("Native operation ownership changed")
         return current
 
     def output(self, callback):
@@ -5626,10 +5815,13 @@ class RegionalOperationOwner:
             raise
         self.output(lambda: self.stream.transition(state, detail))
 
-    def finish(self, state, failure=None):
+    def finish(self, state, failure=None, *, success_detail=None):
         if self.persistence_error is not None:
             raise self.persistence_error
-        detail = ("Regional change verified; sign out and back in for applications to use the locale"
+        if failure is None and self.operation.kind == "delegate" and success_detail is None:
+            raise OperationProtocolError("Delegated completion requires an explicit launch-only result")
+        detail = (success_detail if failure is None and success_detail is not None else
+                  "Regional change verified; sign out and back in for applications to use the locale"
                   if failure is None and self.operation.kind == "locale" else
                   "Regional change verified" if failure is None else failure.detail)
         with lock_writable_journal(self.journal):
@@ -5671,7 +5863,7 @@ def run_regional_mutation(
                     datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                     f"Preparing {action}: {preview.target}")
                 retained.enter_context(retain_native_journal_owner(journal, operation))
-            owner = RegionalOperationOwner(journal, operation, write)
+            owner = NativeOperationOwner(journal, operation, write)
             if owner.output_error is not None:
                 raise owner.output_error
             owner.checkpoint("authorizing", "Regional authorization is pending; a sent change cannot be canceled")
@@ -5708,6 +5900,41 @@ def run_regional_mutation(
         # Settings will publish its own fresh snapshot on origin completion.
         with contextlib.suppress(SnapshotFailure):
             RegionalRead(client.kind).run()
+    if owner.output_error is not None:
+        raise owner.output_error
+    return terminal
+
+
+def run_delegated_launch(journal: JournalDescriptorSet, action: str, write: Callable[[str], object],
+                         *, on_admission: Callable[[], None] | None = None) -> JournalOperation:
+    """Journal only a fixed tool's accepted launch, retaining no ownership of its later work."""
+    if not isinstance(action, str) or action not in DELEGATED_ACTIONS or not callable(write):
+        raise SnapshotFailure("malformed", "Invalid delegated administration request")
+    with lock_writable_journal(journal):
+        prepare_journal_admission(journal)
+    command, label = delegated_command(action)
+    with contextlib.ExitStack() as retained:
+        with lock_writable_journal(journal):
+            prepare_journal_admission(journal)
+            if on_admission is not None:
+                on_admission()
+            operation = begin_journal_operation(journal, action,
+                datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"), "Preparing " + label)
+            retained.enter_context(retain_native_journal_owner(journal, operation))
+        owner = NativeOperationOwner(journal, operation, write)
+        failure = None
+        if owner.output_error is None:
+            owner.checkpoint("running", "Opening " + label + "; administration remains in that tool")
+        if owner.output_error is not None:
+            failure = SnapshotFailure("internal", "Administration output was unavailable; no tool was launched")
+        else:
+            try:
+                launch_delegated_tool(command)
+            except SnapshotFailure as error:
+                failure = error
+        terminal = owner.finish("succeeded" if failure is None else
+            "interrupted" if failure.code == "interrupted" else "failed", failure,
+            success_detail=label + " launch accepted; continue in the tool. Its changes and authorization are not tracked here")
     if owner.output_error is not None:
         raise owner.output_error
     return terminal
@@ -7409,19 +7636,21 @@ def run_operation_control(command: str, operation_id: str,
         return 3
 
 
-def regional_command(action: str, argument: str, generation: str) -> int:
-    """Expose only confirmed native origins with isolated nonblocking output."""
+def native_command(action: str, argument: str = "", generation: str = "") -> int:
+    """Expose only fixed regional and delegated origins with isolated nonblocking output."""
     try:
         with control_output_writers() as writers:
-            return run_regional_command(action, argument, generation, *writers)
+            return run_native_command(action, argument, generation, *writers)
     except OSError:
         return 1
 
 
-def run_regional_command(action: str, argument: str, generation: str,
+def run_native_command(action: str, argument: str, generation: str,
                          output_writer: Callable[[bytes], int] | None,
                          error_writer: Callable[[bytes], int] | None) -> int:
     admission_started = output_started = False
+    delegated = action in DELEGATED_ACTIONS
+    family = "administration" if delegated else "regional"
 
     def admitted():
         nonlocal admission_started
@@ -7439,7 +7668,7 @@ def run_regional_command(action: str, argument: str, generation: str,
                 raise OSError("Incomplete regional operation output")
 
     def diagnostic():
-        message = "regional result could not be confirmed; refresh state and observe the existing operation"
+        message = family + " result could not be confirmed; refresh state and observe the existing operation"
         with contextlib.suppress(OSError):
             if error_writer is None:
                 print(message, file=sys.stderr)
@@ -7454,8 +7683,9 @@ def run_regional_command(action: str, argument: str, generation: str,
             with retain_writable_journal(chain) as journal:
                 started_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
                 try:
-                    terminal = run_regional_mutation(journal, action, argument, generation,
-                                                     write, on_admission=admitted)
+                    terminal = (run_delegated_launch(journal, action, write, on_admission=admitted)
+                                if delegated else run_regional_mutation(journal, action, argument, generation,
+                                                                       write, on_admission=admitted))
                     return 0 if terminal.state == "succeeded" else 1
                 except (SnapshotFailure, JournalFrameError, JournalRecordError,
                         JournalAdmissionError, OSError, OperationProtocolError) as error:
@@ -7468,9 +7698,9 @@ def run_regional_command(action: str, argument: str, generation: str,
                     elif isinstance(error, (JournalAdmissionError, JournalLockError)):
                         failure = SnapshotFailure("conflict", "Another operation or recovery state blocks this request; refresh state before retrying")
                     elif isinstance(error, (JournalFrameError, JournalRecordError, OperationProtocolError)):
-                        failure = SnapshotFailure("malformed", "Regional preflight is malformed; refresh state and inspect recovery guidance")
+                        failure = SnapshotFailure("malformed", family.capitalize() + " preflight is malformed; refresh state and inspect recovery guidance")
                     else:
-                        failure = SnapshotFailure("internal", "Regional preflight failed; check journal storage and refresh state before retrying")
+                        failure = SnapshotFailure("internal", family.capitalize() + " preflight failed; check journal storage and refresh state before retrying")
                     reject_unadmitted_operation(operation_id, action, started_at, failure, write)
                     return 1
     except (SnapshotFailure, JournalFrameError, JournalRecordError, JournalAdmissionError,
@@ -7750,7 +7980,7 @@ def watch_update_events() -> int:
 
 
 def usage() -> int:
-    print(f"usage: {sys.argv[0]} snapshot | watch-updates | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE | timezone-set ZONE GENERATION | ntp-set enabled|disabled GENERATION | locale-set LANG=LOCALE GENERATION", file=sys.stderr)
+    print(f"usage: {sys.argv[0]} snapshot | watch-updates | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE | timezone-set ZONE GENERATION | ntp-set enabled|disabled GENERATION | locale-set LANG=LOCALE GENERATION | accounts-open | password-open | printers-open | sources-open", file=sys.stderr)
     return 2
 
 
@@ -7762,7 +7992,9 @@ def main(argv: Sequence[str]) -> int:
             validate_regional_argument(argv[0], argv[1])
         except SnapshotFailure:
             return usage()
-        return regional_command(*argv)
+        return native_command(*argv)
+    if argv and argv[0] in DELEGATED_ACTIONS:
+        return native_command(argv[0]) if len(argv) == 1 else usage()
     if argv and argv[0] in {"regional-choices", "regional-preview"}:
         try:
             output, code = regional_preflight_output(argv[0], argv[1:])

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -1924,7 +1924,7 @@ def delegated_command(action: str) -> tuple[tuple[str, ...], str]:
     if terminal is None:
         raise SnapshotFailure("missing-provider", "The selected terminal is no longer installed")
     terminal = trusted_delegated_executable(terminal, name)
-    return (terminal, *PASSWORD_TERMINALS[name], passwd), "Change your password"
+    return (terminal, *PASSWORD_TERMINALS[name], passwd), "Password change"
 
 
 def launch_delegated_tool(command: tuple[str, ...]) -> None:

--- a/tests/fixtures/system-delegated-tool.py
+++ b/tests/fixtures/system-delegated-tool.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python3
+"""Record a private launched child's isolation; never performs administration."""
+
+import json
+import os
+import pathlib
+import sys
+import time
+
+descriptors = {}
+for name in os.listdir("/proc/self/fd"):
+    try:
+        descriptors[name] = os.readlink("/proc/self/fd/" + name)
+    except FileNotFoundError:
+        pass
+report = pathlib.Path(sys.argv[1])
+pending = report.with_suffix(".pending")
+pending.write_text(json.dumps({
+    "pid": os.getpid(), "sid": os.getsid(0), "descriptors": descriptors,
+}), encoding="utf-8")
+pending.replace(report)
+if sys.argv[2] == "failed-work":
+    sys.exit(42)
+time.sleep(10)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -2212,7 +2212,7 @@ class DelegatedToolTests(unittest.TestCase):
                     mock.patch.object(provider, "read_terminal_selection", return_value=name), \
                     mock.patch.object(provider.shutil, "which", side_effect=["/usr/local/bin/dwm-terminal", "/usr/bin/" + name]):
                 self.assertEqual(provider.delegated_command("password-open"),
-                    (("/usr/bin/" + name, *arguments, "/usr/bin/passwd"), "Change your password"))
+                    (("/usr/bin/" + name, *arguments, "/usr/bin/passwd"), "Password change"))
 
     def test_unknown_actions_and_unsupported_terminals_never_launch_or_fall_back(self):
         for action in ("health-open", "password-open user", "accounts-open --root", None, []):
@@ -2245,9 +2245,12 @@ class DelegatedToolTests(unittest.TestCase):
                 def unsafe(current, **options):
                     value = metadata(current, **options)
                     if current == target:
-                        if field == "owner": value.st_uid = 1000
-                        elif field == "writable": value.st_mode |= 0o020
-                        else: value.st_mode = stat.S_IFLNK | 0o777
+                        if field == "owner":
+                            value.st_uid = 1000
+                        elif field == "writable":
+                            value.st_mode |= 0o020
+                        else:
+                            value.st_mode = stat.S_IFLNK | 0o777
                     return value
                 with self.subTest(target=target, field=field), mock.patch.object(provider.os.path, "realpath", return_value=path), \
                         mock.patch.object(provider.os, "stat", side_effect=unsafe):
@@ -2306,6 +2309,15 @@ class DelegatedToolTests(unittest.TestCase):
             self.assertIsNotNone(children[0].returncode)
         self.assertLess(time.monotonic() - started, 5.5)
 
+    def test_missing_closefrom_fails_before_open_or_spawn(self):
+        unavailable = types.SimpleNamespace(open=mock.Mock(), posix_spawn=mock.Mock())
+        with mock.patch.object(provider, "os", unavailable):
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                provider.launch_delegated_tool(("/usr/bin/kitty", "/usr/bin/passwd"))
+        self.assertEqual(caught.exception.code, "unsupported")
+        unavailable.open.assert_not_called()
+        unavailable.posix_spawn.assert_not_called()
+
     def test_launch_uses_new_session_null_stdio_and_closefrom(self):
         command = ("/usr/bin/kitty", "/usr/bin/passwd")
         with mock.patch.object(provider.os, "posix_spawn", return_value=1234) as spawn:
@@ -2317,7 +2329,8 @@ class DelegatedToolTests(unittest.TestCase):
         actions = options["file_actions"]
         self.assertEqual([action[2] for action in actions[:3]], [0, 1, 2])
         self.assertEqual(actions[-1], (os.POSIX_SPAWN_CLOSEFROM, 3))
-        with self.assertRaises(OSError): os.fstat(actions[0][1])
+        with self.assertRaises(OSError):
+            os.fstat(actions[0][1])
         for error, code in ((FileNotFoundError(), "missing-provider"), (PermissionError(), "permission-denied"),
                             (OSError(errno.ENOEXEC, "Fixture"), "internal"), (InterruptedError(), "interrupted"),
                             (NotImplementedError(), "unsupported")):
@@ -9902,7 +9915,8 @@ class DelegatedOwnerTests(unittest.TestCase):
                 self.assertEqual(active.state, "running")
                 self.assertEqual(active.action_id, action)
                 self.assertTrue(provider.native_journal_owner_busy(journal, active))
-            with provider._journal_lock(journal.chain.directory_descriptor, exclusive=True): pass
+            with provider._journal_lock(journal.chain.directory_descriptor, exclusive=True):
+                pass
             if failure is not None:
                 raise provider.SnapshotFailure(failure, "Fixture launch result")
         with mock.patch.object(provider, "delegated_command", return_value=(("/usr/bin/fixture",), "Fixture tool")), \
@@ -9945,7 +9959,8 @@ class DelegatedOwnerTests(unittest.TestCase):
             with self.subTest(phase=phase), self.session() as (_path, _chain, journal):
                 output = []
                 def write(chunk):
-                    if "\t" + phase + "\t" in chunk: raise BrokenPipeError()
+                    if "\t" + phase + "\t" in chunk:
+                        raise BrokenPipeError()
                     output.append(chunk)
                 with mock.patch.object(provider, "delegated_command", return_value=(("/usr/bin/fixture",), "Fixture")), \
                         mock.patch.object(provider, "launch_delegated_tool") as launch, self.assertRaises(BrokenPipeError):
@@ -9960,7 +9975,8 @@ class DelegatedOwnerTests(unittest.TestCase):
             with self.subTest(race=race), self.session() as (_path, _chain, journal):
                 admitted, output = mock.Mock(), []
                 def resolve(_action):
-                    if not race: raise provider.SnapshotFailure("missing-provider", "Unavailable fixture")
+                    if not race:
+                        raise provider.SnapshotFailure("missing-provider", "Unavailable fixture")
                     with provider.lock_writable_journal(journal):
                         provider.begin_journal_operation(journal, "ntp-set", "2026-09-06T23:00:00Z", "Competing")
                     return ("/usr/bin/fixture",), "Fixture"
@@ -9979,7 +9995,8 @@ class DelegatedOwnerTests(unittest.TestCase):
                 with self.subTest(stage=stage, after=after), self.session() as (_path, _chain, journal):
                     original, admitted, output = getattr(provider, stage), mock.Mock(), []
                     def fail(*args, **kwargs):
-                        if after: original(*args, **kwargs)
+                        if after:
+                            original(*args, **kwargs)
                         raise provider.JournalCommitError("Uncertain fixture write")
                     with mock.patch.object(provider, stage, side_effect=fail), self.assertRaises(provider.JournalCommitError):
                         self.invoke(journal, write=output.append, admitted=admitted)
@@ -10022,7 +10039,8 @@ class DelegatedOwnerTests(unittest.TestCase):
                     children.append(pid)
                     return pid
                 def write(chunk):
-                    if mode == "lost-output" and "\tsucceeded\t" in chunk: raise BrokenPipeError()
+                    if mode == "lost-output" and "\tsucceeded\t" in chunk:
+                        raise BrokenPipeError()
                     output.append(chunk)
                 try:
                     with mock.patch.object(provider, "delegated_command", return_value=(command, "Fixture")), \
@@ -10033,7 +10051,8 @@ class DelegatedOwnerTests(unittest.TestCase):
                         else:
                             provider.run_delegated_launch(journal, "sources-open", write)
                     deadline = time.monotonic() + 3
-                    while not report.exists() and time.monotonic() < deadline: time.sleep(0.01)
+                    while not report.exists() and time.monotonic() < deadline:
+                        time.sleep(0.01)
                     value = json.loads(report.read_text())
                     self.assertEqual(value["pid"], children[0])
                     self.assertEqual(value["sid"], children[0])
@@ -10056,7 +10075,8 @@ class DelegatedOwnerTests(unittest.TestCase):
                     self.assertTrue("".join(replay).endswith("complete\toperation\n"))
                 finally:
                     for pid in children:
-                        with contextlib.suppress(ProcessLookupError): os.kill(pid, signal.SIGKILL)
+                        with contextlib.suppress(ProcessLookupError):
+                            os.kill(pid, signal.SIGKILL)
                         os.waitpid(pid, 0)
 
 

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -7,6 +7,7 @@ import contextlib
 import errno
 import hashlib
 import io
+import json
 import importlib.util
 import importlib.machinery
 import os
@@ -2159,6 +2160,209 @@ class LocaleEnumerationTests(unittest.TestCase):
                             os.killpg(supervisor, signal.SIGKILL)
                     except (FileNotFoundError, ProcessLookupError):
                         pass
+
+
+class DelegatedToolTests(unittest.TestCase):
+    environment = {"HOME": "/fixture-home", "PATH": "/usr/local/bin:/usr/bin:/bin", "LANG": "C", "LC_ALL": "C"}
+
+    @contextlib.contextmanager
+    def selection(self, program="import os; os.write(1, b'kitty\\n')", *, mode=None, signal_number=None):
+        popen, processes = subprocess.Popen, []
+        def launch(command, **options):
+            self.assertEqual(command, ["/usr/bin/timeout", "--signal=TERM", "--kill-after=1", "3",
+                "/usr/bin/bash", "/usr/local/bin/dwm-terminal", "--print-command"])
+            self.assertEqual(options["env"], self.environment)
+            self.assertTrue(options["start_new_session"])
+            self.assertEqual(options["stdin"], subprocess.DEVNULL)
+            replacement = (["/usr/bin/python3", "-c", program] if mode is None else
+                           ["/usr/bin/python3", str(REPO / "tests/fixtures/system-locale-process.py"), mode])
+            process = popen(command[:4] + replacement, **options)
+            processes.append(process)
+            if signal_number is not None:
+                signal.raise_signal(signal_number)
+            return process
+        try:
+            with mock.patch.object(provider.subprocess, "Popen", side_effect=launch):
+                yield processes
+        finally:
+            for process in processes:
+                if process.returncode is None:
+                    with contextlib.suppress(ProcessLookupError):
+                        os.killpg(process.pid, signal.SIGKILL)
+                    process.wait(timeout=2)
+                process.stdout.close()
+                process.stderr.close()
+
+    def read_selection(self):
+        return provider.read_terminal_selection("/usr/local/bin/dwm-terminal", self.environment)
+
+    def test_fixed_tool_paths_and_password_argv(self):
+        expected = {"accounts-open": "/usr/bin/lxqt-admin-user", "printers-open": "/usr/bin/system-config-printer",
+                    "sources-open": "/usr/bin/dnfdragora"}
+        for action, path in expected.items():
+            with self.subTest(action=action), mock.patch.object(provider, "trusted_delegated_executable", side_effect=lambda path, _name: path) as trusted, \
+                    mock.patch.object(provider, "read_terminal_selection") as selector:
+                self.assertEqual(provider.delegated_command(action)[0], (path,))
+                trusted.assert_called_once_with(path, os.path.basename(path))
+                selector.assert_not_called()
+        for name, arguments in provider.PASSWORD_TERMINALS.items():
+            with self.subTest(name=name), \
+                    mock.patch.object(provider, "trusted_delegated_executable", side_effect=lambda path, _name: path), \
+                    mock.patch.object(provider, "terminal_selection_environment", return_value=self.environment), \
+                    mock.patch.object(provider, "read_terminal_selection", return_value=name), \
+                    mock.patch.object(provider.shutil, "which", side_effect=["/usr/local/bin/dwm-terminal", "/usr/bin/" + name]):
+                self.assertEqual(provider.delegated_command("password-open"),
+                    (("/usr/bin/" + name, *arguments, "/usr/bin/passwd"), "Change your password"))
+
+    def test_unknown_actions_and_unsupported_terminals_never_launch_or_fall_back(self):
+        for action in ("health-open", "password-open user", "accounts-open --root", None, []):
+            with self.subTest(action=action), mock.patch.object(provider, "trusted_delegated_executable") as target:
+                with self.assertRaises(provider.SnapshotFailure):
+                    provider.delegated_command(action)
+                target.assert_not_called()
+        for selected in ("warp-terminal", "kitty -e sh", "bash", "/usr/bin/foot"):
+            with self.subTest(selected=selected), \
+                    mock.patch.object(provider, "trusted_delegated_executable", side_effect=lambda path, _name: path), \
+                    mock.patch.object(provider, "terminal_selection_environment", return_value=self.environment), \
+                    mock.patch.object(provider, "read_terminal_selection", return_value=selected), \
+                    mock.patch.object(provider.shutil, "which", return_value="/usr/local/bin/dwm-terminal") as which:
+                with self.assertRaises(provider.SnapshotFailure) as caught:
+                    provider.delegated_command("password-open")
+                self.assertEqual(caught.exception.code, "unsupported")
+                which.assert_called_once()
+
+    def test_trust_checks_resolved_executable_and_every_parent(self):
+        path = "/usr/bin/passwd"
+        def metadata(current, **_options):
+            return types.SimpleNamespace(st_uid=0, st_mode=(stat.S_IFREG | 0o4755) if current == path else stat.S_IFDIR | 0o755)
+        with mock.patch.object(provider.os.path, "realpath", return_value=path), \
+                mock.patch.object(provider.os, "stat", side_effect=metadata) as inspected, \
+                mock.patch.object(provider.os, "access", return_value=True):
+            self.assertEqual(provider.trusted_delegated_executable("/alias/passwd", "passwd"), path)
+            self.assertEqual([call.args[0] for call in inspected.call_args_list], [path, "/usr/bin", "/usr", "/"])
+        for target in (path, "/usr/bin", "/usr", "/"):
+            for field in ("owner", "writable", "type"):
+                def unsafe(current, **options):
+                    value = metadata(current, **options)
+                    if current == target:
+                        if field == "owner": value.st_uid = 1000
+                        elif field == "writable": value.st_mode |= 0o020
+                        else: value.st_mode = stat.S_IFLNK | 0o777
+                    return value
+                with self.subTest(target=target, field=field), mock.patch.object(provider.os.path, "realpath", return_value=path), \
+                        mock.patch.object(provider.os, "stat", side_effect=unsafe):
+                    with self.assertRaises(provider.SnapshotFailure) as caught:
+                        provider.trusted_delegated_executable(path, "passwd")
+                    self.assertEqual(caught.exception.code, "unsupported")
+        with mock.patch.object(provider.os.path, "realpath", return_value="/usr/bin/sh"):
+            with self.assertRaises(provider.SnapshotFailure):
+                provider.trusted_delegated_executable(path, "passwd")
+
+    def test_selection_environment_excludes_startup_and_loader_inputs(self):
+        source = {**self.environment, "DWM_TERMINAL": "kitty", "XDG_CONFIG_HOME": "/fixture/config",
+                  "BASH_ENV": "/private", "LD_PRELOAD": "/private", "LOCPATH": "/private", "BASH_FUNC_x%%": "() { false; }"}
+        with mock.patch.dict(os.environ, source, clear=True):
+            self.assertEqual(provider.terminal_selection_environment(),
+                {**self.environment, "DWM_TERMINAL": "kitty", "XDG_CONFIG_HOME": "/fixture/config"})
+        for value in ("x" * 4097, "\udcff"):
+            with mock.patch.dict(os.environ, {**self.environment, "DWM_TERMINAL": value}, clear=True):
+                with self.assertRaises(provider.SnapshotFailure):
+                    provider.terminal_selection_environment()
+
+    def test_selection_is_fresh_bounded_and_reaped(self):
+        handlers = {number: signal.getsignal(number) for number in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)}
+        with self.selection() as children:
+            self.assertEqual(self.read_selection(), "kitty")
+            self.assertEqual(self.read_selection(), "kitty")
+            self.assertEqual(len(children), 2)
+            self.assertTrue(all(child.returncode == 0 and child.stdout.closed and child.stderr.closed for child in children))
+        self.assertEqual(handlers, {number: signal.getsignal(number) for number in handlers})
+
+    def test_selector_rejects_partial_malformed_and_excess_output(self):
+        for output in (b"", b"kitty", b"kitty\nxterm\n", b"kitty\n\xff", b"kitty\t\n", b"x" * 4096 + b"\n"):
+            with self.subTest(output=output[:20]), self.selection("import os; os.write(1, " + repr(output) + ")"):
+                with self.assertRaises(provider.SnapshotFailure) as caught:
+                    self.read_selection()
+                self.assertEqual(caught.exception.code, "malformed")
+        with self.selection("import os; os.write(1, b'kitty\\n'); os.write(2, b'x' * 4091)"):
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                self.read_selection()
+            self.assertEqual(caught.exception.code, "malformed")
+        with self.selection("import os; os.write(1, b'kitty\\n'); os.write(2, b'x' * 4090)"):
+            self.assertEqual(self.read_selection(), "kitty")
+
+    def test_selector_exit_status_and_real_deadline_are_required(self):
+        for status, code in ((1, "internal"), (127, "missing-provider"), (124, "timeout")):
+            with self.subTest(status=status), self.selection("import os; os.write(1, b'kitty\\n'); os._exit(" + str(status) + ")"):
+                with self.assertRaises(provider.SnapshotFailure) as caught:
+                    self.read_selection()
+                self.assertEqual(caught.exception.code, code)
+        started = time.monotonic()
+        with self.selection(mode="closed-pipes") as children:
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                self.read_selection()
+            self.assertEqual(caught.exception.code, "timeout")
+            self.assertTrue(children[0].stdout.closed and children[0].stderr.closed)
+            self.assertIsNotNone(children[0].returncode)
+        self.assertLess(time.monotonic() - started, 5.5)
+
+    def test_launch_uses_new_session_null_stdio_and_closefrom(self):
+        command = ("/usr/bin/kitty", "/usr/bin/passwd")
+        with mock.patch.object(provider.os, "posix_spawn", return_value=1234) as spawn:
+            provider.launch_delegated_tool(command)
+        args, options = spawn.call_args
+        self.assertEqual(args[:2], (command[0], command))
+        self.assertTrue(options["setsid"])
+        self.assertEqual(options["setsigmask"], ())
+        actions = options["file_actions"]
+        self.assertEqual([action[2] for action in actions[:3]], [0, 1, 2])
+        self.assertEqual(actions[-1], (os.POSIX_SPAWN_CLOSEFROM, 3))
+        with self.assertRaises(OSError): os.fstat(actions[0][1])
+        for error, code in ((FileNotFoundError(), "missing-provider"), (PermissionError(), "permission-denied"),
+                            (OSError(errno.ENOEXEC, "Fixture"), "internal"), (InterruptedError(), "interrupted"),
+                            (NotImplementedError(), "unsupported")):
+            with self.subTest(code=code), mock.patch.object(provider.os, "posix_spawn", side_effect=error):
+                with self.assertRaises(provider.SnapshotFailure) as caught:
+                    provider.launch_delegated_tool(command)
+                self.assertEqual(caught.exception.code, code)
+
+
+    def test_selector_signals_and_cleanup_failure_cannot_publish_selection(self):
+        handlers = {number: signal.getsignal(number) for number in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)}
+        for number in handlers:
+            with self.subTest(number=number), self.selection(mode="closed-pipes", signal_number=number) as children:
+                with self.assertRaises(SystemExit) as caught:
+                    self.read_selection()
+                self.assertEqual(caught.exception.code, 128 + number)
+                self.assertTrue(children[0].stdout.closed and children[0].stderr.closed)
+                self.assertIsNotNone(children[0].returncode)
+        self.assertEqual(handlers, {number: signal.getsignal(number) for number in handlers})
+        original = provider.close_locale_process
+        def cleanup(process):
+            original(process)
+            raise provider.SnapshotFailure("timeout", "Fixture cleanup failed")
+        with self.selection(), mock.patch.object(provider, "close_locale_process", side_effect=cleanup):
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                self.read_selection()
+            self.assertEqual(caught.exception.code, "timeout")
+            self.assertIn("Terminal selection cleanup", caught.exception.detail)
+
+    def test_kernel_exec_failure_and_post_acceptance_cleanup_are_distinguished(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                provider.launch_delegated_tool((str(pathlib.Path(directory) / "absent"),))
+            self.assertEqual(caught.exception.code, "missing-provider")
+        original = os.close
+        def close(descriptor):
+            original(descriptor)
+            raise OSError(errno.EIO, "Fixture close failure")
+        with mock.patch.object(provider.os, "posix_spawn", return_value=1234) as launch, \
+                mock.patch.object(provider.os, "close", side_effect=close):
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                provider.launch_delegated_tool(("/usr/bin/kitty", "/usr/bin/passwd"))
+            self.assertEqual(caught.exception.code, "interrupted")
+            self.assertIn("may already be open", caught.exception.detail)
+            launch.assert_called_once()
 
 
 class UpdateEventMonitorTests(unittest.TestCase):
@@ -9571,13 +9775,13 @@ class RegionalOwnerTests(unittest.TestCase):
     def test_native_cli_routes_only_fixed_valid_arguments(self):
         for args in (["timezone-set", "UTC", "a" * 64], ["ntp-set", "enabled", "b" * 64],
                      ["locale-set", "LANG=C", "c" * 64]):
-            with mock.patch.object(provider, "regional_command", return_value=0) as command:
+            with mock.patch.object(provider, "native_command", return_value=0) as command:
                 self.assertEqual(provider.main(args), 0)
                 command.assert_called_once_with(*args)
         for args in (["timezone-set"], ["timezone-set", "../UTC", "a" * 64],
                      ["ntp-set", "true", "a" * 64], ["locale-set", "LANG=C", "A" * 64],
                      ["locale-set", "LANG=C", "a" * 64, "extra"]):
-            with mock.patch.object(provider, "regional_command") as command, \
+            with mock.patch.object(provider, "native_command") as command, \
                     contextlib.redirect_stderr(io.StringIO()):
                 self.assertEqual(provider.main(args), 2)
                 command.assert_not_called()
@@ -9597,7 +9801,7 @@ class RegionalCommandTests(unittest.TestCase):
                 mock.patch.object(provider, "RegionalRead"), \
                 mock.patch.object(provider, "PackageKitBackend") as packagekit, \
                 contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(io.StringIO()) as stderr:
-            code = provider.run_regional_command("timezone-set", "Etc/UTC", generation, writer, None)
+            code = provider.run_native_command("timezone-set", "Etc/UTC", generation, writer, None)
             packagekit.assert_not_called()
         return code, stdout.getvalue(), stderr.getvalue()
 
@@ -9672,7 +9876,7 @@ class RegionalCommandTests(unittest.TestCase):
                 mock.patch.object(provider, "open_journal_directory") as journal, \
                 mock.patch.object(provider, "RegionalMutation") as client, \
                 contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(io.StringIO()):
-            self.assertEqual(provider.run_regional_command("timezone-set", "UTC", "a" * 64, None, None), 1)
+            self.assertEqual(provider.run_native_command("timezone-set", "UTC", "a" * 64, None, None), 1)
             journal.assert_not_called()
             client.assert_not_called()
             self.assertEqual(stdout.getvalue(), "")
@@ -9683,6 +9887,177 @@ class RegionalCommandTests(unittest.TestCase):
             capture_output=True, text=True, timeout=60, check=False)
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("Private-bus regional owner: PASS", result.stdout)
+
+
+class DelegatedOwnerTests(unittest.TestCase):
+    boot_id = RegionalOwnerTests.boot_id
+    session = RegionalOwnerTests.session
+
+    def invoke(self, journal, action="accounts-open", *, write=None, failure=None, admitted=None):
+        output = []
+        def launch(command):
+            self.assertEqual(command, ("/usr/bin/fixture",))
+            with provider.lock_writable_journal(journal):
+                active = provider.load_writable_journal_state(journal).active
+                self.assertEqual(active.state, "running")
+                self.assertEqual(active.action_id, action)
+                self.assertTrue(provider.native_journal_owner_busy(journal, active))
+            with provider._journal_lock(journal.chain.directory_descriptor, exclusive=True): pass
+            if failure is not None:
+                raise provider.SnapshotFailure(failure, "Fixture launch result")
+        with mock.patch.object(provider, "delegated_command", return_value=(("/usr/bin/fixture",), "Fixture tool")), \
+                mock.patch.object(provider, "launch_delegated_tool", side_effect=launch) as launcher, \
+                mock.patch.object(provider, "PackageKitBackend") as packagekit:
+            result = provider.run_delegated_launch(journal, action, output.append if write is None else write,
+                on_admission=admitted)
+            packagekit.assert_not_called()
+        return result, "".join(output), launcher
+
+    def test_all_fixed_launches_have_exact_durable_launch_only_results(self):
+        for action in provider.DELEGATED_ACTIONS:
+            with self.subTest(action=action), self.session() as (path, _chain, journal):
+                restart = (path / "restart").read_bytes()
+                result, output, launcher = self.invoke(journal, action)
+                launcher.assert_called_once()
+                self.assertEqual((result.kind, result.state), ("delegate", "succeeded"))
+                self.assertIn("launch accepted", result.detail)
+                self.assertIn("not tracked here", result.detail)
+                self.assertIsNone(result.generation)
+                self.assertIsNone(result.boot_id)
+                state = provider.load_journal_state(journal.chain)
+                self.assertIsNone(state.active)
+                self.assertEqual(state.terminals[state.handoff.slot], result)
+                self.assertEqual((path / "restart").read_bytes(), restart)
+                self.assertEqual([row[4] for row in rows(output.splitlines(), "operation")], ["pending", "running", "succeeded"])
+                self.assertEqual(output.splitlines()[-1], "complete\toperation")
+                self.assertTrue(all(row[6] == "no" for row in rows(output.splitlines(), "operation")))
+
+    def test_launch_errors_and_ambiguity_have_scoped_results_without_retry(self):
+        for code in ("missing-provider", "permission-denied", "unsupported", "internal", "interrupted"):
+            with self.subTest(code=code), self.session() as (_path, _chain, journal):
+                result, output, launcher = self.invoke(journal, failure=code)
+                launcher.assert_called_once()
+                self.assertEqual(result.state, "interrupted" if code == "interrupted" else "failed")
+                self.assertEqual(rows(output.splitlines(), "error")[0][1:3], ["accounts", code])
+
+    def test_output_loss_before_launch_aborts_and_after_acceptance_preserves_handoff(self):
+        for phase in ("pending", "running", "succeeded"):
+            with self.subTest(phase=phase), self.session() as (_path, _chain, journal):
+                output = []
+                def write(chunk):
+                    if "\t" + phase + "\t" in chunk: raise BrokenPipeError()
+                    output.append(chunk)
+                with mock.patch.object(provider, "delegated_command", return_value=(("/usr/bin/fixture",), "Fixture")), \
+                        mock.patch.object(provider, "launch_delegated_tool") as launch, self.assertRaises(BrokenPipeError):
+                    provider.run_delegated_launch(journal, "printers-open", write)
+                self.assertEqual(launch.call_count, int(phase == "succeeded"))
+                state = provider.load_journal_state(journal.chain)
+                self.assertEqual(state.terminals[state.handoff.slot].state, "succeeded" if phase == "succeeded" else "failed")
+                self.assertNotIn("complete\toperation", "".join(output))
+
+    def test_unavailable_tool_and_admission_race_preserve_existing_state(self):
+        for race in (False, True):
+            with self.subTest(race=race), self.session() as (_path, _chain, journal):
+                admitted, output = mock.Mock(), []
+                def resolve(_action):
+                    if not race: raise provider.SnapshotFailure("missing-provider", "Unavailable fixture")
+                    with provider.lock_writable_journal(journal):
+                        provider.begin_journal_operation(journal, "ntp-set", "2026-09-06T23:00:00Z", "Competing")
+                    return ("/usr/bin/fixture",), "Fixture"
+                with mock.patch.object(provider, "delegated_command", side_effect=resolve), \
+                        mock.patch.object(provider, "launch_delegated_tool") as launch, \
+                        self.assertRaises(provider.JournalAdmissionError if race else provider.SnapshotFailure):
+                    provider.run_delegated_launch(journal, "accounts-open", output.append, on_admission=admitted)
+                admitted.assert_not_called()
+                launch.assert_not_called()
+                self.assertEqual(output, [])
+                self.assertEqual(provider.load_journal_state(journal.chain).active is not None, race)
+
+    def test_uncertain_admission_or_handoff_never_emits_complete(self):
+        for stage in ("begin_journal_operation", "complete_journal_terminal"):
+            for after in (False, True):
+                with self.subTest(stage=stage, after=after), self.session() as (_path, _chain, journal):
+                    original, admitted, output = getattr(provider, stage), mock.Mock(), []
+                    def fail(*args, **kwargs):
+                        if after: original(*args, **kwargs)
+                        raise provider.JournalCommitError("Uncertain fixture write")
+                    with mock.patch.object(provider, stage, side_effect=fail), self.assertRaises(provider.JournalCommitError):
+                        self.invoke(journal, write=output.append, admitted=admitted)
+                    admitted.assert_called_once()
+                    self.assertNotIn("complete\toperation", "".join(output))
+                    self.assertTrue(provider._try_native_owner_lock(journal.descriptor("active")))
+                    provider._unlock_native_owner(journal.descriptor("active"))
+
+    def test_cli_fixed_grammar_and_preflight_rejection(self):
+        for action in provider.DELEGATED_ACTIONS:
+            with mock.patch.object(provider, "native_command", return_value=0) as command:
+                self.assertEqual(provider.main([action]), 0)
+                command.assert_called_once_with(action)
+            with mock.patch.object(provider, "native_command") as command, contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(provider.main([action, "unexpected"]), 2)
+                command.assert_not_called()
+            with self.session() as (path, _chain, journal), \
+                    mock.patch.dict(os.environ, {"XDG_STATE_HOME": str(path.parents[1])}), \
+                    mock.patch.object(provider, "read_fedora_identity", return_value={"ID": "fedora"}), \
+                    mock.patch.object(provider, "read_boot_id", return_value=self.boot_id), \
+                    mock.patch.object(provider, "delegated_command", side_effect=provider.SnapshotFailure("missing-provider", "Fixture tool missing")), \
+                    mock.patch.object(provider, "launch_delegated_tool") as launch, \
+                    contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(io.StringIO()) as stderr:
+                self.assertEqual(provider.main([action]), 1)
+                self.assertIn("no administration tool was launched", stdout.getvalue())
+                self.assertEqual(stderr.getvalue(), "")
+                state = provider.load_journal_state(journal.chain)
+                self.assertIsNone(state.active)
+                self.assertIsNone(state.handoff)
+                launch.assert_not_called()
+
+    def test_real_child_is_detached_and_never_inherits_journal_or_output(self):
+        for mode in ("open", "failed-work", "lost-output"):
+            with self.subTest(mode=mode), self.session() as (path, _chain, journal):
+                report = path.parent / "child.json"
+                command = ("/usr/bin/python3", str(REPO / "tests/fixtures/system-delegated-tool.py"), str(report), mode)
+                original, children, output = os.posix_spawn, [], []
+                def spawn(*args, **kwargs):
+                    pid = original(*args, **kwargs)
+                    children.append(pid)
+                    return pid
+                def write(chunk):
+                    if mode == "lost-output" and "\tsucceeded\t" in chunk: raise BrokenPipeError()
+                    output.append(chunk)
+                try:
+                    with mock.patch.object(provider, "delegated_command", return_value=(command, "Fixture")), \
+                            mock.patch.object(provider.os, "posix_spawn", side_effect=spawn):
+                        if mode == "lost-output":
+                            with self.assertRaises(BrokenPipeError):
+                                provider.run_delegated_launch(journal, "sources-open", write)
+                        else:
+                            provider.run_delegated_launch(journal, "sources-open", write)
+                    deadline = time.monotonic() + 3
+                    while not report.exists() and time.monotonic() < deadline: time.sleep(0.01)
+                    value = json.loads(report.read_text())
+                    self.assertEqual(value["pid"], children[0])
+                    self.assertEqual(value["sid"], children[0])
+                    self.assertEqual(value["descriptors"], {"0": "/dev/null", "1": "/dev/null", "2": "/dev/null"})
+                    state = provider.load_journal_state(journal.chain)
+                    self.assertIsNone(state.active)
+                    terminal = state.terminals[state.handoff.slot]
+                    self.assertEqual(terminal.state, "succeeded")
+                    self.assertIn("launch accepted", terminal.detail)
+                    self.assertTrue(provider._try_native_owner_lock(journal.descriptor("active")))
+                    provider._unlock_native_owner(journal.descriptor("active"))
+                    if mode == "failed-work":
+                        pid, status = os.waitpid(children.pop(), 0)
+                        self.assertEqual(pid, value["pid"])
+                        self.assertEqual(os.waitstatus_to_exitcode(status), 42)
+                        self.assertEqual(provider.load_journal_state(journal.chain).terminals[terminal.slot], terminal)
+                    replay = []
+                    with mock.patch.object(provider, "launch_delegated_tool", side_effect=AssertionError("Unexpected relaunch")):
+                        provider.watch_journal_operation(journal, terminal.operation_id, replay.append, boot_id=self.boot_id)
+                    self.assertTrue("".join(replay).endswith("complete\toperation\n"))
+                finally:
+                    for pid in children:
+                        with contextlib.suppress(ProcessLookupError): os.kill(pid, signal.SIGKILL)
+                        os.waitpid(pid, 0)
 
 
 class UpdateCommandTests(unittest.TestCase):


### PR DESCRIPTION
## Scope
One Phase 6 boundary: fixed delegated administration CLI entry points and their durable launch owner. Regional service behavior remains unchanged; the shared native owner now supports both workflows. Settings origins and cumulative minor 1 discovery are still gated. No Phase 7 work or live installation sync.

## Behavior
- Fixed no-argument accounts-open, password-open, printers-open, and sources-open grammar; no usernames, passwords, repository IDs, paths, or caller-selected program arguments.
- Accounts/printers/sources use their fixed Fedora tool paths. Canonical executable files and resolved parent directories must be root-controlled.
- Password selection reuses the installed managed terminal selector with the user's selection inputs, a fixed Bash interpreter, a three-second independent timeout supervisor, shared 4096-byte stdout/stderr budget, and bounded cleanup. Shell startup and loader overrides are excluded from this read-only selector.
- Alacritty/st/xterm receive fixed -e /usr/bin/passwd; Kitty receives positional /usr/bin/passwd. Unsupported forms (including Warp) preserve the terminal preference and degrade only the password action.
- A single POSIX spawn starts the tool in a new session with null stdio and all descriptors above 2 closed. It cannot inherit the journal lease or operation stream.
- Durable admission/checkpoints/handoff precede their output. Succeeded means accepted exec only, never completion of administration inside the tool. Output loss and ambiguous launch observations preserve recovery without retry or relaunch.

## Validation
- Focused delegated and regional/update regression suite after review fixes: 45 tests, 18.695 seconds.
- Read-only Fedora 44 probe: password resolved through Alacritty in 0.056s; system-config-printer available; optional account/source tools reported missing-provider. No tool window or password prompt opened.
- Real private-child fixtures verify fresh session, exactly null stdin/stdout/stderr, no extra inherited descriptors, retained replay, lost output after launch, and unchanged launch result after the tool exits 42.
- `scripts/run-tests make clean all` and `scripts/run-tests`: PASS on the fixed final tree, including 504 system-management tests in 190.870 seconds, X11 smoke, staged/repeated installation, release, dependency, and shell gates; both managed workspaces removed.
- Nested X11: Settings closed 0.033% CPU; power baseline 0.133%, after 0.033% (0.100 percentage-point delta); large closed launcher 0.00% CPU.
- Documentation `npm run check && npm run build`: 15 files with no diagnostics, 11 pages built.
- Independent local CodeRabbit: initial six-file review and the three-file review-fix pass completed with no findings.
- Required post-full-suite Codex review: both the original implementation and final review-fix revision completed with no actionable correctness or security findings.

## Review fixes
- Use a noun phrase for password launch records and expand every newly introduced one-line compound test statement.
- Declare Python 3.13+ with POSIX_SPAWN_CLOSEFROM for isolated delegated launches; verify the supported Fedora 44 Python 3.14.7 runtime and test absence without opening or spawning anything.
- Supplemental diff-scoped Ruff E701: zero new findings. Whole-file E701 checking still reports seven unchanged instances in pre-existing native-watch tests on main; this optional check is not claimed entirely clean.

## Limits
No actual account, password, printer, or repository changes were performed. External tools own their UI, polkit, cancellation, and administrative outcomes; this provider does not wait for or audit that internal work. Launch/local filesystem syscalls are not a hard kernel-I/O deadline. Missing optional tools and unsupported terminal launch forms are expected capability-local results. Settings integration, event-driven discovery, information/storage/security, and combined installed Phase 6 qualification remain outstanding.