### PR TITLE
feat(system): observe authenticated account changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ versions from `config.mk`.
 
 ### Changed
 
+- Add a fixed read-only account event monitor that covers candidate changes
+  before enumeration and filtering. Preserve bounded account inventories,
+  authenticated senders, and a monitor without idle polling; Settings activation
+  remains pending.
+
 - Add fixed read-only time and locale event monitors with acknowledged setup,
   bounded output, and quiet handling of normally idle services. Add an internal
   two-property NTP status reader; visible Settings monitoring and sampling

--- a/TASKS.md
+++ b/TASKS.md
@@ -277,6 +277,22 @@ sender before payload parsing. A private-bus fixture injects forged oversized
 unicast signals at both setup barriers while preserving an authentic pending
 notification.
 
+The fixed read-only account event command now acknowledges manager and user
+change subscriptions before enumeration. One authenticated interface-wide
+Changed match already covers every valid candidate before property reads or
+filtering, including excluded or newly discovered objects. It retains no
+candidate list and performs no independent enumeration, avoiding mismatched
+monitor/read selections. Changes outside the bounded result conservatively
+invalidate without enlarging the inventory. Shared authenticated setup retains
+the regional monitor's owner barriers, bounded output, and quiet departure.
+The 45 focused tests pass, including real signals during enumeration and an
+excluded account changing eligibility during property reads. Setup-unicast,
+owner/denial, full/closed output, and shutdown fixtures also pass. Settings
+activation, two-read settling, and cumulative minor 1 remain outstanding.
+A read-only Fedora 44 probe returned one available account row in 0.028
+seconds. The monitor emitted no events and used zero sampled CPU ticks over
+30 seconds, then terminated cleanly. No account or host setting was changed.
+
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit
 confirmation warning that a sent change cannot be canceled. Local cancellation

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -1976,6 +1976,23 @@ publish a sample. This PR adds no sampling CLI or timer. Neither event commands
 nor this internal reader changes the cumulative snapshot minor. Settings
 activation and the following initialization/sampling contract remain pending.
 
+The fixed `dwm-system-management watch-accounts` command is also implemented.
+It accepts no arguments and emits only `accounts-event<TAB>ready` and
+`accounts-event<TAB>changed`. It shares the authenticated setup lifetime above:
+the owner-change match precedes the initial owner lookup, then three service
+matches are acknowledged before the final owner barrier and readiness. All
+four matches and both owner lookups share one ten-second setup deadline.
+The fixed service matches are manager `UserAdded` and `UserDeleted` plus one
+interface-wide `org.freedesktop.Accounts.User.Changed` subscription. Every
+notification requires the pinned unique sender even during setup; object paths
+and signatures are bounded and validated before invalidation. No account
+method, enumeration, property read, or mutation is called by this monitor.
+It retains no candidate identities and has no idle timer or reconnect loop.
+An absent owner can be dormant, departure quietly clears its identity, and
+arrival/replacement invalidates. Finite reads separately report availability.
+The same bounded output, explicit failure guidance, and TERM/INT/HUP cleanup
+apply. This command does not activate Settings or change the snapshot minor.
+
 - systemd D-Bus property changes drive time and locale refresh while the System
   section is open. On pane open, the root model installs the timedate1 and
   locale1 property subscriptions before starting their initial bounded reads.
@@ -1997,11 +2014,15 @@ activation and the following initialization/sampling contract remain pending.
 - AccountsService manager `UserAdded` and `UserDeleted` signals and the `Changed`
   signal on every valid de-duplicated candidate object selected within the
   256-object bound trigger one bounded, coalesced account-summary refresh while
-  the section is open. On pane open, the root model installs the two manager
-  subscriptions before starting `ListCachedUsers`. It attaches each candidate's
-  `Changed` subscription after validating its object path and before reading or
-  filtering that object's properties, so an excluded object becoming eligible
-  refreshes the list. A matching signal during the initial enumeration or
+  the section is open. On pane open, the root model acknowledges both manager
+  subscriptions and the authenticated interface-wide `Changed` subscription
+  before starting `ListCachedUsers`. The latter already covers every candidate
+  before its properties are read or filtered, including an excluded object
+  becoming eligible. This replaces separate per-candidate attachment without
+  a second monitor enumeration that could select different objects. Valid
+  changes outside the selected set conservatively invalidate, but no additional
+  identities or account values are retained and the 256-object read bound is
+  unchanged. A matching signal during the initial enumeration or
   property reads reserves one serialized reconciliation read. A further signal
   during that settling read or its completion handoff stops the cycle after two
   reads, leaves accounts explicitly `partial` with refresh guidance, and

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -7999,17 +7999,11 @@ class UpdateEventMonitor:
         return self.exit_code
 
 
-class RegionalEventMonitor(UpdateEventMonitor):
-    """Observe fixed regional properties, without activating idle platform services."""
+class AuthenticatedEventMonitor(UpdateEventMonitor):
+    """Acknowledge fixed service matches and authenticate even setup-time signals."""
 
-    record_prefix = "regional-event"
-
-    def __init__(self, kind, Gio, GLib, GLibUnix, emit):
-        if not isinstance(kind, str) or kind not in ("time", "locale"):
-            raise ValueError("Unknown regional monitor")
+    def __init__(self, Gio, GLib, GLibUnix, emit):
         super().__init__(Gio, GLib, GLibUnix, emit)
-        self.name, self.path = REGIONAL_READ_REQUESTS[kind + "-state"][:2]
-        self.relevant = {"Locale"} if kind == "locale" else {"Timezone", "CanNTP", "NTP", "NTPSynchronized"}
         self.started = False
 
     def setting_up(self):
@@ -8039,6 +8033,8 @@ class RegionalEventMonitor(UpdateEventMonitor):
                 return
             if reply.get_type_string() != "()":
                 self.stop(1)
+            elif 1 < len(self.installed_rules) < len(self.match_rules):
+                self.add_match()
             else:
                 # Authenticate the owner after the owner-change match, before
                 # enabling property delivery. Bus-side matches do not filter
@@ -8110,6 +8106,53 @@ class RegionalEventMonitor(UpdateEventMonitor):
         if new:
             self.changed()
 
+    def service_specs(self):
+        raise NotImplementedError
+
+    def connected(self, _source, result, _data):
+        if not self.setting_up():
+            return
+        try:
+            self.connection = self.Gio.bus_get_finish(result)
+            if not self.setting_up():
+                return
+            self.connection.set_exit_on_close(False)
+            self.closed_handler = self.connection.connect("closed", lambda *_args: self.stop(1))
+            specs = [
+                ("org.freedesktop.DBus", "org.freedesktop.DBus", "NameOwnerChanged", "/org/freedesktop/DBus", self.name, self.owner_changed,
+                 f"type='signal',sender='org.freedesktop.DBus',interface='org.freedesktop.DBus',member='NameOwnerChanged',path='/org/freedesktop/DBus',arg0='{self.name}'"),
+            ] + self.service_specs()
+            for sender, interface, member, path, arg0, callback, rule in specs:
+                self.subscriptions.append(self.connection.signal_subscribe(sender, interface, member, path,
+                    arg0, self.Gio.DBusSignalFlags.NO_MATCH_RULE, callback, None))
+                self.match_rules.append(rule)
+            self.add_match()
+        except self.GLib.Error:
+            self.stop(1)
+
+    def run(self):
+        if self.started:
+            raise RuntimeError("Service monitors are single-use")
+        self.started = True
+        return super().run()
+
+
+class RegionalEventMonitor(AuthenticatedEventMonitor):
+    """Observe fixed regional properties, without activating idle platform services."""
+
+    record_prefix = "regional-event"
+
+    def __init__(self, kind, Gio, GLib, GLibUnix, emit):
+        if not isinstance(kind, str) or kind not in ("time", "locale"):
+            raise ValueError("Unknown regional monitor")
+        super().__init__(Gio, GLib, GLibUnix, emit)
+        self.name, self.path = REGIONAL_READ_REQUESTS[kind + "-state"][:2]
+        self.relevant = {"Locale"} if kind == "locale" else {"Timezone", "CanNTP", "NTP", "NTPSynchronized"}
+
+    def service_specs(self):
+        return [(None, PROPERTIES_INTERFACE, "PropertiesChanged", self.path, self.name, self.properties_changed,
+            f"type='signal',sender='{self.name}',interface='{PROPERTIES_INTERFACE}',member='PropertiesChanged',path='{self.path}',arg0='{self.name}'")]
+
     def properties_changed(self, _connection, sender, path, interface, member, parameters, _data):
         if (self.stopped or path != self.path or interface != PROPERTIES_INTERFACE
                 or member != "PropertiesChanged" or not self.owner or sender != self.owner):
@@ -8135,37 +8178,52 @@ class RegionalEventMonitor(UpdateEventMonitor):
         except SnapshotFailure:
             self.stop(1)
 
-    def connected(self, _source, result, _data):
-        if not self.setting_up():
+
+class AccountEventMonitor(AuthenticatedEventMonitor):
+    """Cover candidate changes before enumeration without retaining an unbounded list."""
+
+    record_prefix = "accounts-event"
+
+    def __init__(self, Gio, GLib, GLibUnix, emit):
+        super().__init__(Gio, GLib, GLibUnix, emit)
+        self.name, self.path = ACCOUNTS_NAME, ACCOUNTS_PATH
+
+    def service_specs(self):
+        specs = [(None, self.name, member, self.path, None, self.users_changed,
+            f"type='signal',sender='{self.name}',interface='{self.name}',member='{member}',path='{self.path}'")
+            for member in ("UserAdded", "UserDeleted")]
+        # This single authenticated interface subscription already covers all
+        # selected candidates, including excluded/new objects, before any read.
+        # Extra objects can only invalidate; no identities or values are kept.
+        specs.append((None, ACCOUNT_INTERFACE, "Changed", None, None, self.user_changed,
+            f"type='signal',sender='{self.name}',interface='{ACCOUNT_INTERFACE}',member='Changed'"))
+        return specs
+
+    def users_changed(self, _connection, sender, path, interface, member, parameters, _data):
+        if (self.stopped or not self.owner or sender != self.owner or path != self.path
+                or interface != self.name or member not in ("UserAdded", "UserDeleted")):
             return
         try:
-            self.connection = self.Gio.bus_get_finish(result)
-            if not self.setting_up():
-                return
-            self.connection.set_exit_on_close(False)
-            self.closed_handler = self.connection.connect("closed", lambda *_args: self.stop(1))
-            specs = [
-                ("org.freedesktop.DBus", "org.freedesktop.DBus", "NameOwnerChanged", "/org/freedesktop/DBus", self.name, self.owner_changed,
-                 f"type='signal',sender='org.freedesktop.DBus',interface='org.freedesktop.DBus',member='NameOwnerChanged',path='/org/freedesktop/DBus',arg0='{self.name}'"),
-                (None, PROPERTIES_INTERFACE, "PropertiesChanged", self.path, self.name, self.properties_changed,
-                 f"type='signal',sender='{self.name}',interface='{PROPERTIES_INTERFACE}',member='PropertiesChanged',path='{self.path}',arg0='{self.name}'"),
-            ]
-            for sender, interface, member, path, arg0, callback, rule in specs:
-                self.subscriptions.append(self.connection.signal_subscribe(sender, interface, member, path,
-                    arg0, self.Gio.DBusSignalFlags.NO_MATCH_RULE, callback, None))
-                self.match_rules.append(rule)
-            self.add_match()
-        except self.GLib.Error:
+            if parameters.get_type_string() != "(o)" or parameters.get_size() > MAX_TEXT_BYTES + 8:
+                raise SnapshotFailure("malformed", "Invalid account notification")
+            account_object_path(parameters.get_child_value(0))
+            self.changed()
+        except SnapshotFailure:
             self.stop(1)
 
-    def run(self):
-        if self.started:
-            raise RuntimeError("Regional monitors are single-use")
-        self.started = True
-        return super().run()
+    def user_changed(self, _connection, sender, path, interface, member, parameters, _data):
+        if (self.stopped or not self.owner or sender != self.owner
+                or interface != ACCOUNT_INTERFACE or member != "Changed"):
+            return
+        if (not isinstance(path, str) or len(path) > MAX_TEXT_BYTES
+                or DBUS_OBJECT_PATH.fullmatch(path) is None
+                or parameters.get_type_string() != "()" or parameters.get_size() > 8):
+            self.stop(1)
+            return
+        self.changed()
 
 
-def watch_service_events(regional_kind=None) -> int:
+def watch_service_events(service_kind=None) -> int:
     output_writer = None
 
     def emit(record: str) -> None:
@@ -8187,8 +8245,12 @@ def watch_service_events(regional_kind=None) -> int:
             output_writer = control_output_writer(sys.stdout, resources)
             if output_writer is None:
                 raise OSError("Event output requires a file descriptor")
-            monitor = (UpdateEventMonitor(Gio, GLib, GLibUnix, emit) if regional_kind is None else
-                       RegionalEventMonitor(regional_kind, Gio, GLib, GLibUnix, emit))
+            if service_kind is None:
+                monitor = UpdateEventMonitor(Gio, GLib, GLibUnix, emit)
+            elif service_kind == "accounts":
+                monitor = AccountEventMonitor(Gio, GLib, GLibUnix, emit)
+            else:
+                monitor = RegionalEventMonitor(service_kind, Gio, GLib, GLibUnix, emit)
             code = monitor.run()
     except (ImportError, ValueError, OSError):
         code = 1
@@ -8197,7 +8259,7 @@ def watch_service_events(regional_kind=None) -> int:
             with contextlib.ExitStack() as resources:
                 error_writer = control_output_writer(sys.stderr, resources)
                 if error_writer is not None:
-                    label = "PackageKit" if regional_kind is None else "Regional"
+                    label = "PackageKit" if service_kind is None else "Account" if service_kind == "accounts" else "Regional"
                     error_writer((label + " live change monitoring is unavailable; reload status explicitly\n").encode("ascii"))
         except (OSError, ValueError):
             # Exit status remains authoritative when even diagnostics cannot
@@ -8214,12 +8276,18 @@ def watch_regional_events(kind: str) -> int:
     return watch_service_events(kind)
 
 
+def watch_account_events() -> int:
+    return watch_service_events("accounts")
+
+
 def usage() -> int:
-    print(f"usage: {sys.argv[0]} snapshot | watch-updates | watch-regional time|locale | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE | timezone-set ZONE GENERATION | ntp-set enabled|disabled GENERATION | locale-set LANG=LOCALE GENERATION | accounts-open | password-open | printers-open | sources-open", file=sys.stderr)
+    print(f"usage: {sys.argv[0]} snapshot | watch-updates | watch-regional time|locale | watch-accounts | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE | timezone-set ZONE GENERATION | ntp-set enabled|disabled GENERATION | locale-set LANG=LOCALE GENERATION | accounts-open | password-open | printers-open | sources-open", file=sys.stderr)
     return 2
 
 
 def main(argv: Sequence[str]) -> int:
+    if argv and argv[0] == "watch-accounts":
+        return watch_account_events() if len(argv) == 1 else usage()
     if argv and argv[0] == "watch-regional":
         return watch_regional_events(argv[1]) if len(argv) == 2 and argv[1] in ("time", "locale") else usage()
     if argv and argv[0] in {"timezone-set", "ntp-set", "locale-set"}:

--- a/tests/fixtures/system-account-read-bus.py
+++ b/tests/fixtures/system-account-read-bus.py
@@ -3,6 +3,8 @@
 
 import os
 import runpy
+import selectors
+import subprocess
 import sys
 import time
 
@@ -16,6 +18,7 @@ current = "/users/Current"
 others = ("/users/Other", "/users/System")
 mode = "normal"
 calls, held, registrations = [], [], []
+monitor = None
 manager = Gio.DBusNodeInfo.new_for_xml("""
 <node><interface name="org.freedesktop.Accounts">
 <method name="ListCachedUsers"><arg type="ao" direction="out"/></method>
@@ -28,17 +31,36 @@ properties = Gio.DBusNodeInfo.new_for_xml("""
 
 
 def name_call(method):
+    """Manage the fixture service name on the isolated bus."""
     args = GLib.Variant("(su)", (service, 0)) if method == "RequestName" else GLib.Variant("(s)", (service,))
     return bus.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus",
         "org.freedesktop.DBus", method, args, GLib.VariantType.new("(u)"),
         Gio.DBusCallFlags.NONE, 3000, None).unpack()[0]
 
 
+def changed_user(path):
+    """Notify an arbitrary validated object without exposing a candidate list."""
+    bus.emit_signal(None, path, provider["ACCOUNT_INTERFACE"], "Changed", GLib.Variant("()", ()))
+    bus.flush_sync(None)
+
+
+def monitor_line():
+    """Require a short complete event from the real monitored process."""
+    with selectors.DefaultSelector() as selector:
+        selector.register(monitor.stdout, selectors.EVENT_READ)
+        assert selector.select(3), "Account monitor did not deliver an event"
+        return monitor.stdout.readline(128)
+
+
 def called(_bus, _sender, path, interface, method, args, invocation):
+    """Serve bounded account reads with controlled changes before filtering."""
+    global mode
     calls.append((path, interface, method, args.unpack()))
     if mode == "denied":
         invocation.return_dbus_error("org.freedesktop.DBus.Error.AccessDenied", "fixture denial")
     elif method == "ListCachedUsers":
+        if mode == "event-enumeration":
+            changed_user(others[1])
         invocation.return_value(GLib.Variant("(ao)", ([others[1], others[0], others[0]],)))
     elif method == "FindUserById":
         assert args.unpack() == (os.getuid(),)
@@ -50,9 +72,14 @@ def called(_bus, _sender, path, interface, method, args, invocation):
         assert account_interface == provider["ACCOUNT_INTERFACE"]
         values = {"UserName": GLib.Variant("s", "fixture"),
             "RealName": GLib.Variant("s", "Fixture User"),
-            "SystemAccount": GLib.Variant("b", path != others[0]),
+            "SystemAccount": GLib.Variant("b", path != others[0] and not (mode == "eligible" and path == others[1])),
             "LocalAccount": GLib.Variant("b", path != others[0])}
         assert name in values
+        if mode == "event-property" and path == others[1] and name == "SystemAccount":
+            # Return the old excluded property after announcing the new value.
+            # The monitor must reserve reconciliation even before filtering.
+            mode = "eligible"
+            changed_user(path)
         if mode == "missing" and path == others[0] and name == "UserName":
             invocation.return_dbus_error("org.freedesktop.DBus.Error.UnknownProperty", "fixture missing")
         else:
@@ -65,12 +92,27 @@ try:
     registrations.append(bus.register_object(provider["ACCOUNTS_PATH"], manager, called, None, None))
     for path in (current, *others):
         registrations.append(bus.register_object(path, properties, called, None, None))
+    monitor = subprocess.Popen([sys.argv[1], "watch-accounts"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0)
+    assert monitor_line() == b"accounts-event\tready\n"
     result = provider["AccountRead"]().run()
     assert result.status == "available", result.errors
     assert [row.path for row in result.records] == [current, others[0]]
     assert [row.scope for row in result.records] == ["current", "other"]
     assert not result.records[1].local_account
     assert len(calls) == 14
+    mode = "event-enumeration"
+    assert provider["AccountRead"]().run().status == "available"
+    assert monitor_line() == b"accounts-event\tchanged\n"
+    mode = "event-property"
+    result = provider["AccountRead"]().run()
+    assert [row.path for row in result.records] == [current, others[0]]
+    assert monitor_line() == b"accounts-event\tchanged\n"
+    result = provider["AccountRead"]().run()
+    assert result.status == "available"
+    assert [row.path for row in result.records] == [current, *others]
+    changed_user("/users/DiscoveredLater")
+    assert monitor_line() == b"accounts-event\tchanged\n"
     for mode in ("malformed", "missing"):
         result = provider["AccountRead"]().run()
         assert result.status == "partial"
@@ -100,7 +142,21 @@ try:
     assert result.status == "unavailable"
     assert {error.code for error in result.errors} == {"missing-provider"}
     assert all(call[2] in {"ListCachedUsers", "FindUserById", "Get"} for call in calls)
+    assert monitor.poll() is None
+    monitor.terminate()
+    assert monitor.wait(timeout=3) == 0
+    assert monitor.stderr.read() == b""
     print("Private-bus account reads: PASS (typed rows, filtering, denial, absence, deadline, late replies)")
 finally:
+    if monitor is not None:
+        if monitor.poll() is None:
+            monitor.terminate()
+        try:
+            monitor.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            monitor.kill()
+            monitor.wait(timeout=3)
+        monitor.stdout.close()
+        monitor.stderr.close()
     for registration in registrations:
         bus.unregister_object(registration)

--- a/tests/fixtures/system-regional-setup-bus.py
+++ b/tests/fixtures/system-regional-setup-bus.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-"""Inject real directly addressed signals at controlled regional setup barriers."""
+"""Inject real directly addressed signals at controlled service setup barriers."""
 
 import os
 import runpy
@@ -9,21 +9,27 @@ os.environ["DBUS_SYSTEM_BUS_ADDRESS"] = os.environ["DBUS_SESSION_BUS_ADDRESS"]
 from gi.repository import Gio, GLib, GLibUnix
 
 provider = runpy.run_path(sys.argv[1], run_name="regional_setup_fixture")
+accounts = len(sys.argv) == 3 and sys.argv[2] == "accounts"
 address = os.environ["DBUS_SESSION_BUS_ADDRESS"]
 flags = Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT | Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION
 service = Gio.DBusConnection.new_for_address_sync(address, flags, None, None)
 outsider = Gio.DBusConnection.new_for_address_sync(address, flags, None, None)
 
 
-class SetupMonitor(provider["RegionalEventMonitor"]):
+class SetupMonitor(provider["AccountEventMonitor"] if accounts else provider["RegionalEventMonitor"]):
     """Delay only callback publication, leaving actual bus setup and signals intact."""
 
     def inject(self, sender, oversized=False):
         """Bypass match routing using the monitor's actual unique destination."""
-        fields = {"x" * 20000: GLib.Variant("b", True)} if oversized else {"Timezone": GLib.Variant("s", "UTC")}
-        sender.emit_signal(self.connection.get_unique_name(), self.path,
-            "org.freedesktop.DBus.Properties", "PropertiesChanged",
-            GLib.Variant("(sa{sv}as)", (self.name, fields, [])))
+        if accounts:
+            parameters = GLib.Variant("(s)", ("x" * 20000,)) if oversized else GLib.Variant("()", ())
+            sender.emit_signal(self.connection.get_unique_name(), "/users/Setup",
+                provider["ACCOUNT_INTERFACE"], "Changed", parameters)
+        else:
+            fields = {"x" * 20000: GLib.Variant("b", True)} if oversized else {"Timezone": GLib.Variant("s", "UTC")}
+            sender.emit_signal(self.connection.get_unique_name(), self.path,
+                "org.freedesktop.DBus.Properties", "PropertiesChanged",
+                GLib.Variant("(sa{sv}as)", (self.name, fields, [])))
         sender.flush_sync(None)
 
     def owner_initialized(self, connection, result, epoch):
@@ -54,16 +60,17 @@ class SetupMonitor(provider["RegionalEventMonitor"]):
 
 
 try:
-    name = "org.freedesktop.timedate1"
+    name = provider["ACCOUNTS_NAME"] if accounts else "org.freedesktop.timedate1"
     result = service.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus",
         "org.freedesktop.DBus", "RequestName", GLib.Variant("(su)", (name, 0)),
         GLib.VariantType.new("(u)"), Gio.DBusCallFlags.NONE, 3000, None)
     assert result.unpack() == (1,)
     emitted = []
-    monitor = SetupMonitor("time", Gio, GLib, GLibUnix, emitted.append)
+    monitor = SetupMonitor(Gio, GLib, GLibUnix, emitted.append) if accounts else SetupMonitor("time", Gio, GLib, GLibUnix, emitted.append)
     assert monitor.run() == 0
-    assert emitted == ["regional-event\tready", "regional-event\tchanged"]
-    print("Regional setup unicast authentication: PASS")
+    prefix = "accounts-event" if accounts else "regional-event"
+    assert emitted == [prefix + "\tready", prefix + "\tchanged"]
+    print(("Account" if accounts else "Regional") + " setup unicast authentication: PASS")
 finally:
     outsider.close_sync(None)
     service.close_sync(None)

--- a/tests/fixtures/system-update-events-bus.py
+++ b/tests/fixtures/system-update-events-bus.py
@@ -19,13 +19,13 @@ from gi.repository import Gio, GLib
 NAME = "org.freedesktop.PackageKit"
 PATH = "/org/freedesktop/PackageKit"
 kind = sys.argv[2] if len(sys.argv) == 3 else "updates"
-assert kind in ("updates", "time", "locale")
-command = ["watch-updates"] if kind == "updates" else ["watch-regional", kind]
-prefix = b"update-event" if kind == "updates" else b"regional-event"
+assert kind in ("updates", "time", "locale", "accounts")
+command = ["watch-updates"] if kind == "updates" else ["watch-accounts"] if kind == "accounts" else ["watch-regional", kind]
+prefix = b"update-event" if kind == "updates" else b"accounts-event" if kind == "accounts" else b"regional-event"
 ready = prefix + b"\tready\n"
 changed = prefix + b"\tchanged\n"
 if kind != "updates":
-    NAME = "org.freedesktop." + ("timedate1" if kind == "time" else "locale1")
+    NAME = "org.freedesktop." + {"time": "timedate1", "locale": "locale1", "accounts": "Accounts"}[kind]
     PATH = "/" + NAME.replace(".", "/")
 bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
 address = os.environ["DBUS_SESSION_BUS_ADDRESS"]
@@ -66,8 +66,17 @@ def line(process, timeout=3):
 
 
 def emit(member, *, path=PATH, interface=NAME, parameters=None, connection=bus):
-    """Emit a real signal, adapting global changes for regional properties."""
-    if kind != "updates" and member in ("UpdatesChanged", "InstalledChanged", "RepoListChanged"):
+    """Emit real signals, adapting global changes to the selected service."""
+    if kind == "accounts" and member in ("UpdatesChanged", "InstalledChanged", "RepoListChanged"):
+        interface = NAME
+        if member == "RepoListChanged":
+            member, interface = "Changed", NAME + ".User"
+            path = PATH + "/User1001" if path == PATH else path
+            parameters = GLib.Variant("()", ())
+        else:
+            member = "UserAdded" if member == "UpdatesChanged" else "UserDeleted"
+            parameters = GLib.Variant("(o)", (PATH + "/User1001",))
+    elif kind in ("time", "locale") and member in ("UpdatesChanged", "InstalledChanged", "RepoListChanged"):
         member = "PropertiesChanged"
         interface = "org.freedesktop.DBus.Properties"
         field = "Timezone" if kind == "time" else "Locale"
@@ -86,7 +95,7 @@ try:
         emit(member)
         assert line(process) == changed, member
 
-    if kind != "updates":
+    if kind in ("time", "locale"):
         field = "Timezone" if kind == "time" else "Locale"
         value = GLib.Variant("s", "UTC") if kind == "time" else GLib.Variant("as", ["LANG=C"])
         emit("PropertiesChanged", interface="org.freedesktop.DBus.Properties",
@@ -100,7 +109,7 @@ try:
     outsider = Gio.DBusConnection.new_for_address_sync(address,
         Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT | Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION, None, None)
     emit("UpdatesChanged", connection=outsider)
-    if kind != "updates":
+    if kind in ("time", "locale"):
         emit("PropertiesChanged", interface="org.freedesktop.DBus.Properties",
             parameters=GLib.Variant("(sa{sv}as)", (NAME, {"Unrelated": GLib.Variant("b", True)}, [])))
     assert line(process, 0.2) == b"", "Unrelated signals triggered discovery"

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -2746,6 +2746,157 @@ class RegionalEventMonitorTests(unittest.TestCase):
             self.assertEqual(result.stdout, kind + " private-bus event monitor: PASS\n")
 
 
+class AccountEventMonitorTests(unittest.TestCase):
+    def monitor(self):
+        _regional, emitted, gio, glib, unix = RegionalEventMonitorTests().monitor()
+        monitor = provider.AccountEventMonitor(gio, glib, unix, emitted.append)
+        monitor.deadline = time.monotonic() + 10
+        monitor.deadline_source = 7
+        monitor.connection = gio.bus_get_finish.return_value
+        return monitor, emitted, gio, glib, unix
+
+    def setup(self, monitor, glib):
+        connection = monitor.connection
+        monitor.connected(None, object(), None)
+        for index, rule in enumerate(monitor.match_rules):
+            connection.call_finish.return_value = glib.Variant("()", ())
+            monitor.match_finished(connection, object(), rule)
+            if index == 0:
+                connection.call_finish.return_value = glib.Variant("(s)", (":1.2",))
+                monitor.owner_initialized(connection, object(), 0)
+
+    def test_four_fixed_matches_precede_ready_without_account_enumeration(self):
+        monitor, emitted, gio, glib, _unix = self.monitor()
+        self.setup(monitor, glib)
+        connection = monitor.connection
+        subscriptions = connection.signal_subscribe.call_args_list
+        self.assertEqual(len(subscriptions), 4)
+        self.assertEqual([call.args[2] for call in subscriptions],
+            ["NameOwnerChanged", "UserAdded", "UserDeleted", "Changed"])
+        self.assertEqual(subscriptions[-1].args[:5], (None, provider.ACCOUNT_INTERFACE,
+            "Changed", None, None))
+        self.assertTrue(all(call.args[5] == gio.DBusSignalFlags.NO_MATCH_RULE for call in subscriptions))
+        self.assertEqual([call.args[3] for call in connection.call.call_args_list],
+            ["AddMatch", "GetNameOwner", "AddMatch", "AddMatch", "AddMatch", "GetNameOwner"])
+        self.assertTrue(all(call.args[0] == "org.freedesktop.DBus" for call in connection.call.call_args_list))
+        self.assertEqual(emitted, [])
+        connection.call_finish.return_value = glib.Variant("(s)", (":1.2",))
+        monitor.owner_resolved(connection, object(), 0)
+        self.assertEqual(emitted, ["accounts-event\tready"])
+
+    def test_every_valid_candidate_path_is_covered_before_and_after_ready(self):
+        monitor, emitted, _gio, glib, _unix = self.monitor()
+        monitor.owner = ":1.2"
+        for path in ("/users/Excluded", "/future/New", "/org/freedesktop/Accounts/User1000"):
+            monitor.user_changed(None, ":1.2", path, provider.ACCOUNT_INTERFACE,
+                "Changed", glib.Variant("()", ()), None)
+        self.assertTrue(monitor.dirty)
+        self.assertEqual(emitted, [])
+        monitor.connection.call_finish.return_value = glib.Variant("(s)", (":1.2",))
+        monitor.owner_resolved(monitor.connection, object(), 0)
+        self.assertEqual(emitted, ["accounts-event\tready", "accounts-event\tchanged"])
+        for member in ("UserAdded", "UserDeleted"):
+            monitor.users_changed(None, ":1.2", provider.ACCOUNTS_PATH, provider.ACCOUNTS_NAME,
+                member, glib.Variant("(o)", ("/users/New",)), None)
+        self.assertEqual(len(emitted), 4)
+
+    def test_untrusted_unicast_never_reaches_payload_parsing(self):
+        for owner, sender in (("", ":1.2"), (":1.2", ":1.8")):
+            monitor, emitted, _gio, _glib, _unix = self.monitor()
+            monitor.owner = owner
+            payload = mock.Mock()
+            monitor.users_changed(None, sender, provider.ACCOUNTS_PATH, provider.ACCOUNTS_NAME,
+                "UserAdded", payload, None)
+            monitor.user_changed(None, sender, "/users/Unknown", provider.ACCOUNT_INTERFACE,
+                "Changed", payload, None)
+            payload.get_type_string.assert_not_called()
+            self.assertFalse(monitor.stopped)
+            self.assertFalse(monitor.dirty)
+            self.assertEqual(emitted, [])
+
+    def test_notifications_are_typed_bounded_and_scope_checked(self):
+        for manager in (True, False):
+            monitor, emitted, _gio, glib, _unix = self.monitor()
+            monitor.owner, monitor.ready = ":1.2", True
+            callback = monitor.users_changed if manager else monitor.user_changed
+            interface = provider.ACCOUNTS_NAME if manager else provider.ACCOUNT_INTERFACE
+            path = provider.ACCOUNTS_PATH if manager else "/users/Changed"
+            member = "UserAdded" if manager else "Changed"
+            callback(None, ":1.2", path, "org.example.Unrelated", member, mock.Mock(), None)
+            callback(None, ":1.2", path, interface, "Unrelated", mock.Mock(), None)
+            self.assertEqual(emitted, [])
+            callback(None, ":1.2", path, interface, member, glib.Variant("(s)", ("wrong",)), None)
+            self.assertTrue(monitor.stopped)
+        for manager in (True, False):
+            monitor, _emitted, _gio, glib, _unix = self.monitor()
+            monitor.owner = ":1.2"
+            path = "/" + "x" * 513
+            if manager:
+                monitor.users_changed(None, ":1.2", provider.ACCOUNTS_PATH, provider.ACCOUNTS_NAME,
+                    "UserDeleted", glib.Variant("(o)", (path,)), None)
+            else:
+                monitor.user_changed(None, ":1.2", path, provider.ACCOUNT_INTERFACE,
+                    "Changed", glib.Variant("()", ()), None)
+            self.assertTrue(monitor.stopped)
+
+    def test_owner_replacement_rejects_old_senders_and_departure_is_quiet(self):
+        monitor, emitted, _gio, glib, _unix = self.monitor()
+        monitor.owner, monitor.ready = ":1.2", True
+        owner = RegionalEventMonitorTests().owner
+        owner(monitor, glib, ":1.2", ":1.3")
+        self.assertEqual(emitted, ["accounts-event\tchanged"])
+        monitor.user_changed(None, ":1.2", "/users/Old", provider.ACCOUNT_INTERFACE,
+            "Changed", glib.Variant("()", ()), None)
+        self.assertEqual(len(emitted), 1)
+        owner(monitor, glib, ":1.3", "")
+        self.assertEqual(len(emitted), 1)
+        self.assertEqual(monitor.owner, "")
+
+    def test_denied_partial_setup_removes_only_owned_rules_and_all_local_sources(self):
+        monitor, emitted, gio, glib, unix = self.monitor()
+        connection = monitor.connection
+        connection.signal_subscribe.side_effect = [20, 21, 22, 23]
+        connection.connect.return_value = 24
+        glib.timeout_add.return_value = 10
+        unix.signal_add.side_effect = [11, 12, 13]
+        def run():
+            monitor.connected(None, object(), None)
+            monitor.match_finished(connection, object(), monitor.match_rules[0])
+            connection.call_finish.return_value = glib.Variant("(s)", (":1.2",))
+            monitor.owner_initialized(connection, object(), 0)
+            connection.call_finish.side_effect = glib.Error("denied service match")
+            monitor.match_finished(connection, object(), monitor.match_rules[1])
+        monitor.loop.run.side_effect = run
+        self.assertEqual(monitor.run(), 1)
+        self.assertEqual(emitted, [])
+        self.assertEqual([call.args[0] for call in connection.signal_unsubscribe.call_args_list], [20, 21, 22, 23])
+        self.assertEqual([call.args[0] for call in glib.source_remove.call_args_list], [11, 12, 13, 10])
+        removals = [call for call in connection.call.call_args_list if call.args[3] == "RemoveMatch"]
+        self.assertEqual(len(removals), 1)
+        self.assertEqual(removals[0].args[4].unpack(), (monitor.match_rules[0],))
+        connection.close_sync.assert_not_called()
+        with self.assertRaises(RuntimeError):
+            monitor.run()
+        self.assertEqual(gio.bus_get.call_count, 1)
+
+    def test_cli_is_argument_free_and_private_bus_lifecycle_and_unicast_pass(self):
+        with mock.patch.object(provider, "watch_account_events", return_value=0) as watch, \
+                mock.patch.object(provider, "PackageKitBackend") as backend, \
+                contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(provider.main(["watch-accounts"]), 0)
+            for extra in ("user", "--system", "/users/Selected"):
+                self.assertEqual(provider.main(["watch-accounts", extra]), 2)
+            watch.assert_called_once_with()
+            backend.assert_not_called()
+        for fixture, expected in (("system-update-events-bus.py", "accounts private-bus event monitor: PASS\n"),
+                                  ("system-regional-setup-bus.py", "Account setup unicast authentication: PASS\n")):
+            result = subprocess.run(["dbus-run-session", "--", "/usr/bin/python3",
+                str(REPO / "tests/fixtures" / fixture), str(PROVIDER_PATH), "accounts"],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=30)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, expected)
+
+
 class NtpReadTests(unittest.TestCase):
     def reader(self):
         _regional, connection, gio, glib, variant = RegionalReadTests().reader()


### PR DESCRIPTION
## Summary

- Add the fixed, read-only `dwm-system-management watch-accounts` event stream.
- Share the previously qualified authenticated regional monitor setup lifetime, preserving regional behavior.
- Acknowledge manager additions/deletions and one authenticated interface-wide account change match before readiness. This covers every candidate before enumeration or property filtering without a second potentially divergent monitor enumeration.
- Retain no candidate identities, invoke no AccountsService methods, and add no idle polling or reconnect loop. The finite account reader keeps its 256-candidate and three-second limits.
- Keep Settings activation and cumulative protocol minor 1 for a later Phase 6 PR.

## Validation

- Focused account, regional, and update monitor regression set: 45 tests passed in 13.335 seconds.
- Private-bus fixtures cover changes during enumeration and exclusion-property reads, excluded accounts becoming eligible on reconciliation, arbitrary valid candidate paths, authenticated/forged setup unicasts, malformed replies, setup denial, owner replacement, absent services, output pressure/loss, and TERM/INT/HUP/SIGKILL cleanup.
- Read-only Fedora 44 host qualification: account inventory available in 0.028 seconds; watcher ready, zero events and zero CPU ticks over 30 seconds; clean TERM exit and empty stderr.
- Documentation check/build: 15 files, zero errors/warnings/hints, 11 pages.
- Local CodeRabbit review: eight files reviewed, zero findings.
- `scripts/run-tests make clean all && scripts/run-tests`: passed, including all 522 system-management tests (208.163 seconds), existing QML/native lifecycle checks, shell/static gates, package-map checks, staged install/uninstall symmetry, repeated installation preservation, and release-archive checks. Managed workspaces were removed and the staged tree stayed fixed.
- Required post-gate local Codex review: completed with zero actionable correctness or security findings.

## Scope and limitations

No host account changes or administrative tools were launched. This PR does not expose native action origins in Settings, implement pane reconciliation, or complete Phase 6. Ready means subscriptions are installed, not that AccountsService is available; finite reads report availability. Valid changes outside the selected finite candidate set conservatively invalidate without retaining more state.