### PR TITLE
feat(system): validate regional preflight streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ versions from `config.mk`.
 
 ### Changed
 
+- Validate bounded regional choice and confirmation-preview streams in a
+  standalone parser, preserving complete locale details and typed read errors.
+  Visible confirmation and helper ownership remain pending.
+
 - Route fixed regional and delegated origins through the root operation owner
   with strict arguments, independent native journal admission, and scoped
   discovery invalidation. Visible native action controls remain pending.

--- a/TASKS.md
+++ b/TASKS.md
@@ -351,6 +351,14 @@ Private fixtures cover all seven origins, rejection, denial, unsupported tools,
 uncertain output, replay, and exact acknowledgment without host mutation.
 Native Settings controls, fresh confirmation, and NTP sampling remain pending.
 
+A standalone read-only preflight parser now bounds raw choice and preview
+streams, retains split UTF-8 and complete locale detail, validates exact request
+identity, and requires matching completion and normal process exit. Catalog
+rows remain provisional until that final gate. Invalid selections may still
+produce a validated typed read error. The parser does not launch a helper,
+authorize a mutation, or expose a visible control; Process ownership and
+confirmation integration remain separate pending boundaries.
+
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit
 confirmation warning that a sent change cannot be canceled. Local cancellation

--- a/config/quickshell/systemmanagement/SystemRegionalPreflightProtocol.js
+++ b/config/quickshell/systemmanagement/SystemRegionalPreflightProtocol.js
@@ -1,0 +1,153 @@
+.pragma library
+
+// One bounded, read-only result. Feed cumulative StdioCollector.data bytes.
+// Consumers must wait for finish(); parsed rows alone are not usable evidence.
+function create(command, selection, argument) {
+    const choices = command === "regional-choices";
+    const parser = { command: command, selection: selection, argument: argument,
+        limit: choices ? (selection === "timezone" ? 524288 : 1048576) : 8192,
+        offset: 0, previous: new Uint8Array(0), line: "", lineBytes: 0,
+        remaining: 0, minimum: 0, codepoint: 0, header: false, complete: false,
+        ended: false, failure: "", choices: [], identityBytes: 0, preview: null, error: null };
+    if (choices ? (["timezone", "locale"].indexOf(selection) < 0 || argument !== "")
+            : (command !== "regional-preview"
+                || ["timezone-set", "ntp-set", "locale-set"].indexOf(selection) < 0
+                || typeof argument !== "string" || argument.length > 512))
+        fail(parser, "Invalid preflight request");
+    return parser;
+}
+
+function fail(parser, detail) {
+    if (!parser.failure) parser.failure = detail;
+    return false;
+}
+
+function timezone(value) {
+    return value.length > 0 && value.length <= 255 && !/[^\x20-\x7e]/.test(value)
+        && !value.split("/").some(part => part === "" || part === "." || part === "..");
+}
+
+function locale(value) {
+    return value.length > 0 && value.length <= 128 && !/[^\x21-\x7e]/.test(value);
+}
+
+function utf8Bytes(value) {
+    let size = 0;
+    for (const char of value) {
+        const code = char.codePointAt(0);
+        size += code < 128 ? 1 : code < 2048 ? 2 : code < 65536 ? 3 : 4;
+    }
+    return size;
+}
+
+function validPreview(parser, fields) {
+    if (fields.length !== 7 || fields[1] !== parser.selection || fields[2] !== parser.argument
+            || fields[3].length !== 64 || !/^[0-9a-f]+$/.test(fields[3])) return false;
+    if (fields[1] === "timezone-set")
+        return timezone(fields[2]) && timezone(fields[4]) && fields[5] === fields[2];
+    if (fields[1] === "ntp-set")
+        return ["enabled", "disabled"].indexOf(fields[2]) >= 0
+            && ["enabled", "disabled"].indexOf(fields[4]) >= 0 && fields[5] === fields[2];
+    // Readable LANG can be absent, empty, or broader than localed's mutation grammar.
+    return fields[2].slice(0, 5) === "LANG=" && locale(fields[2].slice(5))
+        && fields[5] === fields[2].slice(5);
+}
+
+function acceptLine(parser, line) {
+    if (parser.complete) return fail(parser, "Records after preflight completion");
+    const fields = line.split("\t");
+    if (fields.some(field => utf8Bytes(field) > 512)) return fail(parser, "Oversized preflight field");
+    const choices = parser.command === "regional-choices";
+    if (!parser.header) {
+        const expected = parser.command + "-protocol\t1\t0" + (choices ? "\t" + parser.selection : "");
+        if (line !== expected) return fail(parser, "Unsupported preflight header");
+        parser.header = true;
+    } else if (fields[0] === "choice" && choices) {
+        const count = parser.selection === "timezone" ? 2048 : 4096;
+        const valid = parser.selection === "timezone" ? timezone(fields[1] || "") : locale(fields[1] || "");
+        if (fields.length !== 2 || !valid || parser.error || parser.choices.length >= count
+                || (parser.choices.length && fields[1] <= parser.choices[parser.choices.length - 1]))
+            return fail(parser, "Invalid, duplicate, or unordered preflight choice");
+        parser.identityBytes += fields[1].length;
+        if (parser.selection === "timezone" && parser.identityBytes > 262144)
+            return fail(parser, "Timezone identities exceed byte limit");
+        parser.choices.push(fields[1]);
+    } else if (fields[0] === "preview" && !choices) {
+        if (parser.preview || parser.error || !validPreview(parser, fields))
+            return fail(parser, "Invalid or mismatched preflight preview");
+        parser.preview = { actionId: fields[1], argument: fields[2], generation: fields[3],
+            current: fields[4], target: fields[5], detail: fields[6] };
+    } else if (fields[0] === "error") {
+        if (fields.length !== 4 || fields[1] !== "regional" || parser.error || parser.preview
+                || parser.choices.length || ["network", "repository", "conflict", "signature", "package",
+                    "unsupported", "malformed", "missing-provider", "permission-denied", "canceled",
+                    "timeout", "interrupted", "internal"].indexOf(fields[2]) < 0)
+            return fail(parser, "Invalid preflight error");
+        parser.error = { code: fields[2], detail: fields[3] };
+    } else if (fields[0] === "complete") {
+        if (fields.length !== 2 || fields[1] !== parser.command || (!choices && !parser.preview && !parser.error))
+            return fail(parser, "Incomplete preflight result");
+        parser.complete = true;
+    } else return fail(parser, "Unexpected preflight record");
+    return true;
+}
+
+function consume(parser, buffer) {
+    if (parser.failure) return false;
+    if (parser.ended || !(buffer instanceof ArrayBuffer) || buffer.byteLength < parser.offset)
+        return fail(parser, "Preflight stream replaced or already ended");
+    if (buffer.byteLength > parser.limit) return fail(parser, "Preflight stream exceeds byte limit");
+    const bytes = new Uint8Array(buffer);
+    for (let i = 0; i < parser.previous.length; i++)
+        if (bytes[i] !== parser.previous[i]) return fail(parser, "Preflight prefix changed");
+    while (parser.offset < bytes.length) {
+        const byte = bytes[parser.offset++];
+        if (++parser.lineBytes > 8192) return fail(parser, "Preflight line exceeds byte limit");
+        if (parser.remaining) {
+            if ((byte & 0xc0) !== 0x80) return fail(parser, "Invalid preflight UTF-8");
+            parser.codepoint = (parser.codepoint << 6) | (byte & 0x3f);
+            if (--parser.remaining) continue;
+            if (parser.codepoint < parser.minimum || parser.codepoint > 0x10ffff
+                    || (parser.codepoint >= 0xd800 && parser.codepoint <= 0xdfff))
+                return fail(parser, "Invalid preflight UTF-8");
+            const char = String.fromCodePoint(parser.codepoint);
+            // QML's ES7 engine does not implement Unicode property escapes.
+            // Reject Unicode 16 control/formatting and separator characters explicitly;
+            // the producer additionally validates Unicode printability.
+            if (/[\u0080-\u00a0\u00ad\u0600-\u0605\u061c\u06dd\u070f\u0890-\u0891\u08e2\u1680\u180e\u2000-\u200f\u2028-\u202f\u205f-\u206f\u3000\ufeff\ufff9-\ufffb]/.test(char)
+                    || parser.codepoint === 0x110bd || parser.codepoint === 0x110cd
+                    || (parser.codepoint >= 0x13430 && parser.codepoint <= 0x1343f)
+                    || (parser.codepoint >= 0x1bca0 && parser.codepoint <= 0x1bca3)
+                    || (parser.codepoint >= 0x1d173 && parser.codepoint <= 0x1d17a)
+                    || (parser.codepoint >= 0xe0000 && parser.codepoint <= 0xe007f))
+                return fail(parser, "Noncanonical preflight text");
+            parser.line += char;
+        } else if (byte === 10) {
+            if (!acceptLine(parser, parser.line)) return false;
+            parser.line = "";
+            parser.lineBytes = 0;
+        } else if (byte < 0x80) {
+            if ((byte < 32 && byte !== 9) || byte === 127) return fail(parser, "Noncanonical preflight text");
+            parser.line += String.fromCharCode(byte);
+        } else {
+            if (byte >= 0xc2 && byte <= 0xdf) { parser.remaining = 1; parser.minimum = 0x80; parser.codepoint = byte & 0x1f; }
+            else if (byte >= 0xe0 && byte <= 0xef) { parser.remaining = 2; parser.minimum = 0x800; parser.codepoint = byte & 0x0f; }
+            else if (byte >= 0xf0 && byte <= 0xf4) { parser.remaining = 3; parser.minimum = 0x10000; parser.codepoint = byte & 7; }
+            else return fail(parser, "Invalid preflight UTF-8");
+        }
+    }
+    parser.previous = bytes.slice();
+    return true;
+}
+
+function finish(parser, exitCode, normalExit) {
+    if (parser.failure) return false;
+    if (parser.ended) return fail(parser, "Preflight stream already ended");
+    parser.ended = true;
+    parser.previous = new Uint8Array(0);
+    if (parser.remaining || parser.line.length || !parser.complete)
+        return fail(parser, "Truncated preflight stream");
+    if (normalExit !== true || exitCode !== (parser.error ? 1 : 0))
+        return fail(parser, "Preflight exit does not match its result");
+    return true;
+}

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -570,6 +570,20 @@ typed regional error and exits 1. Locale detail is the complete preserved
 override description, not a truncated summary. Preflight is not authorization
 or proof that a future mutation is available.
 
+The standalone QML `SystemRegionalPreflightProtocol.js` parser consumes
+cumulative raw bytes with a per-result lifetime. It checks the immutable prefix,
+strict UTF-8, control-free fields, exact record shape and ordering, catalog identity
+and payload limits, selected action/argument/target, and generation syntax.
+Unknown records and trailing fields are not extension space in these separate
+preflight protocols. Parsed choices and preview fields are provisional until
+`finish` verifies completion, a final newline, and normal exit 0; a typed error
+instead requires normal exit 1. A valid empty catalog is distinct from failure.
+The full readable locale detail and current value are preserved, without
+confusing readable aliases with the stricter service mutation grammar. The
+parser itself owns no Process, authorization, operation, or visible control.
+Nested-X11 parser fixtures exercise byte splits, malformed and replaced streams,
+limits, request mismatches, and typed errors without host service calls.
+
 Each preview makes fresh fixed reads: timezone state and timezone choices, NTP
 state, or locale state and installed locale choices. Service reads retain their
 ten-second aggregate bounds; the locale collector retains its three-second

--- a/tests/qml/SystemRegionalPreflightParser.qml
+++ b/tests/qml/SystemRegionalPreflightParser.qml
@@ -30,12 +30,18 @@ ShellRoot {
         const parser = Protocol.create(command, selection, argument);
         return Protocol.consume(parser, root.bytes(text)) && Protocol.finish(parser, code, normal !== false);
     }
+    function exactChoices(kind, values) {
+        const parser = Protocol.create("regional-choices", kind, "");
+        root.check(Protocol.consume(parser, root.bytes(root.choices(kind, values)))
+            && Protocol.finish(parser, 0, true), kind + " catalog completion");
+        root.check(JSON.stringify(parser.choices) === JSON.stringify(values), kind + " exact catalog identities and order");
+    }
     function unitTests() {
         for (const kind of ["timezone", "locale"]) {
             const values = kind === "timezone" ? ["America/Chicago", "Etc/UTC"] : ["C", "en_US.utf8"];
             const good = root.choices(kind, values);
-            root.check(root.parse("regional-choices", kind, "", good, 0), kind + " choices");
-            root.check(root.parse("regional-choices", kind, "", root.choices(kind, []), 0), "empty catalog");
+            root.exactChoices(kind, values);
+            root.exactChoices(kind, []);
             const bad = [good.slice(0, -1), good + "\n", good + "complete\tregional-choices\n",
                 good.replace("\t1\t0", "\t1\t1"), good.replace("\t1\t0", "\t2\t0"),
                 good.replace("choice\t", "unknown\t"), good.replace("choice\t", "choice\textra\t"),

--- a/tests/qml/SystemRegionalPreflightParser.qml
+++ b/tests/qml/SystemRegionalPreflightParser.qml
@@ -1,0 +1,125 @@
+import QtQuick
+import Quickshell
+import "SystemRegionalPreflightProtocol.js" as Protocol
+
+ShellRoot {
+    id: root
+    property int assertions: 0
+    property string generation: "a".repeat(64)
+
+    function check(condition, message) {
+        root.assertions++;
+        if (!condition) throw new Error(message);
+    }
+    function bytes(text) {
+        const encoded = unescape(encodeURIComponent(text));
+        const result = new Uint8Array(encoded.length);
+        for (let i = 0; i < encoded.length; i++) result[i] = encoded.charCodeAt(i);
+        return result.buffer;
+    }
+    function choices(kind, values) {
+        return "regional-choices-protocol\t1\t0\t" + kind + "\n"
+            + values.map(value => "choice\t" + value + "\n").join("") + "complete\tregional-choices\n";
+    }
+    function preview(action, argument, current, detail) {
+        return "regional-preview-protocol\t1\t0\n" + ["preview", action, argument, root.generation,
+            current, action === "locale-set" ? argument.slice(5) : argument, detail].join("\t")
+            + "\ncomplete\tregional-preview\n";
+    }
+    function parse(command, selection, argument, text, code, normal) {
+        const parser = Protocol.create(command, selection, argument);
+        return Protocol.consume(parser, root.bytes(text)) && Protocol.finish(parser, code, normal !== false);
+    }
+    function unitTests() {
+        for (const kind of ["timezone", "locale"]) {
+            const values = kind === "timezone" ? ["America/Chicago", "Etc/UTC"] : ["C", "en_US.utf8"];
+            const good = root.choices(kind, values);
+            root.check(root.parse("regional-choices", kind, "", good, 0), kind + " choices");
+            root.check(root.parse("regional-choices", kind, "", root.choices(kind, []), 0), "empty catalog");
+            const bad = [good.slice(0, -1), good + "\n", good + "complete\tregional-choices\n",
+                good.replace("\t1\t0", "\t1\t1"), good.replace("\t1\t0", "\t2\t0"),
+                good.replace("choice\t", "unknown\t"), good.replace("choice\t", "choice\textra\t"),
+                good.replace("complete\tregional-choices", "complete\tregional-preview"),
+                root.choices(kind, [values[0], values[0]]), root.choices(kind, values.slice().reverse()),
+                root.choices(kind, [""]), root.choices(kind, ["bad\rvalue"]), root.choices(kind, ["bad\u0000value"]),
+                root.choices(kind, ["\u00e9"]), good.replace("choice\t", "error\tregional\tinternal\tbad\nchoice\t")];
+            for (const text of bad) root.check(!root.parse("regional-choices", kind, "", text, 0), "invalid catalog");
+            root.check(!root.parse("regional-choices", kind, "", good, 1), "wrong catalog exit");
+            root.check(!root.parse("regional-choices", kind, "", good, 0, false), "crashed catalog");
+            const count = kind === "timezone" ? 2048 : 4096;
+            const maximum = Array.from({length: count}, (_, i) => "Z" + String(i).padStart(4, "0"));
+            root.check(root.parse("regional-choices", kind, "", root.choices(kind, maximum), 0), "maximum count");
+            maximum.push("Z9999");
+            root.check(!root.parse("regional-choices", kind, "", root.choices(kind, maximum), 0), "count overflow");
+            const length = kind === "timezone" ? 255 : 128;
+            root.check(root.parse("regional-choices", kind, "", root.choices(kind, ["x".repeat(length)]), 0), "maximum identity");
+            root.check(!root.parse("regional-choices", kind, "", root.choices(kind, ["x".repeat(length + 1)]), 0), "identity overflow");
+        }
+        for (const value of ["/Etc/UTC", "Etc//UTC", "Etc/../UTC", "Etc/./UTC", "Etc/UTC/"])
+            root.check(!root.parse("regional-choices", "timezone", "", root.choices("timezone", [value]), 0), "unsafe timezone");
+        root.check(!root.parse("regional-choices", "locale", "", root.choices("locale", ["en US"]), 0), "locale whitespace");
+        const maximumBytes = Array.from({length: 2048}, (_, i) => String(i).padStart(4, "0") + "x".repeat(124));
+        root.check(root.parse("regional-choices", "timezone", "", root.choices("timezone", maximumBytes), 0), "timezone payload at limit");
+        maximumBytes[2047] += "x";
+        root.check(!root.parse("regional-choices", "timezone", "", root.choices("timezone", maximumBytes), 0), "timezone payload overflow");
+
+        for (const request of [["timezone-set", "Etc/UTC", "America/Chicago"],
+                ["ntp-set", "enabled", "disabled"], ["locale-set", "LANG=en_US.utf8", "C"]]) {
+            const action = request[0], argument = request[1];
+            const good = root.preview(action, argument, request[2], "LC_TIME=\u20ac\ud83d\ude00, LANGUAGE=en:de");
+            const all = root.bytes(good);
+            for (let split = 0; split <= all.byteLength; split++) {
+                const parser = Protocol.create("regional-preview", action, argument);
+                root.check(Protocol.consume(parser, all.slice(0, split)) && Protocol.consume(parser, all)
+                    && Protocol.finish(parser, 0, true), "every UTF-8 split: " + split + " " + parser.failure);
+                root.check(parser.preview.detail === "LC_TIME=\u20ac\ud83d\ude00, LANGUAGE=en:de", "full detail retained");
+            }
+            for (const text of [good.replace(root.generation, "A".repeat(64)), good.replace(root.generation, "a".repeat(63)),
+                    good.replace("preview\t" + action, "preview\tntp-unknown"), good.replace("\t" + argument + "\t", "\twrong\t"),
+                    good.replace("\t" + (action === "locale-set" ? argument.slice(5) : argument) + "\tLC_TIME", "\twrong\tLC_TIME"),
+                    good.replace("\ncomplete", "\textra\ncomplete"), good.slice(0, -1), good + good,
+                    good.replace("preview\t", "error\tregional\tinternal\tfailure\npreview\t")])
+                root.check(!root.parse("regional-preview", action, argument, text, 0), "invalid preview");
+            for (const code of [1, 2, -1]) root.check(!root.parse("regional-preview", action, argument, good, code), "preview exit mismatch");
+            for (const detail of ["x".repeat(513), "\u20ac".repeat(171), "\u007f", "\u0085", "\u202e", "\u2028", "\u00a0"])
+                root.check(!root.parse("regional-preview", action, argument, root.preview(action, argument, request[2], detail), 0), "unsafe detail: " + detail.codePointAt(0) + "/" + detail.length);
+            root.check(root.parse("regional-preview", action, argument, root.preview(action, argument, request[2], "\u20ac".repeat(170) + "ab"), 0), "512 UTF-8 bytes");
+        }
+        const header = "regional-preview-protocol\t1\t0\n";
+        for (const code of ["network", "repository", "conflict", "signature", "package", "unsupported", "malformed",
+                "missing-provider", "permission-denied", "canceled", "timeout", "interrupted", "internal"]) {
+            const error = header + "error\tregional\t" + code + "\tNot available\ncomplete\tregional-preview\n";
+            root.check(root.parse("regional-preview", "ntp-set", "invalid selection", error, 1), "typed recognized-request error");
+            root.check(!root.parse("regional-preview", "ntp-set", "enabled", error, 0), "error cannot succeed");
+            root.check(!root.parse("regional-preview", "ntp-set", "enabled", error.replace("\tregional\t", "\tupdates\t"), 1), "wrong error owner");
+        }
+        for (const invalid of [[0xc0, 0x80], [0xed, 0xa0, 0x80], [0xf4, 0x90, 0x80, 0x80], [0xe2, 0x28, 0xa1], [0x80]]) {
+            const parser = Protocol.create("regional-preview", "ntp-set", "enabled");
+            root.check(!Protocol.consume(parser, new Uint8Array(invalid).buffer), "invalid UTF-8");
+        }
+        const truncated = Protocol.create("regional-preview", "ntp-set", "enabled");
+        root.check(Protocol.consume(truncated, new Uint8Array([0xe2]).buffer) && !Protocol.finish(truncated, 0, true), "truncated UTF-8");
+        const parser = Protocol.create("regional-preview", "ntp-set", "enabled");
+        root.check(Protocol.consume(parser, root.bytes(header)), "partial header");
+        root.check(!Protocol.consume(parser, root.bytes(header.replace("1", "2"))), "replaced same-length prefix");
+        const shrink = Protocol.create("regional-preview", "ntp-set", "enabled");
+        root.check(Protocol.consume(shrink, root.bytes(header)) && !Protocol.consume(shrink, root.bytes("short")), "shrunk collector");
+        for (const request of [["unknown", "timezone", ""], ["regional-choices", "unknown", ""],
+                ["regional-choices", "locale", "extra"], ["regional-preview", "unknown", ""], ["regional-preview", "ntp-set", null]])
+            root.check(!!Protocol.create(...request).failure, "invalid request");
+        for (const request of [["regional-choices", "timezone", ""], ["regional-choices", "locale", ""], ["regional-preview", "ntp-set", "enabled"]]) {
+            const bounded = Protocol.create(...request);
+            root.check(!Protocol.consume(bounded, new ArrayBuffer(bounded.limit + 1)), "whole stream overflow");
+        }
+        const ended = Protocol.create("regional-choices", "locale", "");
+        root.check(Protocol.consume(ended, root.bytes(root.choices("locale", []))) && Protocol.finish(ended, 0, true), "finish once");
+        root.check(!Protocol.finish(ended, 0, true), "duplicate finish");
+    }
+    Component.onCompleted: Qt.callLater(function() {
+        try {
+            root.unitTests();
+            console.info("Regional preflight parser tests: PASS (" + root.assertions + " assertions)");
+        } catch (error) { console.error("Regional preflight parser FAILED: " + error); }
+        Qt.quit();
+    })
+}

--- a/tests/test-quickshell-system-management-xvfb.sh
+++ b/tests/test-quickshell-system-management-xvfb.sh
@@ -506,6 +506,22 @@ if [ "$ui_status" -ne 0 ] || ! grep -F 'Update UI native tests: PASS' "$work/upd
 	exit 1
 fi
 
+mkdir -p "$work/regional-preflight-parser"
+cp "$repo/tests/qml/SystemRegionalPreflightParser.qml" "$work/regional-preflight-parser/shell.qml"
+cp "$repo/config/quickshell/systemmanagement/SystemRegionalPreflightProtocol.js" "$work/regional-preflight-parser/"
+timeout --foreground --kill-after=2s 20s env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
+	XDG_DATA_HOME="$data_home" XDG_RUNTIME_DIR="$runtime" QT_QPA_PLATFORMTHEME= \
+	quickshell --no-duplicate --path "$work/regional-preflight-parser/shell.qml" \
+	>"$work/regional-preflight-parser.log" 2>&1 &
+quickshell_pid=$!
+parser_status=0
+wait "$quickshell_pid" || parser_status=$?
+quickshell_pid=
+if [ "$parser_status" -ne 0 ] || ! grep -F 'Regional preflight parser tests: PASS' "$work/regional-preflight-parser.log"; then
+	cat "$work/regional-preflight-parser.log" >&2
+	exit 1
+fi
+
 mkdir -p "$work/operation-parser"
 cp "$repo/tests/qml/SystemOperationParser.qml" "$work/operation-parser/shell.qml"
 cp "$repo/config/quickshell/systemmanagement/SystemOperationProtocol.js" "$work/operation-parser/"


### PR DESCRIPTION
## Summary

Add a standalone, bounded parser for the existing read-only regional choices and preview protocols. It preserves exact catalog identities and full locale details, validates fixed request/action/target and generation syntax, handles split UTF-8 and cumulative collector replacement, and accepts a result only after completion plus matching normal exit. A typed error remains distinct from success.

This is one six-file parser/test/documentation boundary. It does not add a Process, visible controls, authorization, or host mutations. Regional preflight ownership and confirmation UI remain pending.

## Validation

- Focused managed nested-X11 lifecycle passed, including 1,384 new parser assertions, existing 695 operation parser assertions, 334 native snapshot assertions, and all 42 native-origin scenarios.
- Configured QML lint passed with the pre-existing metadata warnings; full ShellCheck and shfmt passed.
- Documentation check/build passed (15 files without diagnostics, 11 pages).
- Independent CodeRabbit local review: six files, no findings.
- Clean build and complete managed suite passed: `scripts/run-tests make clean all` then `scripts/run-tests` (539 backend tests in 225.027s, all native fixtures, staged install, repeated preservation, 66-package map, Kickstart, LightDM, and release archive). Closed Settings CPU 0.067%, large surfaces 0.00%; power lifecycle 0.167% -> 0.067%. Temporary workspaces removed.
- Mandatory post-full Codex review completed with no actionable findings.

## Limitations

Parser fixtures run in a private nested X11 session and do not invoke a regional service or mutate settings. No new visible surface exists, so screenshots and graphical authorization do not apply to this boundary. The producer additionally validates Unicode printability; the ES7-compatible consumer explicitly rejects Unicode 16 control/formatting/separator ranges rather than relying on unsupported Unicode-property regex escapes. Phase 6 remains active; installed graphical qualification and final managed sync have not occurred.

## Review follow-up

The catalog-retention suggestion is covered by explicit comparisons against independent expected identity arrays, in order, for timezone/locale and both empty catalogs. This one-file test follow-up passed focused and full gates, fresh independent review, and mandatory post-full Codex review.

Additional read-only Fedora host compatibility check: the same production parser, loaded in Node as an adjunct to the native-QML fixtures, accepted 598 timezone choices, 39 locale choices, and all three real regional preview responses with exit 0. No settings were applied, no journal action was started, and the live shell was not synced or reloaded.