### PR TITLE
feat(settings): add scoped time discovery interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ versions from `config.mk`.
 
 ### Changed
 
+- Add read-only time discovery interfaces for scoped reconciliation: a bounded
+  time-status result and a passive monitor that distinguishes service arrivals
+  from property changes. Existing Settings activation is unchanged.
+
 - Stop native regional observation cooperatively on TERM, INT, or HUP. Retain
   durable interrupted recovery for sent changes without claiming cancellation
   or waiting on another service read after an explicit local stop.

--- a/TASKS.md
+++ b/TASKS.md
@@ -428,6 +428,15 @@ private-bus child cases cover all three actions and TERM/INT/HUP
 before and after dispatch, without changing host regional settings. Combined
 installed graphical qualification remains pending.
 
+Time discovery now has separate fixed `time-status` and `watch-time` commands.
+The former reads one complete bounded time tuple without PackageKit or journal
+access. The latter distinguishes authenticated owner arrival from property
+change after readiness, while preserving setup reconciliation and quiet idle
+departure. The existing `watch-regional` protocol and Settings subscriptions are
+unchanged. These interfaces prepare the visible NTP sampler's scoped
+reconciliation; its UI integration and combined installed qualification remain
+pending.
+
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit
 confirmation warning that a sent change cannot be canceled. Local cancellation

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -2325,6 +2325,50 @@ must avoid turning these arrivals into repeated cumulative PackageKit reads,
 without dropping genuine concurrent time changes. This CLI boundary does not
 enable that sampler or alter the passive monitor contract.
 
+Two opt-in time discovery commands are now implemented for the upcoming scoped
+reconciliation. Neither is connected to Settings yet, and `watch-regional time`
+keeps its existing protocol. The fixed no-argument `time-status` command makes
+one `Properties.GetAll` call to timedate1 through the existing strict regional
+reader, under its ten-second aggregate connection/reply/decoding deadline:
+
+```text
+time-status-protocol<TAB>1<TAB>0
+time<TAB>TIMEZONE<TAB>CAN_NTP<TAB>NTP_ENABLED<TAB>SYNCHRONIZED
+complete<TAB>time-status
+```
+
+The timezone uses the existing validated identity grammar; each boolean is
+exactly `yes` or `no`. A failure replaces the complete `time` row with
+`error<TAB>time-status<TAB>CODE<TAB>DETAIL`, using the same six fixed error codes
+and printable 512-byte detail limit as `ntp-sample`. The whole stream is at most
+1024 bytes. Success returns 0, a typed failure returns 1, and extra arguments
+return 2. It shares the finite nonblocking output and cooperative signal
+boundary: missing stdout, a short/full/closed write, or an explicit stop cannot
+report success. Unused stderr need not be writable. No journal, PackageKit,
+mutation, clock change, or timer-driven discovery is added. This full-state
+command is for event-driven reconciliation, not the 30-second sampler; that
+sampler must still read only `CanNTP` and `NTPSynchronized`.
+
+The fixed no-argument `watch-time` command uses the same passive, authenticated
+two-match setup, initial/final owner barriers, bounded output, and shutdown as
+`watch-regional time`. Its records are `time-event<TAB>ready`,
+`time-event<TAB>changed`, and `time-event<TAB>owner-arrived`. Before readiness,
+matching properties and owner arrivals coalesce into the existing single
+`changed` after `ready`, preserving initialization reconciliation. Once ready,
+an authenticated nonempty owner arrival or replacement emits `owner-arrived`;
+relevant properties still emit `changed`. Departure stays quiet and clears the
+pinned sender. Untrusted, stale-owner, and unrelated signals cannot produce
+either notification. The monitor makes no platform read or activation call.
+
+An owner-arrival record is uncertainty, not certification that configuration
+is unchanged. The eventual consumer must temporarily gate admission, reconcile
+bounded time state, preserve genuine concurrent changes, and respect the
+existing two-read settling limit. It must not simply ignore arrivals while a
+sample or regional preview is running. The new interfaces do not yet implement
+that consumer behavior or change existing confirmation invalidation. Private-bus
+fixtures exercise the new passive monitor lifecycle, fixed time-status reads,
+malformed/denied/timeout results, late replies, and all three handled signals.
+
 The fixed `dwm-system-management watch-accounts` command is also implemented.
 It accepts no arguments and emits only `accounts-event<TAB>ready` and
 `accounts-event<TAB>changed`. It shares the authenticated setup lifetime above:

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -61,6 +61,7 @@ REGIONAL_LOCALE_ARRAY_BYTES = 8192
 REGIONAL_CHOICE_STREAM_BYTES = {"timezone": 512 * 1024, "locale": 1024 * 1024}
 REGIONAL_PREVIEW_STREAM_BYTES = 8192
 NTP_SAMPLE_STREAM_BYTES = 1024
+TIME_STATUS_STREAM_BYTES = 1024
 NTP_SAMPLE_ERROR_CODES = frozenset(("missing-provider", "permission-denied", "unsupported",
                                   "timeout", "malformed", "internal"))
 REGIONAL_LOCALE_KEYS = (
@@ -1210,6 +1211,30 @@ def ntp_sample_output() -> tuple[str, int]:
     output = "ntp-sample-protocol\t1\t0\n" + record + "\ncomplete\tntp-sample\n"
     if len(output.encode("utf-8")) > NTP_SAMPLE_STREAM_BYTES:
         raise OSError("Network time sample exceeds its output limit")
+    return output, code
+
+
+def time_status_output() -> tuple[str, int]:
+    """Read one complete time configuration for event-driven reconciliation."""
+    try:
+        state = run_interruptible_read(RegionalRead("time-state"))
+        if (not isinstance(state, RegionalTimeState)
+                or any(type(value) is not bool for value in
+                       (state.can_ntp, state.ntp_enabled, state.ntp_synchronized))):
+            raise SnapshotFailure("malformed", "Invalid time status")
+        zone = validate_timezone_name(state.timezone)
+        record = "time\t" + zone + "\t" + "\t".join("yes" if value else "no" for value in
+            (state.can_ntp, state.ntp_enabled, state.ntp_synchronized))
+        code = 0
+    except SnapshotFailure as failure:
+        error_code = failure.code if failure.code in NTP_SAMPLE_ERROR_CODES else "internal"
+        detail = "".join(char if char.isprintable() else " " for char in failure.detail)
+        detail = clean_text(detail.encode("utf-8", "replace").decode("utf-8"))
+        record = f"error\ttime-status\t{error_code}\t{detail or 'Time status read failed'}"
+        code = 1
+    output = "time-status-protocol\t1\t0\n" + record + "\ncomplete\ttime-status\n"
+    if len(output.encode("utf-8")) > TIME_STATUS_STREAM_BYTES:
+        raise OSError("Time status exceeds its output limit")
     return output, code
 
 
@@ -7989,17 +8014,21 @@ def control_output_writers(*, diagnostics: bool = True) -> Iterator[tuple[Callab
 
 
 def ntp_sample_command() -> int:
+    return finite_status_command(ntp_sample_output)
+
+
+def finite_status_command(read_output: Callable[[], tuple[str, int]]) -> int:
     """Keep finite read output nonblocking without altering inherited flags."""
     try:
         with control_output_writers(diagnostics=False) as (writer, _error_writer):
-            output, code = ntp_sample_output()
+            output, code = read_output()
             if writer is None:
                 sys.stdout.write(output)
                 sys.stdout.flush()
             else:
                 payload = output.encode("utf-8")
                 if writer(payload) != len(payload):
-                    raise OSError("Incomplete network time sample output")
+                    raise OSError("Incomplete finite status output")
             return code
     except OSError:
         return 1
@@ -8484,7 +8513,11 @@ class AuthenticatedEventMonitor(UpdateEventMonitor):
         # not a configuration change: rereading here would reactivate forever.
         # Arrival or replacement reconciles state; mutations still fresh-read.
         if new:
-            self.changed()
+            self.owner_arrived()
+
+    def owner_arrived(self):
+        """Existing monitors conservatively invalidate on arrival or replacement."""
+        self.changed()
 
     def service_specs(self):
         raise NotImplementedError
@@ -8564,6 +8597,23 @@ class RegionalEventMonitor(AuthenticatedEventMonitor):
                 self.changed()
         except SnapshotFailure:
             self.stop(1)
+
+
+class TimeEventMonitor(RegionalEventMonitor):
+    """Separate authenticated owner arrival from actual time property changes."""
+
+    record_prefix = "time-event"
+
+    def __init__(self, Gio, GLib, GLibUnix, emit):
+        super().__init__("time", Gio, GLib, GLibUnix, emit)
+
+    def owner_arrived(self):
+        # Setup races still require the initial bounded reconciliation cycle.
+        # After readiness, arrival is uncertainty, not proof of changed state.
+        if self.ready:
+            self.write(self.record_prefix + "\towner-arrived")
+        else:
+            self.changed()
 
 
 class AccountEventMonitor(AuthenticatedEventMonitor):
@@ -8991,6 +9041,8 @@ def watch_service_events(service_kind=None) -> int:
                 monitor = UpdateEventMonitor(Gio, GLib, GLibUnix, emit)
             elif service_kind == "accounts":
                 monitor = AccountEventMonitor(Gio, GLib, GLibUnix, emit)
+            elif service_kind == "time-discovery":
+                monitor = TimeEventMonitor(Gio, GLib, GLibUnix, emit)
             elif service_kind in WATCH_UNIT_SETS:
                 monitor = UnitEventMonitor(service_kind, Gio, GLib, GLibUnix, emit)
             else:
@@ -9025,11 +9077,15 @@ def watch_account_events() -> int:
 
 
 def usage() -> int:
-    print(f"usage: {sys.argv[0]} snapshot | ntp-sample | watch-updates | watch-regional time|locale | watch-accounts | watch-units printers|security | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE | timezone-set ZONE GENERATION | ntp-set enabled|disabled GENERATION | locale-set LANG=LOCALE GENERATION | accounts-open | password-open | printers-open | sources-open", file=sys.stderr)
+    print(f"usage: {sys.argv[0]} snapshot | ntp-sample | time-status | watch-time | watch-updates | watch-regional time|locale | watch-accounts | watch-units printers|security | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE | timezone-set ZONE GENERATION | ntp-set enabled|disabled GENERATION | locale-set LANG=LOCALE GENERATION | accounts-open | password-open | printers-open | sources-open", file=sys.stderr)
     return 2
 
 
 def main(argv: Sequence[str]) -> int:
+    if argv and argv[0] == "time-status":
+        return finite_status_command(time_status_output) if len(argv) == 1 else usage()
+    if argv and argv[0] == "watch-time":
+        return watch_service_events("time-discovery") if len(argv) == 1 else usage()
     if argv and argv[0] == "ntp-sample":
         return ntp_sample_command() if len(argv) == 1 else usage()
     if argv and argv[0] == "watch-units":

--- a/tests/fixtures/system-regional-read-bus.py
+++ b/tests/fixtures/system-regional-read-bus.py
@@ -19,6 +19,7 @@ calls = []
 held = []
 registrations = []
 after_stalled = None
+stalled_count = 2
 properties = Gio.DBusNodeInfo.new_for_xml("""
 <node><interface name="org.freedesktop.DBus.Properties">
 <method name="GetAll"><arg type="s" direction="in"/><arg type="a{sv}" direction="out"/></method>
@@ -45,7 +46,7 @@ def called(_bus, _sender, path, interface, method, args, invocation):
         invocation.return_dbus_error("org.freedesktop.DBus.Error.AccessDenied", "fixture denial")
     elif mode == "stall":
         held.append(invocation)
-        if len(held) == 2 and after_stalled is not None:
+        if len(held) == stalled_count and after_stalled is not None:
             after_stalled()
     elif method == "GetAll":
         invocation.return_value(GLib.Variant("(a{sv})", ({
@@ -64,14 +65,15 @@ def called(_bus, _sender, path, interface, method, args, invocation):
         invocation.return_value(GLib.Variant("(as)", (["UTC", "Etc/UTC"],)))
 
 
-def interrupted_command(signum):
+def interrupted_command(signum, command="ntp-sample"):
     """Stop the actual CLI while Gio is waiting, with a private forced-stop bound."""
-    global after_stalled
+    global after_stalled, stalled_count
+    stalled_count = 1 if command == "time-status" else 2
     assert not held
     loop = GLib.MainLoop()
     result = {}
     timers = {"stop": 0, "deadline": 0}
-    child = Gio.Subprocess.new(["/usr/bin/python3", sys.argv[1], "ntp-sample"],
+    child = Gio.Subprocess.new(["/usr/bin/python3", sys.argv[1], command],
         Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE)
 
     def terminate():
@@ -103,7 +105,7 @@ def interrupted_command(signum):
         assert not result.get("expired", False), result
         assert child.get_if_exited() and child.get_exit_status() == 1, result
         assert result["output"][1:] == ("", ""), result
-        assert len(held) == 2
+        assert len(held) == stalled_count
     finally:
         after_stalled = None
         for timer in timers.values():
@@ -113,7 +115,7 @@ def interrupted_command(signum):
             child.force_exit()
             child.wait(None)
         for invocation in held:
-            invocation.return_value(GLib.Variant("(v)", (GLib.Variant("b", False),)))
+            invocation.return_dbus_error("org.freedesktop.DBus.Error.NoReply", "Late fixture reply")
         held.clear()
 
 
@@ -144,7 +146,7 @@ try:
     assert [call[2:] for call in calls[-2:]] == [
         ("Get", ("org.freedesktop.timedate1", "CanNTP")),
         ("Get", ("org.freedesktop.timedate1", "NTPSynchronized"))]
-    for arguments in (["ntp-sample"], ["regional-choices", "timezone"],
+    for arguments in (["ntp-sample"], ["time-status"], ["regional-choices", "timezone"],
                       ["regional-preview", "timezone-set", "Etc/UTC"],
                       ["regional-preview", "ntp-set", "enabled"],
                       ["regional-preview", "locale-set", "LANG=C"]):
@@ -160,6 +162,10 @@ try:
     assert "error\tntp-sample\tmalformed\t" in output.getvalue()
     assert "\nsample\t" not in output.getvalue()
     with contextlib.redirect_stdout(io.StringIO()) as output:
+        assert provider["main"](["time-status"]) == 1
+    assert "error\ttime-status\tmalformed\t" in output.getvalue()
+    assert "\ntime\t" not in output.getvalue()
+    with contextlib.redirect_stdout(io.StringIO()) as output:
         assert provider["main"](["regional-preview", "ntp-set", "enabled"]) == 1
     assert "error\tregional\tmalformed\t" in output.getvalue()
     assert "\npreview\t" not in output.getvalue()
@@ -169,6 +175,9 @@ try:
     with contextlib.redirect_stdout(io.StringIO()) as output:
         assert provider["main"](["ntp-sample"]) == 1
     assert "error\tntp-sample\tpermission-denied\t" in output.getvalue()
+    with contextlib.redirect_stdout(io.StringIO()) as output:
+        assert provider["main"](["time-status"]) == 1
+    assert "error\ttime-status\tpermission-denied\t" in output.getvalue()
     mode = "normal"
     assert name_call("ReleaseName", "org.freedesktop.locale1") == 1
     failure("locale-state", "missing-provider")
@@ -196,8 +205,22 @@ try:
     mode = "normal"
     assert provider["NtpRead"]().run() == provider["NtpSample"](True, True)
     mode = "stall"
+    started = time.monotonic()
+    with contextlib.redirect_stdout(io.StringIO()) as output:
+        assert provider["main"](["time-status"]) == 1
+    assert "error\ttime-status\ttimeout\t" in output.getvalue()
+    assert "\ntime\t" not in output.getvalue()
+    assert 9.5 <= time.monotonic() - started < 15
+    assert len(held) == 1
+    held.pop().return_dbus_error("org.freedesktop.DBus.Error.NoReply", "Late fixture reply")
+    mode = "normal"
+    with contextlib.redirect_stdout(io.StringIO()) as output:
+        assert provider["main"](["time-status"]) == 0
+    assert output.getvalue() == "time-status-protocol\t1\t0\ntime\tUTC\tyes\tno\tyes\ncomplete\ttime-status\n"
+    mode = "stall"
     for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
         interrupted_command(signum)
+        interrupted_command(signum, "time-status")
     assert all(call[2] in {"Get", "GetAll", "ListTimezones"} for call in calls)
     print("Private-bus regional reads: PASS (typed replies, readonly preflight, denial, absence, deadline, late reply, interruption)")
 finally:

--- a/tests/fixtures/system-update-events-bus.py
+++ b/tests/fixtures/system-update-events-bus.py
@@ -19,11 +19,17 @@ from gi.repository import Gio, GLib
 NAME = "org.freedesktop.PackageKit"
 PATH = "/org/freedesktop/PackageKit"
 kind = sys.argv[2] if len(sys.argv) == 3 else "updates"
+separate_time = kind == "time-discovery"
+if separate_time:
+    kind = "time"
 assert kind in ("updates", "time", "locale", "accounts")
 command = ["watch-updates"] if kind == "updates" else ["watch-accounts"] if kind == "accounts" else ["watch-regional", kind]
 prefix = b"update-event" if kind == "updates" else b"accounts-event" if kind == "accounts" else b"regional-event"
+if separate_time:
+    command, prefix = ["watch-time"], b"time-event"
 ready = prefix + b"\tready\n"
 changed = prefix + b"\tchanged\n"
+arrived = prefix + b"\towner-arrived\n" if separate_time else changed
 if kind != "updates":
     NAME = "org.freedesktop." + {"time": "timedate1", "locale": "locale1", "accounts": "Accounts"}[kind]
     PATH = "/" + NAME.replace(".", "/")
@@ -118,7 +124,7 @@ try:
     assert name_call("ReleaseName") == 1
     assert line(process, 3 if kind == "updates" else 0.2) == (changed if kind == "updates" else b"")
     assert name_call("RequestName") == 1
-    assert line(process) == changed
+    assert line(process) == arrived
     emit("InstalledChanged")
     assert line(process) == changed, "Replacement owner not monitored"
     for _ in range(100):
@@ -222,7 +228,8 @@ try:
         assert b"reload status explicitly" in denied.stderr.read()
     finally:
         denied_connection.close_sync(None)
-    print(("PackageKit" if kind == "updates" else kind) + " private-bus event monitor: PASS")
+    print(("time-discovery" if separate_time else "PackageKit" if kind == "updates" else kind)
+          + " private-bus event monitor: PASS")
 finally:
     for process in processes:
         if process.poll() is None:

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -2794,6 +2794,72 @@ class RegionalEventMonitorTests(unittest.TestCase):
             self.assertEqual(result.stdout, kind + " private-bus event monitor: PASS\n")
 
 
+class TimeEventMonitorTests(unittest.TestCase):
+    owner = RegionalEventMonitorTests.owner
+    properties = RegionalEventMonitorTests.properties
+
+    def monitor(self):
+        _regional, emitted, gio, glib, unix = RegionalEventMonitorTests().monitor()
+        monitor = provider.TimeEventMonitor(gio, glib, unix, emitted.append)
+        monitor.deadline = time.monotonic() + 10
+        monitor.deadline_source = 7
+        monitor.connection = gio.bus_get_finish.return_value
+        return monitor, emitted, gio, glib
+
+    def test_arrivals_are_distinct_but_departure_and_untrusted_signals_are_quiet(self):
+        monitor, emitted, _gio, glib = self.monitor()
+        monitor.ready, monitor.owner = True, ":1.2"
+        self.owner(monitor, glib, ":1.2", "")
+        self.properties(monitor, glib, ["NTP"])
+        self.owner(monitor, glib, "", ":1.8", sender=":1.8")
+        self.assertEqual(emitted, [])
+        self.owner(monitor, glib, "", ":1.3")
+        self.owner(monitor, glib, ":1.3", ":1.4")
+        self.assertEqual(emitted, ["time-event\towner-arrived"] * 2)
+        self.properties(monitor, glib, ["NTP"], sender=":1.3")
+        self.properties(monitor, glib, ["Timezone"], sender=":1.4")
+        self.properties(monitor, glib, invalidated=["NTPSynchronized"], sender=":1.4")
+        self.assertEqual(emitted[2:], ["time-event\tchanged"] * 2)
+        monitor.stop(0)
+        self.owner(monitor, glib, ":1.4", ":1.5")
+        self.assertEqual(len(emitted), 4)
+
+    def test_setup_arrivals_and_properties_coalesce_without_losing_owner_epoch(self):
+        monitor, emitted, _gio, glib = self.monitor()
+        self.owner(monitor, glib, "", ":1.2")
+        self.properties(monitor, glib, ["NTP"])
+        self.owner(monitor, glib, ":1.2", ":1.3")
+        self.assertEqual(emitted, [])
+        monitor.connection.call_finish.return_value = glib.Variant("(s)", (":1.2",))
+        monitor.owner_resolved(monitor.connection, object(), 0)
+        self.assertEqual(monitor.owner, ":1.3")
+        self.assertEqual(emitted, ["time-event\tready", "time-event\tchanged"])
+        self.assertFalse(monitor.dirty)
+
+    def test_failed_arrival_output_stops_monitor(self):
+        monitor, _emitted, _gio, glib = self.monitor()
+        monitor.ready = True
+        monitor.emit = mock.Mock(side_effect=BlockingIOError())
+        self.owner(monitor, glib, "", ":1.2")
+        self.assertTrue(monitor.stopped)
+        self.assertEqual(monitor.exit_code, 1)
+
+    def test_fixed_cli_and_real_private_bus_lifecycle(self):
+        with mock.patch.object(provider, "watch_service_events", return_value=0) as watch, \
+                mock.patch.object(provider, "PackageKitBackend") as backend, \
+                contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(provider.main(["watch-time"]), 0)
+            for args in (["time"], ["locale"], ["--system"], ["extra", "argument"]):
+                self.assertEqual(provider.main(["watch-time", *args]), 2)
+            watch.assert_called_once_with("time-discovery")
+            backend.assert_not_called()
+        result = subprocess.run(["dbus-run-session", "--", "/usr/bin/python3",
+            str(REPO / "tests/fixtures/system-update-events-bus.py"), str(PROVIDER_PATH), "time-discovery"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "time-discovery private-bus event monitor: PASS\n")
+
+
 class AccountEventMonitorTests(unittest.TestCase):
     def monitor(self):
         _regional, emitted, gio, glib, unix = RegionalEventMonitorTests().monitor()
@@ -3159,6 +3225,123 @@ class NtpReadTests(unittest.TestCase):
             connection.call_finish.reset_mock(side_effect=True)
             read.replied(connection, object(), "NTPSynchronized")
             connection.call_finish.assert_not_called()
+
+
+class TimeStatusCommandTests(unittest.TestCase):
+    header = "time-status-protocol\t1\t0\n"
+    complete = "complete\ttime-status\n"
+
+    def test_exact_tuple_and_strict_validation(self):
+        for can_ntp in (False, True):
+            for enabled in (False, True):
+                for synchronized in (False, True):
+                    state = provider.RegionalTimeState("Etc/UTC", can_ntp, enabled, synchronized)
+                    with mock.patch.object(provider, "RegionalRead") as reader:
+                        reader.return_value.run.return_value = state
+                        output, code = provider.time_status_output()
+                    reader.assert_called_once_with("time-state")
+                    self.assertEqual(code, 0)
+                    self.assertEqual(output, self.header + "time\tEtc/UTC\t"
+                        + "\t".join("yes" if value else "no" for value in (can_ntp, enabled, synchronized))
+                        + "\n" + self.complete)
+        for state in (None, ("UTC", True, True, True),
+                      provider.RegionalTimeState("UTC", 1, True, True),
+                      provider.RegionalTimeState("UTC", True, "yes", True),
+                      provider.RegionalTimeState("UTC", True, True, 0),
+                      provider.RegionalTimeState("UTC\nrecord", True, True, True)):
+            with mock.patch.object(provider, "RegionalRead") as reader:
+                reader.return_value.run.return_value = state
+                output, code = provider.time_status_output()
+            self.assertEqual(code, 1)
+            self.assertIn("\nerror\ttime-status\tmalformed\t", output)
+            self.assertNotIn("\ntime\t", output)
+
+    def test_scoped_error_bounds_and_fixed_cli(self):
+        for error_code in (*sorted(provider.NTP_SAMPLE_ERROR_CODES), "other"):
+            with mock.patch.object(provider, "RegionalRead", side_effect=provider.SnapshotFailure(
+                    error_code, "failure\n\t\x00\ud800" + "é" * 600)):
+                output, code = provider.time_status_output()
+            self.assertEqual(code, 1)
+            self.assertEqual(len(output.splitlines()), 3)
+            self.assertTrue(output.startswith(self.header + "error\ttime-status\t"
+                + ("internal" if error_code == "other" else error_code) + "\t"))
+            self.assertTrue(output.endswith(self.complete))
+            self.assertLessEqual(len(output.encode()), provider.TIME_STATUS_STREAM_BYTES)
+        with mock.patch.object(provider, "RegionalRead") as reader, \
+                mock.patch.object(provider, "PackageKitBackend") as backend, \
+                mock.patch.object(provider, "open_journal_directory") as journal, \
+                mock.patch.object(provider, "native_command") as mutation, \
+                contextlib.redirect_stdout(io.StringIO()) as output, \
+                contextlib.redirect_stderr(io.StringIO()):
+            reader.return_value.run.return_value = provider.RegionalTimeState("UTC", True, False, True)
+            self.assertEqual(provider.main(["time-status"]), 0)
+            self.assertEqual(output.getvalue(), self.header + "time\tUTC\tyes\tno\tyes\n" + self.complete)
+            for args in (["time"], ["--system"], ["Timezone"], ["extra", "argument"]):
+                self.assertEqual(provider.main(["time-status", *args]), 2)
+            reader.assert_called_once_with("time-state")
+            backend.assert_not_called()
+            journal.assert_not_called()
+            mutation.assert_not_called()
+
+    def test_output_failure_and_interruption_never_report_success(self):
+        for failure in (0, 1, BlockingIOError(), BrokenPipeError(), InterruptedError()):
+            writer = mock.Mock(side_effect=failure) if isinstance(failure, OSError) else mock.Mock(return_value=failure)
+            with mock.patch.object(provider, "control_output_writers", return_value=contextlib.nullcontext((writer, None))), \
+                    mock.patch.object(provider, "RegionalRead") as reader:
+                reader.return_value.run.return_value = provider.RegionalTimeState("UTC", True, False, True)
+                self.assertEqual(provider.main(["time-status"]), 1)
+            writer.assert_called_once_with((self.header + "time\tUTC\tyes\tno\tyes\n" + self.complete).encode())
+        for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            previous = signal.getsignal(signum)
+            with mock.patch.object(provider, "RegionalRead") as reader, \
+                    contextlib.redirect_stdout(io.StringIO()) as output:
+                def stop():
+                    signal.raise_signal(signum)
+                    signal.raise_signal(signum)
+                    return provider.RegionalTimeState("UTC", True, False, True)
+                reader.return_value.run.side_effect = stop
+                self.assertEqual(provider.main(["time-status"]), 1)
+                self.assertEqual(output.getvalue(), "")
+                reader.return_value.GLib.idle_add.assert_called_once()
+                reader.return_value.GLib.source_remove.assert_called_once()
+            self.assertIs(signal.getsignal(signum), previous)
+
+    def test_actual_command_handles_missing_output_and_unused_diagnostics(self):
+        code = """
+import os, runpy, sys
+from unittest import mock
+provider = runpy.run_path(sys.argv[1], run_name="time_output_fixture")
+mode = sys.argv[2]
+descriptor = 2 if mode.startswith("stderr") else 1
+if mode.endswith("readonly"):
+    source = os.open("/dev/null", os.O_RDONLY)
+    os.dup2(source, descriptor)
+    if source != descriptor:
+        os.close(source)
+elif mode.endswith("stream-closed"):
+    sys.stdout.close()
+else:
+    os.close(descriptor)
+    if mode.endswith("none"):
+        if descriptor == 1:
+            sys.stdout = None
+        else:
+            sys.stderr = None
+output = "time-status-protocol\\t1\\t0\\ntime\\tUTC\\tyes\\tno\\tyes\\ncomplete\\ttime-status\\n"
+reader = (lambda: (output, 0)) if descriptor == 2 else mock.Mock(side_effect=AssertionError("Read without output"))
+with mock.patch.dict(provider["main"].__globals__, time_status_output=reader):
+    raise SystemExit(provider["main"](["time-status"]))
+"""
+        for mode in ("stdout-closed", "stdout-readonly", "stdout-none", "stdout-stream-closed",
+                     "stderr-closed", "stderr-readonly", "stderr-none"):
+            with self.subTest(mode=mode):
+                result = subprocess.run([sys.executable, "-c", code, str(PROVIDER_PATH), mode],
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5, check=False)
+                available = mode.startswith("stderr")
+                self.assertEqual(result.returncode, 0 if available else 1)
+                self.assertEqual(result.stdout,
+                    (self.header + "time\tUTC\tyes\tno\tyes\n" + self.complete).encode() if available else b"")
+                self.assertEqual(result.stderr, b"")
 
 
 class NtpSampleCommandTests(unittest.TestCase):


### PR DESCRIPTION
## Scope
Prepare time-only reconciliation without changing existing Settings activation.

- Add fixed no-argument `time-status`: one bounded timedate1 GetAll read, strict complete time tuple, versioned <=1024-byte output, typed failures, cooperative interruption, and shared isolated output handling.
- Add opt-in `watch-time`: the authenticated passive regional lifetime, but with a distinct owner-arrived record after readiness. Setup events still coalesce into changed; idle departure remains quiet. Genuine properties remain changed.
- Preserve `watch-regional time|locale`, the cumulative snapshot schema, and current QML behavior.
- These are event-driven reconciliation interfaces, not a new poller. The eventual 30-second NTP sampler remains limited to CanNTP/NTPSynchronized.

## Validation
- Focused managed run: 43 tests passed in 40.888s.
- Private bus: monitor lifecycle/authentication/output failure plus time-status success, denial, malformed state, real 10-second timeout, late reply, and TERM/INT/HUP.
- Actual CLI output checks: closed/read-only/missing stdout fail before reading; unusable unused stderr does not prevent status.
- Read-only Fedora 44 observation: two time-status reads 31 seconds apart succeeded; watch-time emitted two owner-arrived records and no property-change records; normal monitor shutdown, no diagnostics.
- Local CodeRabbit: zero findings across seven files.
- Pre-suite Codex review: no actionable introduced defects.
- Documentation check/build: passed, 15 files/11 pages.
- `scripts/run-tests make clean all && scripts/run-tests` passed: 569 backend tests in 247.717s, 42 regional coordinator cases, 66 regional UI cases, 48 delegated UI cases. Closed Settings CPU 0.067%; closed large surfaces 0.00%. Managed workspaces removed.
- Required post-suite `codex review --uncommitted`: completed with no actionable introduced findings.

## Limitations
No UI consumer or sampler is enabled. The consumer must gate admission during owner uncertainty and reconcile genuine concurrent changes without looping through PackageKit or discarding unchanged confirmations. Combined installed graphical Phase 6 qualification remains pending. No host clock, NTP setting, live configuration, or shell activation changed. No Phase 7 work.
