### PR TITLE
feat(system): compose cumulative native discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ versions from `config.mk`.
 
 ### Changed
 
+- Add complete cumulative regional, account, printer, and software-source
+  discovery with a backward-compatible Settings parser. Preserve readable
+  state when a service or tool is missing, independently gate native admission,
+  and enforce complete bounded lists. New Settings action controls remain pending.
+
 - Add fixed read-only printer and firewall unit event monitors with private
   subscription ownership, canonical-alias discovery, bounded reconciliation,
   and no idle polling or service activation. Settings integration remains pending.

--- a/TASKS.md
+++ b/TASKS.md
@@ -239,7 +239,7 @@ actual CLI/private-bus fixtures cover all three actions, denial, stale
 confirmation, write failures, lost output, replay, and acknowledgment without
 repeating the action. Graphical polkit and host mutations are not qualified.
 Post-timeout Settings display refresh and originating Settings controls remain
-outstanding; the snapshot minor remains zero.
+outstanding; cumulative minor 1 discovery is described below.
 
 The four fixed delegated CLI origins now resolve trusted administration tools,
 preserve configured terminal selection for the fixed password command, and
@@ -251,8 +251,8 @@ terminal retention, and replay preserve ownership without tracking the tools'
 internal administration. Unit and real private-child fixtures cover trust,
 selection, denial/failure, lost output, child isolation, and later tool failure
 without falsely reporting its work as completed. No real administration tool or
-password prompt was opened. Settings origins and cumulative minor 1 discovery
-remain outstanding.
+password prompt was opened. Settings origins remain outstanding; cumulative
+minor 1 discovery is described below.
 A read-only Fedora 44 probe resolved the password command through Alacritty in
 0.056 seconds and found the printer tool available. Account and source tools
 were absent and returned their scoped missing-provider results; none was opened.
@@ -265,7 +265,7 @@ would repeatedly reactivate the service. Output loss and bus loss fail with
 explicit reload guidance. An internal NTP reader samples only CanNTP and
 NTPSynchronized under one ten-second budget, without enabling a polling loop.
 Settings subscription handoff, two-read settling, and visible-only sampling
-remain outstanding; the cumulative snapshot minor remains zero.
+remain outstanding; cumulative minor 1 discovery is described below.
 The 38 focused tests pass, including private-bus lifecycle, owner denial,
 output isolation, and real ten-second read deadlines. A read-only Fedora 44
 probe observed each monitor for 36 seconds after its initial service read:
@@ -288,7 +288,8 @@ the regional monitor's owner barriers, bounded output, and quiet departure.
 The 45 focused tests pass, including real signals during enumeration and an
 excluded account changing eligibility during property reads. Setup-unicast,
 owner/denial, full/closed output, and shutdown fixtures also pass. Settings
-activation, two-read settling, and cumulative minor 1 remain outstanding.
+activation and two-read settling remain outstanding; cumulative minor 1 discovery
+is described below.
 A read-only Fedora 44 probe returned one available account row in 0.028
 seconds. The monitor emitted no events and used zero sampled CPU ticks over
 30 seconds, then terminated cleanly. No account or host setting was changed.
@@ -305,8 +306,25 @@ forged notifications, bounded bursts, denial, malformed state, actual setup
 timeout, canceled lookups, full/closed output, and owner loss. Real Fedora 44
 printer and security watchers each emitted zero events and used zero sampled
 CPU ticks over 30 seconds, then stopped cleanly. No host service was changed.
-Settings integration, cumulative minors, and combined qualification remain
-outstanding.
+Settings integration and combined qualification remain outstanding; cumulative
+minor 1 discovery is implemented below.
+
+The managed snapshot now emits the complete cumulative minor 1 provider, state,
+action, account, and repository set. Separate native admission verifies Fedora
+and the fixed journal without depending on update security or logind evidence.
+Missing tools and independent reader failures preserve readable unrelated state;
+partial account inventories retain only their validated bounded subset. The
+producer reserves non-list and total output bytes before publication. The
+Settings parser accepts both minor 0 and 1, validates mandatory records and
+closed fields, isolates owned failures, and removes invalid-owner actions.
+Focused producer/recovery tests and 204 nested-X11 parser assertions pass without
+launching tools or changing host settings. Existing update-only and operation
+streams retain minor 0. Originating native controls, confirmation/monitor
+coordination, NTP sampling, and combined installed qualification remain pending.
+A read-only Fedora 44 cumulative snapshot completed in 2.70 seconds with all
+mandatory records, one account, 28 repositories, 31 updates, and 37 package-change
+rows. Missing tools and unavailable logind evidence were independently reported;
+the isolated test journal was removed and no tool or mutation was dispatched.
 
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit

--- a/config/quickshell/systemmanagement/SystemManagementModel.qml
+++ b/config/quickshell/systemmanagement/SystemManagementModel.qml
@@ -19,6 +19,10 @@ Scope {
     property var actions: []
     property var updates: []
     property var packageChanges: []
+    property var nativeProviders: ({})
+    property var nativeStates: ({})
+    property var accounts: []
+    property var repositories: []
     property var errors: []
     property var activeOperation: null
     property var terminalHandoff: null
@@ -211,6 +215,37 @@ Scope {
         return "";
     }
 
+    function nativeStateOwner(identifier) {
+        if (identifier === "timezone" || identifier === "ntp-enabled"
+                || identifier === "ntp-synchronized" || identifier === "locale") return "regional";
+        if (identifier === "accounts-count") return "accounts";
+        if (identifier === "cups-service") return "printers";
+        return "";
+    }
+
+    function nativeActionOwner(identifier) {
+        if (identifier === "timezone-set" || identifier === "ntp-set" || identifier === "locale-set") return "regional";
+        if (identifier === "accounts-open" || identifier === "password-open") return "accounts";
+        if (identifier === "printers-open") return "printers";
+        if (identifier === "sources-open") return "sources";
+        return "";
+    }
+
+    function validNativeValue(identifier, status, value) {
+        if (identifier === "accounts-count")
+            return status === "available" ? /^(0|[1-9][0-9]*)$/.test(value)
+                && Number(value) <= 256 : value === "unknown";
+        if (identifier === "cups-service")
+            return status === "available" ? (value === "running" || value === "socket-ready" || value === "stopped")
+                : value === "unknown";
+        if (identifier === "ntp-enabled" || identifier === "ntp-synchronized")
+            return status === "available" ? (value === "yes" || value === "no") : value === "unknown";
+        // An explicit LANG= is readable unset configuration, not a malformed
+        // regional provider. A replacement still requires its own fresh preview.
+        if (identifier === "locale") return status === "available" || value === "unknown";
+        return value.length > 0 && (status === "available" || value === "unknown");
+    }
+
     function clearState(detail) {
         root.snapshotState = "failure";
         root.message = detail;
@@ -223,6 +258,10 @@ Scope {
         root.actions = [];
         root.updates = [];
         root.packageChanges = [];
+        root.nativeProviders = {};
+        root.nativeStates = {};
+        root.accounts = [];
+        root.repositories = [];
         root.errors = [];
         root.activeOperation = null;
         root.terminalHandoff = null;
@@ -236,6 +275,7 @@ Scope {
         }
 
         let headerSeen = false;
+        let minor = 0;
         let completeSeen = false;
         let parsedGeneration = "";
         let fatal = "";
@@ -264,6 +304,17 @@ Scope {
         const seenActions = {};
         const seenUpdates = {};
         const seenChanges = {};
+        const nativeOwners = ["regional", "accounts", "printers", "sources"];
+        const nativeStateIds = ["timezone", "ntp-enabled", "ntp-synchronized", "locale", "accounts-count", "cups-service"];
+        const nativeActionIds = ["timezone-set", "ntp-set", "locale-set", "accounts-open", "password-open", "printers-open", "sources-open"];
+        const nativeInvalid = {};
+        const parsedNativeProviders = {};
+        const nativeLists = { account: [], repository: [] };
+        const nativeListCounts = { account: 0, repository: 0 };
+        const nativeListBytes = { account: 0, repository: 0 };
+        const nativeSeen = { account: {}, repository: {} };
+        let nonListBytes = 0;
+        let listRecordCount = 0;
 
         for (const rawLine of text.split("\n")) {
             if (rawLine.length === 0) continue;
@@ -278,13 +329,28 @@ Scope {
                 break;
             }
             recordIndex++;
+            if (type === "update" || type === "package-change" || type === "account" || type === "repository") {
+                // Keep duplicate tracking through a provider-local overflow,
+                // while the complete protocol reservation bounds its memory.
+                if (++listRecordCount > 9216) {
+                    fatal = "System management provider exceeded the overall list reservation";
+                    break;
+                }
+            } else {
+                nonListBytes += root.utf8Bytes(rawLine) + 1;
+                if (nonListBytes > 1024 * 1024) {
+                    fatal = "System management provider exceeded the non-list byte reservation";
+                    break;
+                }
+            }
 
             if (type === "system-management-protocol") {
-                if (headerSeen || fields.length < 3 || fields[1] !== "1" || fields[2] !== "0") {
+                if (headerSeen || fields.length < 3 || fields[1] !== "1" || (fields[2] !== "0" && fields[2] !== "1")) {
                     fatal = "System management provider returned an unsupported protocol";
                     break;
                 }
                 headerSeen = true;
+                minor = Number(fields[2]);
             } else if (type === "snapshot-generation") {
                 if (parsedGeneration.length > 0 || fields.length < 2
                         || !root.validGeneration(fields[1])) {
@@ -293,6 +359,18 @@ Scope {
                 }
                 parsedGeneration = fields[1];
             } else if (type === "provider") {
+                if (minor === 1 && fields.length >= 2 && nativeOwners.indexOf(fields[1]) !== -1) {
+                    const owner = fields[1];
+                    if (seenProviders["$" + owner] !== undefined) {
+                        fatal = "System management provider repeated a provider record";
+                        break;
+                    }
+                    seenProviders["$" + owner] = true;
+                    if (!root.fieldsFit(fields, 6) || !root.validProviderStatus(fields[2]) || fields[3] !== "delegated") {
+                        nativeInvalid[owner] = true;
+                    } else parsedNativeProviders[owner] = { status: fields[2], providerClass: fields[3], owner: fields[4], detail: fields[5] };
+                    continue;
+                }
                 if (fields.length < 2 || (fields[1] !== "updates" && fields[1] !== "recovery")) {
                     fatal = "System management provider returned an unknown provider owner";
                     break;
@@ -321,6 +399,18 @@ Scope {
                     parsedRecoveryProvider = provider;
                 }
             } else if (type === "state") {
+                const owner = fields.length >= 2 ? root.nativeStateOwner(fields[1]) : "";
+                if (minor === 1 && owner.length > 0) {
+                    if (seenStates["$" + fields[1]] !== undefined) {
+                        fatal = "System management provider repeated a state record";
+                        break;
+                    }
+                    seenStates["$" + fields[1]] = true;
+                    if (!root.fieldsFit(fields, 5) || !root.validProviderStatus(fields[2])
+                            || !root.validNativeValue(fields[1], fields[2], fields[3])) nativeInvalid[owner] = true;
+                    else states["$" + fields[1]] = { status: fields[2], value: fields[3], detail: fields[4] };
+                    continue;
+                }
                 if (fields.length < 2 || (fields[1] !== "update-summary"
                         && fields[1] !== "update-last-refresh"
                         && fields[1] !== "update-restart")) {
@@ -355,6 +445,19 @@ Scope {
                 states["$" + fields[1]] = { "status": fields[2], "value": fields[3],
                     "detail": fields[4] };
             } else if (type === "action") {
+                const owner = fields.length >= 2 ? root.nativeActionOwner(fields[1]) : "";
+                if (minor === 1 && owner.length > 0) {
+                    if (seenActions["$" + fields[1]] !== undefined) {
+                        fatal = "System management provider repeated an action record";
+                        break;
+                    }
+                    seenActions["$" + fields[1]] = true;
+                    if (!root.fieldsFit(fields, 7) || (fields[2] !== "available" && fields[2] !== "unavailable")
+                            || fields[3] !== "delegated" || fields[4] !== owner) nativeInvalid[owner] = true;
+                    else parsedActions["$" + fields[1]] = { id: fields[1], availability: fields[2], actionClass: fields[3],
+                        owner: fields[4], label: fields[5], detail: fields[6] };
+                    continue;
+                }
                 if (fields.length < 2 || (fields[1] !== "updates-refresh"
                         && fields[1] !== "updates-install-all"
                         && fields[1] !== "updates-cancel")) {
@@ -377,16 +480,16 @@ Scope {
                     "owner": fields[4], "label": fields[5], "detail": fields[6] };
             } else if (type === "update") {
                 updateRecordCount++;
-                if (updateRecordCount > 4096) {
-                    updatesInvalid = true;
-                    continue;
-                }
                 if (fields.length >= 2 && fields[1].length > 0) {
                     if (seenUpdates["$" + fields[1]] !== undefined) {
                         fatal = "System management provider repeated an update identity";
                         break;
                     }
                     seenUpdates["$" + fields[1]] = true;
+                }
+                if (updateRecordCount > 4096) {
+                    updatesInvalid = true;
+                    continue;
                 }
                 if (!root.fieldsFit(fields, 7) || fields[1].length === 0
                         || !root.validSeverity(fields[2])
@@ -406,16 +509,16 @@ Scope {
                 updateBytes += recordBytes;
             } else if (type === "package-change") {
                 changeRecordCount++;
-                if (changeRecordCount > 4096) {
-                    planInvalid = true;
-                    continue;
-                }
                 if (fields.length >= 2 && fields[1].length > 0) {
                     if (seenChanges["$" + fields[1]] !== undefined) {
                         fatal = "System management provider repeated a plan identity";
                         break;
                     }
                     seenChanges["$" + fields[1]] = true;
+                }
+                if (changeRecordCount > 4096) {
+                    planInvalid = true;
+                    continue;
                 }
                 if (!root.fieldsFit(fields, 6) || fields[1].length === 0
                         || !root.validPlanAction(fields[2]) || fields[3].length === 0
@@ -431,6 +534,39 @@ Scope {
                 parsedChanges.push({ "packageId": fields[1], "action": fields[2],
                     "name": fields[3], "version": fields[4], "summary": fields[5] });
                 changeBytes += recordBytes;
+            } else if (type === "account" || type === "repository") {
+                if (minor !== 1) {
+                    fatal = "System management provider returned an inactive list owner";
+                    break;
+                }
+                const owner = type === "account" ? "accounts" : "sources";
+                if (fields.length < 2 || fields[1].length === 0) {
+                    fatal = "System management provider returned a list without an identity";
+                    break;
+                }
+                if (nativeSeen[type]["$" + fields[1]] !== undefined) {
+                    fatal = "System management provider repeated a list identity";
+                    break;
+                }
+                nativeSeen[type]["$" + fields[1]] = true;
+                nativeListCounts[type]++;
+                nativeListBytes[type] += root.utf8Bytes(rawLine) + 1;
+                const account = type === "account";
+                if (nativeListCounts[type] > (account ? 256 : 512)
+                        || nativeListBytes[type] > (account ? 256 : 384) * 1024) {
+                    nativeInvalid[owner] = true;
+                    continue;
+                }
+                if (!root.fieldsFit(fields, account ? 5 : 4)
+                        || (account ? (fields[2] !== "current" && fields[2] !== "other")
+                            : (fields[2] !== "enabled" && fields[2] !== "disabled"))
+                        || (account && fields[4].length === 0)) {
+                    nativeInvalid[owner] = true;
+                    continue;
+                }
+                if (!nativeInvalid[owner]) nativeLists[type].push(account
+                    ? { id: fields[1], scope: fields[2], displayName: fields[3], loginName: fields[4] }
+                    : { id: fields[1], state: fields[2], description: fields[3] });
             } else if (type === "error") {
                 errorRecordCount++;
                 const recordBytes = root.utf8Bytes(rawLine) + 1;
@@ -439,6 +575,11 @@ Scope {
                     break;
                 }
                 errorBytes += recordBytes;
+                if (minor === 1 && fields.length >= 2 && nativeOwners.indexOf(fields[1]) !== -1) {
+                    if (!root.fieldsFit(fields, 4) || !root.validErrorCode(fields[2])) nativeInvalid[fields[1]] = true;
+                    else parsedErrors.push({ provider: fields[1], code: fields[2], detail: fields[3] });
+                    continue;
+                }
                 if (fields.length < 2 || (fields[1] !== "updates" && fields[1] !== "recovery")) {
                     fatal = "System management provider returned an unknown error owner";
                     break;
@@ -502,6 +643,26 @@ Scope {
                 || parsedActions["$updates-install-all"] === undefined
                 || parsedActions["$updates-cancel"] === undefined) updatesInvalid = true;
         if (parsedRecoveryProvider === null) recoveryInvalid = true;
+        if (minor === 1) {
+            for (const owner of nativeOwners) {
+                if (parsedNativeProviders[owner] === undefined) nativeInvalid[owner] = true;
+            }
+            for (const identifier of nativeStateIds) {
+                if (states["$" + identifier] === undefined) nativeInvalid[root.nativeStateOwner(identifier)] = true;
+            }
+            for (const identifier of nativeActionIds) {
+                if (parsedActions["$" + identifier] === undefined) nativeInvalid[root.nativeActionOwner(identifier)] = true;
+            }
+            if (!nativeInvalid.accounts) {
+                const count = states["$accounts-count"];
+                if ((count.status === "available" && Number(count.value) !== nativeLists.account.length)
+                        || (count.status !== "available" && count.status !== "partial" && nativeLists.account.length > 0)
+                        || nativeLists.account.filter(item => item.scope === "current").length > 1) nativeInvalid.accounts = true;
+            }
+            if (!nativeInvalid.sources && nativeLists.repository.length > 0
+                    && parsedNativeProviders.sources.status !== "available"
+                    && parsedNativeProviders.sources.status !== "partial") nativeInvalid.sources = true;
+        }
         if (!updatesInvalid) {
             const cancelAvailable = parsedActions["$updates-cancel"].availability === "available";
             const canCancelActive = parsedActive !== null && parsedActive.cancelable;
@@ -619,8 +780,36 @@ Scope {
                 "owner": "dwm-system-management",
                 "detail": "System management provider returned malformed recovery state" }
             : parsedRecoveryProvider;
+        const publishedProviders = {};
+        const publishedStates = {};
+        let nativeMalformed = false;
+        if (minor === 1) {
+            for (const owner of nativeOwners) {
+                if (nativeInvalid[owner]) {
+                    nativeMalformed = true;
+                    const detail = "System management provider returned malformed " + owner + " state";
+                    publishedProviders[owner] = { status: "partial", providerClass: "delegated", owner: "", detail: detail };
+                    parsedErrors.push({ provider: owner, code: "malformed", detail: detail });
+                } else publishedProviders[owner] = parsedNativeProviders[owner];
+            }
+            for (const identifier of nativeStateIds) {
+                const owner = root.nativeStateOwner(identifier);
+                publishedStates[identifier] = nativeInvalid[owner]
+                    ? { status: "partial", value: "unknown", detail: publishedProviders[owner].detail }
+                    : states["$" + identifier];
+            }
+            const nativeActions = [];
+            for (const identifier of nativeActionIds) {
+                if (!nativeInvalid[root.nativeActionOwner(identifier)]) nativeActions.push(parsedActions["$" + identifier]);
+            }
+            root.actions = root.actions.concat(nativeActions);
+        }
+        root.nativeProviders = publishedProviders;
+        root.nativeStates = publishedStates;
+        root.accounts = minor === 1 && !nativeInvalid.accounts ? nativeLists.account : [];
+        root.repositories = minor === 1 && !nativeInvalid.sources ? nativeLists.repository : [];
         root.errors = parsedErrors;
-        root.snapshotState = updatesInvalid || planInvalid || planUnsupported || recoveryInvalid
+        root.snapshotState = updatesInvalid || planInvalid || planUnsupported || recoveryInvalid || nativeMalformed
             ? "partial" : "ready";
         root.message = root.snapshotState === "ready"
             ? parsedUpdates.length + " updates reported"

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -476,8 +476,8 @@ durable handoffs, denial, stale generation, ambiguous replies, output loss after
 dispatch, retained replay, and acknowledgment without repeating the action.
 For an ambiguous sent result, a new independent read begins only after durable
 interruption and lease release; it cannot reclassify the terminal result.
-Settings still needs its own display refresh and confirmation/origin controls,
-and the cumulative snapshot remains minor zero. These fixtures do not change
+Settings still needs its own display refresh and confirmation/origin controls.
+Cumulative minor 1 discovery is described below. These fixtures do not change
 host settings or qualify graphical polkit authorization.
 
 Each regional mutation uses a 60-second monotonic aggregate deadline beginning
@@ -734,8 +734,9 @@ filesystem/exec operations do not claim a hard kernel-I/O deadline.
 Unit and real private-child fixtures cover fixed argv, trust failures, bounded
 selection, launch errors, lost output, descriptor/session isolation, handoff
 replay, and a tool exiting unsuccessfully after its launch was accepted.
-Originating Settings controls and cumulative minor 1 discovery remain
-outstanding; the cumulative snapshot remains minor zero.
+Originating Settings controls remain outstanding. The cumulative snapshot now
+implements minor 1 as described below; discovery alone does not enable those
+controls.
 
 The internal repository reader now bounds connection setup, optional activation
 of an absent PackageKit daemon, transaction setup, signals, and decoding under
@@ -913,6 +914,53 @@ never emits a later planned ID as `unsupported`. Within that minor, every
 active provider, state, and action is mandatory even when its platform source
 is absent. A consumer that supports a later minor accepts earlier cumulative
 sets; a producer bumps the minor only when the entire next row is implemented.
+
+The managed `snapshot` command now emits the complete minor 1 set. Time and
+locale are read independently, with all six new states and seven new action
+rows present even when their sources are absent. Missing administration tools
+disable only their own actions, without hiding readable account rows, CUPS
+status, or repository records. Partial account enumeration retains the validated
+subset and uses an unknown count; an available count exactly equals its emitted
+rows. Every repository result is complete or discarded. The producer enforces
+the complete stream and separate non-list byte reservations before publication.
+
+Native offers require a validated empty recovery state and a separate Fedora
+identity and bounded, locked journal-admission check. The check verifies current
+ownership, handoff, commit headroom, and a reusable terminal slot; it neither
+commits an operation nor retains a lease. It has no PackageKit security-floor or
+logind dependency. Failure to read update/session restart evidence therefore
+does not hide independently admissible native actions, while missing journal
+state, an active owner, or an unacknowledged result still blocks them. All offers
+are advisory: originating commands repeat their own admission and fresh-state
+checks. Delegated discovery resolves fixed trusted arguments but never launches
+the tool. Unsupported preserved locale overrides disable the language action
+without discarding readable locale state; choices and complete previews remain
+separate fresh reads.
+
+The Settings parser accepts complete minor 0 and minor 1 snapshots, isolates
+known-owner failures, checks mandatory records and list identity/count/byte
+limits, and removes every action from an invalid native owner. A replacement
+minor 0 snapshot clears older native projections. This boundary does not change
+root operation ownership policy or add originating native/delegated controls,
+monitor coordination, or NTP sampling. Those integrations remain required.
+The update-only compatibility formatter and operation streams retain minor 0;
+the snapshot minor selects capability advertisement, not a new operation format.
+Provider tests and 204 native Quickshell assertions qualify cumulative sets,
+failure isolation, missing tools, partial inventories, encoded bounds, and
+backward compatibility without changing host settings or launching tools.
+An explicit empty `LANG=` remains readable and does not hide timezone or NTP
+state; replacing it still requires a fresh locale choice and confirmation.
+Duplicate list identities remain stream-fatal even after that provider's count
+or byte limit is exceeded. The overall 9216-list-record reservation separately
+bounds duplicate tracking; exceeding it rejects the whole snapshot.
+A read-only Fedora 44 managed snapshot completed in 2.70 seconds with one
+account, 28 repositories, 31 updates, and 37 package-change rows. Missing account
+and source tools disabled only their own launch offers; password and printer
+tool resolution remained available. This agent's missing logind session kept
+update recovery partial while regional status and native admission remained
+independently available. Its journal was isolated in the managed test workspace
+and removed afterward. No system setting, package, or service configuration was
+changed, and no administration tool was opened.
 
 Required fields are single-line UTF-8 with tabs and line breaks replaced by
 spaces. Unknown records and trailing fields are ignored. Consumers reject a
@@ -1161,13 +1209,16 @@ and `succeeded` are terminal and appear exactly once.
 Snapshot record failures are provider-scoped only when a valid known provider,
 state, action, or list-record ID still identifies the owner; the consumer marks
 that provider invalid and continues parsing unrelated providers. A malformed
-header or completion, a missing or unknown owner ID, duplicate ID, illegal enum,
+header or completion, a missing or unknown owner ID, duplicate ID,
 duplicate `active-operation`, duplicate `terminal-handoff`, both snapshot-only
 operation records in one snapshot, operation-ID, action-ID, or action-kind mismatch,
 a terminal `active-operation`, transition outside the table,
 an operation record after a terminal state, any record after the required
 completion, or missing completion rejects the entire stream. Operation and
-audit record failures always reject the operation stream. Text fields are
+audit record failures always reject the operation stream. An illegal enum in a
+snapshot record with a known fixed owner invalidates that owner, just like its
+other malformed fields; illegal header or operation enums remain stream-fatal.
+Text fields are
 capped at 512 bytes. Fixed per-type count and encoded-byte budgets are 4096 and
 3 MiB for `update`, 4096 and 3 MiB for `package-change`, 512 and 384 KiB for
 `repository`, 256 and 256 KiB for `account`, and 256 and 384 KiB for

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -30,6 +30,7 @@ from typing import Callable, Iterable, Iterator, Mapping, Protocol, Sequence
 
 PROTOCOL_MAJOR = 1
 PROTOCOL_MINOR = 0
+SNAPSHOT_MINOR = 1
 MAX_TEXT_BYTES = 512
 MAX_LIST_RECORDS = 4096
 MAX_LIST_BYTES = 3 * 1024 * 1024
@@ -5374,7 +5375,211 @@ def read_recovery_snapshot(backend: PackageKitBackend) -> RecoverySnapshot:
         return RecoverySnapshot(prior_restart=prior_restart, failures=tuple(failures + [failure]))
 
 
-def build_managed_snapshot(backend: PackageKitBackend) -> list[str]:
+class NativeSnapshotSources:
+    """Fixed read-only sources; construction neither reads state nor starts tools."""
+
+    def time_state(self):
+        return RegionalRead("time-state").run()
+
+    def locale_state(self):
+        return RegionalRead("locale-state").run()
+
+    def accounts(self):
+        return AccountRead().run()
+
+    def printers(self):
+        return CupsRead().run()
+
+    def repositories(self):
+        return RepositoryRead().run()
+
+    def delegate(self, action):
+        if not hasattr(os, "POSIX_SPAWN_CLOSEFROM"):
+            raise SnapshotFailure("unsupported", "Isolated administration launches are unavailable", "unsupported")
+        return delegated_command(action)
+
+    def admission(self):
+        """Check advisory native admission without PackageKit, logind, or a lease."""
+        read_fedora_identity()
+        try:
+            with open_journal_directory() as chain:
+                with open_writable_journal(chain) as journal:
+                    prepare_journal_admission(journal)
+        except (JournalAdmissionError, JournalLockError) as error:
+            raise SnapshotFailure("conflict", "Another operation or recovery state blocks administration; reload status") from error
+        except (JournalFrameError, JournalRecordError, OSError) as error:
+            raise SnapshotFailure("internal", "Durable journal storage is unavailable; inspect recovery guidance and reload status") from error
+
+
+def native_list_lines(records, limit: int, byte_limit: int) -> list[str]:
+    """Retain a complete bounded source result, never an apparently complete prefix."""
+    if len(records) > limit:
+        raise SnapshotFailure("malformed", "System management list exceeds its record limit")
+    result, seen, size = [], set(), 0
+    for record in records:
+        fields = record.fields()
+        if not fields[1] or fields[1] in seen:
+            raise SnapshotFailure("malformed", "System management list has a missing or duplicate identity")
+        seen.add(fields[1])
+        for field in fields[1:]:
+            clean_text(field, truncate=False)
+            if "\t" in field or "\n" in field or "\r" in field:
+                raise SnapshotFailure("malformed", "System management list has unsafe text")
+        line = "\t".join(fields)
+        size += len(line.encode("utf-8")) + 1
+        if size > byte_limit:
+            raise SnapshotFailure("malformed", "System management list exceeds its byte limit")
+        result.append(line)
+    return result
+
+
+def build_native_snapshot(sources: NativeSnapshotSources,
+                          blocker: SnapshotFailure | None) -> list[str]:
+    """Produce every minor-one record, isolating failures to its fixed owner."""
+    groups = {name: {"states": [], "actions": [], "lists": [], "errors": [], "statuses": []}
+              for name in ("regional", "accounts", "printers", "sources")}
+
+    def error(owner, failure):
+        groups[owner]["errors"].append(failure)
+
+    def state(owner, identifier, status, value, detail):
+        groups[owner]["statuses"].append(status)
+        groups[owner]["states"].append("\t".join(("state", identifier, status, value, clean_text(detail))))
+
+    def action(owner, identifier, label, detail, failure=None):
+        failure = failure or blocker
+        groups[owner]["actions"].append("\t".join(("action", identifier,
+            "unavailable" if failure else "available", "delegated", owner, label,
+            clean_text(failure.detail if failure else detail))))
+
+    try:
+        clock = sources.time_state()
+    except SnapshotFailure as failure:
+        error("regional", failure)
+        for identifier in ("timezone", "ntp-enabled", "ntp-synchronized"):
+            state("regional", identifier, failure.status, "unknown", failure.detail)
+        action("regional", "timezone-set", "Change timezone", "", failure)
+        action("regional", "ntp-set", "Configure network time", "", failure)
+    else:
+        state("regional", "timezone", "available", clock.timezone, "System timezone")
+        state("regional", "ntp-enabled", "available", "yes" if clock.ntp_enabled else "no", "Network time enablement")
+        state("regional", "ntp-synchronized", "available", "yes" if clock.ntp_synchronized else "no", "Network time synchronization at this read")
+        action("regional", "timezone-set", "Change timezone", "Requires a fresh selected timezone preview and explicit confirmation")
+        ntp_failure = None if clock.can_ntp else SnapshotFailure("unsupported", "No supported network time service is available", "unsupported")
+        action("regional", "ntp-set", "Configure network time", "Requires a fresh network time preview and explicit confirmation", ntp_failure)
+
+    try:
+        locale = sources.locale_state()
+    except SnapshotFailure as failure:
+        error("regional", failure)
+        state("regional", "locale", failure.status, "unknown", failure.detail)
+        action("regional", "locale-set", "Change system language", "", failure)
+    else:
+        state("regional", "locale", "available", locale.lang, locale.detail)
+        locale_failure = None
+        try:
+            # The old LANG will be replaced. Only preserved overrides can rule
+            # out every future selection; choices and full preview remain fresh.
+            overrides = tuple(value for value in locale.assignments if not value.startswith("LANG="))
+            require_locale_service_arguments(parse_locale_configuration(("LANG=C", *overrides)))
+        except SnapshotFailure as failure:
+            locale_failure = failure
+            error("regional", failure)
+        action("regional", "locale-set", "Change system language",
+            "Requires a fresh installed locale preview; existing overrides are preserved", locale_failure)
+
+    try:
+        accounts = sources.accounts()
+        account_lines = native_list_lines(accounts.records, ACCOUNT_LIMIT, ACCOUNT_LIST_BYTES)
+    except SnapshotFailure as failure:
+        error("accounts", failure)
+        state("accounts", "accounts-count", failure.status, "unknown", failure.detail)
+    else:
+        groups["accounts"]["lists"] = account_lines
+        groups["accounts"]["errors"].extend(accounts.errors)
+        state("accounts", "accounts-count", accounts.status,
+            str(len(account_lines)) if accounts.status == "available" else "unknown",
+            "AccountsService account inventory" if accounts.status == "available" else "Validated account subset; enumeration is incomplete")
+
+    try:
+        printers = sources.printers()
+    except SnapshotFailure as failure:
+        error("printers", failure)
+        state("printers", "cups-service", failure.status, "unknown", failure.detail)
+    else:
+        groups["printers"]["errors"].extend(printers.errors)
+        state("printers", "cups-service", printers.status, printers.value,
+            "Fixed CUPS scheduler and socket status; printer administration stays in its platform tool")
+
+    try:
+        repositories = native_list_lines(sources.repositories(), REPOSITORY_MAX_ROWS, REPOSITORY_MAX_BYTES)
+    except SnapshotFailure as failure:
+        error("sources", failure)
+        groups["sources"]["statuses"].append(failure.status)
+    else:
+        groups["sources"]["lists"] = repositories
+        groups["sources"]["statuses"].append("available")
+
+    for owner, identifier, label in (("accounts", "accounts-open", "Manage accounts"),
+            ("accounts", "password-open", "Change my password"),
+            ("printers", "printers-open", "Manage printers"),
+            ("sources", "sources-open", "Manage software sources")):
+        failure = None
+        try:
+            sources.delegate(identifier)  # Resolve fixed trusted argv only; never exec it.
+        except SnapshotFailure as unavailable:
+            failure = unavailable
+            error(owner, unavailable)
+        action(owner, identifier, label, "Confirm opening the fixed platform tool; the tool owns authorization and completion", failure)
+
+    lines = []
+    owners = {"regional": "systemd timedated/localed", "accounts": "AccountsService",
+              "printers": "CUPS/systemd", "sources": "PackageKit"}
+    for owner, group in groups.items():
+        if blocker is not None:
+            error(owner, blocker)
+        statuses = group["statuses"]
+        if all(value == "available" for value in statuses) and not group["errors"]:
+            status = "available"
+        elif any(value in {"available", "partial"} for value in statuses):
+            status = "partial"
+        elif all(value == "unsupported" for value in statuses):
+            status = "unsupported"
+        elif all(value == "restricted" for value in statuses):
+            status = "restricted"
+        else:
+            status = "unavailable"
+        lines.append("\t".join(("provider", owner, status, "delegated", owners[owner],
+            "Readable status and individually confirmed platform actions" if status == "available"
+            else "Inspect individual state, action availability, and capability errors")))
+        lines.extend(group["states"])
+        lines.extend(group["actions"])
+        lines.extend(group["lists"])
+        seen = set()
+        for failure in group["errors"]:
+            record = f"error\t{owner}\t{failure.code}\t{clean_text(failure.detail)}"
+            if record not in seen:
+                seen.add(record)
+                lines.append(record)
+    return lines
+
+
+def validate_snapshot_size(lines: Sequence[str]) -> None:
+    """Keep the cumulative non-list reservation separate from bounded lists."""
+    non_list = total = list_count = 0
+    for line in lines:
+        size = len(line.encode("utf-8")) + 1
+        total += size
+        if line.partition("\t")[0] in {"update", "package-change", "repository", "account", "filesystem"}:
+            list_count += 1
+        else:
+            non_list += size
+        if list_count > 9216 or non_list > 1024 * 1024 or total > 8 * 1024 * 1024:
+            raise SnapshotFailure("malformed", "System management snapshot exceeds its output reservation")
+
+
+def build_managed_snapshot(backend: PackageKitBackend, *,
+                           native_sources: NativeSnapshotSources | None = None) -> list[str]:
     """Combine readable discovery with independently validated durable recovery."""
     recovery = read_recovery_snapshot(backend)
     state = recovery.state
@@ -5431,7 +5636,19 @@ def build_managed_snapshot(backend: PackageKitBackend) -> list[str]:
         operation = state.terminals[state.handoff.slot]
         lines.append("\t".join(("terminal-handoff", operation.operation_id, operation.action_id, operation.kind)))
     lines.extend(f"error\trecovery\t{failure.code}\t{failure.detail}" for failure in recovery.failures)
+    if native_sources is not None:
+        native_blocker = None
+        if state is None or state.active is not None or state.handoff is not None:
+            native_blocker = SnapshotFailure("conflict", "Complete idle journal recovery is required before administration; reload status")
+        else:
+            try:
+                native_sources.admission()
+            except SnapshotFailure as failure:
+                native_blocker = failure
+        lines.extend(build_native_snapshot(native_sources, native_blocker))
+        lines[0] = f"system-management-protocol\t{PROTOCOL_MAJOR}\t{SNAPSHOT_MINOR}"
     lines.append("complete\tsnapshot")
+    validate_snapshot_size(lines)
     return lines
 
 
@@ -8720,7 +8937,7 @@ def main(argv: Sequence[str]) -> int:
                 raise self.failure
 
         backend = FailedBackend(failure)
-    lines = build_managed_snapshot(backend)
+    lines = build_managed_snapshot(backend, native_sources=NativeSnapshotSources())
     print("\n".join(lines))
     return 0
 

--- a/tests/qml/SystemNativeSnapshot.qml
+++ b/tests/qml/SystemNativeSnapshot.qml
@@ -1,0 +1,206 @@
+import QtQuick
+import Quickshell
+import qs.systemmanagement
+
+ShellRoot {
+    id: root
+    property int assertions: 0
+
+    function check(condition, detail) {
+        root.assertions++;
+        if (!condition) {
+            console.error("Native snapshot FAILED: " + detail);
+            Qt.callLater(function() { Qt.quit(); });
+            throw new Error(detail);
+        }
+    }
+
+    function base() {
+        return ["system-management-protocol\t1\t0", "snapshot-generation\t" + "a".repeat(64),
+            "provider\tupdates\tavailable\tdelegated\tPackageKit\tFixture updates",
+            "provider\trecovery\tavailable\tuser-session\tJournal\tValidated journal",
+            "state\tupdate-summary\tavailable\t1\tOne update",
+            "state\tupdate-last-refresh\tavailable\t10\tRecent",
+            "state\tupdate-restart\tavailable\tnone\tNo restart",
+            "action\tupdates-refresh\tavailable\tdelegated\tupdates\tRefresh\tConfirm first",
+            "action\tupdates-install-all\tavailable\tdelegated\tupdates\tInstall\tConfirm first",
+            "action\tupdates-cancel\tunavailable\tdelegated\tupdates\tCancel\tNo owner",
+            "update\talpha;1;x86_64;updates\tsecurity\tinstallable\talpha\t1\tUpdate",
+            "package-change\talpha;1;x86_64;updates\tupdate\talpha\t1\tUpdate"];
+    }
+
+    function nativeRows() {
+        return ["provider\tregional\tavailable\tdelegated\tsystemd\tRegional state",
+            "provider\taccounts\tavailable\tdelegated\tAccountsService\tAccount state",
+            "provider\tprinters\tavailable\tdelegated\tCUPS\tPrinter state",
+            "provider\tsources\tavailable\tdelegated\tPackageKit\tSources",
+            "state\ttimezone\tavailable\tAmerica/Chicago\tSystem timezone",
+            "state\tntp-enabled\tavailable\tyes\tEnabled",
+            "state\tntp-synchronized\tavailable\tno\tNot yet synchronized",
+            "state\tlocale\tavailable\ten_US.UTF-8\tLC_TIME=C",
+            "state\taccounts-count\tavailable\t1\tOne account",
+            "state\tcups-service\tavailable\tsocket-ready\tReady socket",
+            "action\ttimezone-set\tavailable\tdelegated\tregional\tTimezone\tConfirm first",
+            "action\tntp-set\tavailable\tdelegated\tregional\tNetwork time\tConfirm first",
+            "action\tlocale-set\tavailable\tdelegated\tregional\tLanguage\tConfirm first",
+            "action\taccounts-open\tavailable\tdelegated\taccounts\tAccounts\tConfirm launch",
+            "action\tpassword-open\tavailable\tdelegated\taccounts\tPassword\tConfirm launch",
+            "action\tprinters-open\tavailable\tdelegated\tprinters\tPrinters\tConfirm launch",
+            "action\tsources-open\tavailable\tdelegated\tsources\tSources\tConfirm launch",
+            "account\t/opaque/current\tcurrent\tCurrent user\tfixture",
+            "repository\tfedora\tenabled\tFedora"];
+    }
+
+    function snapshot() {
+        const lines = root.base();
+        lines[0] = "system-management-protocol\t1\t1";
+        return lines.concat(root.nativeRows());
+    }
+
+    function parse(lines) {
+        return model.parseSnapshot(lines.concat(["complete\tsnapshot"]).join("\n") + "\n", model.requestGeneration);
+    }
+
+    function replaceRow(lines, prefix, replacement) {
+        return lines.map(line => line.startsWith(prefix) ? replacement : line);
+    }
+
+    function malformedOwner(lines, owner, detail) {
+        root.parse(lines);
+        root.check(model.snapshotState === "partial", detail + " must be partial");
+        root.check(model.nativeProviders[owner].status === "partial", detail + " must invalidate its owner");
+        root.check(!model.actions.some(action => action.owner === owner), detail + " must remove originating offers");
+        root.check(model.updates.length === 1 && model.packageChanges.length === 1, detail + " must preserve updates");
+        const unaffected = owner === "regional" ? "printers" : "regional";
+        root.check(model.nativeProviders[unaffected].status === "available", detail + " must preserve unrelated native state");
+    }
+
+    function run() {
+        root.check(root.parse(root.snapshot()), "Complete recovery remains known");
+        root.check(model.snapshotState === "ready" && model.actions.length === 10, "Complete cumulative snapshot accepted");
+        root.check(model.nativeStates.locale.detail === "LC_TIME=C", "Full override detail retained");
+        root.check(model.accounts.length === 1 && model.repositories.length === 1, "Both native lists retained");
+        root.check(model.accounts[0].id === "/opaque/current", "Account object remains opaque display data");
+        root.check(!model.prepareUpdate("timezone-set"), "Native snapshot does not enable a new origin through update controls");
+        root.parse(root.replaceRow(root.snapshot(), "state\tlocale\t", "state\tlocale\tavailable\t\tnone"));
+        root.check(model.snapshotState === "ready" && model.nativeStates.locale.value === "", "Explicit empty LANG remains readable");
+        root.check(model.nativeStates.timezone.status === "available" && model.actions.some(action => action.id === "locale-set"),
+            "Empty LANG cannot hide timezone state or an independently offered replacement");
+
+        root.parse(root.base());
+        root.check(model.snapshotState === "ready" && model.actions.length === 3, "Minor zero remains compatible");
+        root.check(Object.keys(model.nativeProviders).length === 0 && Object.keys(model.nativeStates).length === 0
+            && model.accounts.length === 0 && model.repositories.length === 0, "Older snapshot clears stale cumulative projections");
+
+        for (const row of root.nativeRows()) {
+            const fields = row.split("\t");
+            if (fields[0] === "account" || fields[0] === "repository") continue;
+            const owner = fields[0] === "provider" ? fields[1]
+                : fields[0] === "state" ? model.nativeStateOwner(fields[1]) : model.nativeActionOwner(fields[1]);
+            root.malformedOwner(root.snapshot().filter(line => line !== row), owner, "Missing " + fields[1]);
+            root.parse(root.snapshot().concat([row]));
+            root.check(model.snapshotState === "failure", "Duplicate " + fields[1] + " is framing failure");
+        }
+        for (const type of ["account", "repository"]) {
+            const row = root.nativeRows().find(line => line.startsWith(type + "\t"));
+            root.parse(root.snapshot().concat([row]));
+            root.check(model.snapshotState === "failure" && model.actions.length === 0, "Duplicate list identity clears every action");
+            root.parse(root.base().concat([row]));
+            root.check(model.snapshotState === "failure", "Minor zero cannot advertise an inactive list");
+        }
+        for (const row of ["provider\tfuture\tavailable\tdelegated\tOther\tUnknown",
+                "state\tfuture\tavailable\tyes\tUnknown", "action\tfuture\tavailable\tdelegated\tregional\tUnknown\tUnknown",
+                "error\tfuture\tinternal\tUnknown"]) {
+            root.parse(root.snapshot().concat([row]));
+            root.check(model.snapshotState === "failure", "Unknown known-record owner is fatal");
+        }
+        for (const mutation of [
+                ["provider\tregional\t", "provider\tregional\tavailable\tprivileged\tsystemd\tWrong class", "regional"],
+                ["state\tntp-enabled\t", "state\tntp-enabled\tavailable\ttrue\tWrong enum", "regional"],
+                ["state\tntp-synchronized\t", "state\tntp-synchronized\tpartial\tyes\tWrong status", "regional"],
+                ["state\tcups-service\t", "state\tcups-service\tpartial\trunning\tWrong status", "printers"],
+                ["state\taccounts-count\t", "state\taccounts-count\tavailable\t2\tWrong count", "accounts"],
+                ["action\taccounts-open\t", "action\taccounts-open\tavailable\tdelegated\tprinters\tWrong owner\tMismatch", "accounts"],
+                ["account\t", "account\t/opaque/current\tcurrent\tName", "accounts"],
+                ["repository\t", "repository\tfedora\tunknown\tWrong enum", "sources"]]) {
+            root.malformedOwner(root.replaceRow(root.snapshot(), mutation[0], mutation[1]), mutation[2], mutation[0]);
+        }
+        let lines = root.replaceRow(root.snapshot(), "state\taccounts-count\t", "state\taccounts-count\tpartial\tunknown\tIncomplete inventory");
+        lines = root.replaceRow(lines, "provider\taccounts\t", "provider\taccounts\tpartial\tdelegated\tAccountsService\tIncomplete inventory");
+        root.parse(lines.concat(["error\taccounts\ttimeout\tPartial inventory"]));
+        root.check(model.accounts.length === 1 && model.nativeStates["accounts-count"].value === "unknown", "Validated partial account subset retained");
+        lines = root.replaceRow(root.snapshot(), "action\tsources-open\t", "action\tsources-open\tunavailable\tdelegated\tsources\tSources\tTool missing");
+        lines = root.replaceRow(lines, "provider\tsources\t", "provider\tsources\tpartial\tdelegated\tPackageKit\tTool missing");
+        root.parse(lines);
+        root.check(model.repositories.length === 1, "Missing source tool cannot hide repository records");
+        lines = root.replaceRow(root.snapshot(), "state\tupdate-summary\t", "state\tupdate-summary\tavailable\tbad\tMalformed updates");
+        root.parse(lines);
+        root.check(model.updates.length === 0 && model.nativeStates.timezone.status === "available"
+            && model.actions.some(action => action.id === "timezone-set"), "Malformed updates do not suppress valid native state");
+        lines = root.replaceRow(root.snapshot(), "provider\trecovery\t", "provider\trecovery\tpartial\tuser-session\tJournal\tNo session timestamp");
+        root.check(!root.parse(lines), "Native offers do not silently relax root recovery ownership");
+        root.check(model.nativeStates.timezone.status === "available", "Partial recovery preserves readable native state");
+
+        for (const family of ["account", "repository"]) {
+            const count = family === "account" ? 256 : 512;
+            lines = root.snapshot().filter(line => !line.startsWith(family + "\t"));
+            if (family === "account") lines = root.replaceRow(lines, "state\taccounts-count\t",
+                "state\taccounts-count\tavailable\t256\tComplete bounded inventory");
+            const records = [];
+            for (let index = 0; index < count; index++) records.push(family === "account"
+                ? "account\t/opaque/" + index + "\tother\tName\tuser" + index
+                : "repository\tid" + index + "\tdisabled\tDescription");
+            root.parse(lines.concat(records));
+            root.check(model.snapshotState === "ready" && (family === "account" ? model.accounts.length : model.repositories.length) === count,
+                "Exact " + family + " count boundary accepted");
+            root.malformedOwner(lines.concat(records, [records[0].replace(family === "account" ? "/opaque/0" : "id0", "extra")]),
+                family === "account" ? "accounts" : "sources", family + " count overflow");
+            const overflowRow = records[0].replace(family === "account" ? "/opaque/0" : "id0", "extra");
+            root.parse(lines.concat(records, [overflowRow, overflowRow]));
+            root.check(model.snapshotState === "failure", family + " duplicate after count overflow remains fatal");
+            const oversized = [];
+            for (let index = 0; index < count; index++) oversized.push(family === "account"
+                ? "account\t/" + String(index).padStart(511, "x") + "\tother\t" + "n".repeat(512) + "\t" + "u".repeat(512)
+                : "repository\t" + String(index).padStart(512, "x") + "\tenabled\t" + "d".repeat(512));
+            root.malformedOwner(lines.concat(oversized), family === "account" ? "accounts" : "sources", family + " encoded-byte overflow");
+            root.parse(lines.concat(oversized, [oversized[oversized.length - 1]]));
+            root.check(model.snapshotState === "failure", family + " duplicate after byte overflow remains fatal");
+        }
+        for (const family of ["update", "package-change"]) {
+            lines = root.snapshot().filter(line => !line.startsWith(family + "\t"));
+            const records = [];
+            for (let index = 0; index < 4097; index++) records.push(family === "update"
+                ? "update\tid" + index + "\tnormal\tblocked\tname\t1\tSummary"
+                : "package-change\tid" + index + "\tinstall\tname\t1\tSummary");
+            root.parse(lines.concat(records, [records[records.length - 1]]));
+            root.check(model.snapshotState === "failure", family + " duplicate after overflow remains fatal");
+        }
+        lines = root.snapshot().filter(line => !line.startsWith("account\t"));
+        for (let index = 0; index < 9217; index++) lines.push("account\t/" + index + "\tother\tName\tuser");
+        root.parse(lines);
+        root.check(model.snapshotState === "failure", "Overall list reservation bounds duplicate tracking");
+        root.malformedOwner(root.snapshot().concat(["error\tregional\tbogus\tBad code"]), "regional", "Owned illegal enum");
+        root.parse(root.snapshot().concat(["future-record\tignored", "error\tregional\tunsupported\tReadable state\textra ignored"]));
+        root.check(model.snapshotState === "ready", "Unknown records and trailing fields remain append-compatible");
+        root.parse(root.snapshot().concat(["future-record\t" + "x".repeat(1024 * 1024)]));
+        root.check(model.snapshotState === "failure", "Non-list reservation enforced independently of total size");
+        root.parse(root.snapshot().concat(["complete\tsnapshot"]));
+        root.check(model.snapshotState === "failure", "Duplicate completion is fatal");
+        root.parse(root.snapshot());
+        const old = model.nativeStates;
+        model.parseSnapshot("malformed", model.requestGeneration - 1);
+        root.check(model.nativeStates === old, "Stale snapshot cannot replace current projections");
+        root.check(!model.operation.streamOwned, "Parsing never originates an operation");
+        console.info("Native snapshot tests: PASS (" + root.assertions + " assertions)");
+        Qt.quit();
+    }
+
+    SystemManagementModel {
+        id: model
+        // This fixture exercises only parsing. Reserve the finite-read slot
+        // so automatic startup recovery queues instead of launching a helper
+        // that Qt.quit would kill before its capture-file cleanup can finish.
+        snapshotOwned: true
+    }
+    Component.onCompleted: Qt.callLater(root.run)
+}

--- a/tests/test-quickshell-system-management-xvfb.sh
+++ b/tests/test-quickshell-system-management-xvfb.sh
@@ -398,6 +398,27 @@ if ! grep -F 'Operation parser native tests: PASS' "$work/operation-parser.log";
 fi
 
 # Exercise the real root-owned Process lifecycle with a private fixed helper.
+mkdir -p "$work/native-snapshot"
+cp -a "$repo/config/quickshell/core" "$repo/config/quickshell/systemmanagement" "$work/native-snapshot/"
+cp "$repo/tests/qml/SystemNativeSnapshot.qml" "$work/native-snapshot/shell.qml"
+timeout --foreground --kill-after=2s 20s env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
+	XDG_DATA_HOME="$data_home" XDG_RUNTIME_DIR="$runtime" QT_QPA_PLATFORMTHEME= \
+	DWM_SYSTEM_MANAGEMENT_TEST_FIXTURE="$fixture" \
+	quickshell --no-duplicate --path "$work/native-snapshot/shell.qml" >"$work/native-snapshot.log" 2>&1 &
+quickshell_pid=$!
+native_status=0
+wait "$quickshell_pid" || native_status=$?
+quickshell_pid=
+if [ "$native_status" -ne 0 ] || ! grep -F 'Native snapshot tests: PASS' "$work/native-snapshot.log" ||
+	grep -Fq 'Native snapshot FAILED:' "$work/native-snapshot.log"; then
+	cat "$work/native-snapshot.log" >&2
+	exit 1
+fi
+if find "$runtime" -type f -name 'dwm-checked-command*' -print -quit | grep -q .; then
+	printf 'Parser-only fixture started a capture that outlived its process\n' >&2
+	exit 1
+fi
+
 mkdir -p "$work/update-action" "$work/update-action-data/dwm-titus/scripts"
 cp -a "$repo/config/quickshell/core" "$repo/config/quickshell/systemmanagement" "$work/update-action/"
 cp "$repo/tests/qml/SystemUpdateActionOwner.qml" "$work/update-action/shell.qml"

--- a/tests/test-quickshell-system-management.sh
+++ b/tests/test-quickshell-system-management.sh
@@ -36,7 +36,7 @@ if grep -Fq 'repeat: true' "$model"; then
 fi
 
 grep -Fq 'recordIndex === 0 && type !== "system-management-protocol"' "$model"
-grep -Fq 'fields[1] !== "1" || fields[2] !== "0"' "$model"
+grep -Fq 'fields[1] !== "1" || (fields[2] !== "0" && fields[2] !== "1")' "$model"
 grep -Fq 'System management provider emitted records after completion' "$model"
 grep -Fq '!headerSeen || !completeSeen || parsedGeneration.length === 0' "$model"
 grep -Fq 'return /^[0-9a-f]{64}$/.test(value);' "$model"

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -11129,13 +11129,16 @@ class RecoverySnapshotTests(unittest.TestCase):
                 mock.patch.dict(os.environ, {"XDG_STATE_HOME": directory}), \
                 mock.patch.object(provider, "read_boot_id", return_value=self.boot_id), \
                 mock.patch.object(provider, "PackageKitBackend", return_value=self.backend()), \
+                mock.patch.object(provider, "NativeSnapshotSources", return_value=FixtureNativeSources()), \
                 contextlib.redirect_stdout(io.StringIO()) as stdout:
             self.assertEqual(provider.main(["snapshot"]), 0)
             output = stdout.getvalue().splitlines()
             self.assertEqual(output[-1], "complete\tsnapshot")
             self.assertEqual(self.restart_row(output)[2:4], ["available", "none"])
-            self.assertEqual([row[2] for row in rows(output, "action")],
+            self.assertEqual([row[2] for row in rows(output, "action")[:3]],
                 ["available", "unavailable", "unavailable"])
+            self.assertEqual(output[0], "system-management-protocol\t1\t1")
+            self.assertEqual(len(rows(output, "action")), 10)
             path = pathlib.Path(directory) / "dwm-titus" / "system-management"
             self.assertEqual({item.name for item in path.iterdir()}, set(provider.JOURNAL_NAMES))
             self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o700)
@@ -11377,9 +11380,197 @@ class RecoverySnapshotTests(unittest.TestCase):
             with mock.patch.dict(os.environ, {"XDG_STATE_HOME": str(pathlib.Path(journal.chain.path).parents[1])}), \
                     mock.patch.object(provider, "read_boot_id", return_value=self.boot_id), \
                     mock.patch.object(provider, "PackageKitBackend", side_effect=provider.SnapshotFailure("missing-provider", "Bindings missing")), \
+                    mock.patch.object(provider, "NativeSnapshotSources", return_value=FixtureNativeSources()), \
                     contextlib.redirect_stdout(io.StringIO()) as stdout:
                 self.assertEqual(provider.main(["snapshot"]), 0)
             self.assertEqual(rows(stdout.getvalue().splitlines(), "terminal-handoff")[0][1], operation.operation_id)
+
+
+class FixtureNativeSources:
+    """Typed finite results; no test silently consults or launches host providers."""
+
+    def __init__(self):
+        self.time_state = mock.Mock(return_value=provider.RegionalTimeState("America/Chicago", True, True, False))
+        self.locale_state = mock.Mock(return_value=provider.parse_locale_configuration(("LANG=en_US.UTF-8", "LC_TIME=C")))
+        account = provider.AccountRecord("/arbitrary/current", "current", "Current user", "fixture", True)
+        self.accounts = mock.Mock(return_value=provider.AccountInventory((account,), (account.path,), account.path, "available", ()))
+        self.printers = mock.Mock(return_value=provider.CupsState("available", "socket-ready", (), ()))
+        self.repositories = mock.Mock(return_value=(provider.RepositoryRow("fedora", True, "Fedora"),
+            provider.RepositoryRow("disabled", False, "Disabled source")))
+        self.delegate = mock.Mock(return_value=(("/usr/bin/fixed-fixture",), "Fixture tool"))
+        self.admission = mock.Mock()
+
+
+class NativeSnapshotTests(unittest.TestCase):
+    def snapshot(self, sources=None, *, backend=None, active=False, recovery_failure=None, missing_state=False):
+        fixture = RecoverySnapshotTests()
+        sources = sources or FixtureNativeSources()
+        backend = backend or fixture.backend()
+        with fixture.journal() as journal:
+            if active:
+                fixture.begin(journal, "timezone")
+            recovery = provider.RecoverySnapshot(None if missing_state else provider.load_journal_state(journal.chain),
+                failures=(recovery_failure,) if recovery_failure else ())
+            with mock.patch.object(provider, "read_recovery_snapshot", return_value=recovery), \
+                    mock.patch.object(provider, "launch_delegated_tool") as launch:
+                output = provider.build_managed_snapshot(backend, native_sources=sources)
+            launch.assert_not_called()
+            return output
+
+    def by_id(self, output, kind):
+        return {row[1]: row for row in rows(output, kind)}
+
+    def test_complete_cumulative_set_and_no_dispatch(self):
+        sources = FixtureNativeSources()
+        output = self.snapshot(sources)
+        self.assertEqual(output[0], "system-management-protocol\t1\t1")
+        self.assertEqual(output[-1], "complete\tsnapshot")
+        self.assertEqual(len(rows(output, "provider")), 6)
+        self.assertEqual(len(rows(output, "state")), 9)
+        self.assertEqual(len(rows(output, "action")), 10)
+        self.assertEqual(len(rows(output, "account")), 1)
+        self.assertEqual(len(rows(output, "repository")), 2)
+        self.assertEqual(self.by_id(output, "state")["accounts-count"][2:4], ["available", "1"])
+        self.assertEqual(self.by_id(output, "state")["ntp-synchronized"][3], "no")
+        self.assertEqual(self.by_id(output, "state")["locale"][3:], ["en_US.UTF-8", "LC_TIME=C"])
+        for method in (sources.time_state, sources.locale_state, sources.accounts,
+                       sources.printers, sources.repositories, sources.admission):
+            method.assert_called_once_with()
+        self.assertEqual({call.args[0] for call in sources.delegate.call_args_list}, provider.DELEGATED_ACTIONS)
+        self.assertEqual(rows(output, "error"), [])
+        self.assertEqual(provider.build_snapshot(FixtureBackend())[0], "system-management-protocol\t1\t0")
+
+    def test_independent_reader_failures_keep_every_mandatory_record(self):
+        for name, owner, state_id in (("time_state", "regional", "timezone"),
+                ("locale_state", "regional", "locale"), ("accounts", "accounts", "accounts-count"),
+                ("printers", "printers", "cups-service"), ("repositories", "sources", None)):
+            with self.subTest(name=name):
+                sources = FixtureNativeSources()
+                getattr(sources, name).side_effect = provider.SnapshotFailure("permission-denied", "Read denied", "restricted")
+                output = self.snapshot(sources)
+                self.assertEqual(len(rows(output, "provider")), 6)
+                self.assertEqual(len(rows(output, "state")), 9)
+                self.assertEqual(len(rows(output, "action")), 10)
+                if state_id:
+                    self.assertEqual(self.by_id(output, "state")[state_id][2:4], ["restricted", "unknown"])
+                self.assertIn(["error", owner, "permission-denied", "Read denied"], rows(output, "error"))
+                self.assertEqual(self.by_id(output, "state")["locale" if name == "time_state" else "timezone"][2], "available")
+                self.assertEqual(self.by_id(output, "action")["accounts-open"][2], "available")
+
+    def test_missing_tools_preserve_rows_and_readable_state(self):
+        sources = FixtureNativeSources()
+        sources.delegate.side_effect = provider.SnapshotFailure("missing-provider", "Tool is missing", "unavailable")
+        output = self.snapshot(sources)
+        self.assertEqual(len(rows(output, "account")), 1)
+        self.assertEqual(len(rows(output, "repository")), 2)
+        self.assertEqual(self.by_id(output, "state")["cups-service"][2:4], ["available", "socket-ready"])
+        for identifier in provider.DELEGATED_ACTIONS:
+            self.assertEqual(self.by_id(output, "action")[identifier][2], "unavailable")
+        self.assertEqual(self.by_id(output, "action")["timezone-set"][2], "available")
+
+    def test_partial_accounts_and_running_printer_survive_scoped_errors(self):
+        sources = FixtureNativeSources()
+        failure = provider.SnapshotFailure("timeout", "Optional lookup timed out", "unavailable")
+        sources.accounts.return_value = replace(sources.accounts.return_value, status="partial", errors=(failure,))
+        sources.printers.return_value = provider.CupsState("available", "running", (), (failure,))
+        output = self.snapshot(sources)
+        self.assertEqual(len(rows(output, "account")), 1)
+        self.assertEqual(self.by_id(output, "state")["accounts-count"][2:4], ["partial", "unknown"])
+        self.assertEqual(self.by_id(output, "state")["cups-service"][2:4], ["available", "running"])
+        self.assertEqual(self.by_id(output, "provider")["printers"][2], "partial")
+
+    def test_native_offers_do_not_require_packagekit_or_logind_safety(self):
+        fixture = RecoverySnapshotTests()
+        backend = fixture.backend()
+        backend.require_mutation_safe.side_effect = provider.SnapshotFailure("unsupported", "Update security floor is unavailable")
+        for failure in (None, provider.SnapshotFailure("missing-provider", "No logind session", "unavailable")):
+            with self.subTest(failure=failure):
+                sources = FixtureNativeSources()
+                output = self.snapshot(sources, backend=backend, recovery_failure=failure)
+                actions = self.by_id(output, "action")
+                self.assertEqual(actions["updates-refresh"][2], "unavailable")
+                for identifier in provider.JOURNAL_OPERATION_ACTION_KINDS:
+                    if identifier not in {"updates-refresh", "updates-install-all"}:
+                        self.assertEqual(actions[identifier][2], "available")
+                sources.admission.assert_called_once_with()
+
+    def test_missing_recovery_active_owner_and_admission_failures_block_native(self):
+        for scenario in ("missing", "active", "admission"):
+            with self.subTest(scenario=scenario):
+                sources = FixtureNativeSources()
+                if scenario == "admission":
+                    sources.admission.side_effect = provider.SnapshotFailure("conflict", "Journal is busy")
+                output = self.snapshot(sources, active=scenario == "active", missing_state=scenario == "missing")
+                for row in rows(output, "action")[3:]:
+                    self.assertEqual(row[2], "unavailable")
+                if scenario != "admission":
+                    sources.admission.assert_not_called()
+                self.assertEqual(self.by_id(output, "state")["timezone"][2], "available")
+
+    def test_ntp_and_unwritable_locale_preserve_readable_status(self):
+        for assignments in (("LANG=en_US.UTF-8", "LANGUAGE=en:fr"), ("LANG=en_US.UTF-8", "LC_TIME=")):
+            sources = FixtureNativeSources()
+            sources.time_state.return_value = replace(sources.time_state.return_value, can_ntp=False)
+            sources.locale_state.return_value = provider.parse_locale_configuration(assignments)
+            output = self.snapshot(sources)
+            actions = self.by_id(output, "action")
+            self.assertEqual(actions["ntp-set"][2], "unavailable")
+            self.assertEqual(actions["locale-set"][2], "unavailable")
+            self.assertEqual(actions["timezone-set"][2], "available")
+            self.assertEqual(self.by_id(output, "state")["locale"][2:4], ["available", "en_US.UTF-8"])
+        sources.locale_state.return_value = provider.parse_locale_configuration(("LANG=old:invalid", "LC_TIME=C"))
+        self.assertEqual(self.by_id(self.snapshot(sources), "action")["locale-set"][2], "available")
+        sources.locale_state.return_value = provider.parse_locale_configuration(("LANG=",))
+        output = self.snapshot(sources)
+        self.assertEqual(self.by_id(output, "state")["locale"][2:4], ["available", ""])
+        self.assertEqual(self.by_id(output, "action")["locale-set"][2], "available")
+
+    def test_list_count_byte_and_duplicate_failures_discard_only_owner(self):
+        for family in ("account-count", "account-bytes", "account-duplicate", "repository-count", "repository-bytes", "repository-duplicate"):
+            with self.subTest(family=family):
+                sources = FixtureNativeSources()
+                if family.startswith("account"):
+                    original = sources.accounts.return_value
+                    count = 257 if family.endswith("count") else 256 if family.endswith("bytes") else 2
+                    records = tuple(provider.AccountRecord("/arbitrary/" + str(i) if not family.endswith("duplicate") else "/same",
+                        "other", "x" * 512, "y" * 512, True) for i in range(count))
+                    sources.accounts.return_value = replace(original, records=records)
+                    owner, kind = "accounts", "account"
+                else:
+                    count = 513 if family.endswith("count") else 512 if family.endswith("bytes") else 2
+                    records = tuple(provider.RepositoryRow((str(i) + "x" * 500) if not family.endswith("duplicate") else "same",
+                        True, "y" * 512) for i in range(count))
+                    sources.repositories.return_value = records
+                    owner, kind = "sources", "repository"
+                output = self.snapshot(sources)
+                self.assertEqual(rows(output, kind), [])
+                self.assertTrue(any(row[1:3] == [owner, "malformed"] for row in rows(output, "error")))
+                self.assertEqual(self.by_id(output, "state")["timezone"][2], "available")
+
+    def test_non_list_and_total_byte_reservations(self):
+        provider.validate_snapshot_size(["account\trow"] * 9216)
+        with self.assertRaises(provider.SnapshotFailure):
+            provider.validate_snapshot_size(["account\trow"] * 9217)
+        provider.validate_snapshot_size(["future\t" + "x" * (1024 * 1024 - 8)])
+        with self.assertRaises(provider.SnapshotFailure):
+            provider.validate_snapshot_size(["future\t" + "x" * (1024 * 1024 - 7)])
+        with self.assertRaises(provider.SnapshotFailure):
+            provider.validate_snapshot_size(["account\t" + "x" * (8 * 1024 * 1024)])
+
+    def test_real_native_admission_is_fedora_gated_and_does_not_commit(self):
+        fixture = RecoverySnapshotTests()
+        with fixture.journal() as journal:
+            before = {name: os.pread(journal.descriptor(name), provider.JOURNAL_FILE_SIZE, 0) for name in provider.JOURNAL_NAMES}
+            with mock.patch.dict(os.environ, {"XDG_STATE_HOME": str(pathlib.Path(journal.chain.path).parents[1])}), \
+                    mock.patch.object(provider, "read_fedora_identity", return_value={"ID": "fedora"}) as identity:
+                provider.NativeSnapshotSources().admission()
+                identity.assert_called_once_with()
+            self.assertEqual(before, {name: os.pread(journal.descriptor(name), provider.JOURNAL_FILE_SIZE, 0) for name in provider.JOURNAL_NAMES})
+            with mock.patch.object(provider, "read_fedora_identity", side_effect=provider.SnapshotFailure("unsupported", "Not Fedora")), \
+                    mock.patch.object(provider, "open_journal_directory") as open_journal:
+                with self.assertRaises(provider.SnapshotFailure):
+                    provider.NativeSnapshotSources().admission()
+                open_journal.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Publish the complete cumulative 1.1 snapshot for regional, account, printer, and software-source discovery. Keep the update-only compatibility formatter and operation streams at 1.0.
- Compose the existing bounded readers, resolve only fixed trusted administration commands without launching them, and independently check Fedora/native journal admission without PackageKit security-floor or logind coupling.
- Preserve readable state and validated account subsets when another reader or an optional tool is unavailable. Enforce complete list, non-list, and total encoded-byte reservations.
- Extend the Settings parser with complete mandatory sets, backward compatibility, fixed ownership, scoped failure isolation, count/status checks, and bounded native list projections. Invalid native providers cannot retain originating action offers.
- Keep all new Settings origins, monitor coordination, and NTP sampling disabled pending the next boundary.

## Validation

Focused provider/recovery/compatibility tests: 38 passed in 2.825 seconds. Native Quickshell parser: 204 assertions in isolated X11, with an immediate no-capture-file assertion. The complete targeted System Settings lifecycle also passed. ShellCheck, shfmt, and configured Qt/Quickshell lint passed; lint retains the existing packaged metadata warnings. Docs: 15 files, zero diagnostics, 11 pages built.

A read-only Fedora 44 cumulative snapshot completed in 2.70 seconds with one account, 28 repositories, 31 updates and 37 planned package changes. Missing account/source tools were independently reported. The agent's missing logind session kept update recovery partial while regional state/native admission remained independently available. Only an isolated managed test journal was used and removed. No system setting, package, or service configuration was changed and no administration tool was opened.

Local inspection reproduced and fixed an empty-LANG compatibility defect. The full suite also caught the new parser-only fixture launching startup recovery just before exiting, leaving temporary capture files. The fixture now reserves the finite-read slot to prevent that unintended launch and explicitly checks cleanup. The mandatory post-gate Codex review then found duplicate identities could escape stream rejection after a provider-local list overflow. A reproduced regression now verifies duplicate tracking continues through count/byte overflow, with the overall 9216-record reservation bounding its memory. The update and package-change lists follow the same rule. Earlier interrupted or failed runs are not treated as final passing evidence.

Final frozen-tree gate: `scripts/run-tests make clean all` and `scripts/run-tests` both passed. The backend suite passed all 539 tests in 223.855 seconds; the complete nested-X11 System Settings lifecycle, staged install, repeated-install preservation, Fedora package/Kickstart contracts, LightDM rendering, and release archive checks passed. Settings closed CPU was 0.033%; large surfaces closed CPU was 0.00%. The exact managed build/test workspaces were removed. CodeRabbit's fresh independent review found zero findings across all nine files.

The required built-in Codex review ran after the final full gate and found no actionable correctness or security findings.

## Boundary and limitations

This is the complete minor 1 producer/parser boundary, not completion of Phase 6. Native/delegated Settings confirmation controls, pane-scoped monitor integration, visible NTP sampling, minor 2 sections, and combined installed qualification remain outstanding. Root operation-ownership policy is intentionally unchanged. No Phase 7 work, installed synchronization, live shell restart, logout, or reboot is included.