### PR TITLE
feat(system): observe fixed regional service changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ versions from `config.mk`.
 
 ### Changed
 
+- Add fixed read-only time and locale event monitors with acknowledged setup,
+  bounded output, and quiet handling of normally idle services. Add an internal
+  two-property NTP status reader; visible Settings monitoring and sampling
+  remain pending integration.
+
 - Add fixed account, password, printer, and software-source CLI entry points.
   Resolve trusted tools, keep password handling in the configured supported
   terminal, and record only accepted launches with durable recovery. Missing

--- a/TASKS.md
+++ b/TASKS.md
@@ -257,6 +257,26 @@ A read-only Fedora 44 probe resolved the password command through Alacritty in
 0.056 seconds and found the printer tool available. Account and source tools
 were absent and returned their scoped missing-provider results; none was opened.
 
+Read-only regional event streams now observe only the fixed time or locale
+service. Acknowledged subscriptions and bounded owner barriers precede
+readiness; setup events coalesce, and sender replacement invalidates state.
+Normal idle departure clears the pinned sender without triggering a read that
+would repeatedly reactivate the service. Output loss and bus loss fail with
+explicit reload guidance. An internal NTP reader samples only CanNTP and
+NTPSynchronized under one ten-second budget, without enabling a polling loop.
+Settings subscription handoff, two-read settling, and visible-only sampling
+remain outstanding; the cumulative snapshot minor remains zero.
+The 38 focused tests pass, including private-bus lifecycle, owner denial,
+output isolation, and real ten-second read deadlines. A read-only Fedora 44
+probe observed each monitor for 36 seconds after its initial service read:
+each emitted one arrival invalidation and consumed zero sampled CPU ticks.
+Both stopped cleanly; no host settings or administration tools were changed.
+The local review identified a setup-time unicast sender gap. The corrected
+ordering authenticates the owner before property delivery and checks every
+sender before payload parsing. A private-bus fixture injects forged oversized
+unicast signals at both setup barriers while preserving an authentic pending
+notification.
+
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit
 confirmation warning that a sent change cannot be canceled. Local cancellation

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -1934,6 +1934,48 @@ remain a separate implementation boundary.
   publishes an idle provider, whether recovery adopts a transaction, finds
   history, or records `interrupted`. These fallbacks make invalidation independent
   of terminal-frame success while preserving the simulation exclusion.
+The preparatory regional event commands are now implemented:
+
+```text
+dwm-system-management watch-regional time
+dwm-system-management watch-regional locale
+```
+
+Each accepts only its fixed selector, subscribes to the service's fixed
+`PropertiesChanged` path/interface and bus-daemon `NameOwnerChanged`, and
+acknowledges the owner-change match and authenticates the initial owner before
+acknowledging the property match and repeating the owner barrier. Only then does
+it emit `regional-event<TAB>ready`. The entire setup has one ten-second
+deadline. Only a missing owner is accepted as dormant; denied or malformed
+setup never reports readiness. Relevant changed or invalidated properties and
+owner arrivals/replacements emit `regional-event<TAB>changed`. Changes during
+setup coalesce into one record immediately after readiness, and a newer owner
+notification wins over an older in-flight lookup.
+Property callbacks require the authenticated unique sender even before
+readiness. This also rejects unicast signals addressed directly to the monitor,
+which can bypass bus-side match rules, before parsing their payload or changing
+the setup dirty bit. Authentic changes during setup still coalesce normally.
+
+Readiness means the subscriptions are installed, not that the service is
+running. systemd's timedated and localed normally exit after being idle;
+departure clears the pinned sender without emitting a change or requesting a
+read. This avoids repeatedly reactivating an idle service. A later owner arrival
+invalidates state, and native actions still establish their own fresh monitored
+confirmation evidence. The monitor never calls a platform service method,
+activates a service, or starts an idle timer. Closed/full output, bus loss, or
+setup failure exits 1 with reload guidance; TERM, INT, and HUP clean up and exit
+0. Output uses the same isolated bounded writes as `watch-updates` and never
+changes inherited descriptor flags. Cleanup removes only acknowledged match
+rules, releases local sources, and does not close shared service connections.
+
+The internal `NtpRead` client separately issues exactly two fixed
+`Properties.Get` requests for `CanNTP` and `NTPSynchronized`, accepts only
+bounded boolean replies, and publishes a pair only after both succeed under
+one ten-second deadline. Partial, late, denied, and malformed replies do not
+publish a sample. This PR adds no sampling CLI or timer. Neither event commands
+nor this internal reader changes the cumulative snapshot minor. Settings
+activation and the following initialization/sampling contract remain pending.
+
 - systemd D-Bus property changes drive time and locale refresh while the System
   section is open. On pane open, the root model installs the timedate1 and
   locale1 property subscriptions before starting their initial bounded reads.

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -1092,6 +1092,62 @@ class RegionalRead(ServiceRead):
                 self.finish(failure=error)
 
 
+@dataclass(frozen=True)
+class NtpSample:
+    """The two explicitly sampled, non-emitting network time properties."""
+
+    can_ntp: bool
+    synchronized: bool
+
+
+class NtpRead(ServiceRead):
+    """Read only the two non-emitting timedate1 properties under one deadline."""
+
+    label = "Network time status"
+
+    def __init__(self, Gio=None, GLib=None):
+        super().__init__(Gio, GLib)
+        self.values = {}
+        self.waiting = {"CanNTP", "NTPSynchronized"}
+
+    def connected(self, _source, result, _data):
+        if not self.pending():
+            return
+        try:
+            self.connection = self.Gio.bus_get_finish(result)
+            self.connection.set_exit_on_close(False)
+            name, path = REGIONAL_READ_REQUESTS["time-state"][:2]
+            for field in ("CanNTP", "NTPSynchronized"):
+                if not self.pending():
+                    return
+                self.connection.call(name, path, PROPERTIES_INTERFACE, "Get",
+                    self.GLib.Variant("(ss)", (name, field)), self.GLib.VariantType.new("(v)"),
+                    self.Gio.DBusCallFlags.NONE, max(1, int((self.deadline - time.monotonic()) * 1000)),
+                    self.cancellable, self.replied, field)
+        except self.GLib.Error as error:
+            self.fail(self.bus_failure(error))
+
+    def replied(self, connection, result, field):
+        if not self.pending() or field not in self.waiting:
+            return
+        try:
+            reply = connection.call_finish(result)
+            if reply.get_type_string() != "(v)" or reply.get_size() > 32:
+                raise SnapshotFailure("malformed", "Invalid network time status reply")
+            value = reply.get_child_value(0).get_variant()
+            if value.get_type_string() != "b":
+                raise SnapshotFailure("malformed", "Invalid network time status property")
+            self.values[field] = value.unpack()
+            self.waiting.remove(field)
+            if not self.waiting and self.pending():
+                self.finish(NtpSample(self.values["CanNTP"], self.values["NTPSynchronized"]))
+        except self.GLib.Error as error:
+            self.fail(self.bus_failure(error))
+        except SnapshotFailure as error:
+            if self.pending():
+                self.fail(error)
+
+
 class RegionalMutation(ServiceRead):
     """Internal fixed service client; durable admission is a required caller hook.
 
@@ -7770,6 +7826,8 @@ def update_command(action_id: str, generation: str | None = None) -> int:
 class UpdateEventMonitor:
     """Read-only manager signals, with bounded setup and no transaction calls."""
 
+    record_prefix = "update-event"
+
     def __init__(self, Gio, GLib, GLibUnix, emit: Callable[[str], None]) -> None:
         self.Gio, self.GLib, self.GLibUnix = Gio, GLib, GLibUnix
         self.emit = emit
@@ -7810,7 +7868,7 @@ class UpdateEventMonitor:
         if not self.ready:
             self.dirty = True
         else:
-            self.write("update-event\tchanged")
+            self.write(self.record_prefix + "\tchanged")
 
     def global_changed(self, _connection, sender, _path, _interface, _member, _parameters, _data) -> None:
         # The bus-side match restricts the well-known sender. Avoid GDBus's
@@ -7846,9 +7904,9 @@ class UpdateEventMonitor:
         self.GLib.source_remove(self.deadline_source)
         self.deadline_source = 0
         self.ready = True
-        self.write("update-event\tready")
+        self.write(self.record_prefix + "\tready")
         if self.dirty and not self.stopped:
-            self.write("update-event\tchanged")
+            self.write(self.record_prefix + "\tchanged")
         self.dirty = False
 
     def match_finished(self, connection, result, rule) -> None:
@@ -7941,7 +7999,173 @@ class UpdateEventMonitor:
         return self.exit_code
 
 
-def watch_update_events() -> int:
+class RegionalEventMonitor(UpdateEventMonitor):
+    """Observe fixed regional properties, without activating idle platform services."""
+
+    record_prefix = "regional-event"
+
+    def __init__(self, kind, Gio, GLib, GLibUnix, emit):
+        if not isinstance(kind, str) or kind not in ("time", "locale"):
+            raise ValueError("Unknown regional monitor")
+        super().__init__(Gio, GLib, GLibUnix, emit)
+        self.name, self.path = REGIONAL_READ_REQUESTS[kind + "-state"][:2]
+        self.relevant = {"Locale"} if kind == "locale" else {"Timezone", "CanNTP", "NTP", "NTPSynchronized"}
+        self.started = False
+
+    def setting_up(self):
+        if self.stopped:
+            return False
+        if time.monotonic() >= self.deadline:
+            self.stop(1)
+            return False
+        return True
+
+    def remove_match(self, connection, rule):
+        with contextlib.suppress(self.GLib.Error):
+            connection.call("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                "RemoveMatch", self.GLib.Variant("(s)", (rule,)), None,
+                self.Gio.DBusCallFlags.NONE, 1000, None, None, None)
+
+    def match_finished(self, connection, result, rule):
+        try:
+            reply = connection.call_finish(result)
+            # Only acknowledged rules belong to this caller. A late reply can
+            # release that rule, but can never resume an expired monitor.
+            if self.stopped:
+                self.remove_match(connection, rule)
+                return
+            self.installed_rules.append(rule)
+            if not self.setting_up():
+                return
+            if reply.get_type_string() != "()":
+                self.stop(1)
+            else:
+                # Authenticate the owner after the owner-change match, before
+                # enabling property delivery. Bus-side matches do not filter
+                # signals addressed directly to this connection.
+                callback = self.owner_initialized if len(self.installed_rules) == 1 else self.owner_resolved
+                connection.call("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                    "GetNameOwner", self.GLib.Variant("(s)", (self.name,)), self.GLib.VariantType.new("(s)"),
+                    self.Gio.DBusCallFlags.NONE, max(1, int((self.deadline - time.monotonic()) * 1000)),
+                    self.cancellable, callback, self.owner_epoch)
+        except self.GLib.Error:
+            self.stop(1)
+
+    def resolve_owner(self, connection, result, epoch):
+        if not self.setting_up():
+            return
+        try:
+            reply = connection.call_finish(result)
+            if reply.get_type_string() != "(s)" or reply.get_size() > 256:
+                self.stop(1)
+                return
+            owner = reply.unpack()[0]
+            if not self.Gio.dbus_is_unique_name(owner):
+                self.stop(1)
+                return
+        except self.GLib.Error as error:
+            if self.Gio.dbus_error_get_remote_error(error) != "org.freedesktop.DBus.Error.NameHasNoOwner":
+                self.stop(1)
+                return
+            owner = ""
+        if not self.setting_up():
+            return
+        if epoch == self.owner_epoch:
+            self.owner = owner
+        return True
+
+    def owner_initialized(self, connection, result, epoch):
+        if self.resolve_owner(connection, result, epoch):
+            self.add_match()
+
+    def owner_resolved(self, connection, result, epoch):
+        if not self.resolve_owner(connection, result, epoch):
+            return
+        self.GLib.source_remove(self.deadline_source)
+        self.deadline_source = 0
+        self.ready = True
+        self.write(self.record_prefix + "\tready")
+        if self.dirty and not self.stopped:
+            self.write(self.record_prefix + "\tchanged")
+        self.dirty = False
+
+    def owner_changed(self, _connection, sender, path, interface, member, parameters, _data):
+        if (self.stopped or sender != "org.freedesktop.DBus" or path != "/org/freedesktop/DBus"
+                or interface != "org.freedesktop.DBus" or member != "NameOwnerChanged"):
+            return
+        if parameters.get_type_string() != "(sss)" or parameters.get_size() > 768:
+            self.stop(1)
+            return
+        name, old, new = parameters.unpack()
+        if name != self.name:
+            return
+        if any(len(value) > 255 or value and not self.Gio.dbus_is_unique_name(value) for value in (old, new)):
+            self.stop(1)
+            return
+        self.owner_epoch += 1
+        self.owner = new
+        # timedated/localed normally exit after 30 idle seconds. Departure is
+        # not a configuration change: rereading here would reactivate forever.
+        # Arrival or replacement reconciles state; mutations still fresh-read.
+        if new:
+            self.changed()
+
+    def properties_changed(self, _connection, sender, path, interface, member, parameters, _data):
+        if (self.stopped or path != self.path or interface != PROPERTIES_INTERFACE
+                or member != "PropertiesChanged" or not self.owner or sender != self.owner):
+            return
+        try:
+            if parameters.get_type_string() != "(sa{sv}as)" or parameters.get_size() > 16384:
+                raise SnapshotFailure("malformed", "Invalid regional notification")
+            if parameters.get_child_value(0).unpack() != self.name:
+                return
+            changed = parameters.get_child_value(1)
+            invalidated = regional_string_array(parameters.get_child_value(2),
+                REGIONAL_TIME_PROPERTY_COUNT, MAX_TEXT_BYTES, 8192)
+            if changed.n_children() > REGIONAL_TIME_PROPERTY_COUNT:
+                raise SnapshotFailure("malformed", "Oversized regional notification")
+            keys = set()
+            for index in range(changed.n_children()):
+                key = changed.get_child_value(index).get_child_value(0)
+                if key.get_size() > MAX_TEXT_BYTES + 1 or key.unpack() in keys:
+                    raise SnapshotFailure("malformed", "Invalid regional notification key")
+                keys.add(key.unpack())
+            if self.relevant.intersection(keys.union(invalidated)):
+                self.changed()
+        except SnapshotFailure:
+            self.stop(1)
+
+    def connected(self, _source, result, _data):
+        if not self.setting_up():
+            return
+        try:
+            self.connection = self.Gio.bus_get_finish(result)
+            if not self.setting_up():
+                return
+            self.connection.set_exit_on_close(False)
+            self.closed_handler = self.connection.connect("closed", lambda *_args: self.stop(1))
+            specs = [
+                ("org.freedesktop.DBus", "org.freedesktop.DBus", "NameOwnerChanged", "/org/freedesktop/DBus", self.name, self.owner_changed,
+                 f"type='signal',sender='org.freedesktop.DBus',interface='org.freedesktop.DBus',member='NameOwnerChanged',path='/org/freedesktop/DBus',arg0='{self.name}'"),
+                (None, PROPERTIES_INTERFACE, "PropertiesChanged", self.path, self.name, self.properties_changed,
+                 f"type='signal',sender='{self.name}',interface='{PROPERTIES_INTERFACE}',member='PropertiesChanged',path='{self.path}',arg0='{self.name}'"),
+            ]
+            for sender, interface, member, path, arg0, callback, rule in specs:
+                self.subscriptions.append(self.connection.signal_subscribe(sender, interface, member, path,
+                    arg0, self.Gio.DBusSignalFlags.NO_MATCH_RULE, callback, None))
+                self.match_rules.append(rule)
+            self.add_match()
+        except self.GLib.Error:
+            self.stop(1)
+
+    def run(self):
+        if self.started:
+            raise RuntimeError("Regional monitors are single-use")
+        self.started = True
+        return super().run()
+
+
+def watch_service_events(regional_kind=None) -> int:
     output_writer = None
 
     def emit(record: str) -> None:
@@ -7963,7 +8187,9 @@ def watch_update_events() -> int:
             output_writer = control_output_writer(sys.stdout, resources)
             if output_writer is None:
                 raise OSError("Event output requires a file descriptor")
-            code = UpdateEventMonitor(Gio, GLib, GLibUnix, emit).run()
+            monitor = (UpdateEventMonitor(Gio, GLib, GLibUnix, emit) if regional_kind is None else
+                       RegionalEventMonitor(regional_kind, Gio, GLib, GLibUnix, emit))
+            code = monitor.run()
     except (ImportError, ValueError, OSError):
         code = 1
     if code:
@@ -7971,7 +8197,8 @@ def watch_update_events() -> int:
             with contextlib.ExitStack() as resources:
                 error_writer = control_output_writer(sys.stderr, resources)
                 if error_writer is not None:
-                    error_writer(b"PackageKit live change monitoring is unavailable; reload status explicitly\n")
+                    label = "PackageKit" if regional_kind is None else "Regional"
+                    error_writer((label + " live change monitoring is unavailable; reload status explicitly\n").encode("ascii"))
         except (OSError, ValueError):
             # Exit status remains authoritative when even diagnostics cannot
             # be delivered (including stderr sharing the full stdout pipe).
@@ -7979,12 +8206,22 @@ def watch_update_events() -> int:
     return code
 
 
+def watch_update_events() -> int:
+    return watch_service_events()
+
+
+def watch_regional_events(kind: str) -> int:
+    return watch_service_events(kind)
+
+
 def usage() -> int:
-    print(f"usage: {sys.argv[0]} snapshot | watch-updates | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE | timezone-set ZONE GENERATION | ntp-set enabled|disabled GENERATION | locale-set LANG=LOCALE GENERATION | accounts-open | password-open | printers-open | sources-open", file=sys.stderr)
+    print(f"usage: {sys.argv[0]} snapshot | watch-updates | watch-regional time|locale | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE | timezone-set ZONE GENERATION | ntp-set enabled|disabled GENERATION | locale-set LANG=LOCALE GENERATION | accounts-open | password-open | printers-open | sources-open", file=sys.stderr)
     return 2
 
 
 def main(argv: Sequence[str]) -> int:
+    if argv and argv[0] == "watch-regional":
+        return watch_regional_events(argv[1]) if len(argv) == 2 and argv[1] in ("time", "locale") else usage()
     if argv and argv[0] in {"timezone-set", "ntp-set", "locale-set"}:
         if len(argv) != 3 or JOURNAL_GENERATION_PATTERN.fullmatch(argv[2]) is None:
             return usage()

--- a/tests/fixtures/system-regional-read-bus.py
+++ b/tests/fixtures/system-regional-read-bus.py
@@ -29,6 +29,7 @@ timedate = Gio.DBusNodeInfo.new_for_xml("""
 
 
 def name_call(method, name):
+    """Manage only the selected fixture-owned name on the private bus."""
     args = GLib.Variant("(su)", (name, 0)) if method == "RequestName" else GLib.Variant("(s)", (name,))
     return bus.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus",
         "org.freedesktop.DBus", method, args, GLib.VariantType.new("(u)"),
@@ -36,6 +37,7 @@ def name_call(method, name):
 
 
 def called(_bus, _sender, path, interface, method, args, invocation):
+    """Serve typed read-only replies and retain deliberate stalled requests."""
     calls.append((path, interface, method, args.unpack()))
     if mode == "denied":
         invocation.return_dbus_error("org.freedesktop.DBus.Error.AccessDenied", "fixture denial")
@@ -47,14 +49,21 @@ def called(_bus, _sender, path, interface, method, args, invocation):
             "NTP": GLib.Variant("u", 1) if mode == "malformed" else GLib.Variant("b", False),
             "NTPSynchronized": GLib.Variant("b", True)},)))
     elif method == "Get":
-        invocation.return_value(GLib.Variant("(v)", (GLib.Variant("as", ["LANG=C"]),)))
+        if path == "/org/freedesktop/timedate1":
+            assert args.unpack() in (("org.freedesktop.timedate1", "CanNTP"),
+                                     ("org.freedesktop.timedate1", "NTPSynchronized"))
+            value = GLib.Variant("s", "invalid") if mode == "malformed" else GLib.Variant("b", True)
+        else:
+            value = GLib.Variant("as", ["LANG=C"])
+        invocation.return_value(GLib.Variant("(v)", (value,)))
     else:
         invocation.return_value(GLib.Variant("(as)", (["UTC", "Etc/UTC"],)))
 
 
 def failure(kind, expected):
+    """Require a scoped failure without publishing a successful value."""
     try:
-        provider["RegionalRead"](kind).run()
+        (provider["NtpRead"]() if kind == "ntp" else provider["RegionalRead"](kind)).run()
     except provider["SnapshotFailure"] as error:
         assert error.code == expected, (error.code, expected)
     else:
@@ -74,6 +83,10 @@ try:
     assert [call[2:] for call in calls] == [
         ("GetAll", ("org.freedesktop.timedate1",)),
         ("Get", ("org.freedesktop.locale1", "Locale")), ("ListTimezones", ())]
+    assert provider["NtpRead"]().run() == provider["NtpSample"](True, True)
+    assert [call[2:] for call in calls[-2:]] == [
+        ("Get", ("org.freedesktop.timedate1", "CanNTP")),
+        ("Get", ("org.freedesktop.timedate1", "NTPSynchronized"))]
     for arguments in (["regional-choices", "timezone"],
                       ["regional-preview", "timezone-set", "Etc/UTC"],
                       ["regional-preview", "ntp-set", "enabled"],
@@ -84,12 +97,14 @@ try:
         assert output.getvalue().endswith("complete\t" + arguments[0] + "\n")
     mode = "malformed"
     failure("time-state", "malformed")
+    failure("ntp", "malformed")
     with contextlib.redirect_stdout(io.StringIO()) as output:
         assert provider["main"](["regional-preview", "ntp-set", "enabled"]) == 1
     assert "error\tregional\tmalformed\t" in output.getvalue()
     assert "\npreview\t" not in output.getvalue()
     mode = "denied"
     failure("locale-state", "permission-denied")
+    failure("ntp", "permission-denied")
     mode = "normal"
     assert name_call("ReleaseName", "org.freedesktop.locale1") == 1
     failure("locale-state", "missing-provider")
@@ -102,6 +117,17 @@ try:
     held.pop().return_value(GLib.Variant("(as)", (["Late/Reply"],)))
     mode = "normal"
     assert provider["RegionalRead"]("timezone-choices").run() == ("UTC", "Etc/UTC")
+    mode = "stall"
+    started = time.monotonic()
+    failure("ntp", "timeout")
+    elapsed = time.monotonic() - started
+    assert 9.5 <= elapsed < 15, elapsed
+    assert len(held) == 2
+    for invocation in held:
+        invocation.return_value(GLib.Variant("(v)", (GLib.Variant("b", False),)))
+    held.clear()
+    mode = "normal"
+    assert provider["NtpRead"]().run() == provider["NtpSample"](True, True)
     assert all(call[2] in {"Get", "GetAll", "ListTimezones"} for call in calls)
     print("Private-bus regional reads: PASS (typed replies, readonly preflight, denial, absence, deadline, late reply)")
 finally:

--- a/tests/fixtures/system-regional-setup-bus.py
+++ b/tests/fixtures/system-regional-setup-bus.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+"""Inject real directly addressed signals at controlled regional setup barriers."""
+
+import os
+import runpy
+import sys
+
+os.environ["DBUS_SYSTEM_BUS_ADDRESS"] = os.environ["DBUS_SESSION_BUS_ADDRESS"]
+from gi.repository import Gio, GLib, GLibUnix
+
+provider = runpy.run_path(sys.argv[1], run_name="regional_setup_fixture")
+address = os.environ["DBUS_SESSION_BUS_ADDRESS"]
+flags = Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT | Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION
+service = Gio.DBusConnection.new_for_address_sync(address, flags, None, None)
+outsider = Gio.DBusConnection.new_for_address_sync(address, flags, None, None)
+
+
+class SetupMonitor(provider["RegionalEventMonitor"]):
+    """Delay only callback publication, leaving actual bus setup and signals intact."""
+
+    def inject(self, sender, oversized=False):
+        """Bypass match routing using the monitor's actual unique destination."""
+        fields = {"x" * 20000: GLib.Variant("b", True)} if oversized else {"Timezone": GLib.Variant("s", "UTC")}
+        sender.emit_signal(self.connection.get_unique_name(), self.path,
+            "org.freedesktop.DBus.Properties", "PropertiesChanged",
+            GLib.Variant("(sa{sv}as)", (self.name, fields, [])))
+        sender.flush_sync(None)
+
+    def owner_initialized(self, connection, result, epoch):
+        """Deliver a forged oversized payload while the owner is still unknown."""
+        self.inject(outsider, oversized=True)
+
+        def resume():
+            """Check that the forged signal changed neither readiness nor state."""
+            assert not self.stopped and not self.dirty and not self.ready
+            super(SetupMonitor, self).owner_initialized(connection, result, epoch)
+            return GLib.SOURCE_REMOVE
+
+        GLib.timeout_add(50, resume)
+
+    def owner_resolved(self, connection, result, epoch):
+        """Test forged and authentic unicast delivery after the first owner barrier."""
+        self.inject(outsider, oversized=True)
+        self.inject(service)
+
+        def resume():
+            """Preserve a legitimate setup invalidation and finish the real barrier."""
+            assert not self.stopped and self.dirty and not self.ready
+            super(SetupMonitor, self).owner_resolved(connection, result, epoch)
+            self.stop(0)
+            return GLib.SOURCE_REMOVE
+
+        GLib.timeout_add(50, resume)
+
+
+try:
+    name = "org.freedesktop.timedate1"
+    result = service.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus",
+        "org.freedesktop.DBus", "RequestName", GLib.Variant("(su)", (name, 0)),
+        GLib.VariantType.new("(u)"), Gio.DBusCallFlags.NONE, 3000, None)
+    assert result.unpack() == (1,)
+    emitted = []
+    monitor = SetupMonitor("time", Gio, GLib, GLibUnix, emitted.append)
+    assert monitor.run() == 0
+    assert emitted == ["regional-event\tready", "regional-event\tchanged"]
+    print("Regional setup unicast authentication: PASS")
+finally:
+    outsider.close_sync(None)
+    service.close_sync(None)

--- a/tests/fixtures/system-update-events-bus.py
+++ b/tests/fixtures/system-update-events-bus.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-"""Exercise the real update monitor on a private bus, never host PackageKit."""
+"""Exercise fixed service monitors on a private bus, never host services."""
 
 import fcntl
 import os
@@ -18,6 +18,15 @@ from gi.repository import Gio, GLib
 
 NAME = "org.freedesktop.PackageKit"
 PATH = "/org/freedesktop/PackageKit"
+kind = sys.argv[2] if len(sys.argv) == 3 else "updates"
+assert kind in ("updates", "time", "locale")
+command = ["watch-updates"] if kind == "updates" else ["watch-regional", kind]
+prefix = b"update-event" if kind == "updates" else b"regional-event"
+ready = prefix + b"\tready\n"
+changed = prefix + b"\tchanged\n"
+if kind != "updates":
+    NAME = "org.freedesktop." + ("timedate1" if kind == "time" else "locale1")
+    PATH = "/" + NAME.replace(".", "/")
 bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
 address = os.environ["DBUS_SESSION_BUS_ADDRESS"]
 environment = dict(os.environ, DBUS_SYSTEM_BUS_ADDRESS=address)
@@ -26,6 +35,7 @@ retained_writers = []
 
 
 def name_call(method, connection=bus):
+    """Own or release only the fixture's selected service name."""
     parameters = GLib.Variant("(su)", (NAME, 0)) if method == "RequestName" else GLib.Variant("(s)", (NAME,))
     return connection.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus",
         "org.freedesktop.DBus", method, parameters, GLib.VariantType.new("(u)"),
@@ -33,13 +43,15 @@ def name_call(method, connection=bus):
 
 
 def launch(monitor_environment=environment):
-    process = subprocess.Popen([sys.argv[1], "watch-updates"], env=monitor_environment,
+    """Start the real provider against the selected disposable bus."""
+    process = subprocess.Popen([sys.argv[1], *command], env=monitor_environment,
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0)
     processes.append(process)
     return process
 
 
 def line(process, timeout=3):
+    """Collect one bounded line without buffering subsequent events."""
     output = b""
     deadline = time.monotonic() + timeout
     with selectors.DefaultSelector() as selector:
@@ -54,6 +66,12 @@ def line(process, timeout=3):
 
 
 def emit(member, *, path=PATH, interface=NAME, parameters=None, connection=bus):
+    """Emit a real signal, adapting global changes for regional properties."""
+    if kind != "updates" and member in ("UpdatesChanged", "InstalledChanged", "RepoListChanged"):
+        member = "PropertiesChanged"
+        interface = "org.freedesktop.DBus.Properties"
+        field = "Timezone" if kind == "time" else "Locale"
+        parameters = GLib.Variant("(sa{sv}as)", (NAME, {}, [field]))
     connection.emit_signal(None, path, interface, member, parameters)
     connection.flush_sync(None)
 
@@ -61,12 +79,19 @@ def emit(member, *, path=PATH, interface=NAME, parameters=None, connection=bus):
 try:
     assert name_call("RequestName") == 1
     process = launch()
-    assert line(process) == b"update-event\tready\n"
-    # No PackageKit methods are exported. Reaching ready proves setup only
+    assert line(process) == ready
+    # No platform methods are exported. Reaching ready proves setup only
     # calls the bus daemon, without activating a transaction or reading state.
     for member in ("UpdatesChanged", "InstalledChanged", "RepoListChanged"):
         emit(member)
-        assert line(process) == b"update-event\tchanged\n", member
+        assert line(process) == changed, member
+
+    if kind != "updates":
+        field = "Timezone" if kind == "time" else "Locale"
+        value = GLib.Variant("s", "UTC") if kind == "time" else GLib.Variant("as", ["LANG=C"])
+        emit("PropertiesChanged", interface="org.freedesktop.DBus.Properties",
+            parameters=GLib.Variant("(sa{sv}as)", (NAME, {field: value}, [])))
+        assert line(process) == changed
 
     emit("TransactionListChanged", parameters=GLib.Variant("(ao)", (["/18_fixture"],)))
     emit("UpdatesChanged", path="/18_fixture", interface=NAME + ".Transaction")
@@ -75,18 +100,21 @@ try:
     outsider = Gio.DBusConnection.new_for_address_sync(address,
         Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT | Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION, None, None)
     emit("UpdatesChanged", connection=outsider)
+    if kind != "updates":
+        emit("PropertiesChanged", interface="org.freedesktop.DBus.Properties",
+            parameters=GLib.Variant("(sa{sv}as)", (NAME, {"Unrelated": GLib.Variant("b", True)}, [])))
     assert line(process, 0.2) == b"", "Unrelated signals triggered discovery"
     outsider.close_sync(None)
 
     assert name_call("ReleaseName") == 1
-    assert line(process) == b"update-event\tchanged\n"
+    assert line(process, 3 if kind == "updates" else 0.2) == (changed if kind == "updates" else b"")
     assert name_call("RequestName") == 1
-    assert line(process) == b"update-event\tchanged\n"
+    assert line(process) == changed
     emit("InstalledChanged")
-    assert line(process) == b"update-event\tchanged\n", "Replacement owner not monitored"
+    assert line(process) == changed, "Replacement owner not monitored"
     for _ in range(100):
         emit("UpdatesChanged")
-    assert all(line(process) == b"update-event\tchanged\n" for _ in range(100))
+    assert all(line(process) == changed for _ in range(100))
     assert line(process, 0.2) == b"", "Idle monitor emitted output"
     process.send_signal(signal.SIGTERM)
     assert process.wait(timeout=3) == 0
@@ -94,7 +122,7 @@ try:
 
     # Lost stdout is not a successful monitor or an interpreter flush failure.
     broken = launch()
-    assert line(broken) == b"update-event\tready\n"
+    assert line(broken) == ready
     broken.stdout.close()
     emit("UpdatesChanged")
     assert broken.wait(timeout=3) == 1
@@ -110,12 +138,12 @@ try:
         reader, writer = os.pipe()
         retained_writers.append(writer)
         os.set_blocking(writer, originally_blocking)
-        inherited = subprocess.Popen([sys.argv[1], "watch-updates"], env=environment,
+        inherited = subprocess.Popen([sys.argv[1], *command], env=environment,
             stdout=writer, stderr=subprocess.STDOUT if merged else subprocess.PIPE, bufsize=0)
         processes.append(inherited)
         inherited.stdout = os.fdopen(reader, "rb", buffering=0)
         fcntl.fcntl(writer, fcntl.F_SETPIPE_SZ, 4096)
-        assert line(inherited) == b"update-event\tready\n"
+        assert line(inherited) == ready
         assert os.get_blocking(writer) == originally_blocking, "Live monitor changed inherited stdout mode"
         os.write(writer, b"parent output\n")
         assert line(inherited) == b"parent output\n"
@@ -133,7 +161,7 @@ try:
     # and its subscriptions. Overflow exits explicitly, with no event queue.
     stalled = launch()
     fcntl.fcntl(stalled.stdout.fileno(), fcntl.F_SETPIPE_SZ, 4096)
-    assert line(stalled) == b"update-event\tready\n"
+    assert line(stalled) == ready
     for _ in range(1000):
         emit("UpdatesChanged")
         if stalled.poll() is not None:
@@ -142,13 +170,17 @@ try:
     error = stalled.stderr.read()
     assert b"reload status explicitly" in error and b"Traceback" not in error
 
-    # Missing PackageKit does not prevent an installed subscription; finite
+    # A missing service does not prevent an installed subscription; finite
     # discovery separately reports capability availability.
     assert name_call("ReleaseName") == 1
     absent = launch()
-    assert line(absent) == b"update-event\tready\n"
+    assert line(absent) == ready
     absent.send_signal(signal.SIGINT)
     assert absent.wait(timeout=3) == 0
+    hungup = launch()
+    assert line(hungup) == ready
+    hungup.send_signal(signal.SIGHUP)
+    assert hungup.wait(timeout=3) == 0
 
     # A separate disposable bus lets the fixture prove connection loss without
     # terminating its own control bus or touching any host session/system bus.
@@ -158,7 +190,7 @@ try:
     private_address = line(daemon).decode().strip()
     assert private_address.startswith("unix:")
     disconnected = launch(dict(environment, DBUS_SYSTEM_BUS_ADDRESS=private_address))
-    assert line(disconnected) == b"update-event\tready\n"
+    assert line(disconnected) == ready
     daemon.terminate()
     daemon.wait(timeout=3)
     assert disconnected.wait(timeout=3) == 1
@@ -181,7 +213,7 @@ try:
         assert b"reload status explicitly" in denied.stderr.read()
     finally:
         denied_connection.close_sync(None)
-    print("PackageKit private-bus event monitor: PASS")
+    print(("PackageKit" if kind == "updates" else kind) + " private-bus event monitor: PASS")
 finally:
     for process in processes:
         if process.poll() is None:

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -1917,7 +1917,7 @@ class RegionalReadTests(unittest.TestCase):
             str(REPO / "tests/fixtures/system-regional-read-bus.py"), str(PROVIDER_PATH)],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True)
         try:
-            stdout, stderr = process.communicate(timeout=30)
+            stdout, stderr = process.communicate(timeout=45)
             self.assertEqual(process.returncode, 0, stderr.decode("utf-8", "replace"))
             self.assertIn(b"Private-bus regional reads: PASS", stdout)
         finally:
@@ -2557,6 +2557,247 @@ class UpdateEventMonitorTests(unittest.TestCase):
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=30)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout, "PackageKit private-bus event monitor: PASS\n")
+
+
+class RegionalEventMonitorTests(unittest.TestCase):
+    def monitor(self, kind="time"):
+        from gi.repository import Gio, GLib
+        glib = mock.Mock(Error=GLib.Error, Variant=GLib.Variant,
+            VariantType=GLib.VariantType, SOURCE_REMOVE=False, SOURCE_CONTINUE=True,
+            PRIORITY_DEFAULT=0)
+        gio = mock.Mock(dbus_is_unique_name=Gio.dbus_is_unique_name)
+        unix, emitted = mock.Mock(), []
+        monitor = provider.RegionalEventMonitor(kind, gio, glib, unix, emitted.append)
+        monitor.deadline = time.monotonic() + 10
+        monitor.deadline_source = 7
+        monitor.connection = gio.bus_get_finish.return_value
+        monitor.connection.call_finish.return_value = GLib.Variant("()", ())
+        return monitor, emitted, gio, glib, unix
+
+    def owner(self, monitor, glib, old, new, sender="org.freedesktop.DBus"):
+        monitor.owner_changed(None, sender, "/org/freedesktop/DBus", "org.freedesktop.DBus",
+            "NameOwnerChanged", glib.Variant("(sss)", (monitor.name, old, new)), None)
+
+    def properties(self, monitor, glib, fields=(), invalidated=(), sender=":1.2"):
+        monitor.properties_changed(None, sender, monitor.path, provider.PROPERTIES_INTERFACE,
+            "PropertiesChanged", glib.Variant("(sa{sv}as)", (monitor.name,
+                {field: glib.Variant("b", True) for field in fields}, list(invalidated))), None)
+
+    def test_fixed_subscriptions_require_both_acknowledgements_and_owner_barrier(self):
+        for kind in ("time", "locale"):
+            monitor, emitted, gio, glib, _unix = self.monitor(kind)
+            connection = monitor.connection
+            monitor.connected(None, object(), None)
+            subscriptions = connection.signal_subscribe.call_args_list
+            self.assertEqual(len(subscriptions), 2)
+            self.assertEqual(subscriptions[1].args[:5], (None, provider.PROPERTIES_INTERFACE,
+                "PropertiesChanged", monitor.path, monitor.name))
+            self.assertTrue(all(call.args[5] == gio.DBusSignalFlags.NO_MATCH_RULE for call in subscriptions))
+            for index, rule in enumerate(monitor.match_rules):
+                connection.call_finish.return_value = glib.Variant("()", ())
+                monitor.match_finished(connection, object(), rule)
+                self.assertEqual(emitted, [])
+                if index == 0:
+                    connection.call_finish.return_value = glib.Variant("(s)", (":1.2",))
+                    monitor.owner_initialized(connection, object(), 0)
+            self.assertEqual([call.args[3] for call in connection.call.call_args_list],
+                ["AddMatch", "GetNameOwner", "AddMatch", "GetNameOwner"])
+            self.assertTrue(all(call.args[0] == "org.freedesktop.DBus" for call in connection.call.call_args_list))
+            self.assertEqual(connection.call.call_args.args[4].unpack(), (monitor.name,))
+            connection.call_finish.return_value = glib.Variant("(s)", (":1.2",))
+            monitor.owner_resolved(connection, object(), 0)
+            self.assertEqual(emitted, ["regional-event\tready"])
+            self.assertEqual(monitor.deadline_source, 0)
+
+    def test_absence_is_ready_but_denial_and_malformed_owner_are_not(self):
+        for error in ("NameHasNoOwner", "AccessDenied", "NoReply", None):
+            monitor, emitted, gio, glib, _unix = self.monitor()
+            if error:
+                monitor.connection.call_finish.side_effect = glib.Error("fixture failure")
+                gio.dbus_error_get_remote_error.return_value = "org.freedesktop.DBus.Error." + error
+            else:
+                monitor.connection.call_finish.return_value = glib.Variant("(s)", (monitor.name,))
+            monitor.owner_resolved(monitor.connection, object(), 0)
+            self.assertEqual(monitor.ready, error == "NameHasNoOwner")
+            self.assertEqual(emitted, ["regional-event\tready"] if error == "NameHasNoOwner" else [])
+
+    def test_owner_epoch_race_coalescing_departure_and_forged_sender(self):
+        monitor, emitted, _gio, glib, _unix = self.monitor()
+        monitor.owner = ":1.2"
+        for _ in range(100):
+            self.properties(monitor, glib, ["NTP"])
+        self.owner(monitor, glib, ":1.2", ":1.3")
+        monitor.connection.call_finish.return_value = glib.Variant("(s)", (":1.2",))
+        monitor.owner_resolved(monitor.connection, object(), 0)
+        self.assertEqual(monitor.owner, ":1.3")
+        self.assertEqual(emitted, ["regional-event\tready", "regional-event\tchanged"])
+        self.properties(monitor, glib, ["NTP"], sender=":1.2")
+        self.owner(monitor, glib, ":1.3", ":1.8", sender=":1.8")
+        self.assertEqual(monitor.owner, ":1.3")
+        self.owner(monitor, glib, ":1.3", "")
+        self.assertEqual(monitor.owner, "")
+        self.assertEqual(len(emitted), 2, "Idle departure must not reactivate a service")
+        self.properties(monitor, glib, ["NTP"], sender=":1.3")
+        self.assertEqual(len(emitted), 2)
+        self.owner(monitor, glib, "", ":1.4")
+        self.owner(monitor, glib, ":1.4", ":1.5")
+        self.assertEqual(len(emitted), 4)
+
+    def test_only_relevant_properties_invalidate_and_bounds_fail_closed(self):
+        for kind in ("time", "locale"):
+            monitor, emitted, _gio, glib, _unix = self.monitor(kind)
+            monitor.ready, monitor.owner = True, ":1.2"
+            self.properties(monitor, glib, ["Unrelated"])
+            self.assertEqual(emitted, [])
+            for field in monitor.relevant:
+                self.properties(monitor, glib, [field])
+                self.properties(monitor, glib, invalidated=[field])
+            self.assertEqual(len(emitted), len(monitor.relevant) * 2)
+            self.properties(monitor, glib, ["x" * 513])
+            self.assertTrue(monitor.stopped)
+        for fields, invalidated in (([str(i) for i in range(65)], []), ([], ["x" * 513])):
+            monitor, _emitted, _gio, glib, _unix = self.monitor()
+            monitor.owner = ":1.2"
+            self.properties(monitor, glib, fields, invalidated)
+            self.assertTrue(monitor.stopped)
+
+    def test_setup_rejects_unicast_senders_before_parsing_or_dirtying(self):
+        monitor, emitted, _gio, glib, _unix = self.monitor()
+        self.properties(monitor, glib, ["Timezone"])
+        self.properties(monitor, glib, ["x" * 20000])
+        self.assertFalse(monitor.stopped)
+        self.assertFalse(monitor.dirty)
+        monitor.owner = ":1.2"
+        self.properties(monitor, glib, ["x" * 20000], sender=":1.8")
+        self.assertFalse(monitor.stopped)
+        self.assertFalse(monitor.dirty)
+        self.properties(monitor, glib, ["Timezone"])
+        self.assertTrue(monitor.dirty)
+        self.assertEqual(emitted, [])
+
+    def test_real_setup_unicast_is_authenticated_before_readiness(self):
+        result = subprocess.run(["dbus-run-session", "--", "/usr/bin/python3",
+            str(REPO / "tests/fixtures/system-regional-setup-bus.py"), str(PROVIDER_PATH)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=15)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "Regional setup unicast authentication: PASS\n")
+
+    def test_expired_setup_late_ack_and_denial_never_report_ready(self):
+        for callback in ("connected", "match_finished", "owner_resolved"):
+            monitor, emitted, _gio, _glib, _unix = self.monitor()
+            monitor.deadline = time.monotonic() - 1
+            getattr(monitor, callback)(monitor.connection, object(), "fixture")
+            self.assertTrue(monitor.stopped)
+            self.assertEqual(emitted, [])
+        for denied in (True, False):
+            monitor, emitted, _gio, glib, _unix = self.monitor()
+            monitor.stop(0)
+            if denied:
+                monitor.connection.call_finish.side_effect = glib.Error("denied")
+            monitor.match_finished(monitor.connection, object(), "owned-rule")
+            self.assertEqual(monitor.exit_code, 0)
+            self.assertEqual(emitted, [])
+            if denied:
+                monitor.connection.call.assert_not_called()
+            else:
+                self.assertEqual(monitor.connection.call.call_args.args[3], "RemoveMatch")
+                self.assertEqual(monitor.connection.call.call_args.args[4].unpack(), ("owned-rule",))
+
+    def test_cleanup_is_single_use_and_removes_only_acknowledged_rules(self):
+        monitor, _emitted, gio, glib, unix = self.monitor()
+        connection = monitor.connection
+        connection.signal_subscribe.side_effect = [20, 21]
+        connection.connect.return_value = 24
+        glib.timeout_add.return_value = 10
+        unix.signal_add.side_effect = [11, 12, 13]
+        def run():
+            monitor.connected(None, object(), None)
+            monitor.match_finished(connection, object(), monitor.match_rules[0])
+            connection.call_finish.side_effect = glib.Error("second match denied")
+            monitor.match_finished(connection, object(), monitor.match_rules[1])
+        monitor.loop.run.side_effect = run
+        self.assertEqual(monitor.run(), 1)
+        self.assertEqual([call.args[0] for call in connection.signal_unsubscribe.call_args_list], [20, 21])
+        removals = [call for call in connection.call.call_args_list if call.args[3] == "RemoveMatch"]
+        self.assertEqual(len(removals), 1)
+        self.assertEqual(removals[0].args[4].unpack(), (monitor.match_rules[0],))
+        self.assertEqual([call.args[0] for call in glib.source_remove.call_args_list], [11, 12, 13, 10])
+        connection.close_sync.assert_not_called()
+        self.assertTrue(monitor.cancellable.cancel.called)
+        with self.assertRaises(RuntimeError):
+            monitor.run()
+        self.assertEqual(gio.bus_get.call_count, 1)
+
+    def test_closed_cli_and_real_private_bus_lifecycle(self):
+        with mock.patch.object(provider, "watch_regional_events", return_value=0) as watch, \
+                mock.patch.object(provider, "PackageKitBackend") as backend, \
+                contextlib.redirect_stderr(io.StringIO()):
+            for kind in ("time", "locale"):
+                self.assertEqual(provider.main(["watch-regional", kind]), 0)
+            self.assertEqual(watch.call_args_list, [mock.call("time"), mock.call("locale")])
+            for args in ([], ["other"], ["time", "extra"], ["--system"]):
+                self.assertEqual(provider.main(["watch-regional", *args]), 2)
+            backend.assert_not_called()
+        for kind in ("time", "locale"):
+            result = subprocess.run(["dbus-run-session", "--", "/usr/bin/python3",
+                str(REPO / "tests/fixtures/system-update-events-bus.py"), str(PROVIDER_PATH), kind],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=30)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, kind + " private-bus event monitor: PASS\n")
+
+
+class NtpReadTests(unittest.TestCase):
+    def reader(self):
+        _regional, connection, gio, glib, variant = RegionalReadTests().reader()
+        return provider.NtpRead(gio, glib), connection, gio, glib, variant
+
+    def test_only_two_fixed_boolean_gets_under_one_deadline(self):
+        read, connection, gio, glib, variant = self.reader()
+        def run():
+            read.connected(None, object(), None)
+            for field, value in (("NTPSynchronized", False), ("CanNTP", True)):
+                connection.call_finish.return_value = variant.Variant("(v)", (variant.Variant("b", value),))
+                read.replied(connection, object(), field)
+        read.loop.run.side_effect = run
+        self.assertEqual(read.run(), provider.NtpSample(True, False))
+        calls = connection.call.call_args_list
+        self.assertEqual(len(calls), 2)
+        for call, field in zip(calls, ("CanNTP", "NTPSynchronized")):
+            self.assertEqual(call.args[:4], ("org.freedesktop.timedate1", "/org/freedesktop/timedate1",
+                provider.PROPERTIES_INTERFACE, "Get"))
+            self.assertEqual(call.args[4].unpack(), ("org.freedesktop.timedate1", field))
+            self.assertEqual(call.args[6], gio.DBusCallFlags.NONE)
+            self.assertTrue(0 < call.args[7] <= 10000)
+        glib.source_remove.assert_called_once_with(17)
+        connection.close_sync.assert_not_called()
+        with self.assertRaises(RuntimeError):
+            read.run()
+
+    def test_partial_timeout_denial_and_bad_types_do_not_publish_a_sample(self):
+        for failure in ("timeout", "denial", "type", "oversized"):
+            read, connection, gio, _glib, variant = self.reader()
+            def run():
+                read.connected(None, object(), None)
+                connection.call_finish.return_value = variant.Variant("(v)", (variant.Variant("b", True),))
+                read.replied(connection, object(), "CanNTP")
+                self.assertFalse(read.done)
+                if failure == "timeout":
+                    read.deadline = time.monotonic() - 1
+                elif failure == "denial":
+                    gio.dbus_error_get_remote_error.return_value = "org.freedesktop.DBus.Error.AccessDenied"
+                    connection.call_finish.side_effect = variant.Error("denied")
+                else:
+                    connection.call_finish.return_value = variant.Variant("(v)",
+                        (variant.Variant("s", "x" * (100 if failure == "oversized" else 1)),))
+                read.replied(connection, object(), "NTPSynchronized")
+            read.loop.run.side_effect = run
+            with self.assertRaises(provider.SnapshotFailure) as caught:
+                read.run()
+            self.assertEqual(caught.exception.code, {"timeout": "timeout", "denial": "permission-denied"}.get(failure, "malformed"))
+            self.assertIsNone(read.value)
+            connection.call_finish.reset_mock(side_effect=True)
+            read.replied(connection, object(), "NTPSynchronized")
+            connection.call_finish.assert_not_called()
 
 
 class OperationStreamTests(unittest.TestCase):


### PR DESCRIPTION
## Scope

Add fixed read-only regional event sources and the internal two-property NTP sampler. This is a preparatory Phase 6 boundary, not Settings activation or Phase 6 completion.

- `watch-regional time|locale`: acknowledge the owner-change match, authenticate the initial owner, acknowledge the property match, and repeat the owner barrier before readiness. One ten-second aggregate setup deadline.
- Require the pinned unique sender even during setup, before parsing property payloads. Authentic setup changes coalesce; forged unicast cannot dirty or terminate the monitor. A controlled private-bus fixture exercises both setup barriers.
- Ordinary timedated/localed idle departure clears the sender quietly. Arrival/replacement invalidates; no platform-service calls, activation, idle polling, or reconnect loop.
- Internal `NtpRead`: exactly two fixed boolean Properties.Get requests under one ten-second aggregate deadline. No sampling CLI or UI timer yet.
- Reuse bounded isolated event output and fixed signal cleanup. Shared private-bus fixtures cover time, locale, and unchanged update behavior.

## Validation

- `scripts/run-tests /usr/bin/python3 tests/test-system-management.py RegionalReadTests NtpReadTests RegionalEventMonitorTests UpdateEventMonitorTests`: 38 tests, PASS (27.433 seconds).
- `scripts/run-tests make clean all && scripts/run-tests`: PASS after the review fix; 515 system-management tests in 208.730 seconds; all relevant repository gates passed.
- Nested X11: Settings closed 0.100% CPU, large surfaces 0.00%; power lifecycle 0.133% baseline and 0.100% after (0.033-point delta). Discovery 43, update UI 48, parser 674 assertions; owner/cancellation/recovery/handoff and lifecycle fixtures passed.
- Staged install manifest, repeated install preservation, package map, Kickstart/static image contract, managed workspace cleanup, and release archive checks passed. No new real image boot is claimed.
- Corrected-tree read-only Fedora 44 host probe: both monitors observed for 36 seconds; each emitted one initial owner-arrival invalidation and used zero sampled CPU ticks; clean termination. NTP pair read successfully. No host mutations or administration launches.
- Documentation: `npm run check && npm run build`, 15 files, zero diagnostics, 11 pages.
- CodeRabbit CLI 0.7.6: repeated review, eight files, zero findings.
- Mandatory post-full Codex review: repeated after corrected full gate; zero actionable correctness or security findings.
- Exact managed test workspaces were automatically cleaned and verified absent.

## Review correction

The first local Codex review identified unauthenticated property delivery during setup. This was verified and fixed before publication, with real-unicast regression coverage and repeated full validation. Bus-side match rules alone cannot authenticate directly addressed signals ([D-Bus routing specification](https://dbus.freedesktop.org/doc/dbus-specification.html#message-bus-routing)).

## Limitations and follow-up

Settings origins remain disabled and cumulative snapshot minor stays zero. Regional initialization handoff, bounded two-read settling, visible-only NTP sampling, AccountsService/CUPS/source integration, minor 1/2 UI, and final installed synchronization remain outstanding. No logout/reboot or host service setting changes. No Phase 7 work.