### PR TITLE
fix(settings): preserve regional recovery on interruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ versions from `config.mk`.
 
 ### Changed
 
+- Stop native regional observation cooperatively on TERM, INT, or HUP. Retain
+  durable interrupted recovery for sent changes without claiming cancellation
+  or waiting on another service read after an explicit local stop.
+
 - Add a finite, read-only `ntp-sample` helper command with versioned bounded
   output, scoped failures, and no journal, package discovery, or polling loop.
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -415,6 +415,19 @@ success, denial, unsupported, and maximum-inventory scenarios. Keyboard and
 screenshot evidence is recorded in `docs/P6-DELEGATE-UI-EVIDENCE.md`.
 Visible NTP sampling and combined installed qualification remain pending.
 
+Native regional CLI interruption now queues one high-priority GLib stop instead
+of raising an exception inside a callback. Repeated signals coalesce, startup
+cannot lose an early quit, and a stop racing with observer completion cannot
+become a successful result. Cooperative handlers remain through terminal/lease
+cleanup, and locale enumeration stops retain subprocess cleanup before typed
+rejection. Sent changes retain an interrupted terminal and handoff before
+the native lease is released; explicit local stops skip the optional subsequent
+service read. Ordinary ambiguous transport failures retain a fresh read, now
+cooperatively interruptible without changing the recorded terminal. Eighteen
+private-bus child cases cover all three actions and TERM/INT/HUP
+before and after dispatch, without changing host regional settings. Combined
+installed graphical qualification remains pending.
+
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit
 confirmation warning that a sent change cannot be canceled. Local cancellation

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -479,11 +479,50 @@ deadline.
 Actual CLI/private-bus fixtures cover all three fixed calls, live leases,
 durable handoffs, denial, stale generation, ambiguous replies, output loss after
 dispatch, retained replay, and acknowledgment without repeating the action.
-For an ambiguous sent result, a new independent read begins only after durable
+For an ambiguous sent result other than an explicit local stop, a new
+independent read begins only after durable
 interruption and lease release; it cannot reclassify the terminal result.
+That read uses the same cooperative read boundary as the finite NTP sample;
+a signal during it stops observation without changing the retained terminal.
 Settings still needs its own display refresh and confirmation/origin controls.
 Cumulative minor 1 discovery is described below. These fixtures do not change
 host settings or qualify graphical polkit authorization.
+
+The native CLI handles TERM, INT, and HUP during regional service observation
+without raising through GLib callbacks, where Python exceptions can be swallowed.
+The first signal sets a synchronous stop flag and queues one high-priority
+main-context stop; repeated signals coalesce. Pending work and final dispatch
+checks consult that flag, including after argument and timeout preparation, so
+the current callback cannot ignore a stop while the queued callback waits.
+Queuing prevents a quit just before `MainLoop.run()` from being lost.
+Pending stop sources are removed when observation ends. Cooperative handlers
+remain installed through durable terminalization and native-lease release, then
+are restored; repeated stops cannot interrupt that cleanup. A first stop during
+cleanup also suppresses any optional follow-up read without queuing an unused
+main-loop source. The caller rejects success explicitly if interruption races
+with observer completion. Locale enumeration retains its own subprocess-group
+cleanup and signal coalescing; its handled signal exit is converted into the
+typed regional preflight rejection only after that cleanup returns.
+A pre-admission stop emits the normal typed rejection without creating an
+operation or sending a mutation. After dispatch, the existing durable owner
+records `interrupted`, retains the terminal/handoff, and releases its lease;
+the platform change may still complete. No service-side cancellation or rollback
+is claimed. An explicit local stop does not enter the optional post-terminal
+service read, allowing the command to return after cleanup. Settings must still
+refresh state before another confirmation. Existing journal persistence failures
+remain uncertain recovery, not fabricated terminal completion.
+
+Eighteen private-bus cases run actual CLI children for all three fixed actions,
+with each handled signal before and after dispatch. They require normal exit 1
+within a four-second fixture guard, no traceback, no pre-dispatch mutation,
+durable interrupted post-dispatch handoff, released lease, no automatic retry or
+post-stop read, and no terminal change after a late service reply. Separate
+tests inject the startup gap, locale enumeration stops, repeated signals at
+just-completed reads, and signals during terminal commit and lease release.
+Twenty-seven argument-construction, timer-arming, and final request-preparation
+injections also prove stops after the last preflight event drain prevent all
+three mutating bus calls. Once dispatch handoff has begun, a stop still retains
+the conservative unconfirmed result rather than claiming the platform did nothing.
 
 Each regional mutation uses a 60-second monotonic aggregate deadline beginning
 immediately before the fixed mutating D-Bus method is sent and covering its

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -1154,8 +1154,12 @@ class NtpRead(ServiceRead):
 
 
 def read_ntp_sample() -> NtpSample:
+    """Return the NTP pair through the shared cooperative read boundary."""
+    return run_interruptible_read(NtpRead())
+
+
+def run_interruptible_read(read: ServiceRead):
     """Cancel the asynchronous read instead of raising inside a GLib callback."""
-    read = NtpRead()
     handlers = {}
     interrupted = False
     cancel_source = 0
@@ -1163,7 +1167,7 @@ def read_ntp_sample() -> NtpSample:
     def cancel_read():
         nonlocal cancel_source
         cancel_source = 0
-        read.fail(SnapshotFailure("internal", "Network time read was interrupted"))
+        read.fail(SnapshotFailure("internal", f"{read.label} read was interrupted"))
         return read.GLib.SOURCE_REMOVE
 
     def cancel(_signum, _frame):
@@ -1185,7 +1189,7 @@ def read_ntp_sample() -> NtpSample:
         if cancel_source:
             read.GLib.source_remove(cancel_source)
         if interrupted:
-            raise InterruptedError("Network time read was interrupted")
+            raise InterruptedError(f"{read.label} read was interrupted")
 
 
 def ntp_sample_output() -> tuple[str, int]:
@@ -1236,6 +1240,7 @@ class RegionalMutation(ServiceRead):
         self.name, self.path = REGIONAL_READ_REQUESTS[self.kind][:2]
         self.owner = ""
         self.sent = self.acknowledged = False
+        self.local_interrupted = False
         self.dirty = False
         self.observed = self.expected = self.preview = None
         self.choices = ()
@@ -1245,6 +1250,14 @@ class RegionalMutation(ServiceRead):
         self.installed_rules = []
         self.closed_handler = 0
         super().__init__(Gio, GLib)
+
+    def pending(self) -> bool:
+        if not super().pending():
+            return False
+        if self.local_interrupted:
+            self.fail(regional_interruption_failure(self))
+            return False
+        return True
 
     def timeout_failure(self) -> SnapshotFailure:
         detail = ("Regional operation timed out after dispatch; the outcome is unknown. Refresh state before a new confirmation"
@@ -1286,9 +1299,12 @@ class RegionalMutation(ServiceRead):
         flags = (self.Gio.DBusCallFlags.ALLOW_INTERACTIVE_AUTHORIZATION
                  if interactive else self.Gio.DBusCallFlags.NONE)
         try:
+            expected_type = self.GLib.VariantType.new(reply_type)
+            remaining = max(1, int((self.deadline - time.monotonic()) * 1000))
+            if not self.pending():
+                return
             self.connection.call(name, path, interface, method, parameters,
-                self.GLib.VariantType.new(reply_type), flags,
-                max(1, int((self.deadline - time.monotonic()) * 1000)),
+                expected_type, flags, remaining,
                 self.cancellable, replied, None)
         except self.GLib.Error as error:
             self.fail(self.bus_failure(error))
@@ -1437,6 +1453,8 @@ class RegionalMutation(ServiceRead):
         self.GLib.source_remove(self.deadline_source)
         self.deadline = time.monotonic() + REGIONAL_MUTATION_SECONDS
         self.deadline_source = self.GLib.timeout_add(REGIONAL_MUTATION_SECONDS * 1000, self.expire)
+        if not self.pending():
+            return
         self.sent = True
         self.request(self.owner, self.path, self.name, method, arguments, "()",
             self.method_replied, interactive=True)
@@ -6169,6 +6187,65 @@ class NativeOperationOwner:
         return terminal
 
 
+class RegionalCommandInterrupted(SnapshotFailure):
+    """An explicit local stop, not cancellation of a dispatched system change."""
+
+
+def regional_interruption_failure(client) -> RegionalCommandInterrupted:
+    """Distinguish an unsent preflight stop from an unconfirmed dispatched change."""
+    return RegionalCommandInterrupted("interrupted",
+        "Regional observation was interrupted after dispatch; the change may still complete. Refresh state before a new confirmation"
+        if client.sent else "Regional preflight was interrupted; no change was sent")
+
+
+def run_interruptible_regional(client: RegionalMutation, retained: contextlib.ExitStack):
+    """Stop the GLib observer cooperatively and preserve durable caller cleanup."""
+    interrupted = False
+    observing = True
+    stop_source = 0
+    client.local_interrupted = False
+
+    def stop_observation():
+        nonlocal stop_source
+        stop_source = 0
+        client.fail(regional_interruption_failure(client))
+        return client.GLib.SOURCE_REMOVE
+
+    def stop(_signum, _frame):
+        nonlocal interrupted, stop_source
+        if interrupted:
+            return
+        interrupted = True
+        client.local_interrupted = True
+        # Exceptions raised inside GLib callbacks can be swallowed. A queued
+        # stop also avoids losing quit in the gap before MainLoop.run().
+        if observing:
+            stop_source = client.GLib.idle_add(stop_observation, priority=client.GLib.PRIORITY_HIGH)
+
+    try:
+        for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            previous = signal.signal(signum, stop)
+            # The caller registers its native lease later, so LIFO cleanup
+            # releases that lease before restoring these handlers.
+            retained.callback(signal.signal, signum, previous)
+        if interrupted:
+            raise regional_interruption_failure(client)
+        return client.run()
+    except SystemExit as error:
+        # The fixed locale collector owns and reaps its subprocess before
+        # restoring our handlers and exiting with the received signal code.
+        if (client.action != "locale-set" or client.started
+                or error.code not in (128 + signal.SIGTERM, 128 + signal.SIGINT, 128 + signal.SIGHUP)):
+            raise
+        stop(error.code - 128, None)
+    finally:
+        observing = False
+        if stop_source:
+            client.GLib.source_remove(stop_source)
+        if interrupted:
+            raise regional_interruption_failure(client)
+
+
 def run_regional_mutation(
     journal: JournalDescriptorSet, action: str, argument: str, generation: str,
     write: Callable[[str], object], *, on_admission: Callable[[], None] | None = None,
@@ -6208,7 +6285,7 @@ def run_regional_mutation(
 
         client = RegionalMutation(action, argument, generation, before_send, after_reply)
         try:
-            client.run()
+            run_interruptible_regional(client, retained)
         except SnapshotFailure as error:
             if owner is None:
                 raise client.hook_error or error
@@ -6227,12 +6304,15 @@ def run_regional_mutation(
                  "permission-denied" if failure.code == "permission-denied" and owner.operation.state == "authorizing" else
                  "failed")
         terminal = owner.finish(state, failure)
-    if client.sent and failure is not None and failure.code in {"timeout", "interrupted"}:
+    if (client.sent and failure is not None and failure.code in {"timeout", "interrupted"}
+            and not client.local_interrupted):
         # The terminal/handoff is durable and the native lease is released
         # before this independent read. Its outcome cannot reclassify the call.
         # Settings will publish its own fresh snapshot on origin completion.
-        with contextlib.suppress(SnapshotFailure):
-            RegionalRead(client.kind).run()
+        # Explicit local stops must return after durable cleanup rather than
+        # entering another service wait. Their caller still needs fresh state.
+        with contextlib.suppress(SnapshotFailure, InterruptedError):
+            run_interruptible_read(RegionalRead(client.kind))
     if owner.output_error is not None:
         raise owner.output_error
     return terminal

--- a/tests/fixtures/system-regional-interruption-bus.py
+++ b/tests/fixtures/system-regional-interruption-bus.py
@@ -1,0 +1,192 @@
+#!/usr/bin/python3
+"""Interrupt actual native CLI children against private services and journals."""
+
+import os
+import runpy
+import signal
+import sys
+
+os.environ["DBUS_SYSTEM_BUS_ADDRESS"] = os.environ["DBUS_SESSION_BUS_ADDRESS"]
+from gi.repository import Gio, GLib
+
+provider = runpy.run_path(sys.argv[1], run_name="regional_interruption_fixture")
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+time_name = "org.freedesktop.timedate1"
+locale_name = "org.freedesktop.locale1"
+interfaces = Gio.DBusNodeInfo.new_for_xml("""
+<node>
+<interface name="org.freedesktop.DBus.Properties">
+<method name="GetAll"><arg type="s" direction="in"/><arg type="a{sv}" direction="out"/></method>
+<method name="Get"><arg type="s" direction="in"/><arg type="s" direction="in"/><arg type="v" direction="out"/></method>
+</interface>
+<interface name="org.freedesktop.timedate1">
+<method name="ListTimezones"><arg type="as" direction="out"/></method>
+<method name="SetTimezone"><arg type="s" direction="in"/><arg type="b" direction="in"/></method>
+<method name="SetNTP"><arg type="b" direction="in"/><arg type="b" direction="in"/></method>
+</interface>
+<interface name="org.freedesktop.locale1">
+<method name="SetLocale"><arg type="as" direction="in"/><arg type="b" direction="in"/></method>
+</interface>
+</node>""").interfaces
+registrations = []
+current = None
+
+
+def called(_bus, _sender, _path, interface, method, args, invocation):
+    case = current
+    try:
+        case["calls"].append(method)
+        if method == "GetAll":
+            assert args.unpack() == (time_name,)
+            reply = GLib.Variant("(a{sv})", ({
+                "Timezone": GLib.Variant("s", case["zone"]),
+                "CanNTP": GLib.Variant("b", True),
+                "NTP": GLib.Variant("b", case["ntp"]),
+                "NTPSynchronized": GLib.Variant("b", True)},))
+        elif method == "Get":
+            assert args.unpack() == (locale_name, "Locale")
+            reply = GLib.Variant("(v)", (GLib.Variant("as", case["locale"]),))
+        elif method == "ListTimezones":
+            reply = GLib.Variant("(as)", (["UTC", "Etc/UTC"],))
+        else:
+            assert method == case["method"] and interface in (time_name, locale_name)
+            assert args.unpack()[-1] is True
+            assert invocation.get_message().get_flags() & Gio.DBusMessageFlags.ALLOW_INTERACTIVE_AUTHORIZATION
+            if method == "SetTimezone":
+                assert args.unpack()[0] == "Etc/UTC"
+                case["zone"] = "Etc/UTC"
+            elif method == "SetNTP":
+                assert args.unpack()[0] is True
+                case["ntp"] = True
+            else:
+                assert args.unpack()[0] == ["LANG=C"]
+                case["locale"] = ["LANG=C"]
+            reply = GLib.Variant("()", ())
+        if ((case["stage"] == "before" and len(case["calls"]) == 1)
+                or method.startswith("Set")):
+            case["held"].append((invocation, reply))
+            case["stop_source"] = GLib.timeout_add(100, case["stop"])
+        else:
+            invocation.return_value(reply)
+    except Exception as error:
+        # Callback exceptions must fail the fixture, not disappear in GLib.
+        case["callback_error"] = error
+        invocation.return_dbus_error("org.freedesktop.DBus.Error.Failed", "Fixture assertion failed")
+        case["child"].force_exit()
+
+
+def journal_state():
+    with provider["open_journal_directory"]() as chain, provider["retain_writable_journal"](chain) as journal:
+        with provider["lock_writable_journal"](journal):
+            state = provider["load_writable_journal_state"](journal)
+            assert provider["_try_native_owner_lock"](journal.descriptor("active"))
+            provider["_unlock_native_owner"](journal.descriptor("active"))
+            return state
+
+
+def check(action, argument, method, signum, stage):
+    global current
+    case = {"calls": [], "held": [], "zone": "UTC", "ntp": False,
+            "locale": ["LANG=POSIX"], "method": method, "stage": stage,
+            "stop_source": 0, "deadline_source": 0, "done": False}
+    current = case
+    state_home = os.path.join(os.environ["DWM_TEST_WORKSPACE"], f"regional-{action}-{signum}-{stage}")
+    os.mkdir(state_home, 0o700)
+    os.environ["XDG_STATE_HOME"] = state_home
+    state = (provider["parse_locale_configuration"](case["locale"]) if action == "locale-set"
+             else provider["RegionalTimeState"]("UTC", True, False, True))
+    choices = ["C", "POSIX"] if action == "locale-set" else ["UTC", "Etc/UTC"]
+    generation = provider["make_regional_preview"](action, argument, state, choices).generation
+    loop = GLib.MainLoop()
+
+    def stop():
+        case["stop_source"] = 0
+        case["child"].send_signal(signum)
+        return GLib.SOURCE_REMOVE
+
+    def expired():
+        case["deadline_source"] = 0
+        case["expired"] = True
+        case["child"].force_exit()
+        return GLib.SOURCE_REMOVE
+
+    def finished(process, reply, _data):
+        try:
+            case["output"] = process.communicate_utf8_finish(reply)
+        except Exception as error:
+            case["callback_error"] = error
+        finally:
+            case["done"] = True
+            loop.quit()
+
+    case["stop"] = stop
+    child = Gio.Subprocess.new(["/usr/bin/python3", sys.argv[1], action, argument, generation],
+        Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE)
+    case["child"] = child
+    child.communicate_utf8_async(None, None, finished, None)
+    case["deadline_source"] = GLib.timeout_add(4000, expired)
+    try:
+        loop.run()
+        assert not case.get("expired", False), (action, signum, stage, "forced stop")
+        assert "callback_error" not in case, case.get("callback_error")
+        assert child.get_if_exited() and child.get_exit_status() == 1
+        _, output, diagnostic = case["output"]
+        assert diagnostic == "", diagnostic
+        assert output.endswith("complete\toperation\n"), output
+        assert "\nerror\tregional\tinterrupted\t" in output, output
+        durable = journal_state()
+        assert durable.active is None
+        if stage == "before":
+            assert case["calls"] == ["Get" if action == "locale-set" else "GetAll"]
+            assert durable.handoff is None and all(item is None for item in durable.terminals)
+            assert "no regional mutation was dispatched" in output
+        else:
+            expected = (["Get", "Get", method] if action == "locale-set" else
+                        ["GetAll", "ListTimezones", "GetAll", method] if action == "timezone-set" else
+                        ["GetAll", "GetAll", method])
+            assert case["calls"] == expected, case["calls"]  # No retry or post-stop service read.
+            assert durable.handoff is not None
+            terminal = durable.terminals[durable.handoff.slot]
+            assert terminal.operation_id == durable.handoff.operation_id
+            assert (terminal.action_id, terminal.state, terminal.error_code) == (action, "interrupted", "interrupted")
+            assert "may still complete" in terminal.detail
+            operations = [line.split("\t") for line in output.splitlines() if line.startswith("operation\t")]
+            assert [row[4] for row in operations] == ["pending", "authorizing", "interrupted"]
+            assert all(row[6] == "no" for row in operations)  # Never claim cancellation is available.
+        for invocation, reply in case["held"]:
+            invocation.return_value(reply)
+        case["held"].clear()
+        assert journal_state() == durable  # A late service reply cannot change the terminal.
+        print(f"Regional signal case: PASS ({action}/{stage}/{signum})")
+    finally:
+        for key in ("stop_source", "deadline_source"):
+            if case[key]:
+                GLib.source_remove(case[key])
+        if not case["done"]:
+            child.force_exit()
+            child.wait(None)
+        for invocation, reply in case["held"]:
+            invocation.return_value(reply)
+
+
+try:
+    for name in (time_name, locale_name):
+        result = bus.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+            "RequestName", GLib.Variant("(su)", (name, 0)), GLib.VariantType.new("(u)"),
+            Gio.DBusCallFlags.NONE, 3000, None)
+        assert result.unpack()[0] == 1
+    for path, info in (("/org/freedesktop/timedate1", interfaces[0]),
+                       ("/org/freedesktop/timedate1", interfaces[1]),
+                       ("/org/freedesktop/locale1", interfaces[0]),
+                       ("/org/freedesktop/locale1", interfaces[2])):
+        registrations.append(bus.register_object(path, info, called, None, None))
+    for action, argument, method in (("timezone-set", "Etc/UTC", "SetTimezone"),
+                                     ("ntp-set", "enabled", "SetNTP"),
+                                     ("locale-set", "LANG=C", "SetLocale")):
+        for stage in ("before", "after"):
+            for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+                check(action, argument, method, signum, stage)
+    print("Private-bus regional interruption: PASS (18 actual child cases)")
+finally:
+    for registration in registrations:
+        bus.unregister_object(registration)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -1399,10 +1399,13 @@ class RegionalMutationTests(unittest.TestCase):
         self.gio, self.glib = gio, glib
         return client
 
-    def run_client(self, client):
+    def run_client(self, client, *, interruptible=False):
         with mock.patch.object(provider, "read_fedora_identity", return_value={"ID": "fedora"}), \
                 mock.patch.object(provider, "read_locale_choices", return_value=("C", "en_US.utf8")), \
                 mock.patch.object(provider.time, "monotonic", side_effect=lambda: self.clock):
+            if interruptible:
+                with contextlib.ExitStack() as retained:
+                    return provider.run_interruptible_regional(client, retained)
             return client.run()
 
     def failure(self, client, code):
@@ -1501,6 +1504,40 @@ class RegionalMutationTests(unittest.TestCase):
             self.assertLessEqual(self.context.iteration.call_count, provider.REGIONAL_CALLBACK_LIMIT)
             if scenario == "checkpoint":
                 self.assertIsInstance(client.hook_error, OSError)
+
+    def test_stop_after_final_drain_prevents_mutating_request(self):
+        for action, argument in (("timezone-set", "Etc/UTC"), ("ntp-set", "enabled"),
+                                 ("locale-set", "LANG=en_US.utf8")):
+            for stage in ("arguments", "timer", "request"):
+                for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+                    with self.subTest(action=action, stage=stage, signum=signum):
+                        client = self.client(action, argument)
+                        self.glib.idle_add = mock.Mock(return_value=1000)
+                        self.glib.PRIORITY_HIGH = -100
+                        variant, timer = self.glib.Variant, self.glib.timeout_add.side_effect
+                        variant_type = self.glib.VariantType
+                        def arguments(signature, values):
+                            if stage == "arguments" and signature in ("(sb)", "(bb)", "(asb)"):
+                                signal.raise_signal(signum)
+                            return variant(signature, values)
+                        def arm(milliseconds, callback):
+                            if stage == "timer" and milliseconds == 60000:
+                                signal.raise_signal(signum)
+                            return next(timer)
+                        def expected_type(signature):
+                            if stage == "request" and client.sent:
+                                signal.raise_signal(signum)
+                            return variant_type.new(signature)
+                        self.glib.Variant = arguments
+                        self.glib.VariantType = types.SimpleNamespace(new=expected_type)
+                        self.glib.timeout_add.side_effect = arm
+                        with self.assertRaises(provider.RegionalCommandInterrupted):
+                            self.run_client(client, interruptible=True)
+                        self.assertEqual(self.mutations(), [])
+                        # Once handoff has begun, a stopped request remains
+                        # conservatively unconfirmed even if the bus was not called.
+                        self.assertEqual(client.sent, stage == "request")
+                        self.assertEqual([event[0] for event in self.events], ["authorizing"])
 
     def test_matching_notifications_are_accepted_but_conflict_history_is_retained(self):
         for conflict in (False, True):
@@ -10345,6 +10382,100 @@ class OperationWatchTests(unittest.TestCase):
             self.assertEqual(provider.load_journal_state(journal.chain).handoff.operation_id, operation.operation_id)
 
 
+class RegionalInterruptionTests(unittest.TestCase):
+    catalog = LocaleEnumerationTests.catalog
+
+    def run_client(self, client):
+        with contextlib.ExitStack() as retained:
+            return provider.run_interruptible_regional(client, retained)
+
+    def test_locale_enumeration_stop_reaps_child_and_becomes_typed_rejection(self):
+        from gi.repository import GLib
+        for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            gio = mock.Mock()
+            client = provider.RegionalMutation("locale-set", "LANG=C", "a" * 64,
+                mock.Mock(), mock.Mock(), gio, GLib)
+            with self.subTest(signum=signum), self.catalog("closed-pipes", signal_number=signum) as processes:
+                with mock.patch.object(provider, "read_fedora_identity"), \
+                        self.assertRaises(provider.RegionalCommandInterrupted) as raised:
+                    self.run_client(client)
+                self.assertIn("no change was sent", raised.exception.detail)
+                self.assertFalse(client.sent)
+                gio.bus_get.assert_not_called()
+                self.assertTrue(all(p.returncode is not None and p.stdout.closed and p.stderr.closed for p in processes))
+
+    def test_repeated_stop_coalesces_and_rejects_a_just_completed_read(self):
+        handlers = {number: signal.getsignal(number)
+                    for number in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)}
+        for signum in handlers:
+            for sent in (False, True):
+                with self.subTest(signum=signum, sent=sent):
+                    client = mock.Mock(sent=sent)
+                    def run():
+                        signal.raise_signal(signum)
+                        signal.raise_signal(signum)
+                        return "verified"
+                    client.run.side_effect = run
+                    with self.assertRaises(provider.RegionalCommandInterrupted) as raised:
+                        self.run_client(client)
+                    self.assertEqual(raised.exception.code, "interrupted")
+                    self.assertIn("may still complete" if sent else "no change was sent", raised.exception.detail)
+                    client.GLib.idle_add.assert_called_once()
+                    client.GLib.source_remove.assert_called_once_with(client.GLib.idle_add.return_value)
+                    client.fail.assert_not_called()
+                    for number, handler in handlers.items():
+                        self.assertIs(signal.getsignal(number), handler)
+
+    def test_unrelated_system_exit_is_not_reclassified_as_a_stop(self):
+        for action, started, code in (("timezone-set", False, 143),
+                                      ("locale-set", True, 143), ("locale-set", False, 2)):
+            client = mock.Mock(action=action, started=started, sent=False)
+            client.run.side_effect = SystemExit(code)
+            with self.subTest(action=action, started=started, code=code), self.assertRaises(SystemExit) as raised:
+                self.run_client(client)
+            self.assertEqual(raised.exception.code, code)
+            client.GLib.idle_add.assert_not_called()
+
+    def test_startup_gap_cannot_lose_the_queued_stop(self):
+        from gi.repository import GLib
+        for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            gio = mock.Mock()
+            client = provider.RegionalMutation("timezone-set", "Etc/UTC", "a" * 64,
+                mock.Mock(), mock.Mock(), gio, GLib)
+            loop = client.loop
+            expired = []
+            def guard_stop():
+                expired.append(True)
+                loop.quit()
+                return GLib.SOURCE_REMOVE
+            def start():
+                signal.raise_signal(signum)
+                loop.run()
+            client.loop = types.SimpleNamespace(run=start, quit=loop.quit)
+            guard = GLib.timeout_add(200, guard_stop)
+            try:
+                with mock.patch.object(provider, "read_fedora_identity"), \
+                        contextlib.redirect_stderr(io.StringIO()) as diagnostic, \
+                        self.assertRaises(provider.RegionalCommandInterrupted):
+                    self.run_client(client)
+                self.assertEqual(expired, [], "Regional stop was lost before loop startup")
+                self.assertNotIn("Traceback", diagnostic.getvalue())
+                self.assertTrue(client.done)
+                self.assertFalse(client.sent)
+                gio.bus_get_finish.assert_not_called()
+            finally:
+                if not expired:
+                    GLib.source_remove(guard)
+
+    def test_actual_cli_signal_matrix_on_private_bus(self):
+        result = subprocess.run(["dbus-run-session", "--", "/usr/bin/python3",
+            str(REPO / "tests/fixtures/system-regional-interruption-bus.py"), str(PROVIDER_PATH)],
+            capture_output=True, text=True, timeout=90, check=False)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(result.stdout.count("Regional signal case: PASS"), 18)
+        self.assertIn("Private-bus regional interruption: PASS", result.stdout)
+
+
 class RegionalOwnerTests(unittest.TestCase):
     boot_id = JournalRetainedSessionTests.boot_id
     session = JournalRetainedSessionTests.session
@@ -10498,6 +10629,115 @@ class RegionalOwnerTests(unittest.TestCase):
             self.assertEqual(output, [])
             admitted.assert_not_called()
             self.assertEqual(provider.load_journal_state(journal.chain), before)
+
+    def test_local_stop_terminalizes_a_running_owner_without_another_service_wait(self):
+        for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            with self.subTest(signum=signum), self.session() as (_path, _chain, journal):
+                def configure():
+                    self.before_admission = lambda: setattr(self.client, "GLib", mock.Mock())
+                    self.during = lambda: signal.raise_signal(signum)
+                terminal, output, fresh = self.invoke(journal, configure=configure)
+                self.assertEqual((terminal.state, terminal.error_code), ("interrupted", "interrupted"))
+                self.assertEqual([row[4] for row in rows(output.splitlines(), "operation")],
+                    ["pending", "authorizing", "running", "interrupted"])
+                fresh.assert_not_called()
+                durable = provider.load_journal_state(journal.chain)
+                self.assertIsNone(durable.active)
+                self.assertEqual(durable.terminals[durable.handoff.slot], terminal)
+                self.assertTrue(provider._try_native_owner_lock(journal.descriptor("active")))
+                provider._unlock_native_owner(journal.descriptor("active"))
+
+    def test_repeated_stop_during_terminal_commit_and_lease_release_is_coalesced(self):
+        for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            with self.subTest(signum=signum), self.session() as (_path, _chain, journal):
+                def configure():
+                    self.before_admission = lambda: setattr(self.client, "GLib", mock.Mock())
+                    self.during = lambda: signal.raise_signal(signum)
+                advance, unlock = provider.advance_journal_operation, provider._unlock_native_owner
+                terminal_started = []
+                def commit(current_journal, current, following, **kwargs):
+                    if following.state == "interrupted":
+                        terminal_started.append(True)
+                        signal.raise_signal(signum)
+                    return advance(current_journal, current, following, **kwargs)
+                def release(descriptor):
+                    if terminal_started:
+                        signal.raise_signal(signum)
+                    return unlock(descriptor)
+                with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()), \
+                        provider.control_output_writers(), \
+                        mock.patch.object(provider, "advance_journal_operation", side_effect=commit), \
+                        mock.patch.object(provider, "_unlock_native_owner", side_effect=release):
+                    terminal, _output, fresh = self.invoke(journal, configure=configure)
+                self.assertEqual(terminal.state, "interrupted")
+                fresh.assert_not_called()
+                durable = provider.load_journal_state(journal.chain)
+                self.assertIsNone(durable.active)
+                self.assertEqual(durable.terminals[durable.handoff.slot], terminal)
+                self.assertTrue(provider._try_native_owner_lock(journal.descriptor("active")))
+                provider._unlock_native_owner(journal.descriptor("active"))
+
+    def test_first_stop_during_timeout_handoff_skips_the_optional_read(self):
+        for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            with self.subTest(signum=signum), self.session() as (_path, _chain, journal):
+                complete = provider.complete_journal_terminal
+                def handoff(*args, **kwargs):
+                    signal.raise_signal(signum)
+                    return complete(*args, **kwargs)
+                with mock.patch.object(provider, "complete_journal_terminal", side_effect=handoff):
+                    terminal, _output, fresh = self.invoke(journal, mode="timeout")
+                self.assertEqual((terminal.state, terminal.error_code), ("interrupted", "timeout"))
+                self.assertTrue(self.client.local_interrupted)
+                fresh.assert_not_called()
+                durable = provider.load_journal_state(journal.chain)
+                self.assertIsNone(durable.active)
+                self.assertEqual(durable.terminals[durable.handoff.slot], terminal)
+
+    def test_stop_during_independent_read_preserves_the_durable_terminal(self):
+        from gi.repository import GLib
+        for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            with self.subTest(signum=signum), self.session() as (_path, _chain, journal):
+                factory, generation = self.setup_client(journal, mode="transport")
+                gio = mock.Mock()
+                read = provider.RegionalRead("time-state", gio, GLib)
+                expired, output = [], []
+                trigger_source = 0
+                def trigger():
+                    nonlocal trigger_source
+                    trigger_source = 0
+                    durable = provider.load_journal_state(journal.chain)
+                    self.assertIsNone(durable.active)
+                    self.assertEqual(durable.terminals[durable.handoff.slot].state, "interrupted")
+                    self.assertTrue(provider._try_native_owner_lock(journal.descriptor("active")))
+                    provider._unlock_native_owner(journal.descriptor("active"))
+                    signal.raise_signal(signum)
+                    return GLib.SOURCE_REMOVE
+                def guard_stop():
+                    expired.append(True)
+                    read.loop.quit()
+                    return GLib.SOURCE_REMOVE
+                guard = GLib.timeout_add(1000, guard_stop)
+                trigger_source = GLib.idle_add(trigger)
+                try:
+                    with mock.patch.object(provider, "RegionalMutation", side_effect=factory), \
+                            mock.patch.object(provider, "RegionalRead", return_value=read), \
+                            contextlib.redirect_stdout(io.StringIO()), \
+                            contextlib.redirect_stderr(io.StringIO()) as diagnostic, \
+                            provider.control_output_writers():
+                        terminal = provider.run_regional_mutation(journal, "timezone-set", "Etc/UTC",
+                            generation, output.append)
+                    self.assertEqual(expired, [], "Independent read ignored the local stop")
+                    self.assertNotIn("Traceback", diagnostic.getvalue())
+                    self.assertTrue(read.done)
+                    self.assertEqual((terminal.state, terminal.error_code), ("interrupted", "interrupted"))
+                    durable = provider.load_journal_state(journal.chain)
+                    self.assertEqual(durable.terminals[durable.handoff.slot], terminal)
+                    self.assertTrue(output[-1].endswith("complete\toperation\n"))
+                finally:
+                    if not expired:
+                        GLib.source_remove(guard)
+                    if trigger_source:
+                        GLib.source_remove(trigger_source)
 
     def test_output_loss_before_dispatch_aborts_but_after_dispatch_keeps_verification(self):
         for phase in ("pending", "authorizing", "running", "succeeded"):


### PR DESCRIPTION
## Scope
Make the three fixed regional commands stop observing cooperatively on TERM, INT, or HUP, without claiming that a dispatched platform change was canceled.

- Queue cancellation outside GLib callbacks and check synchronous dispatch gaps.
- Keep coalescing handlers through durable terminal publication and native lease release.
- Convert the owned locale collector's handled signal exit after process-group cleanup.
- Skip optional fresh reads after an explicit local stop; ordinary ambiguous transport failures retain a bounded fresh read, now itself interruptible.
- Preserve interrupted recovery records, and never retry or roll back a mutation automatically.

## Validation
- 34 focused backend tests passed, including 18 real private-D-Bus CLI cases and 27 injected dispatch-gap cases.
- CodeRabbit reviewed all six changed files with zero findings.
- Read-only Codex review found no actionable introduced defects.
- Documentation check and build passed (15 files, 11 pages).
- `scripts/run-tests make clean all && scripts/run-tests` passed: 561 backend tests (233.523s), 66 regional UI cases, 48 delegated UI cases, and the complete repository gate. Closed Settings CPU 0.067%; closed large surfaces 0.00%. Managed workspaces removed.
- Required post-full-suite `codex review --uncommitted` completed with no actionable introduced findings.

## Limitations
Private services changed fixture state only. No host settings, live Quickshell configuration, or activation changed. Real graphical authorization and combined installed Phase 6 qualification remain pending. This does not complete Phase 6 or begin Phase 7.
