### PR TITLE
feat(system): observe fixed systemd unit changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ versions from `config.mk`.
 
 ### Changed
 
+- Add fixed read-only printer and firewall unit event monitors with private
+  subscription ownership, canonical-alias discovery, bounded reconciliation,
+  and no idle polling or service activation. Settings integration remains pending.
+
 - Add a fixed read-only account event monitor that covers candidate changes
   before enumeration and filtering. Preserve bounded account inventories,
   authenticated senders, and a monitor without idle polling; Settings activation

--- a/TASKS.md
+++ b/TASKS.md
@@ -293,6 +293,21 @@ A read-only Fedora 44 probe returned one available account row in 0.028
 seconds. The monitor emitted no events and used zero sampled CPU ticks over
 30 seconds, then terminated cleanly. No account or host setting was changed.
 
+The fixed printer and security unit event commands now observe only CUPS or
+firewalld through a private systemd subscription. Six acknowledged matches,
+owner barriers, Subscribe, and fixed non-loading GetUnit lookups precede
+readiness under one ten-second setup budget. Canonical aliases and initially
+unloaded units are reconciled through at most two fixed-name passes per event
+burst; unstable monitoring fails with explicit-refresh guidance. There is no
+idle timer, unit enumeration, service activation, or authorization request.
+Private-bus tests cover alias arrivals, independent subscriber shutdown,
+forged notifications, bounded bursts, denial, malformed state, actual setup
+timeout, canceled lookups, full/closed output, and owner loss. Real Fedora 44
+printer and security watchers each emitted zero events and used zero sampled
+CPU ticks over 30 seconds, then stopped cleanly. No host service was changed.
+Settings integration, cumulative minors, and combined qualification remain
+outstanding.
+
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit
 confirmation warning that a sent change cannot be canceled. Local cancellation

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -1993,6 +1993,41 @@ arrival/replacement invalidates. Finite reads separately report availability.
 The same bounded output, explicit failure guidance, and TERM/INT/HUP cleanup
 apply. This command does not activate Settings or change the snapshot minor.
 
+The fixed `dwm-system-management watch-units printers|security` command is
+implemented separately. It emits only `units-event<TAB>ready` and
+`units-event<TAB>changed`. Printers selects `cups.service` and `cups.socket`;
+security selects only `firewalld.service`. A private asynchronous bus connection
+owns its systemd `Subscribe`, avoiding interference with another subscriber on
+a shared connection. Six acknowledged matches cover owner changes, manager
+`UnitNew`, `UnitRemoved`, `UnitFilesChanged`, `Reloading`, and interface-wide
+unit property changes. Owner authentication, subscription acceptance, fixed
+`GetUnit` lookups, and a final owner barrier all precede readiness within one
+ten-second aggregate setup budget. Every notification requires the pinned
+unique sender before decoding, including directly addressed setup signals.
+
+The monitor never loads, references, starts, or enumerates units. `GetUnit`
+resolves already-loaded fixed names and accepts no-such-unit as dormant state.
+Manager arrivals can name canonical aliases, so they coalesce into one fixed
+lookup pass and at most one settling pass under a shared ten-second burst
+deadline. An unrelated arrival with unchanged fixed mappings does not invalidate
+the UI. Matching removals, configuration reloads, unit-file changes, changed
+fixed mappings, and relevant properties invalidate state. Properties received
+while a mapping is unresolved conservatively invalidate without retaining other
+unit identities. A further manager event during the settling pass fails the
+monitor explicitly; there is no idle polling or reconnect loop. Stale resolution
+or owner-barrier callbacks cannot publish readiness. Systemd owner loss or
+replacement fails monitoring because its replacement does not inherit the old
+sender's subscription. Finite snapshots remain independently readable.
+
+Shutdown cancels outstanding local lookups and closes only the private
+connection, waiting at most one second for close completion. Unconfirmed cleanup
+is failure, not success; process disconnection also removes the sender's matches
+and subscription. Full or closed output retains bounded failure and never
+changes inherited file-status flags. This command adds no Settings activation
+or cumulative protocol minor. The finite CUPS reader still separately uses
+`ListUnitsByNames`, which may load fixed unit configuration but does not start
+the service; that method is not used by the monitor.
+
 - systemd D-Bus property changes drive time and locale refresh while the System
   section is open. On pane open, the root model installs the timedate1 and
   locale1 property subscriptions before starting their initial bounded reads.
@@ -2031,9 +2066,11 @@ apply. This command does not activate Settings or change the snapshot minor.
   enumeration remains explicitly `partial`.
 - The systemd manager's `UnitNew` and `UnitRemoved` signals for the fixed
   `cups.service`, `cups.socket`, and `firewalld.service` names, plus
-  `PropertiesChanged` for each loaded unit's `ActiveState` and the CUPS
-  socket's `SubState`, trigger one bounded, coalesced refresh of the owning
+  `PropertiesChanged` for each loaded unit's `LoadState`, `ActiveState`, and
+  `SubState`, trigger one bounded, coalesced refresh of the owning
   state while the section is open. Those subscriptions stop on section close.
+  Fixed alias mappings are also reconciled after unit-file changes and completed
+  manager reloads, which can retarget an alias without creating a new object.
   Delegated-tool availability remains a bounded snapshot; Phase 6 adds no CUPS
   or firewalld polling loop.
 - A single pane-scoped `dwm-system-management watch-mounts` process monitors
@@ -2279,6 +2316,8 @@ together without changing existing health or session-action contracts.
 - PackageKit transaction API: <https://packagekit.freedesktop.org/gtk-doc/Transaction.html>
 - systemd timedate1 API: <https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.timedate1.html>
 - systemd locale1 API: <https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.locale1.html>
+- systemd manager implementation (GetUnit, ListUnitsByNames, Subscribe): <https://github.com/systemd/systemd/blob/v259/src/core/dbus-manager.c>
+- Gio private connection lifecycle: <https://docs.gtk.org/gio/method.DBusConnection.close.html>
 - AccountsService manager D-Bus XML: <https://gitlab.freedesktop.org/accountsservice/accountsservice/-/raw/main/data/org.freedesktop.Accounts.xml>
 - AccountsService user D-Bus XML: <https://gitlab.freedesktop.org/accountsservice/accountsservice/-/raw/main/data/org.freedesktop.Accounts.User.xml>
 - CUPS administration guidance: <https://openprinting.github.io/cups/doc/admin.html>

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -211,6 +211,7 @@ SYSTEMD_NAME = "org.freedesktop.systemd1"
 SYSTEMD_PATH = "/org/freedesktop/systemd1"
 SYSTEMD_MANAGER = "org.freedesktop.systemd1.Manager"
 CUPS_UNITS = ("cups.service", "cups.socket")
+WATCH_UNIT_SETS = {"printers": CUPS_UNITS, "security": ("firewalld.service",)}
 CUPS_READ_SECONDS = 10
 UNIT_REPLY_TYPE = "(a(ssssssouso))"
 UNIT_REPLY_BYTES = 64 * 1024
@@ -8116,6 +8117,13 @@ class AuthenticatedEventMonitor(UpdateEventMonitor):
             self.connection = self.Gio.bus_get_finish(result)
             if not self.setting_up():
                 return
+            self.subscribe_connection()
+        except self.GLib.Error:
+            self.stop(1)
+
+    def subscribe_connection(self):
+        """Attach only local filters and acknowledged fixed bus matches."""
+        try:
             self.connection.set_exit_on_close(False)
             self.closed_handler = self.connection.connect("closed", lambda *_args: self.stop(1))
             specs = [
@@ -8223,6 +8231,361 @@ class AccountEventMonitor(AuthenticatedEventMonitor):
         self.changed()
 
 
+class UnitEventMonitor(AuthenticatedEventMonitor):
+    """Observe fixed loaded units on a private, sender-owned systemd subscription."""
+
+    record_prefix = "units-event"
+
+    def __init__(self, kind, Gio, GLib, GLibUnix, emit):
+        if not isinstance(kind, str) or kind not in WATCH_UNIT_SETS:
+            raise ValueError("Unknown unit monitor")
+        super().__init__(Gio, GLib, GLibUnix, emit)
+        self.name, self.path = SYSTEMD_NAME, SYSTEMD_PATH
+        self.units = WATCH_UNIT_SETS[kind]
+        self.paths = dict.fromkeys(self.units, "")
+        self.subscribed_owner = ""
+        self.subscription_ready = False
+        self.resolving = False
+        self.resolve_again = False
+        self.resolve_round = 0
+        self.resolution_epoch = 0
+        self.resolve_source = 0
+        self.resolve_cancel = None
+        self.connecting = False
+        self.closing = False
+        self.cleanup_done = False
+        self.cleanup_loop = None
+
+    def service_specs(self):
+        specs = [(None, SYSTEMD_MANAGER, member, self.path, None, self.manager_event,
+            f"type='signal',sender='{self.name}',interface='{SYSTEMD_MANAGER}',member='{member}',path='{self.path}'")
+            for member in ("UnitNew", "UnitRemoved", "UnitFilesChanged", "Reloading")]
+        specs.append((None, PROPERTIES_INTERFACE, "PropertiesChanged", None, SYSTEMD_NAME + ".Unit", self.properties_changed,
+            f"type='signal',sender='{self.name}',interface='{PROPERTIES_INTERFACE}',member='PropertiesChanged',arg0='{SYSTEMD_NAME}.Unit'"))
+        return specs
+
+    def connected(self, _source, result, _data):
+        self.connecting = False
+        try:
+            self.connection = self.Gio.DBusConnection.new_for_address_finish(result)
+            self.connection.set_exit_on_close(False)
+            if not self.setting_up():
+                self.close_connection()
+                return
+            self.subscribe_connection()
+        except self.GLib.Error:
+            self.stop(1)
+            if self.cleanup_loop is not None:
+                self.cleanup_done = True
+                self.cleanup_loop.quit()
+
+    def owner_resolved(self, connection, result, epoch):
+        """Subscribe only after all matches and an authenticated owner barrier."""
+        if not self.resolve_owner(connection, result, epoch):
+            return
+        if not self.owner:
+            self.stop(1)
+            return
+        self.subscribed_owner = self.owner
+        try:
+            connection.call(self.owner, self.path, SYSTEMD_MANAGER, "Subscribe", None,
+                self.GLib.VariantType.new("()"), self.Gio.DBusCallFlags.NO_AUTO_START,
+                max(1, int((self.deadline - time.monotonic()) * 1000)), self.cancellable,
+                self.subscribed, None)
+        except self.GLib.Error:
+            self.stop(1)
+
+    def subscribed(self, connection, result, _data):
+        try:
+            reply = connection.call_finish(result)
+            if not self.setting_up():
+                return
+            if reply.get_type_string() != "()" or reply.get_size() > 8:
+                self.stop(1)
+                return
+            self.subscription_ready = True
+            self.reconcile()
+        except self.GLib.Error:
+            self.stop(1)
+
+    def owner_changed(self, *args):
+        super().owner_changed(*args)
+        if self.subscribed_owner and self.owner != self.subscribed_owner:
+            # A new daemon does not inherit the old sender's Subscribe state.
+            # Fail explicitly instead of silently reconnecting or reauthorizing.
+            self.stop(1)
+
+    @staticmethod
+    def valid_path(path):
+        return (isinstance(path, str) and len(path) <= MAX_TEXT_BYTES
+                and path.startswith(SYSTEMD_PATH + "/unit/")
+                and DBUS_OBJECT_PATH.fullmatch(path) is not None)
+
+    def manager_event(self, _connection, sender, path, interface, member, parameters, _data):
+        if (self.stopped or not self.owner or sender != self.owner
+                or path != self.path or interface != SYSTEMD_MANAGER):
+            return
+        relevant = True
+        if member in ("UnitNew", "UnitRemoved"):
+            if parameters.get_type_string() != "(so)" or parameters.get_size() > 2 * MAX_TEXT_BYTES + 16:
+                self.stop(1)
+                return
+            name, unit_path = parameters.unpack()
+            if (not name or len(name.encode("utf-8")) > MAX_TEXT_BYTES
+                    or any(ord(char) < 32 or ord(char) == 127 for char in name)
+                    or not self.valid_path(unit_path)):
+                self.stop(1)
+                return
+            relevant = name in self.units or unit_path in self.paths.values()
+            if member == "UnitRemoved" and not relevant:
+                return
+        elif member == "UnitFilesChanged":
+            if parameters.get_type_string() != "()" or parameters.get_size() > 8:
+                self.stop(1)
+                return
+        elif member == "Reloading":
+            if parameters.get_type_string() != "(b)" or parameters.get_size() > 8:
+                self.stop(1)
+                return
+            if parameters.unpack()[0]:
+                return
+        else:
+            return
+        if relevant:
+            self.changed()
+        # An arrival may use a previously unknown canonical alias. Resolve
+        # only our fixed names; never enumerate or load the announced unit.
+        self.reconcile()
+
+    def properties_changed(self, _connection, sender, path, interface, member, parameters, _data):
+        if (self.stopped or not self.owner or sender != self.owner
+                or interface != PROPERTIES_INTERFACE or member != "PropertiesChanged"
+                or not self.valid_path(path)):
+            return
+        if path not in self.paths.values() and self.ready and not self.resolving:
+            return
+        try:
+            if parameters.get_type_string() != "(sa{sv}as)" or parameters.get_size() > UNIT_REPLY_BYTES:
+                raise SnapshotFailure("malformed", "Invalid unit notification")
+            fields = parameters.get_child_value(1)
+            invalidated = parameters.get_child_value(2)
+            if (parameters.get_child_value(0).unpack() != SYSTEMD_NAME + ".Unit"):
+                return
+            if fields.n_children() > 256 or invalidated.n_children() > 256:
+                raise SnapshotFailure("malformed", "Oversized unit notification")
+            relevant = {"LoadState", "ActiveState", "SubState"}
+            changed = False
+            for index in range(fields.n_children()):
+                item = fields.get_child_value(index)
+                key = item.get_child_value(0)
+                if key.get_size() > MAX_TEXT_BYTES + 1:
+                    raise SnapshotFailure("malformed", "Oversized unit property")
+                if key.unpack() in relevant:
+                    value = item.get_child_value(1).get_variant()
+                    if value.get_type_string() != "s" or value.get_size() > 65 or UNIT_STATE_TOKEN.fullmatch(value.unpack()) is None:
+                        raise SnapshotFailure("malformed", "Invalid unit property")
+                    changed = True
+            for index in range(invalidated.n_children()):
+                key = invalidated.get_child_value(index)
+                if key.get_size() > MAX_TEXT_BYTES + 1:
+                    raise SnapshotFailure("malformed", "Oversized invalidated unit property")
+                changed = changed or key.unpack() in relevant
+            if changed:
+                self.changed()
+        except SnapshotFailure:
+            self.stop(1)
+
+    def reconcile(self):
+        """Resolve at most two fixed-name passes for one in-flight event burst."""
+        if self.stopped or not self.subscription_ready:
+            return
+        if self.resolving:
+            self.resolve_again = True
+            return
+        self.resolving = True
+        self.resolution_epoch += 1
+        self.resolve_again = False
+        self.resolve_round = 0
+        self.resolve_deadline = min(self.deadline, time.monotonic() + 10) if not self.ready else time.monotonic() + 10
+        self.resolve_cancel = self.Gio.Cancellable()
+        self.resolve_source = self.GLib.timeout_add(max(1, int((self.resolve_deadline - time.monotonic()) * 1000)), self.resolve_timeout)
+        self.resolve_pass()
+
+    def resolve_timeout(self):
+        self.resolve_source = 0
+        self.stop(1)
+        return self.GLib.SOURCE_REMOVE
+
+    def resolve_pass(self):
+        self.waiting = set(self.units)
+        self.next_paths = {}
+        for name in self.units:
+            if self.stopped or time.monotonic() >= self.resolve_deadline:
+                self.stop(1)
+                return
+            try:
+                self.connection.call(self.subscribed_owner, self.path, SYSTEMD_MANAGER, "GetUnit",
+                    self.GLib.Variant("(s)", (name,)), self.GLib.VariantType.new("(o)"),
+                    self.Gio.DBusCallFlags.NO_AUTO_START,
+                    max(1, int((self.resolve_deadline - time.monotonic()) * 1000)),
+                    self.resolve_cancel, self.unit_resolved, (self.resolution_epoch, self.resolve_round, name))
+            except self.GLib.Error:
+                self.stop(1)
+                return
+
+    def unit_resolved(self, connection, result, identity):
+        epoch, round_id, name = identity
+        if (self.stopped or not self.resolving or epoch != self.resolution_epoch
+                or round_id != self.resolve_round or name not in self.waiting):
+            return
+        if time.monotonic() >= self.resolve_deadline:
+            self.stop(1)
+            return
+        try:
+            reply = connection.call_finish(result)
+            if reply.get_type_string() != "(o)" or reply.get_size() > MAX_TEXT_BYTES + 8:
+                self.stop(1)
+                return
+            path = reply.unpack()[0]
+            if not self.valid_path(path):
+                self.stop(1)
+                return
+        except self.GLib.Error as error:
+            if self.Gio.dbus_error_get_remote_error(error) != "org.freedesktop.systemd1.NoSuchUnit":
+                self.stop(1)
+                return
+            path = ""
+        if time.monotonic() >= self.resolve_deadline:
+            self.stop(1)
+            return
+        self.next_paths[name] = path
+        self.waiting.remove(name)
+        if self.waiting:
+            return
+        changed = self.paths != self.next_paths
+        self.paths = self.next_paths
+        if changed and self.ready:
+            self.changed()
+        if self.resolve_again:
+            if self.resolve_round:
+                self.stop(1)
+                return
+            self.resolve_again = False
+            self.resolve_round = 1
+            self.resolve_pass()
+            return
+        self.resolving = False
+        self.GLib.source_remove(self.resolve_source)
+        self.resolve_source = 0
+        if not self.ready:
+            try:
+                self.connection.call("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                    "GetNameOwner", self.GLib.Variant("(s)", (self.name,)), self.GLib.VariantType.new("(s)"),
+                    self.Gio.DBusCallFlags.NONE, max(1, int((self.deadline - time.monotonic()) * 1000)),
+                    self.cancellable, self.final_owner, (self.owner_epoch, self.resolution_epoch))
+            except self.GLib.Error:
+                self.stop(1)
+
+    def final_owner(self, connection, result, identity):
+        owner_epoch, resolution_epoch = identity
+        if (self.stopped or self.ready or self.resolving
+                or resolution_epoch != self.resolution_epoch):
+            return
+        if not self.resolve_owner(connection, result, owner_epoch):
+            return
+        if self.owner != self.subscribed_owner:
+            self.stop(1)
+            return
+        self.GLib.source_remove(self.deadline_source)
+        self.deadline_source = 0
+        self.ready = True
+        self.write(self.record_prefix + "\tready")
+        if self.dirty and not self.stopped:
+            self.write(self.record_prefix + "\tchanged")
+        self.dirty = False
+
+    def close_connection(self):
+        """Close only this sender's connection; never unsubscribe another client."""
+        if self.connection is None or self.closing:
+            return
+        self.closing = True
+        if self.connection.is_closed():
+            self.cleanup_done = True
+            if self.cleanup_loop is not None:
+                self.cleanup_loop.quit()
+            return
+
+        def closed(connection, result, _data):
+            try:
+                connection.close_finish(result)
+            except self.GLib.Error:
+                if not connection.is_closed():
+                    self.exit_code = 1
+            self.cleanup_done = True
+            if self.cleanup_loop is not None:
+                self.cleanup_loop.quit()
+
+        self.connection.close(None, closed, None)
+
+    def run(self):
+        if self.started:
+            raise RuntimeError("Service monitors are single-use")
+        self.started = True
+
+        def expired():
+            self.deadline_source = 0
+            self.stop(1)
+            return self.GLib.SOURCE_REMOVE
+
+        def terminate():
+            self.stop(0)
+            return self.GLib.SOURCE_CONTINUE
+
+        try:
+            self.deadline = time.monotonic() + 10
+            self.deadline_source = self.GLib.timeout_add(10000, expired)
+            for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+                self.sources.append(self.GLibUnix.signal_add(self.GLib.PRIORITY_DEFAULT, signum, terminate))
+            address = self.Gio.dbus_address_get_for_bus_sync(self.Gio.BusType.SYSTEM, self.cancellable)
+            if self.setting_up():
+                self.connecting = True
+                flags = self.Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT | self.Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION
+                self.Gio.DBusConnection.new_for_address(address, flags, None, self.cancellable, self.connected, None)
+                self.loop.run()
+        except self.GLib.Error:
+            self.stop(1)
+        finally:
+            self.stopped = True
+            self.cancellable.cancel()
+            if self.resolve_cancel is not None:
+                self.resolve_cancel.cancel()
+            if self.connection is not None:
+                for subscription in self.subscriptions:
+                    self.connection.signal_unsubscribe(subscription)
+                if self.closed_handler:
+                    self.connection.disconnect(self.closed_handler)
+            for source in self.sources + [self.deadline_source, self.resolve_source]:
+                if source:
+                    self.GLib.source_remove(source)
+            self.cleanup_loop = self.GLib.MainLoop()
+            cleanup_expired = False
+
+            def cleanup_timeout():
+                nonlocal cleanup_expired
+                cleanup_expired = True
+                self.exit_code = 1
+                self.cleanup_loop.quit()
+                return self.GLib.SOURCE_REMOVE
+
+            cleanup_source = self.GLib.timeout_add(1000, cleanup_timeout)
+            self.close_connection()
+            if not self.cleanup_done and (self.connection is not None or self.connecting):
+                self.cleanup_loop.run()
+            if not cleanup_expired:
+                self.GLib.source_remove(cleanup_source)
+        return self.exit_code
+
+
 def watch_service_events(service_kind=None) -> int:
     output_writer = None
 
@@ -8249,6 +8612,8 @@ def watch_service_events(service_kind=None) -> int:
                 monitor = UpdateEventMonitor(Gio, GLib, GLibUnix, emit)
             elif service_kind == "accounts":
                 monitor = AccountEventMonitor(Gio, GLib, GLibUnix, emit)
+            elif service_kind in WATCH_UNIT_SETS:
+                monitor = UnitEventMonitor(service_kind, Gio, GLib, GLibUnix, emit)
             else:
                 monitor = RegionalEventMonitor(service_kind, Gio, GLib, GLibUnix, emit)
             code = monitor.run()
@@ -8259,7 +8624,7 @@ def watch_service_events(service_kind=None) -> int:
             with contextlib.ExitStack() as resources:
                 error_writer = control_output_writer(sys.stderr, resources)
                 if error_writer is not None:
-                    label = "PackageKit" if service_kind is None else "Account" if service_kind == "accounts" else "Regional"
+                    label = "PackageKit" if service_kind is None else "Account" if service_kind == "accounts" else "Unit" if service_kind in WATCH_UNIT_SETS else "Regional"
                     error_writer((label + " live change monitoring is unavailable; reload status explicitly\n").encode("ascii"))
         except (OSError, ValueError):
             # Exit status remains authoritative when even diagnostics cannot
@@ -8281,11 +8646,13 @@ def watch_account_events() -> int:
 
 
 def usage() -> int:
-    print(f"usage: {sys.argv[0]} snapshot | watch-updates | watch-regional time|locale | watch-accounts | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE | timezone-set ZONE GENERATION | ntp-set enabled|disabled GENERATION | locale-set LANG=LOCALE GENERATION | accounts-open | password-open | printers-open | sources-open", file=sys.stderr)
+    print(f"usage: {sys.argv[0]} snapshot | watch-updates | watch-regional time|locale | watch-accounts | watch-units printers|security | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE | timezone-set ZONE GENERATION | ntp-set enabled|disabled GENERATION | locale-set LANG=LOCALE GENERATION | accounts-open | password-open | printers-open | sources-open", file=sys.stderr)
     return 2
 
 
 def main(argv: Sequence[str]) -> int:
+    if argv and argv[0] == "watch-units":
+        return watch_service_events(argv[1]) if len(argv) == 2 and argv[1] in WATCH_UNIT_SETS else usage()
     if argv and argv[0] == "watch-accounts":
         return watch_account_events() if len(argv) == 1 else usage()
     if argv and argv[0] == "watch-regional":

--- a/tests/fixtures/system-unit-events-bus.py
+++ b/tests/fixtures/system-unit-events-bus.py
@@ -1,0 +1,268 @@
+#!/usr/bin/python3
+"""Exercise private systemd subscriptions without calling the host system bus."""
+
+import fcntl
+import os
+import selectors
+import signal
+import subprocess
+import sys
+import time
+
+from gi.repository import Gio, GLib
+
+NAME = "org.freedesktop.systemd1"
+PATH = "/org/freedesktop/systemd1"
+MANAGER = NAME + ".Manager"
+UNIT = NAME + ".Unit"
+PROPERTIES = "org.freedesktop.DBus.Properties"
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+context = GLib.MainContext.default()
+environment = dict(os.environ, DBUS_SYSTEM_BUS_ADDRESS=os.environ["DBUS_SESSION_BUS_ADDRESS"])
+paths = {"cups.service": PATH + "/unit/CanonicalPrinter", "cups.socket": PATH + "/unit/SocketAlias",
+         "firewalld.service": PATH + "/unit/FirewallAlias"}
+calls, processes, held = [], [], []
+subscribers = set()
+mode = "normal"
+manager_xml = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.systemd1.Manager">
+<method name="Subscribe"/>
+<method name="GetUnit"><arg type="s" direction="in"/><arg type="o" direction="out"/></method>
+</interface></node>
+""").interfaces[0]
+
+
+def pump():
+    """Dispatch a bounded batch of local fixture service callbacks."""
+    for _ in range(64):
+        if not context.pending():
+            break
+        context.iteration(False)
+
+
+def line(process, seconds=3):
+    """Serve fixture calls while collecting exactly one bounded watcher line."""
+    result = b""
+    deadline = time.monotonic() + seconds
+    with selectors.DefaultSelector() as selector:
+        selector.register(process.stdout, selectors.EVENT_READ)
+        while time.monotonic() < deadline and len(result) < 128:
+            pump()
+            if selector.select(min(0.005, max(0, deadline - time.monotonic()))):
+                value = os.read(process.stdout.fileno(), 1)
+                if not value:
+                    break
+                result += value
+                if value == b"\n":
+                    break
+    return result
+
+
+def wait_for(predicate, seconds=3):
+    """Bound fixture progress while continuing to answer private-bus calls."""
+    deadline = time.monotonic() + seconds
+    while not predicate() and time.monotonic() < deadline:
+        pump()
+        time.sleep(0.005)
+    assert predicate(), "Fixture progress deadline expired"
+
+
+def emit(member, signature, values, *, path=PATH, interface=MANAGER, connection=bus, destination=None):
+    """Send controlled broadcast or directly addressed fixture notifications."""
+    connection.emit_signal(destination, path, interface, member, GLib.Variant(signature, values))
+    connection.flush_sync(None)
+
+
+def property_event(path, *, connection=bus, destination=None, malformed=False):
+    """Emit only typed unit state unless explicitly testing a malformed peer."""
+    values = (UNIT, {"ActiveState": GLib.Variant("s", "active")}, [])
+    signature = "(sa{sv}as)"
+    if malformed:
+        signature, values = "(s)", ("x" * 70000,)
+    emit("PropertiesChanged", signature, values, path=path, interface=PROPERTIES,
+         connection=connection, destination=destination)
+
+
+def called(_connection, sender, _path, _interface, method, args, invocation):
+    """Implement exactly Subscribe and fixed, non-loading GetUnit reads."""
+    calls.append((sender, method, args.unpack()))
+    if mode == "denied":
+        invocation.return_dbus_error("org.freedesktop.DBus.Error.AccessDenied", "fixture denial")
+    elif mode == "stall" or mode == "stall-unit" and method == "GetUnit":
+        held.append(invocation)
+    elif method == "Subscribe":
+        assert sender not in subscribers, "Duplicate Subscribe on one sender"
+        subscribers.add(sender)
+        invocation.return_value(GLib.Variant("()", ()))
+    else:
+        assert method == "GetUnit" and sender in subscribers
+        name = args.unpack()[0]
+        assert name in ("cups.service", "cups.socket", "firewalld.service")
+        if mode == "burst":
+            emit("UnitNew", "(so)", ("unrelated.service", PATH + "/unit/Unrelated"))
+        if mode == "malformed":
+            invocation.return_value(GLib.Variant("(o)", ("/wrong_scope",)))
+        elif name not in paths:
+            invocation.return_dbus_error("org.freedesktop.systemd1.NoSuchUnit", "not loaded")
+        else:
+            invocation.return_value(GLib.Variant("(o)", (paths[name],)))
+
+
+def owner_changed(_connection, _sender, _path, _interface, _member, args, _data):
+    """Mirror systemd's sender-owned subscription cleanup on disconnect."""
+    name, old, new = args.unpack()
+    if old and not new:
+        subscribers.discard(name)
+
+
+def launch(kind="printers", *, output=None):
+    """Launch a real fixed CLI command on the disposable bus."""
+    process = subprocess.Popen([sys.argv[1], "watch-units", kind], env=environment,
+        stdout=subprocess.PIPE if output is None else output, stderr=subprocess.PIPE, bufsize=0)
+    processes.append(process)
+    return process
+
+
+def stop(process, signum=signal.SIGTERM, expected=0):
+    """Require bounded shutdown and no unexpected diagnostics."""
+    process.send_signal(signum)
+    wait_for(lambda: process.poll() is not None)
+    assert process.returncode == expected, (process.returncode, process.stderr.read())
+    if expected == 0:
+        assert process.stderr.read() == b""
+
+
+registration = bus.register_object(PATH, manager_xml, called, None, None)
+owner_subscription = bus.signal_subscribe("org.freedesktop.DBus", "org.freedesktop.DBus", "NameOwnerChanged",
+    "/org/freedesktop/DBus", None, Gio.DBusSignalFlags.NONE, owner_changed, None)
+outsider = Gio.DBusConnection.new_for_address_sync(os.environ["DBUS_SESSION_BUS_ADDRESS"],
+    Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT | Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION, None, None)
+try:
+    reply = bus.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+        "RequestName", GLib.Variant("(su)", (NAME, 0)), GLib.VariantType.new("(u)"), Gio.DBusCallFlags.NONE, 3000, None)
+    assert reply.unpack() == (1,)
+    process = launch()
+    assert line(process) == b"units-event\tready\n"
+    assert [call[1] for call in calls] == ["Subscribe", "GetUnit", "GetUnit"], calls
+    first_sender = calls[0][0]
+    assert first_sender != bus.get_unique_name()
+    before = len(calls)
+    assert line(process, 0.2) == b"" and len(calls) == before
+    property_event(paths["cups.service"])
+    assert line(process) == b"units-event\tchanged\n"
+    property_event(paths["cups.service"], connection=outsider, destination=first_sender, malformed=True)
+    property_event(PATH + "/unit/Unrelated")
+    assert line(process, 0.2) == b"" and process.poll() is None
+    emit("UnitNew", "(so)", ("unrelated.service", PATH + "/unit/Unrelated"))
+    assert line(process, 0.2) == b""
+    assert len(calls) == before + 2
+    # A requested alias can resolve to an unrelated-looking canonical name.
+    paths["cups.service"] = PATH + "/unit/NewCanonical"
+    emit("UnitNew", "(so)", ("canonical.service", paths["cups.service"]))
+    assert line(process) == b"units-event\tchanged\n"
+    property_event(paths["cups.service"])
+    assert line(process) == b"units-event\tchanged\n"
+    old_path = paths.pop("cups.socket")
+    emit("UnitRemoved", "(so)", ("canonical.socket", old_path))
+    assert line(process) == b"units-event\tchanged\n"
+    assert line(process) == b"units-event\tchanged\n"
+    assert line(process, 0.1) == b""
+    # Another monitor's subscription survives the first private connection.
+    second = launch("security")
+    assert line(second) == b"units-event\tready\n"
+    second_sender = next(sender for sender in subscribers if sender != first_sender)
+    stop(process)
+    wait_for(lambda: first_sender not in subscribers)
+    assert second_sender in subscribers
+    property_event(paths["firewalld.service"])
+    assert line(second) == b"units-event\tchanged\n"
+    stop(second, signal.SIGKILL, -signal.SIGKILL)
+    wait_for(lambda: not subscribers)
+    # Initially unloaded fixed names remain dormant until a canonical arrival.
+    paths.clear()
+    process = launch()
+    assert line(process) == b"units-event\tready\n"
+    paths["cups.socket"] = PATH + "/unit/LaterSocket"
+    emit("UnitNew", "(so)", ("other-name.socket", paths["cups.socket"]))
+    assert line(process) == b"units-event\tchanged\n"
+    stop(process, signal.SIGINT)
+    wait_for(lambda: not subscribers)
+    for signum in (signal.SIGHUP, signal.SIGTERM):
+        process = launch("security")
+        assert line(process) == b"units-event\tready\n"
+        stop(process, signum)
+        wait_for(lambda: not subscribers)
+    for mode in ("denied", "malformed", "burst"):
+        before = len(calls)
+        process = launch()
+        assert line(process) == b""
+        wait_for(lambda: process.poll() is not None)
+        assert process.returncode == 1 and b"reload status explicitly" in process.stderr.read()
+        assert len(calls) - before <= 5, calls[before:]
+        wait_for(lambda: not subscribers)
+    mode = "stall"
+    process = launch()
+    started = time.monotonic()
+    assert line(process, 12) == b""
+    wait_for(lambda: process.poll() is not None)
+    assert 9 <= time.monotonic() - started < 12
+    assert process.returncode == 1 and b"reload status explicitly" in process.stderr.read()
+    assert len(held) == 1
+    held.pop().return_dbus_error("org.freedesktop.DBus.Error.NoReply", "late fixture reply")
+    mode = "stall-unit"
+    process = launch()
+    wait_for(lambda: len(held) == 2)
+    assert len(subscribers) == 1
+    stop(process)
+    wait_for(lambda: not subscribers)
+    for invocation in held:
+        invocation.return_dbus_error("org.freedesktop.DBus.Error.NoReply", "late canceled lookup")
+    held.clear()
+    mode = "normal"
+    for closed in (False, True):
+        read_fd, write_fd = os.pipe()
+        try:
+            if closed:
+                os.close(read_fd)
+                read_fd = -1
+            else:
+                os.set_blocking(write_fd, False)
+                try:
+                    while True:
+                        os.write(write_fd, b"x" * 4096)
+                except BlockingIOError:
+                    pass
+                os.set_blocking(write_fd, True)
+            flags = fcntl.fcntl(write_fd, fcntl.F_GETFL)
+            process = launch(output=write_fd)
+            wait_for(lambda: process.poll() is not None)
+            assert process.returncode == 1
+            assert fcntl.fcntl(write_fd, fcntl.F_GETFL) == flags
+            wait_for(lambda: not subscribers)
+        finally:
+            os.close(write_fd)
+            if read_fd >= 0:
+                os.close(read_fd)
+    process = launch()
+    assert line(process) == b"units-event\tready\n"
+    bus.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus", "ReleaseName",
+        GLib.Variant("(s)", (NAME,)), GLib.VariantType.new("(u)"), Gio.DBusCallFlags.NONE, 3000, None)
+    wait_for(lambda: process.poll() is not None)
+    assert process.returncode == 1
+    wait_for(lambda: not subscribers)
+    process = launch()
+    assert line(process) == b""
+    wait_for(lambda: process.poll() is not None)
+    assert process.returncode == 1
+    print("Private-bus unit events: PASS")
+finally:
+    for process in processes:
+        if process.poll() is None:
+            process.kill()
+        process.wait(timeout=3)
+        if process.stdout is not None:
+            process.stdout.close()
+        process.stderr.close()
+    outsider.close_sync(None)
+    bus.signal_unsubscribe(owner_subscription)
+    bus.unregister_object(registration)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -2897,6 +2897,168 @@ class AccountEventMonitorTests(unittest.TestCase):
             self.assertEqual(result.stdout, expected)
 
 
+class UnitEventMonitorTests(unittest.TestCase):
+    def monitor(self, kind="printers"):
+        _regional, emitted, gio, glib, unix = RegionalEventMonitorTests().monitor()
+        monitor = provider.UnitEventMonitor(kind, gio, glib, unix, emitted.append)
+        monitor.deadline = time.monotonic() + 10
+        monitor.deadline_source = 7
+        monitor.connection = mock.Mock()
+        gio.DBusConnection.new_for_address_finish.return_value = monitor.connection
+        return monitor, emitted, gio, glib, unix
+
+    def resolve(self, monitor, glib):
+        identity = (monitor.resolution_epoch, monitor.resolve_round)
+        for index, name in enumerate(monitor.units):
+            monitor.connection.call_finish.return_value = glib.Variant("(o)",
+                (provider.SYSTEMD_PATH + "/unit/Alias" + str(index),))
+            monitor.unit_resolved(monitor.connection, object(), (*identity, name))
+
+    def setup(self, monitor, glib, finish=True):
+        connection = monitor.connection
+        monitor.connected(None, object(), None)
+        for index, rule in enumerate(monitor.match_rules):
+            connection.call_finish.return_value = glib.Variant("()", ())
+            monitor.match_finished(connection, object(), rule)
+            if index == 0:
+                connection.call_finish.return_value = glib.Variant("(s)", (":1.2",))
+                monitor.owner_initialized(connection, object(), 0)
+        connection.call_finish.return_value = glib.Variant("(s)", (":1.2",))
+        monitor.owner_resolved(connection, object(), 0)
+        connection.call_finish.return_value = glib.Variant("()", ())
+        monitor.subscribed(connection, object(), None)
+        self.resolve(monitor, glib)
+        if finish:
+            connection.call_finish.return_value = glib.Variant("(s)", (":1.2",))
+            monitor.final_owner(connection, object(), (0, monitor.resolution_epoch))
+
+    def manager(self, monitor, glib, member="UnitNew", sender=":1.2"):
+        monitor.manager_event(None, sender, monitor.path, provider.SYSTEMD_MANAGER, member,
+            glib.Variant("(so)", ("unrelated.service", provider.SYSTEMD_PATH + "/unit/Unknown")), None)
+
+    def test_private_connection_fixed_calls_and_all_barriers_precede_readiness(self):
+        for kind, count in (("printers", 2), ("security", 1)):
+            monitor, emitted, gio, glib, _unix = self.monitor(kind)
+            self.setup(monitor, glib)
+            self.assertEqual(emitted, ["units-event\tready"])
+            gio.bus_get.assert_not_called()
+            gio.bus_get_finish.assert_not_called()
+            calls = monitor.connection.call.call_args_list
+            self.assertEqual([call.args[3] for call in calls],
+                ["AddMatch", "GetNameOwner", *(["AddMatch"] * 5), "GetNameOwner",
+                 "Subscribe", *(["GetUnit"] * count), "GetNameOwner"])
+            system_calls = [call for call in calls if call.args[0] == ":1.2"]
+            self.assertEqual([call.args[3] for call in system_calls], ["Subscribe", *(["GetUnit"] * count)])
+            self.assertEqual([call.args[4].unpack()[0] for call in system_calls[1:]], list(monitor.units))
+            self.assertTrue(all(call.args[6] == gio.DBusCallFlags.NO_AUTO_START for call in system_calls))
+            subscriptions = monitor.connection.signal_subscribe.call_args_list
+            self.assertEqual(len(subscriptions), 6)
+            self.assertEqual(subscriptions[-1].args[3:5], (None, provider.SYSTEMD_NAME + ".Unit"))
+            self.assertEqual(set(monitor.paths), set(monitor.units))
+
+    def test_authentication_precedes_decoding_during_setup_and_after_readiness(self):
+        for ready in (False, True):
+            monitor, emitted, _gio, glib, _unix = self.monitor()
+            monitor.ready = ready
+            for owner in ("", ":1.2"):
+                monitor.owner = owner
+                bad = glib.Variant("(s)", ("x" * 70000,))
+                monitor.manager_event(None, ":1.9", monitor.path, provider.SYSTEMD_MANAGER, "UnitNew", bad, None)
+                monitor.properties_changed(None, ":1.9", provider.SYSTEMD_PATH + "/unit/Alias",
+                    provider.PROPERTIES_INTERFACE, "PropertiesChanged", bad, None)
+            self.assertFalse(monitor.stopped)
+            self.assertFalse(monitor.dirty)
+            self.assertEqual(emitted, [])
+
+    def test_reconciliation_has_one_settling_pass_and_rejects_late_epochs(self):
+        monitor, emitted, _gio, glib, _unix = self.monitor()
+        self.setup(monitor, glib)
+        monitor.connection.call.reset_mock()
+        self.manager(monitor, glib)
+        old_identity = (monitor.resolution_epoch - 1, 0, monitor.units[0])
+        monitor.unit_resolved(monitor.connection, object(), old_identity)
+        self.assertEqual(monitor.waiting, set(monitor.units))
+        for _ in range(100):
+            self.manager(monitor, glib)
+        self.resolve(monitor, glib)
+        self.assertEqual(monitor.resolve_round, 1)
+        for _ in range(100):
+            self.manager(monitor, glib)
+        self.resolve(monitor, glib)
+        self.assertTrue(monitor.stopped)
+        self.assertEqual(monitor.exit_code, 1)
+        self.assertEqual(len(monitor.connection.call.call_args_list), 4)
+        self.assertEqual(emitted, ["units-event\tready"])
+
+    def test_event_during_final_barrier_cannot_publish_stale_or_duplicate_ready(self):
+        monitor, emitted, _gio, glib, _unix = self.monitor()
+        self.setup(monitor, glib, finish=False)
+        old = (0, monitor.resolution_epoch)
+        self.manager(monitor, glib)
+        monitor.connection.call_finish.return_value = glib.Variant("(s)", (":1.2",))
+        monitor.final_owner(monitor.connection, object(), old)
+        self.assertEqual(emitted, [])
+        self.resolve(monitor, glib)
+        monitor.connection.call_finish.return_value = glib.Variant("(s)", (":1.2",))
+        current = (0, monitor.resolution_epoch)
+        monitor.final_owner(monitor.connection, object(), current)
+        monitor.final_owner(monitor.connection, object(), old)
+        monitor.final_owner(monitor.connection, object(), current)
+        self.assertEqual(emitted, ["units-event\tready"])
+
+    def test_typed_scope_deadline_and_owner_loss_fail_without_reconnect(self):
+        for invalid in ("signature", "path", "deadline", "owner"):
+            monitor, emitted, gio, glib, _unix = self.monitor()
+            self.setup(monitor, glib)
+            if invalid == "owner":
+                RegionalEventMonitorTests().owner(monitor, glib, ":1.2", ":1.3")
+            else:
+                monitor.reconcile()
+                if invalid == "deadline":
+                    monitor.resolve_deadline = time.monotonic() - 1
+                signature, value = ("(s)", "bad") if invalid == "signature" else ("(o)", "/wrong_scope")
+                monitor.connection.call_finish.return_value = glib.Variant(signature, (value,))
+                monitor.unit_resolved(monitor.connection, object(),
+                    (monitor.resolution_epoch, monitor.resolve_round, monitor.units[0]))
+            self.assertTrue(monitor.stopped)
+            self.assertEqual(monitor.exit_code, 1)
+            gio.bus_get.assert_not_called()
+            self.assertEqual(emitted[0], "units-event\tready")
+
+    def test_property_bounds_and_synchronous_call_errors_fail_closed(self):
+        for signature, value in (("(s)", ("x",)),
+                ("(sa{sv}as)", (provider.SYSTEMD_NAME + ".Unit", {"ActiveState": None}, []))):
+            monitor, emitted, _gio, glib, _unix = self.monitor()
+            self.setup(monitor, glib)
+            if signature == "(sa{sv}as)":
+                value[1]["ActiveState"] = glib.Variant("b", True)
+            monitor.properties_changed(None, ":1.2", monitor.paths[monitor.units[0]],
+                provider.PROPERTIES_INTERFACE, "PropertiesChanged", glib.Variant(signature, value), None)
+            self.assertTrue(monitor.stopped)
+            self.assertEqual(emitted, ["units-event\tready"])
+        monitor, _emitted, _gio, glib, _unix = self.monitor()
+        self.setup(monitor, glib)
+        monitor.connection.call.side_effect = glib.Error("fixture call failure")
+        monitor.reconcile()
+        self.assertTrue(monitor.stopped)
+
+    def test_cli_grammar_and_real_private_bus_lifecycle(self):
+        with mock.patch.object(provider, "watch_service_events", return_value=0) as watch, \
+                mock.patch.object(provider, "PackageKitBackend") as backend, \
+                contextlib.redirect_stderr(io.StringIO()):
+            for kind in ("printers", "security"):
+                self.assertEqual(provider.main(["watch-units", kind]), 0)
+            for args in ([], ["cups.service"], ["printers", "extra"], ["--system"]):
+                self.assertEqual(provider.main(["watch-units", *args]), 2)
+            self.assertEqual(watch.call_args_list, [mock.call("printers"), mock.call("security")])
+            backend.assert_not_called()
+        result = subprocess.run(["dbus-run-session", "--", "/usr/bin/python3",
+            str(REPO / "tests/fixtures/system-unit-events-bus.py"), str(PROVIDER_PATH)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=45)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "Private-bus unit events: PASS\n")
+
+
 class NtpReadTests(unittest.TestCase):
     def reader(self):
         _regional, connection, gio, glib, variant = RegionalReadTests().reader()


### PR DESCRIPTION
## Summary

- Add fixed read-only `watch-units printers|security` streams for the CUPS service/socket and firewalld service.
- Use a private asynchronous D-Bus connection, authenticated unique senders, six acknowledged matches, sender-owned systemd `Subscribe`, fixed non-loading `GetUnit` lookups, and a final owner barrier before readiness.
- Resolve canonical aliases and initially unloaded units without guessing object paths or enumerating arbitrary units. Each in-flight event burst gets at most one fixed lookup pass and one settling pass under a ten-second deadline.
- Keep cleanup private to this sender; wait at most one second for connection-close evidence. Output loss, denied/malformed state, owner replacement, or an unstable burst fails with explicit-refresh guidance.
- Do not load/reference/start units, request authorization, add an idle poller, enable Settings controls, or change the cumulative protocol minor.

## Validation

- Focused monitor and CUPS regression command: 46 tests passed in 43.066 seconds.
- Real private-bus fixtures cover aliases, dormant units becoming loaded, authentication before parsing, independent subscribers, clean TERM/INT/HUP, SIGKILL disconnection, subscription denial, malformed replies, bounded event bursts, a real ten-second setup timeout, canceled in-flight lookups and late replies, full/closed output with unchanged inherited flags, absent systemd, and owner loss.
- Callback regressions cover stale resolution epochs and an event arriving during the final owner barrier without stale or duplicate readiness.
- Read-only Fedora 44 host: both printer and security watchers reached readiness, emitted zero events, and used zero sampled CPU ticks over 30 seconds; both stopped cleanly with empty stderr.
- Documentation check/build: 15 files, zero diagnostics, 11 pages.
- Local independent CodeRabbit review: six files, zero findings.
- `scripts/run-tests make clean all && scripts/run-tests`: complete gate passed, including 529 system-management tests in 222.443 seconds, QML/native lifecycle, shell/static gates, package-map, staged install/uninstall symmetry, repeated install preservation, and release-archive checks. Closed Settings CPU 0.033%, large closed surfaces 0.00%; power baseline 0.133%, after 0.033%, delta 0.100 percentage points. The staged tree remained fixed and managed workspaces were removed.
- Required post-gate Codex review: completed with zero actionable correctness or security findings.

## Design notes and limitations

`GetUnit` observes loaded state. The separate finite CUPS reader still uses `ListUnitsByNames`, which may load fixed unit configuration but never starts CUPS. The monitor does not use that method. `RefUnit` is deliberately excluded because it requires manage-units authorization.

Manager arrivals may announce canonical names unrelated to a requested alias. They trigger only bounded fixed-name mapping lookups; an unrelated arrival with unchanged mappings does not invalidate the UI. Unit-file and completed-reload notifications also reconcile aliases. No unrelated unit identities are retained.

Settings integration, cumulative provider activation, and combined Phase 6 qualification remain outstanding. No host service settings or account settings were changed.