### PR TITLE
feat(settings): expose bounded NTP sample command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ versions from `config.mk`.
 
 ### Changed
 
+- Add a finite, read-only `ntp-sample` helper command with versioned bounded
+  output, scoped failures, and no journal, package discovery, or polling loop.
+
 - Share the panel's minute-level clock with System Settings and refresh both
   displays after verified timezone discovery, retaining the same instant across
   timezone changes without an extra poller or shell restart.

--- a/TASKS.md
+++ b/TASKS.md
@@ -394,6 +394,14 @@ preserved the exact instant across UTC/Chicago changes and qualified the next
 minute tick. See `docs/P6-CLOCK-EVIDENCE.md`. NTP sampling and combined installed
 qualification remain pending.
 
+The finite `ntp-sample` command now exposes the internal two-property reader
+through a separate version 1.0 stream. It emits a complete boolean pair or a
+scoped error only, with bounded isolated output and no PackageKit, journal,
+mutation, or timer. Visible sampling remains pending. A read-only Fedora probe
+confirmed that spaced samples can reactivate idle timedated and produce owner
+arrival events; integration must reconcile those events without repeatedly
+reading unrelated package state or suppressing genuine configuration changes.
+
 The root now provides internal confirmation for the four fixed delegated tools.
 It requires fresh owning-provider and journal evidence, captures snapshot and
 cycle identity, rejects update-workflow overlap, and rechecks state after prompt

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -2255,7 +2255,10 @@ Detail is printable UTF-8 capped at 512 bytes. The complete stream is at most
 exit 2 without a sample. Consumers must require the exact header, one sample or
 error, matching completion, and corresponding normal exit before publication.
 
-The command buffers the entire result before a single bounded output write.
+The command buffers the entire result before a single bounded stdout write.
+It does not initialize an unused stderr writer; closed, absent, or read-only
+stderr does not prevent a valid sample. Child-process regressions cover these
+descriptor states independently of the private-bus checks.
 Closed, full, or short output fails with exit 1, without retry or a partial-value
 success claim. Output setup and TERM/INT/HUP interruption release private
 descriptors and restore signal handlers. The inherited output file-status flags

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -2259,8 +2259,10 @@ The command buffers the entire result before a single bounded stdout write.
 It does not initialize an unused stderr writer; closed, absent, or read-only
 stderr does not prevent a valid sample. Child-process regressions cover these
 descriptor states independently of the private-bus checks.
-Closed, full, or short output fails with exit 1, without retry or a partial-value
-success claim. Output setup and TERM/INT/HUP interruption release private
+Absent stdout, a closed descriptor or Python stream, and read-only, full, or
+short stdout fail with exit 1, without traceback, retry, or a partial-value
+success claim. Invalid output setup does not start a service read.
+Output setup and TERM/INT/HUP interruption release private
 descriptors and restore signal handlers. The inherited output file-status flags
 are never changed. Regular-file output preserves its original offset/append
 semantics; this does not impose a deadline on storage I/O. The existing private

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -2236,9 +2236,50 @@ The internal `NtpRead` client separately issues exactly two fixed
 `Properties.Get` requests for `CanNTP` and `NTPSynchronized`, accepts only
 bounded boolean replies, and publishes a pair only after both succeed under
 one ten-second deadline. Partial, late, denied, and malformed replies do not
-publish a sample. This internal reader adds no sampling CLI or timer. Neither
-event commands nor this reader changes the cumulative snapshot minor. Settings
-activation uses the shared root subscriptions; visible NTP sampling remains pending.
+publish a sample. The finite `dwm-system-management ntp-sample` command now
+exposes that reader without arguments, PackageKit discovery, journal access,
+authorization, mutation, or a timer. It uses a separate version 1.0 stream and
+does not change the cumulative snapshot minor. Successful output is exactly:
+
+```text
+ntp-sample-protocol<TAB>1<TAB>0
+sample<TAB>CAN_NTP<TAB>SYNCHRONIZED
+complete<TAB>ntp-sample
+```
+
+Both values are exactly `yes` or `no`. A failure replaces the sample line with
+`error<TAB>ntp-sample<TAB>CODE<TAB>DETAIL`; codes are `missing-provider`,
+`permission-denied`, `unsupported`, `timeout`, `malformed`, or `internal`.
+Detail is printable UTF-8 capped at 512 bytes. The complete stream is at most
+1024 bytes. Success exits 0, a typed read failure exits 1, and invalid arguments
+exit 2 without a sample. Consumers must require the exact header, one sample or
+error, matching completion, and corresponding normal exit before publication.
+
+The command buffers the entire result before a single bounded output write.
+Closed, full, or short output fails with exit 1, without retry or a partial-value
+success claim. Output setup and TERM/INT/HUP interruption release private
+descriptors and restore signal handlers. The inherited output file-status flags
+are never changed. Regular-file output preserves its original offset/append
+semantics; this does not impose a deadline on storage I/O. The existing private
+bus fixture also exercises the CLI through typed success, denial, malformed
+data, a real ten-second timeout, and discarded late replies.
+Actual child-process TERM, INT, and HUP checks interrupt stalled private-bus
+calls and require exit 1 with empty output and no traceback. The signal handler
+queues one high-priority main-context cancellation and quit; it does not raise
+inside a GLib callback, where the exception can be swallowed. A deterministic
+loop-start fixture also signals after the reader's done check but before
+`MainLoop.run()`, proving that an early quit cannot be lost. Pending cancellation
+sources are removed on return, repeated signals coalesce, and the command
+rejects publication explicitly even if the read has just completed.
+A read-only Fedora 44 command check returned `sample<TAB>yes<TAB>yes` with
+matching completion and exit 0, without changing NTP or the system clock.
+
+Settings activation uses the shared root subscriptions; visible NTP sampling
+remains pending. Spaced read-only Fedora samples can reactivate idle timedated
+and therefore emit owner-arrival notifications. The eventual 30-second sampler
+must avoid turning these arrivals into repeated cumulative PackageKit reads,
+without dropping genuine concurrent time changes. This CLI boundary does not
+enable that sampler or alter the passive monitor contract.
 
 The fixed `dwm-system-management watch-accounts` command is also implemented.
 It accepts no arguments and emits only `accounts-event<TAB>ready` and

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -7842,10 +7842,14 @@ def cancel_journal_operation(journal: JournalDescriptorSet, operation_id: str, *
 
 def control_output_writer(output, resources: contextlib.ExitStack) -> Callable[[bytes], int] | None:
     """Never set file-status flags on an inherited open-file description."""
+    if output is None:
+        raise OSError("Operation output is unavailable")
     try:
         descriptor = output.fileno()
     except io.UnsupportedOperation:
         return None  # In-memory test consumers have no kernel writer.
+    except ValueError as error:
+        raise OSError("Operation output is closed") from error
     original = os.fstat(descriptor)
     flags = fcntl.fcntl(descriptor, fcntl.F_GETFL)
     if (flags & os.O_ACCMODE) not in (os.O_WRONLY, os.O_RDWR):

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -60,6 +60,9 @@ REGIONAL_LOCALE_OUTPUT_BYTES = 2 * 1024 * 1024
 REGIONAL_LOCALE_ARRAY_BYTES = 8192
 REGIONAL_CHOICE_STREAM_BYTES = {"timezone": 512 * 1024, "locale": 1024 * 1024}
 REGIONAL_PREVIEW_STREAM_BYTES = 8192
+NTP_SAMPLE_STREAM_BYTES = 1024
+NTP_SAMPLE_ERROR_CODES = frozenset(("missing-provider", "permission-denied", "unsupported",
+                                  "timeout", "malformed", "internal"))
 REGIONAL_LOCALE_KEYS = (
     "LANG", "LANGUAGE", "LC_CTYPE", "LC_NUMERIC", "LC_TIME", "LC_COLLATE",
     "LC_MONETARY", "LC_MESSAGES", "LC_PAPER", "LC_NAME", "LC_ADDRESS",
@@ -1148,6 +1151,62 @@ class NtpRead(ServiceRead):
         except SnapshotFailure as error:
             if self.pending():
                 self.fail(error)
+
+
+def read_ntp_sample() -> NtpSample:
+    """Cancel the asynchronous read instead of raising inside a GLib callback."""
+    read = NtpRead()
+    handlers = {}
+    interrupted = False
+    cancel_source = 0
+
+    def cancel_read():
+        nonlocal cancel_source
+        cancel_source = 0
+        read.fail(SnapshotFailure("internal", "Network time read was interrupted"))
+        return read.GLib.SOURCE_REMOVE
+
+    def cancel(_signum, _frame):
+        nonlocal interrupted, cancel_source
+        if interrupted:
+            return
+        interrupted = True
+        # A quit before MainLoop.run() is lost. Dispatch on the context so a
+        # signal in the startup gap cannot mark the reader done prematurely.
+        cancel_source = read.GLib.idle_add(cancel_read, priority=read.GLib.PRIORITY_HIGH)
+
+    try:
+        for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            handlers[signum] = signal.signal(signum, cancel)
+        return read.run()
+    finally:
+        for signum, handler in handlers.items():
+            signal.signal(signum, handler)
+        if cancel_source:
+            read.GLib.source_remove(cancel_source)
+        if interrupted:
+            raise InterruptedError("Network time read was interrupted")
+
+
+def ntp_sample_output() -> tuple[str, int]:
+    """Publish one complete pair or one scoped error, never a partial sample."""
+    try:
+        sample = read_ntp_sample()
+        if (not isinstance(sample, NtpSample) or type(sample.can_ntp) is not bool
+                or type(sample.synchronized) is not bool):
+            raise SnapshotFailure("malformed", "Invalid network time sample")
+        record = "sample\t" + ("yes" if sample.can_ntp else "no") + "\t" + ("yes" if sample.synchronized else "no")
+        code = 0
+    except SnapshotFailure as failure:
+        error_code = failure.code if failure.code in NTP_SAMPLE_ERROR_CODES else "internal"
+        detail = "".join(char if char.isprintable() else " " for char in failure.detail)
+        detail = clean_text(detail.encode("utf-8", "replace").decode("utf-8"))
+        record = f"error\tntp-sample\t{error_code}\t{detail or 'Network time read failed'}"
+        code = 1
+    output = "ntp-sample-protocol\t1\t0\n" + record + "\ncomplete\tntp-sample\n"
+    if len(output.encode("utf-8")) > NTP_SAMPLE_STREAM_BYTES:
+        raise OSError("Network time sample exceeds its output limit")
+    return output, code
 
 
 class RegionalMutation(ServiceRead):
@@ -7843,6 +7902,23 @@ def control_output_writers() -> Iterator[tuple[Callable[[bytes], int] | None, Ca
             signal.signal(signum, handler)
 
 
+def ntp_sample_command() -> int:
+    """Keep finite read output nonblocking without altering inherited flags."""
+    try:
+        with control_output_writers() as (writer, _error_writer):
+            output, code = ntp_sample_output()
+            if writer is None:
+                sys.stdout.write(output)
+                sys.stdout.flush()
+            else:
+                payload = output.encode("utf-8")
+                if writer(payload) != len(payload):
+                    raise OSError("Incomplete network time sample output")
+            return code
+    except OSError:
+        return 1
+
+
 def operation_control(command: str, operation_id: str) -> int:
     try:
         with control_output_writers() as writers:
@@ -8863,11 +8939,13 @@ def watch_account_events() -> int:
 
 
 def usage() -> int:
-    print(f"usage: {sys.argv[0]} snapshot | watch-updates | watch-regional time|locale | watch-accounts | watch-units printers|security | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE | timezone-set ZONE GENERATION | ntp-set enabled|disabled GENERATION | locale-set LANG=LOCALE GENERATION | accounts-open | password-open | printers-open | sources-open", file=sys.stderr)
+    print(f"usage: {sys.argv[0]} snapshot | ntp-sample | watch-updates | watch-regional time|locale | watch-accounts | watch-units printers|security | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE | timezone-set ZONE GENERATION | ntp-set enabled|disabled GENERATION | locale-set LANG=LOCALE GENERATION | accounts-open | password-open | printers-open | sources-open", file=sys.stderr)
     return 2
 
 
 def main(argv: Sequence[str]) -> int:
+    if argv and argv[0] == "ntp-sample":
+        return ntp_sample_command() if len(argv) == 1 else usage()
     if argv and argv[0] == "watch-units":
         return watch_service_events(argv[1]) if len(argv) == 2 and argv[1] in WATCH_UNIT_SETS else usage()
     if argv and argv[0] == "watch-accounts":

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -7885,8 +7885,8 @@ def control_output_writer(output, resources: contextlib.ExitStack) -> Callable[[
 
 
 @contextlib.contextmanager
-def control_output_writers() -> Iterator[tuple[Callable[[bytes], int] | None, Callable[[bytes], int] | None]]:
-    """Retain isolated writers and close them even on handled interruption."""
+def control_output_writers(*, diagnostics: bool = True) -> Iterator[tuple[Callable[[bytes], int] | None, Callable[[bytes], int] | None]]:
+    """Retain required isolated writers and close them on handled interruption."""
     handlers = {}
 
     def interrupted(_signum, _frame):
@@ -7896,7 +7896,9 @@ def control_output_writers() -> Iterator[tuple[Callable[[bytes], int] | None, Ca
         for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
             handlers[signum] = signal.signal(signum, interrupted)
         with contextlib.ExitStack() as resources:
-            yield tuple(control_output_writer(output, resources) for output in (sys.stdout, sys.stderr))
+            writer = control_output_writer(sys.stdout, resources)
+            error_writer = control_output_writer(sys.stderr, resources) if diagnostics else None
+            yield writer, error_writer
     finally:
         for signum, handler in handlers.items():
             signal.signal(signum, handler)
@@ -7905,7 +7907,7 @@ def control_output_writers() -> Iterator[tuple[Callable[[bytes], int] | None, Ca
 def ntp_sample_command() -> int:
     """Keep finite read output nonblocking without altering inherited flags."""
     try:
-        with control_output_writers() as (writer, _error_writer):
+        with control_output_writers(diagnostics=False) as (writer, _error_writer):
             output, code = ntp_sample_output()
             if writer is None:
                 sys.stdout.write(output)

--- a/tests/fixtures/system-regional-read-bus.py
+++ b/tests/fixtures/system-regional-read-bus.py
@@ -5,6 +5,7 @@ import contextlib
 import io
 import os
 import runpy
+import signal
 import sys
 import time
 
@@ -17,6 +18,7 @@ mode = "normal"
 calls = []
 held = []
 registrations = []
+after_stalled = None
 properties = Gio.DBusNodeInfo.new_for_xml("""
 <node><interface name="org.freedesktop.DBus.Properties">
 <method name="GetAll"><arg type="s" direction="in"/><arg type="a{sv}" direction="out"/></method>
@@ -43,6 +45,8 @@ def called(_bus, _sender, path, interface, method, args, invocation):
         invocation.return_dbus_error("org.freedesktop.DBus.Error.AccessDenied", "fixture denial")
     elif mode == "stall":
         held.append(invocation)
+        if len(held) == 2 and after_stalled is not None:
+            after_stalled()
     elif method == "GetAll":
         invocation.return_value(GLib.Variant("(a{sv})", ({
             "Timezone": GLib.Variant("s", "UTC"), "CanNTP": GLib.Variant("b", True),
@@ -58,6 +62,59 @@ def called(_bus, _sender, path, interface, method, args, invocation):
         invocation.return_value(GLib.Variant("(v)", (value,)))
     else:
         invocation.return_value(GLib.Variant("(as)", (["UTC", "Etc/UTC"],)))
+
+
+def interrupted_command(signum):
+    """Stop the actual CLI while Gio is waiting, with a private forced-stop bound."""
+    global after_stalled
+    assert not held
+    loop = GLib.MainLoop()
+    result = {}
+    timers = {"stop": 0, "deadline": 0}
+    child = Gio.Subprocess.new(["/usr/bin/python3", sys.argv[1], "ntp-sample"],
+        Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE)
+
+    def terminate():
+        timers["stop"] = 0
+        child.send_signal(signum)
+        return GLib.SOURCE_REMOVE
+
+    def expired():
+        timers["deadline"] = 0
+        result["expired"] = True
+        child.force_exit()
+        return GLib.SOURCE_REMOVE
+
+    def finished(process, reply, _data):
+        try:
+            result["output"] = process.communicate_utf8_finish(reply)
+        finally:
+            result["done"] = True
+            loop.quit()
+
+    def schedule_stop():
+        timers["stop"] = GLib.timeout_add(100, terminate)
+
+    after_stalled = schedule_stop
+    child.communicate_utf8_async(None, None, finished, None)
+    timers["deadline"] = GLib.timeout_add(4000, expired)
+    try:
+        loop.run()
+        assert not result.get("expired", False), result
+        assert child.get_if_exited() and child.get_exit_status() == 1, result
+        assert result["output"][1:] == ("", ""), result
+        assert len(held) == 2
+    finally:
+        after_stalled = None
+        for timer in timers.values():
+            if timer:
+                GLib.source_remove(timer)
+        if not result.get("done", False):
+            child.force_exit()
+            child.wait(None)
+        for invocation in held:
+            invocation.return_value(GLib.Variant("(v)", (GLib.Variant("b", False),)))
+        held.clear()
 
 
 def failure(kind, expected):
@@ -87,7 +144,7 @@ try:
     assert [call[2:] for call in calls[-2:]] == [
         ("Get", ("org.freedesktop.timedate1", "CanNTP")),
         ("Get", ("org.freedesktop.timedate1", "NTPSynchronized"))]
-    for arguments in (["regional-choices", "timezone"],
+    for arguments in (["ntp-sample"], ["regional-choices", "timezone"],
                       ["regional-preview", "timezone-set", "Etc/UTC"],
                       ["regional-preview", "ntp-set", "enabled"],
                       ["regional-preview", "locale-set", "LANG=C"]):
@@ -99,12 +156,19 @@ try:
     failure("time-state", "malformed")
     failure("ntp", "malformed")
     with contextlib.redirect_stdout(io.StringIO()) as output:
+        assert provider["main"](["ntp-sample"]) == 1
+    assert "error\tntp-sample\tmalformed\t" in output.getvalue()
+    assert "\nsample\t" not in output.getvalue()
+    with contextlib.redirect_stdout(io.StringIO()) as output:
         assert provider["main"](["regional-preview", "ntp-set", "enabled"]) == 1
     assert "error\tregional\tmalformed\t" in output.getvalue()
     assert "\npreview\t" not in output.getvalue()
     mode = "denied"
     failure("locale-state", "permission-denied")
     failure("ntp", "permission-denied")
+    with contextlib.redirect_stdout(io.StringIO()) as output:
+        assert provider["main"](["ntp-sample"]) == 1
+    assert "error\tntp-sample\tpermission-denied\t" in output.getvalue()
     mode = "normal"
     assert name_call("ReleaseName", "org.freedesktop.locale1") == 1
     failure("locale-state", "missing-provider")
@@ -119,7 +183,10 @@ try:
     assert provider["RegionalRead"]("timezone-choices").run() == ("UTC", "Etc/UTC")
     mode = "stall"
     started = time.monotonic()
-    failure("ntp", "timeout")
+    with contextlib.redirect_stdout(io.StringIO()) as output:
+        assert provider["main"](["ntp-sample"]) == 1
+    assert "error\tntp-sample\ttimeout\t" in output.getvalue()
+    assert "\nsample\t" not in output.getvalue()
     elapsed = time.monotonic() - started
     assert 9.5 <= elapsed < 15, elapsed
     assert len(held) == 2
@@ -128,8 +195,11 @@ try:
     held.clear()
     mode = "normal"
     assert provider["NtpRead"]().run() == provider["NtpSample"](True, True)
+    mode = "stall"
+    for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+        interrupted_command(signum)
     assert all(call[2] in {"Get", "GetAll", "ListTimezones"} for call in calls)
-    print("Private-bus regional reads: PASS (typed replies, readonly preflight, denial, absence, deadline, late reply)")
+    print("Private-bus regional reads: PASS (typed replies, readonly preflight, denial, absence, deadline, late reply, interruption)")
 finally:
     for registration in registrations:
         bus.unregister_object(registration)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -3245,6 +3245,35 @@ with mock.patch.dict(provider["ntp_sample_output"].__globals__,
                     (self.header + "sample\tyes\tno\n" + self.complete).encode())
                 self.assertEqual(result.stderr, b"")
 
+    def test_unavailable_stdout_is_a_controlled_failure(self):
+        code = """
+import os, runpy, sys
+from unittest import mock
+provider = runpy.run_path(sys.argv[1], run_name="ntp_output_fixture")
+mode = sys.argv[2]
+if mode == "readonly":
+    descriptor = os.open("/dev/null", os.O_RDONLY)
+    os.dup2(descriptor, 1)
+    if descriptor != 1:
+        os.close(descriptor)
+elif mode == "stream-closed":
+    sys.stdout.close()
+else:
+    os.close(1)
+    if mode == "none":
+        sys.stdout = None
+with mock.patch.dict(provider["ntp_sample_output"].__globals__,
+        read_ntp_sample=mock.Mock(side_effect=AssertionError("Read without output"))):
+    raise SystemExit(provider["main"](["ntp-sample"]))
+"""
+        for mode in ("closed", "readonly", "none", "stream-closed"):
+            with self.subTest(mode=mode):
+                result = subprocess.run([sys.executable, "-c", code, str(PROVIDER_PATH), mode],
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5, check=False)
+                self.assertEqual(result.returncode, 1)
+                self.assertEqual(result.stdout, b"")
+                self.assertEqual(result.stderr, b"")
+
     def test_interruption_releases_output_context_and_restores_handlers(self):
         handlers = {signum: signal.getsignal(signum) for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)}
         for signum in handlers:

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -3124,6 +3124,155 @@ class NtpReadTests(unittest.TestCase):
             connection.call_finish.assert_not_called()
 
 
+class NtpSampleCommandTests(unittest.TestCase):
+    header = "ntp-sample-protocol\t1\t0\n"
+    complete = "complete\tntp-sample\n"
+
+    def test_all_boolean_pairs_have_one_exact_bounded_stream(self):
+        for can_ntp in (False, True):
+            for synchronized in (False, True):
+                with mock.patch.object(provider, "NtpRead") as reader:
+                    reader.return_value.run.return_value = provider.NtpSample(can_ntp, synchronized)
+                    output, code = provider.ntp_sample_output()
+                self.assertEqual(code, 0)
+                self.assertEqual(output, self.header + "sample\t"
+                    + ("yes" if can_ntp else "no") + "\t" + ("yes" if synchronized else "no") + "\n" + self.complete)
+                self.assertLessEqual(len(output.encode()), provider.NTP_SAMPLE_STREAM_BYTES)
+                reader.assert_called_once_with()
+                reader.return_value.run.assert_called_once_with()
+
+    def test_invalid_values_never_coerce_to_a_successful_sample(self):
+        for value in (None, (True, True), provider.NtpSample(1, True),
+                      provider.NtpSample(True, "yes")):
+            with mock.patch.object(provider, "NtpRead") as reader:
+                reader.return_value.run.return_value = value
+                output, code = provider.ntp_sample_output()
+            self.assertEqual(code, 1)
+            self.assertIn("\nerror\tntp-sample\tmalformed\t", output)
+            self.assertNotIn("\nsample\t", output)
+
+    def test_typed_errors_are_bounded_and_cannot_inject_records(self):
+        for error_code in (*sorted(provider.NTP_SAMPLE_ERROR_CODES), "unrecognized"):
+            failure = provider.SnapshotFailure(error_code, "denied\t\n\r\x00\ud800" + "é" * 600)
+            with mock.patch.object(provider, "NtpRead", side_effect=failure):
+                output, code = provider.ntp_sample_output()
+            self.assertEqual(code, 1)
+            self.assertEqual(len(output.splitlines()), 3)
+            expected_code = "internal" if error_code == "unrecognized" else error_code
+            self.assertTrue(output.startswith(self.header + "error\tntp-sample\t" + expected_code + "\t"))
+            self.assertTrue(output.endswith(self.complete))
+            self.assertNotIn("\nsample\t", output)
+            self.assertLessEqual(len(output.encode()), provider.NTP_SAMPLE_STREAM_BYTES)
+            self.assertTrue(output.splitlines()[1].split("\t")[3].isprintable())
+
+    def test_fixed_cli_never_enters_packagekit_journal_or_mutation_paths(self):
+        with mock.patch.object(provider, "NtpRead") as reader, \
+                mock.patch.object(provider, "PackageKitBackend") as backend, \
+                mock.patch.object(provider, "open_journal_directory") as journal, \
+                mock.patch.object(provider, "native_command") as mutation, \
+                contextlib.redirect_stdout(io.StringIO()) as output, \
+                contextlib.redirect_stderr(io.StringIO()):
+            reader.return_value.run.return_value = provider.NtpSample(True, False)
+            self.assertEqual(provider.main(["ntp-sample"]), 0)
+            self.assertEqual(output.getvalue(), self.header + "sample\tyes\tno\n" + self.complete)
+            for arguments in (["time"], ["--system"], ["CanNTP"], ["enabled"], ["extra", "argument"]):
+                self.assertEqual(provider.main(["ntp-sample", *arguments]), 2)
+            reader.assert_called_once_with()
+            backend.assert_not_called()
+            journal.assert_not_called()
+            mutation.assert_not_called()
+
+    def test_short_or_failed_write_cannot_report_completion(self):
+        for result in (0, 1, BlockingIOError(), BrokenPipeError(), InterruptedError()):
+            writer = mock.Mock(side_effect=result) if isinstance(result, OSError) else mock.Mock(return_value=result)
+            with mock.patch.object(provider, "control_output_writers", return_value=contextlib.nullcontext((writer, None))), \
+                    mock.patch.object(provider, "NtpRead") as reader:
+                reader.return_value.run.return_value = provider.NtpSample(True, False)
+                self.assertEqual(provider.ntp_sample_command(), 1)
+            writer.assert_called_once_with((self.header + "sample\tyes\tno\n" + self.complete).encode())
+
+    def test_real_pipe_output_preserves_parent_flags_and_fails_when_full(self):
+        for blocking in (False, True):
+            for full in (False, True):
+                read_fd, write_fd = os.pipe()
+                try:
+                    os.set_blocking(write_fd, False)
+                    if full:
+                        with self.assertRaises(BlockingIOError):
+                            while True:
+                                os.write(write_fd, b"x" * 4096)
+                    os.set_blocking(write_fd, blocking)
+                    original = provider.fcntl.fcntl(write_fd, provider.fcntl.F_GETFL)
+                    with mock.patch.object(provider.sys, "stdout", types.SimpleNamespace(fileno=lambda: write_fd)), \
+                            contextlib.redirect_stderr(io.StringIO()), \
+                            mock.patch.object(provider, "NtpRead") as reader:
+                        reader.return_value.run.return_value = provider.NtpSample(False, False)
+                        started = time.monotonic()
+                        self.assertEqual(provider.ntp_sample_command(), 1 if full else 0)
+                        self.assertLess(time.monotonic() - started, 1)
+                    self.assertEqual(provider.fcntl.fcntl(write_fd, provider.fcntl.F_GETFL), original)
+                    if not full:
+                        self.assertTrue(select.select([read_fd], [], [], 1)[0])
+                        self.assertEqual(os.read(read_fd, 4096), (self.header + "sample\tno\tno\n" + self.complete).encode())
+                finally:
+                    os.close(read_fd)
+                    os.close(write_fd)
+
+    def test_interruption_releases_output_context_and_restores_handlers(self):
+        handlers = {signum: signal.getsignal(signum) for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)}
+        for signum in handlers:
+            with contextlib.redirect_stdout(io.StringIO()) as output, \
+                    contextlib.redirect_stderr(io.StringIO()), mock.patch.object(provider, "NtpRead") as reader:
+                def signal_read():
+                    signal.raise_signal(signum)
+                    signal.raise_signal(signum)
+                    return provider.NtpSample(True, True)
+                reader.return_value.run.side_effect = signal_read
+                self.assertEqual(provider.ntp_sample_command(), 1)
+                self.assertEqual(output.getvalue(), "")
+                reader.return_value.fail.assert_not_called()
+                reader.return_value.GLib.idle_add.assert_called_once()
+                reader.return_value.GLib.source_remove.assert_called_once_with(
+                    reader.return_value.GLib.idle_add.return_value)
+            for selected, handler in handlers.items():
+                self.assertIs(signal.getsignal(selected), handler)
+
+    def test_signal_between_done_check_and_loop_start_cannot_lose_quit(self):
+        from gi.repository import GLib
+        for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            gio = mock.Mock()
+            read = provider.NtpRead(gio, GLib)
+            loop = read.loop
+            expired = []
+
+            def guarded_stop():
+                expired.append(True)
+                loop.quit()
+                return GLib.SOURCE_REMOVE
+
+            def start():
+                # ServiceRead.run has already passed `if not self.done`.
+                signal.raise_signal(signum)
+                loop.run()
+
+            read.loop = types.SimpleNamespace(run=start, quit=loop.quit)
+            guard = GLib.timeout_add(200, guarded_stop)
+            try:
+                with mock.patch.object(provider, "NtpRead", return_value=read), \
+                        contextlib.redirect_stdout(io.StringIO()) as output, \
+                        contextlib.redirect_stderr(io.StringIO()) as diagnostic:
+                    self.assertEqual(provider.ntp_sample_command(), 1)
+                self.assertEqual(expired, [], "Cancellation quit before the main loop could observe it")
+                self.assertEqual(output.getvalue(), "")
+                # PyGObject's first loop may emit Python deprecation warnings.
+                self.assertNotIn("Traceback", diagnostic.getvalue())
+                self.assertTrue(read.done)
+                gio.bus_get_finish.assert_not_called()
+            finally:
+                if not expired:
+                    GLib.source_remove(guard)
+
+
 class OperationStreamTests(unittest.TestCase):
     operation_id = "op-" + "1" * 32
     started = "2026-09-05T01:00:00Z"

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -3218,6 +3218,33 @@ class NtpSampleCommandTests(unittest.TestCase):
                     os.close(read_fd)
                     os.close(write_fd)
 
+    def test_unused_stderr_does_not_prevent_stdout_sampling(self):
+        code = """
+import os, runpy, sys
+from unittest import mock
+provider = runpy.run_path(sys.argv[1], run_name="ntp_output_fixture")
+if sys.argv[2] == "readonly":
+    descriptor = os.open("/dev/null", os.O_RDONLY)
+    os.dup2(descriptor, 2)
+    if descriptor != 2:
+        os.close(descriptor)
+else:
+    os.close(2)
+    if sys.argv[2] == "none":
+        sys.stderr = None
+with mock.patch.dict(provider["ntp_sample_output"].__globals__,
+        read_ntp_sample=lambda: provider["NtpSample"](True, False)):
+    raise SystemExit(provider["main"](["ntp-sample"]))
+"""
+        for mode in ("closed", "readonly", "none"):
+            with self.subTest(mode=mode):
+                result = subprocess.run([sys.executable, "-c", code, str(PROVIDER_PATH), mode],
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5, check=False)
+                self.assertEqual(result.returncode, 0)
+                self.assertEqual(result.stdout,
+                    (self.header + "sample\tyes\tno\n" + self.complete).encode())
+                self.assertEqual(result.stderr, b"")
+
     def test_interruption_releases_output_context_and_restores_handlers(self):
         handlers = {signum: signal.getsignal(signum) for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)}
         for signum in handlers:


### PR DESCRIPTION
## Scope
Expose the existing two-property NTP reader through the fixed, finite `ntp-sample` command. The separate 1.0 stream contains one complete boolean pair or one scoped error, matching completion, and bounded output. No PackageKit discovery, journal access, mutation, QML, timer, or visible sampling is added.

Actual private-bus child-process tests exposed swallowed Python signal exceptions inside GLib; cancellation now queues one high-priority main-context callback and rejects publication after interruption. A deterministic startup-gap regression reproduces the old lost-quit race and checks the correction. TERM/INT/HUP, repeated signals, source cleanup, slow/closed/short output, inherited descriptor flags, typed failures, and fixed CLI arguments are covered.

## Validation
- `scripts/run-tests make clean all` and `scripts/run-tests`: passed on staged tree `50a14741b40af8aad0a63fd252ecf408e04de40e`; 551 backend tests, 34 clock, 42 regional coordinator, 66 regional UI, and 48 delegated UI assertions/cases. Dependency, staged install/uninstall, repeated-install preservation, and release gates passed; owned test workspaces removed.
- Focused NTP/private-bus coverage: 26 tests passed, including real child TERM/INT/HUP and the deterministic startup race.
- `cd docs && npm run check && npm run build`: passed (zero diagnostics).
- `coderabbit review --agent -t uncommitted`: zero findings across all six files. Final post-full-suite `codex review --uncommitted`: no actionable introduced defects.
- Fedora 44 actual read-only `timeout 15 scripts/dwm-system-management ntp-sample`: exit 0 with complete yes/yes sample.
- Existing nested-X11 gates passed: Settings CPU 0.067%, large fixture 0.000%; no new visible UI in this boundary.

## Review follow-up
Commit `678ca5f` fixes the hosted finding that unused stderr could prevent sampling. The command now opens only stdout; other commands keep diagnostic writers. Child tests cover closed, read-only, and absent stderr. Real Fedora read-only checks passed with both `2>&-` and `2</dev/null`. The full local gate and post-suite Codex review were repeated after this fix; hosted checks must pass on the new exact head before merge.

Commit `feee225` also handles absent/closed stdout as a controlled failure before any service read. Child regressions cover missing/closed/read-only stdout with exit 1 and no traceback. The full local gate, full-PR review, independent review, and post-suite Codex review passed again on the updated tree.

## Remaining Phase 6 work
Visible 30-second sampling remains disabled until service reactivation can reconcile time state without repeated cumulative PackageKit reads. Information/security/recovery surfaces and combined installed graphical qualification remain pending.

A separate private-bus probe confirmed a pre-existing signal-interruption issue in native regional commands, both before and after dispatch: their old exception-based handler can be swallowed by GLib. That path is unchanged here and will be addressed in a separate follow-up, preserving durable interrupted recovery and the non-cancelable sent-action contract. No host timezone, NTP, clock, live managed configuration, or shell activation was changed. This does not complete Phase 6 or start Phase 7.