### PR TITLE
feat(system): guard delegated action confirmations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ versions from `config.mk`.
 
 ### Changed
 
+- Add internal confirmation guards for the four fixed administration tools,
+  with fresh provider evidence, update-workflow exclusion, and reentrant
+  dispatch checks. Visible delegated controls remain pending.
+
 - Install snapshot capture cleanup handlers before temporary-file allocation,
   and prevent helper launch when cancellation arrives during setup.
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -369,8 +369,15 @@ requests while active. It retains one Process through completion publication,
 close, timeout, and forced-stop cleanup; stale callbacks cannot own a replacement.
 Complete bytes remain provisional until the matching process exits. Private
 nested-X11 fixtures cover 18 success, error, cancellation, timeout, reentrant,
-and failed-start scenarios without host service calls. Root confirmation
+and failed-start scenarios without host service calls. Regional root confirmation
 integration and visible controls remain separate pending boundaries.
+
+The root now provides internal confirmation for the four fixed delegated tools.
+It requires fresh owning-provider and journal evidence, captures snapshot and
+cycle identity, rejects update-workflow overlap, and rechecks state after prompt
+callbacks before fixed dispatch. Private nested-X11 cases cover each tool's
+success, denial, unsupported result, and reentrant closure without opening real
+administration tools. Visible controls and combined qualification remain pending.
 
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit

--- a/config/quickshell/systemmanagement/SystemManagementModel.qml
+++ b/config/quickshell/systemmanagement/SystemManagementModel.qml
@@ -37,6 +37,9 @@ Scope {
     property var updateConfirmation: null
     property string confirmationMessage: ""
     property bool dispatchingUpdate: false
+    property var nativeConfirmation: null
+    property string nativeConfirmationMessage: ""
+    property bool dispatchingNative: false
     readonly property alias operation: operationModel
     readonly property alias discovery: discoveryModel
     readonly property alias timeDiscovery: timeDiscoveryModel
@@ -100,8 +103,10 @@ Scope {
     function updateActionReason(actionId) {
         if (actionId !== "updates-refresh" && actionId !== "updates-install-all")
             return "This update action is not supported.";
-        if (!root.settingsVisible || root.dispatchingUpdate)
+        if (!root.settingsVisible)
             return "Open System Settings to prepare an update action.";
+        if (root.dispatchingUpdate || root.dispatchingNative || root.nativeConfirmation !== null)
+            return "Finish or dismiss the current confirmation first.";
         if (root.snapshotOwned || root.snapshotPending || root.requiredPending || !discoveryModel.fresh)
             return "Wait for fresh update discovery, or reload status to retry.";
         if (!root.validGeneration(root.generation) || root.recoveryProvider.status !== "available")
@@ -162,6 +167,91 @@ Scope {
         if (root.updateConfirmation !== null)
             root.confirmationMessage = "Update state changed. Review a fresh preview and confirm again.";
         root.updateConfirmation = null;
+        root.invalidateNativeConfirmation("");
+    }
+
+    function delegateDiscovery(actionId) {
+        if (actionId === "accounts-open" || actionId === "password-open") return accountDiscoveryModel;
+        if (actionId === "printers-open") return printerDiscoveryModel;
+        if (actionId === "sources-open") return discoveryModel;
+        return null;
+    }
+
+    function delegateContextReason(actionId) {
+        const monitor = root.delegateDiscovery(actionId);
+        if (monitor === null) return "This delegated action is not supported.";
+        if (!root.settingsVisible) return "Open System Settings to prepare this action.";
+        if (root.snapshotOwned || root.snapshotPending || root.requiredPending || root.discoveryBatch
+                || !monitor.visible || !monitor.ready || monitor.failed || !monitor.cycle.enabled
+                || monitor.cycle.phase !== "idle" || monitor.cycle.unresolved)
+            return "Wait for fresh provider status, or reload status to retry.";
+        if (!root.validGeneration(root.generation) || !operationModel.canStart)
+            return "An operation or its recovery still owns the system workflow.";
+        const action = root.actions.find(item => item.id === actionId);
+        if (!action || action.availability !== "available")
+            return action && action.detail.length > 0 ? action.detail : "The provider did not offer this action.";
+        return "";
+    }
+
+    function delegateActionReason(actionId) {
+        if (root.dispatchingUpdate || root.dispatchingNative || root.updateConfirmation !== null)
+            return "Finish or dismiss the current confirmation first.";
+        return root.delegateContextReason(actionId);
+    }
+
+    function prepareDelegate(actionId) {
+        if (root.nativeConfirmation !== null) return false;
+        const reason = root.delegateActionReason(actionId);
+        if (reason.length > 0) {
+            root.nativeConfirmationMessage = reason;
+            return false;
+        }
+        const pending = { actionId: actionId, generation: root.generation,
+            requestGeneration: root.requestGeneration, epoch: root.delegateDiscovery(actionId).cycle.epoch };
+        root.dispatchingNative = true;
+        root.nativeConfirmationMessage = "";
+        // Reentrant closure or discovery callbacks may retire this preparation.
+        if (root.delegateContextReason(actionId) === "" && pending.generation === root.generation
+                && pending.requestGeneration === root.requestGeneration
+                && pending.epoch === root.delegateDiscovery(actionId).cycle.epoch)
+            root.nativeConfirmation = pending;
+        root.dispatchingNative = false;
+        return root.nativeConfirmation === pending;
+    }
+
+    function discardDelegate() {
+        root.nativeConfirmation = null;
+        root.nativeConfirmationMessage = "";
+    }
+
+    function invalidateNativeConfirmation(domain) {
+        const pending = root.nativeConfirmation;
+        if (pending === null) return;
+        const monitor = root.delegateDiscovery(pending.actionId);
+        if (domain !== "" && (monitor === null || monitor.domain !== domain)) return;
+        root.nativeConfirmationMessage = "Provider state changed. Reload status and confirm again.";
+        root.nativeConfirmation = null;
+    }
+
+    function confirmDelegate() {
+        const pending = root.nativeConfirmation;
+        if (pending === null || root.dispatchingUpdate || root.dispatchingNative) return false;
+        if (root.delegateActionReason(pending.actionId) !== "") {
+            root.invalidateNativeConfirmation("");
+            return false;
+        }
+        root.dispatchingNative = true;
+        root.nativeConfirmation = null;
+        // Recheck after prompt callbacks; the operation owner checks its own
+        // source ownership again before constructing the fixed empty argv.
+        const monitor = root.delegateDiscovery(pending.actionId);
+        const current = root.delegateContextReason(pending.actionId) === ""
+            && pending.generation === root.generation && pending.requestGeneration === root.requestGeneration
+            && monitor !== null && pending.epoch === monitor.cycle.epoch;
+        const started = current && operationModel.startNative(pending.actionId, "", "");
+        root.nativeConfirmationMessage = started ? "" : "Provider state changed. Reload status and confirm again.";
+        root.dispatchingNative = false;
+        return started;
     }
 
     function providerFallback(detail) {
@@ -1007,11 +1097,13 @@ Scope {
         id: accountDiscoveryModel
         domain: "accounts"
         onSnapshotRequested: root.requestSnapshot(false)
+        onInvalidated: root.invalidateNativeConfirmation("accounts")
     }
     SystemProviderDiscovery {
         id: printerDiscoveryModel
         domain: "printers"
         onSnapshotRequested: root.requestSnapshot(false)
+        onInvalidated: root.invalidateNativeConfirmation("printers")
     }
 
     SystemOperationModel {

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -2029,6 +2029,22 @@ points and verify output, child shutdown, and absence of capture files.
 Abrupt process KILL or host failure cannot run shell cleanup handlers and is not
 covered by the graceful-termination guarantee.
 
+The root's internal delegated confirmation entry admits only `accounts-open`,
+`password-open`, `printers-open`, and `sources-open`. It requires a visible
+Settings section, a quiet snapshot owner, fresh owning-provider cycle, validated
+available action, and empty operation/recovery ownership. Native admission does
+not require update-only recovery evidence. A pending confirmation captures the
+action, snapshot generation, request identity, and provider epoch; provider or
+global invalidation, replacement reads, and closure retire it. Update and native
+prompts cannot overlap. Dispatch is claimed before clearing the prompt and state
+is rechecked after reentrant callbacks, then the existing owner independently
+validates fixed empty arguments. Discarding or closing a prompt never starts an
+operation; closing after dispatch preserves observation. Sixteen private nested
+X11 cases cover all four tools, typed denial and unsupported results, and closure
+during dispatch callbacks. Accepted launch still does not verify administration
+inside the tool. These entry points are not exposed by IPC or visible controls;
+regional confirmation and visible native Settings remain separate boundaries.
+
 The shared subscription owner starts a discovery cycle only after readiness, with a 12-second frontend
 startup deadline covering the helper's ten-second setup and process startup.
 Failure falls back to a finite read with visible monitoring-unavailable guidance;

--- a/tests/fixtures/system-delegate-confirmation-provider.py
+++ b/tests/fixtures/system-delegate-confirmation-provider.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+"""Compose private discovery and native-owner fixtures without host calls."""
+
+import importlib.util
+from pathlib import Path
+import signal
+import sys
+
+
+def load(name):
+    spec = importlib.util.spec_from_file_location(name, Path(__file__).with_name(name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+discovery = load("system-native-discovery-provider")
+operation = load("system-native-action-provider")
+original_row = discovery.row
+
+
+def row(*fields):
+    if fields[:2] == ("provider", "recovery"):
+        fields = (*fields[:2], "partial", *fields[3:])
+    elif fields[0] == "action" and fields[1] != "updates-cancel":
+        fields = (*fields[:2], "available", *fields[3:-1], "Fixed private action")
+    elif fields == ("complete", "snapshot"):
+        if (operation.DIRECTORY / operation.ACTION).exists() and not (operation.DIRECTORY / "ack-operation").exists():
+            original_row("terminal-handoff", operation.IDENTITY, operation.ACTION, "delegate")
+    original_row(*fields)
+
+
+discovery.row = row
+for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+    signal.signal(signum, discovery.stop)
+if sys.argv[1] in (operation.ACTION, "watch-operation", "ack-operation"):
+    raise SystemExit(operation.main())
+discovery.main()

--- a/tests/qml/SystemDelegateConfirmation.qml
+++ b/tests/qml/SystemDelegateConfirmation.qml
@@ -1,0 +1,132 @@
+import QtQuick
+import Quickshell
+import qs.systemmanagement
+
+ShellRoot {
+    id: root
+    property string action: Quickshell.env("DWM_NATIVE_ACTION")
+    property string scenario: Quickshell.env("DWM_NATIVE_ACTION_SCENARIO")
+    property int stage: 0
+    property int assertions: 0
+    property bool dispatchProbe: false
+    property bool done: false
+
+    function check(value, detail) {
+        assertions++;
+        if (!value) {
+            console.error("Delegate confirmation FAILED: " + action + "/" + scenario + ": " + detail);
+            throw new Error(detail);
+        }
+    }
+
+    function finish() {
+        if (done) return;
+        done = true;
+        check(!model.settingsVisible && !model.operation.busy, "Closed fixture releases completed ownership");
+        check(!model.discoveryModels().some(item => item.monitorOwned), "Closed fixture stops subscriptions");
+        if (scenario !== "close-dispatch") {
+            check(model.operation.result !== null && model.operation.audit !== null, "Result requires verified audit");
+            check(model.operation.result.state === (scenario === "denied" ? "permission-denied"
+                : scenario === "unsupported" ? "failed" : "succeeded"), "Typed result preserved");
+            if (scenario === "success")
+                check(model.operation.result.detail.indexOf("not verified") >= 0, "Launch acceptance is not completed administration");
+        } else check(model.operation.result === null, "Reentrant closure prevents dispatch");
+        console.info("Delegate confirmation tests: PASS (" + action + "/" + scenario + ", " + assertions + " assertions)");
+        Qt.quit();
+    }
+
+    function advance() {
+        if (done) return;
+        if (stage === 0 && !model.busy && model.operation.canStart) {
+            check(!model.prepareDelegate(action) && !model.confirmDelegate(), "Closed startup cannot dispatch");
+            stage = 1;
+            model.openSettings();
+        } else if (stage === 1 && !model.busy && model.discoveryModels().every(item => item.fresh)) {
+            stage = -1;
+            check(model.recoveryProvider.status === "partial" && model.delegateActionReason(action) === "",
+                "Native offers admit independently of update-only recovery limitations");
+            for (const invalid of ["unknown", "updates-refresh", "timezone-set", "ntp-set", "locale-set", "watch-operation"])
+                check(!model.prepareDelegate(invalid), "Closed delegated action allowlist");
+            for (const field of ["snapshotOwned", "snapshotPending", "requiredPending", "discoveryBatch"]) {
+                model[field] = true;
+                check(!model.prepareDelegate(action), field + " blocks preparation");
+                model[field] = false;
+            }
+            model.operation.snapshotKnown = false;
+            check(!model.prepareDelegate(action), "Unknown journal blocks preparation");
+            model.operation.snapshotKnown = true;
+            const monitor = model.delegateDiscovery(action);
+            for (const field of ["ready", "failed"]) {
+                const previous = monitor[field];
+                monitor[field] = field === "failed";
+                check(!model.prepareDelegate(action), "Unavailable monitor " + field + " blocks preparation");
+                monitor[field] = previous;
+            }
+            for (const change of [["enabled", false], ["unresolved", true], ["phase", "initial-pending"]]) {
+                const previous = monitor.cycle[change[0]];
+                monitor.cycle[change[0]] = change[1];
+                check(!model.prepareDelegate(action), "Source cycle " + change[0] + " blocks before binding publication");
+                monitor.cycle[change[0]] = previous;
+            }
+            const actions = model.actions;
+            model.actions = actions.map(item => item.id === action ? Object.assign({}, item, {availability: "unavailable", detail: ""}) : item);
+            check(!model.prepareDelegate(action), "Unavailable offer blocks without requiring detail");
+            model.actions = actions;
+            model.updateConfirmation = {actionId: "updates-refresh"};
+            check(!model.prepareDelegate(action), "Update prompt blocks delegated preparation");
+            model.updateConfirmation = null;
+            check(model.prepareDelegate(action), "Fixed action prepares without dispatch");
+            check(!model.prepareDelegate(action) && !model.prepareUpdate("updates-refresh"), "Prompt rejects replacement and update overlap");
+            check(model.confirmationMessage === "Finish or dismiss the current confirmation first.",
+                "Visible prompt conflict does not ask to reopen Settings");
+            check(model.operation.result === null && !model.operation.busy, "Preparation is passive");
+            model.discardDelegate();
+            check(!model.confirmDelegate(), "Discarded prompt cannot dispatch");
+            check(model.prepareDelegate(action), "Prepare generation check");
+            const generation = model.generation;
+            model.generation = "e".repeat(64);
+            check(!model.confirmDelegate() && model.nativeConfirmation === null, "Changed generation retires prompt");
+            model.generation = generation;
+            check(model.prepareDelegate(action), "Prepare request identity check");
+            model.requestGeneration++;
+            check(!model.confirmDelegate(), "Changed request identity blocks dispatch");
+            check(model.prepareDelegate(action), "Prepare epoch check");
+            model.delegateDiscovery(action).cycle.epoch++;
+            check(!model.confirmDelegate(), "Changed provider epoch blocks dispatch");
+            check(model.prepareDelegate(action), "Prepare invalidation check");
+            model.invalidateNativeConfirmation("locale");
+            check(model.nativeConfirmation !== null, "Unrelated optional domain does not retire prompt");
+            model.discoveryBatch = true;
+            model.delegateDiscovery(action).invalidate();
+            check(model.nativeConfirmation === null && !model.confirmDelegate(), "Owning event immediately retires prompt");
+            model.discoveryBatch = false;
+            stage = 2;
+            model.refresh();
+        } else if (stage === 2 && !model.busy && model.delegateActionReason(action) === "") {
+            stage = -1;
+            check(model.prepareDelegate(action), "Fresh explicit confirmation available");
+            dispatchProbe = true;
+            const started = model.confirmDelegate();
+            check(!dispatchProbe && started === (scenario !== "close-dispatch"), "Dispatch guard survives prompt callbacks");
+            check(!model.confirmDelegate(), "Duplicate confirmation cannot dispatch");
+            model.closeSettings();
+            if (started) check(model.operation.streamOwned, "Pane closure retains started owner");
+            stage = 3;
+        } else if (stage === 3 && !model.busy && !model.operation.busy
+                && !model.discoveryModels().some(item => item.monitorOwned)
+                && (scenario === "close-dispatch" || model.operation.acknowledgedIds.length === 1)) finish();
+    }
+
+    SystemManagementModel {
+        id: model
+        onNativeConfirmationChanged: {
+            if (nativeConfirmation !== null || !root.dispatchProbe) return;
+            root.dispatchProbe = false;
+            root.check(dispatchingNative && !model.prepareDelegate(root.action)
+                && !model.prepareUpdate("updates-refresh") && !model.confirmDelegate(), "Reentrant callback cannot overlap dispatch");
+            if (root.scenario === "close-dispatch") model.closeSettings();
+        }
+    }
+    Timer { interval: 20; running: true; repeat: true; onTriggered: root.advance() }
+    Timer { interval: 15000; running: true; onTriggered: { console.error("Delegate confirmation FAILED: timeout"); Qt.quit(); } }
+}

--- a/tests/test-quickshell-system-management-xvfb.sh
+++ b/tests/test-quickshell-system-management-xvfb.sh
@@ -40,6 +40,11 @@ cleanup() {
 	cleanup_status=$?
 	set +e
 	stop_process "${quickshell_pid:-}"
+	if [ -n "${delegate_helper:-}" ]; then
+		for helper_pid in $(pgrep -f "$delegate_helper " 2>/dev/null || true); do
+			stop_process "$helper_pid"
+		done
+	fi
 	if [ -n "${checked_helper:-}" ]; then
 		for helper_pid in $(pgrep -f "$checked_helper " 2>/dev/null || true); do
 			stop_process "$helper_pid"
@@ -651,6 +656,44 @@ if find "$runtime" -type f -name 'dwm-checked-command*' -print -quit | grep -q .
 	printf 'Parser-only fixture started a capture that outlived its process\n' >&2
 	exit 1
 fi
+
+mkdir -p "$work/delegate-confirmation" "$work/delegate-data/dwm-titus/scripts"
+cp -a "$repo/config/quickshell/core" "$repo/config/quickshell/systemmanagement" "$work/delegate-confirmation/"
+cp "$repo/tests/qml/SystemDelegateConfirmation.qml" "$work/delegate-confirmation/shell.qml"
+delegate_helper=$work/delegate-data/dwm-titus/scripts/dwm-system-management
+cp "$repo/tests/fixtures/system-delegate-confirmation-provider.py" "$delegate_helper"
+cp "$repo/tests/fixtures/system-native-discovery-provider.py" "$repo/tests/fixtures/system-native-action-provider.py" "$(dirname "$delegate_helper")/"
+chmod +x "$delegate_helper"
+for delegate_action in accounts-open password-open printers-open sources-open; do
+	for delegate_scenario in success denied unsupported close-dispatch; do
+		delegate_state=$work/delegate-$delegate_action-$delegate_scenario
+		mkdir -p "$delegate_state"
+		delegate_status=0
+		timeout --foreground --kill-after=2s 20s env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
+			XDG_DATA_HOME="$work/delegate-data" XDG_RUNTIME_DIR="$runtime" QT_QPA_PLATFORMTHEME= \
+			DWM_NATIVE_DISCOVERY_FIXTURE="$delegate_state" DWM_NATIVE_ACTION_FIXTURE="$delegate_state" \
+			DWM_NATIVE_ACTION="$delegate_action" DWM_NATIVE_ACTION_SCENARIO="$delegate_scenario" \
+			quickshell --no-duplicate --path "$work/delegate-confirmation/shell.qml" >"$delegate_state/log" 2>&1 &
+		quickshell_pid=$!
+		wait "$quickshell_pid" || delegate_status=$?
+		quickshell_pid=
+		if [ "$delegate_status" -ne 0 ] || ! grep -F 'Delegate confirmation tests: PASS' "$delegate_state/log" ||
+			grep -Fq 'Delegate confirmation FAILED:' "$delegate_state/log" ||
+			[ -e "$delegate_state/invalid-arguments" ] || [ -e "$delegate_state/overlap" ] ||
+			[ -e "$delegate_state/unexpected-command" ] ||
+			[ -n "$(find "$delegate_state" -maxdepth 1 -name '*.active' -print -quit)" ]; then
+			cat "$delegate_state/log" >&2
+			exit 1
+		fi
+		if [ "$delegate_scenario" = close-dispatch ]; then
+			[ ! -e "$delegate_state/$delegate_action" ]
+			[ ! -e "$delegate_state/ack-operation" ]
+		else
+			[ "$(sed -n '1p' "$delegate_state/$delegate_action")" = 1 ]
+			[ "$(sed -n '1p' "$delegate_state/ack-operation")" = 1 ]
+		fi
+	done
+done
 
 mkdir -p "$work/native-action" "$work/native-action-data/dwm-titus/scripts"
 cp -a "$repo/config/quickshell/core" "$repo/config/quickshell/systemmanagement" "$work/native-action/"


### PR DESCRIPTION
## Summary
- Add internal confirmation for four fixed delegated origins: accounts, password, printers, and software sources.
- Require visible Settings, fresh owning-provider source state, quiet snapshots, validated offers, and available operation ownership independently of update-only recovery limitations.
- Capture snapshot/request/provider identities, invalidate stale prompts, exclude update overlap, and recheck after reentrant prompt callbacks before fixed empty-argument dispatch.
- Keep visible controls, regional confirmation, installed synchronization, and combined Phase 6 qualification out of this boundary.

## Validation
- `scripts/run-tests tests/test-quickshell-system-management-xvfb.sh`: passed; 16 new scenarios cover all four tools with success, denial, unsupported results and reentrant closure. No real tools or host mutations.
- `scripts/run-tests make clean all` and `scripts/run-tests`: passed on tree `9a71f36d1c55bba236dcbeaa9f48c39c45cea637`; 539 backend tests in 221.859s, existing parser/operation/discovery lifecycle coverage, staged and repeated installation, 66-package Fedora map, Kickstart/ISO static checks and release archive.
- Closed Settings 0.067% CPU; large surfaces 0.00%; power baseline 0.133% -> 0.067%.
- Full ShellCheck/shfmt and configured Quickshell QML lint: passed; established metadata warnings only.
- Documentation check/build: passed, 15 files without diagnostics and 11 generated pages.
- Independent CodeRabbit review: one wording finding fixed and regression-tested; repeat review zero findings.
- Mandatory post-full-suite local Codex review: no actionable findings.
- All owned managed test workspaces cleaned. An earlier full run was intentionally interrupted before applying the review fix and is not counted as passed.

No installed shell was synchronized or restarted. Delegated success means accepted launch only, not completed administration. This internal boundary adds no IPC or visible UI; graphical authorization and final installed-session acceptance remain pending.