### PR TITLE
feat(settings): validate finite QML time observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ versions from `config.mk`.
 
 ### Changed
 
+- Extend the finite QML regional reader to validate scoped time observations,
+  with bounded output, deadlines, and cancellation cleanup. Settings scheduling
+  and confirmation behavior are unchanged at this preparatory boundary.
+
 - Add read-only time discovery interfaces for scoped reconciliation: a bounded
   time-status result and a passive monitor that distinguishes service arrivals
   from property changes. Existing Settings activation is unchanged.

--- a/TASKS.md
+++ b/TASKS.md
@@ -437,6 +437,13 @@ unchanged. These interfaces prepare the visible NTP sampler's scoped
 reconciliation; its UI integration and combined installed qualification remain
 pending.
 
+The existing finite QML reader now accepts the two fixed no-argument time
+commands. It validates their exact bounded streams and withholds observations
+until complete output and a matching normal exit. Scoped reads have a 12-second
+outer guard and retain the existing reaping, cancellation, and publication
+ownership. They are not yet scheduled or connected to Settings; owner-arrival
+reconciliation and visible sampling remain pending.
+
 The user approved the narrow regional cancellation exception on 2026-09-06.
 Keep native timezone, NTP enablement, and system locale actions, with an explicit
 confirmation warning that a sent change cannot be canceled. Local cancellation

--- a/config/quickshell/systemmanagement/SystemRegionalPreflightModel.qml
+++ b/config/quickshell/systemmanagement/SystemRegionalPreflightModel.qml
@@ -17,6 +17,8 @@ Scope {
     onActiveChanged: { if (!root.active) root.cancel(); }
 
     function argumentsFor(command, selection, argument) {
+        if (command === "time-status" || command === "ntp-sample")
+            return selection === "" && argument === "" ? [] : null;
         if (command === "regional-choices")
             return ["timezone", "locale"].indexOf(selection) >= 0 && argument === "" ? [selection] : null;
         if (command !== "regional-preview" || typeof argument !== "string") return null;
@@ -29,6 +31,8 @@ Scope {
 
     function requestChoices(kind) { return root.start("regional-choices", kind, ""); }
     function requestPreview(action, argument) { return root.start("regional-preview", action, argument); }
+    function requestTimeStatus() { return root.start("time-status", "", ""); }
+    function requestNtpSample() { return root.start("ntp-sample", "", ""); }
 
     function start(command, selection, argument) {
         const args = root.argumentsFor(command, selection, argument);
@@ -52,6 +56,9 @@ Scope {
         if (root.current !== run || run.retired || run.finished || run.started) return;
         if (!root.active) { root.cancel(); return; }
         run.started = true;
+        // The scoped helper has a ten-second service budget; retain a bounded
+        // outer guard without changing the existing catalog/preview deadline.
+        readDeadline.interval = run.command === "time-status" || run.command === "ntp-sample" ? 12000 : 25000;
         readDeadline.restart();
         reader.running = true;
     }
@@ -120,7 +127,8 @@ Scope {
                 const outcome = { id: run.id, command: run.command, selection: run.selection,
                     status: error === null ? "available" : "failure", error: error,
                     choices: error === null ? run.parser.choices.slice() : [],
-                    preview: error === null ? run.parser.preview : null };
+                    preview: error === null ? run.parser.preview : null,
+                    observation: error === null ? run.parser.observation : null };
                 root.result = outcome;
                 // Closing from resultChanged must not publish a stale completion.
                 if (root.current === run && !run.retired) root.completed(outcome);

--- a/config/quickshell/systemmanagement/SystemRegionalPreflightProtocol.js
+++ b/config/quickshell/systemmanagement/SystemRegionalPreflightProtocol.js
@@ -90,7 +90,7 @@ function acceptLine(parser, line) {
         parser.preview = { actionId: fields[1], argument: fields[2], generation: fields[3],
             current: fields[4], target: fields[5], detail: fields[6] };
     } else if (fields[0] === "error") {
-        const codes = observation ? ["missing-provider", "permission-denied", "timeout", "malformed", "interrupted", "internal"]
+        const codes = observation ? ["missing-provider", "permission-denied", "unsupported", "timeout", "malformed", "internal"]
             : ["network", "repository", "conflict", "signature", "package",
                     "unsupported", "malformed", "missing-provider", "permission-denied", "canceled",
                     "timeout", "interrupted", "internal"];

--- a/config/quickshell/systemmanagement/SystemRegionalPreflightProtocol.js
+++ b/config/quickshell/systemmanagement/SystemRegionalPreflightProtocol.js
@@ -4,12 +4,14 @@
 // Consumers must wait for finish(); parsed rows alone are not usable evidence.
 function create(command, selection, argument) {
     const choices = command === "regional-choices";
+    const observation = command === "time-status" || command === "ntp-sample";
     const parser = { command: command, selection: selection, argument: argument,
-        limit: choices ? (selection === "timezone" ? 524288 : 1048576) : 8192,
+        limit: observation ? 1024 : choices ? (selection === "timezone" ? 524288 : 1048576) : 8192,
         offset: 0, previous: new Uint8Array(0), line: "", lineBytes: 0,
         remaining: 0, minimum: 0, codepoint: 0, header: false, complete: false,
-        ended: false, failure: "", choices: [], identityBytes: 0, preview: null, error: null };
-    if (choices ? (["timezone", "locale"].indexOf(selection) < 0 || argument !== "")
+        ended: false, failure: "", choices: [], identityBytes: 0, preview: null, observation: null, error: null };
+    if (observation ? (selection !== "" || argument !== "")
+        : choices ? (["timezone", "locale"].indexOf(selection) < 0 || argument !== "")
             : (command !== "regional-preview"
                 || ["timezone-set", "ntp-set", "locale-set"].indexOf(selection) < 0
                 || typeof argument !== "string" || argument.length > 512))
@@ -58,6 +60,7 @@ function acceptLine(parser, line) {
     const fields = line.split("\t");
     if (fields.some(field => utf8Bytes(field) > 512)) return fail(parser, "Oversized preflight field");
     const choices = parser.command === "regional-choices";
+    const observation = parser.command === "time-status" || parser.command === "ntp-sample";
     if (!parser.header) {
         const expected = parser.command + "-protocol\t1\t0" + (choices ? "\t" + parser.selection : "");
         if (line !== expected) return fail(parser, "Unsupported preflight header");
@@ -72,20 +75,32 @@ function acceptLine(parser, line) {
         if (parser.selection === "timezone" && parser.identityBytes > 262144)
             return fail(parser, "Timezone identities exceed byte limit");
         parser.choices.push(fields[1]);
-    } else if (fields[0] === "preview" && !choices) {
+    } else if (observation && fields[0] === (parser.command === "time-status" ? "time" : "sample")) {
+        const time = parser.command === "time-status";
+        if (parser.observation || parser.error || fields.length !== (time ? 5 : 3)
+                || (time && !timezone(fields[1]))
+                || fields.slice(time ? 2 : 1).some(value => ["yes", "no"].indexOf(value) < 0))
+            return fail(parser, "Invalid time observation");
+        parser.observation = time
+            ? { timezone: fields[1], canNtp: fields[2] === "yes", ntpEnabled: fields[3] === "yes", synchronized: fields[4] === "yes" }
+            : { canNtp: fields[1] === "yes", synchronized: fields[2] === "yes" };
+    } else if (fields[0] === "preview" && parser.command === "regional-preview") {
         if (parser.preview || parser.error || !validPreview(parser, fields))
             return fail(parser, "Invalid or mismatched preflight preview");
         parser.preview = { actionId: fields[1], argument: fields[2], generation: fields[3],
             current: fields[4], target: fields[5], detail: fields[6] };
     } else if (fields[0] === "error") {
-        if (fields.length !== 4 || fields[1] !== "regional" || parser.error || parser.preview
-                || parser.choices.length || ["network", "repository", "conflict", "signature", "package",
+        const codes = observation ? ["missing-provider", "permission-denied", "timeout", "malformed", "interrupted", "internal"]
+            : ["network", "repository", "conflict", "signature", "package",
                     "unsupported", "malformed", "missing-provider", "permission-denied", "canceled",
-                    "timeout", "interrupted", "internal"].indexOf(fields[2]) < 0)
+                    "timeout", "interrupted", "internal"];
+        if (fields.length !== 4 || fields[1] !== (observation ? parser.command : "regional")
+                || parser.error || parser.preview || parser.observation || parser.choices.length || codes.indexOf(fields[2]) < 0)
             return fail(parser, "Invalid preflight error");
         parser.error = { code: fields[2], detail: fields[3] };
     } else if (fields[0] === "complete") {
-        if (fields.length !== 2 || fields[1] !== parser.command || (!choices && !parser.preview && !parser.error))
+        if (fields.length !== 2 || fields[1] !== parser.command
+                || (!choices && !parser.preview && !parser.observation && !parser.error))
             return fail(parser, "Incomplete preflight result");
         parser.complete = true;
     } else return fail(parser, "Unexpected preflight record");

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -2369,6 +2369,20 @@ that consumer behavior or change existing confirmation invalidation. Private-bus
 fixtures exercise the new passive monitor lifecycle, fixed time-status reads,
 malformed/denied/timeout results, late replies, and all three handled signals.
 
+The shared `SystemRegionalPreflightModel` now also accepts these fixed
+no-argument `time-status` and `ntp-sample` reads. Its existing strict cumulative
+byte parser enforces the exact headers, one appropriate observation row or
+one command-owned error, the six closed error codes, and the 1024-byte stream
+limit. An observation is usable only after completion and a matching normal
+process exit; errors withhold all provisional values. The scoped commands use
+a 12-second outer deadline around the helper's ten-second budget, with the
+existing three-second TERM-to-KILL reaping grace. Catalogs and previews retain
+their 25-second outer deadline. Ownership remains claimed through publication
+callbacks, and close, overflow, timeout, or replacement cannot publish retired
+data. This reader addition does not schedule reads, change discovery ownership,
+or connect observations to Settings or journal recovery. Reconciliation and
+the visible 30-second sampler remain separate integration work.
+
 The fixed `dwm-system-management watch-accounts` command is also implemented.
 It accepts no arguments and emits only `accounts-event<TAB>ready` and
 `accounts-event<TAB>changed`. It shares the authenticated setup lifetime above:

--- a/tests/fixtures/system-regional-preflight-provider.py
+++ b/tests/fixtures/system-regional-preflight-provider.py
@@ -13,7 +13,7 @@ args = sys.argv[1:]
 allowed = [["regional-choices", "timezone"], ["regional-choices", "locale"],
            ["regional-preview", "timezone-set", "Etc/UTC"],
            ["regional-preview", "ntp-set", "enabled"],
-           ["regional-preview", "locale-set", "LANG=C"]]
+           ["regional-preview", "locale-set", "LANG=C"], ["time-status"], ["ntp-sample"]]
 if args not in allowed:
     (directory / "invalid-arguments").touch()
     raise SystemExit(2)
@@ -30,7 +30,11 @@ with (directory / "lock").open("a") as lock:
     choices = args[0] == "regional-choices"
     header = args[0] + "-protocol\t1\t0" + ("\t" + args[1] if choices else "") + "\n"
     completion = "complete\t" + args[0] + "\n"
-    if choices:
+    if args[0] == "time-status":
+        payload = "time\tEtc/UTC\tyes\tno\tyes\n"
+    elif args[0] == "ntp-sample":
+        payload = "sample\tyes\tno\n"
+    elif choices:
         values = ["America/Chicago", "Etc/UTC"] if args[1] == "timezone" else ["C", "en_US.utf8"]
         payload = "".join("choice\t" + value + "\n" for value in values)
     else:
@@ -59,7 +63,8 @@ with (directory / "lock").open("a") as lock:
         time.sleep(60)
     code = 0
     if scenario == "typed-error":
-        payload = "error\tregional\tpermission-denied\tFixture read denied\n"
+        owner = args[0] if args[0] in {"time-status", "ntp-sample"} else "regional"
+        payload = "error\t" + owner + "\tpermission-denied\tFixture read denied\n"
         code = 1
     elif scenario == "wrong-exit":
         code = 1

--- a/tests/fixtures/system-regional-preflight-provider.py
+++ b/tests/fixtures/system-regional-preflight-provider.py
@@ -62,9 +62,10 @@ with (directory / "lock").open("a") as lock:
             time.sleep(0.001)
         time.sleep(60)
     code = 0
-    if scenario == "typed-error":
+    if scenario in {"typed-error", "unsupported-error"}:
         owner = args[0] if args[0] in {"time-status", "ntp-sample"} else "regional"
-        payload = "error\t" + owner + "\tpermission-denied\tFixture read denied\n"
+        error_code = "permission-denied" if scenario == "typed-error" else "unsupported"
+        payload = "error\t" + owner + "\t" + error_code + "\tFixture read unavailable\n"
         code = 1
     elif scenario == "wrong-exit":
         code = 1

--- a/tests/qml/SystemRegionalPreflightOwner.qml
+++ b/tests/qml/SystemRegionalPreflightOwner.qml
@@ -5,6 +5,7 @@ import qs.systemmanagement
 ShellRoot {
     id: root
     property string scenario: Quickshell.env("DWM_PREFLIGHT_SCENARIO")
+    property string mode: Quickshell.env("DWM_PREFLIGHT_MODE") || "regional"
     property int phase: 0
     property int assertions: 0
     property int completions: 0
@@ -21,7 +22,8 @@ ShellRoot {
     property var lastRun: null
     property var requests: [["regional-choices", "timezone", ""], ["regional-choices", "locale", ""],
         ["regional-preview", "timezone-set", "Etc/UTC"], ["regional-preview", "ntp-set", "enabled"],
-        ["regional-preview", "locale-set", "LANG=C"], ["regional-choices", "timezone", ""]]
+        ["regional-preview", "locale-set", "LANG=C"], ["time-status", "", ""],
+        ["ntp-sample", "", ""], ["regional-choices", "timezone", ""]]
     readonly property bool replaces: ["close", "kill-close", "close-stdout-overflow", "close-stderr-overflow",
         "timeout", "cancel-queued", "cancel-claim", "close-result"].indexOf(scenario) >= 0
 
@@ -41,7 +43,7 @@ ShellRoot {
         received = null;
         starting = true;
         model.active = true;
-        const request = scenario === "success" ? requests[phase]
+        const request = mode !== "regional" ? [mode, "", ""] : scenario === "success" ? requests[phase]
             : phase === 1 ? requests[1] : requests[3];
         const accepted = model.start(request[0], request[1], request[2]);
         check(accepted === !(scenario === "cancel-claim" && phase === 0), "Expected request admission");
@@ -62,7 +64,7 @@ ShellRoot {
         if (replaces && phase === 0) {
             if (scenario === "timeout") {
                 check(received !== null && received.error.code === "timeout", "Deadline reports typed failure");
-                check(Date.now() - startedAt >= 27500, "Real deadline retains kill grace");
+                check(Date.now() - startedAt >= (mode === "regional" ? 27500 : 14500), "Real deadline retains kill grace");
             } else {
                 check(received === null && model.result === null && completions === 0, "Retired read publishes no completion or result");
                 if (scenario === "kill-close") check(Date.now() - canceledAt >= 2800, "Close retains ownership through kill grace");
@@ -74,13 +76,14 @@ ShellRoot {
             begin();
             return;
         }
-        if (scenario === "success" && phase < requests.length - 1) {
+        if (scenario === "success" && phase < (mode === "regional" ? requests.length - 1 : 1)) {
             oldRun = lastRun;
             phase++;
             begin();
             return;
         }
-        check(completions === (scenario === "success" ? 6 : scenario === "timeout" ? 2 : 1), "No duplicate or missing completion");
+        check(completions === (scenario === "success" ? (mode === "regional" ? requests.length : 2)
+            : scenario === "timeout" ? 2 : 1), "No duplicate or missing completion");
         if (["stdout-overflow", "stderr-overflow"].indexOf(scenario) >= 0)
             check(Date.now() - startedAt < 2500, "Output flood is killed without a TERM grace period");
         if (["success", "typed-error", "wrong-exit", "protocol-exit-127"].indexOf(scenario) >= 0 || replaces)
@@ -92,7 +95,7 @@ ShellRoot {
         model.active = false;
         check(model.result === null && !model.busy, "Close clears retained optional data");
         done = true;
-        console.info("Regional preflight owner tests: PASS (" + scenario + ", " + assertions + " assertions)");
+        console.info("Regional preflight owner tests: PASS (" + mode + ", " + scenario + ", " + assertions + " assertions)");
         Qt.quit();
     }
     function run() {
@@ -102,7 +105,8 @@ ShellRoot {
                 ["regional-choices", "timezone", "extra"], ["regional-preview", "unknown", "enabled"],
                 ["regional-preview", "timezone-set", "../etc"], ["regional-preview", "timezone-set", null],
                 ["regional-preview", "ntp-set", "yes"], ["regional-preview", "locale-set", "LANG="],
-                ["regional-preview", "locale-set", "LANG=C\n"]])
+                ["regional-preview", "locale-set", "LANG=C\n"], ["time-status", "time", ""],
+                ["time-status", "", "extra"], ["ntp-sample", "ntp", ""], ["ntp-sample", "", "extra"]])
             check(!model.start(...args), "Invalid fixed request rejected before helper");
         startedTest = true;
         startedAt = Date.now();
@@ -132,12 +136,17 @@ ShellRoot {
                 if (outcome.command === "regional-choices")
                     root.check(JSON.stringify(outcome.choices) === JSON.stringify(outcome.selection === "timezone"
                         ? ["America/Chicago", "Etc/UTC"] : ["C", "en_US.utf8"]), "Exact catalog retained across collector reuse");
-                else root.check(outcome.preview.detail === "Full fixture detail", "Complete preview retained");
+                else if (outcome.command === "regional-preview")
+                    root.check(outcome.preview.detail === "Full fixture detail", "Complete preview retained");
+                else root.check(JSON.stringify(outcome.observation) === JSON.stringify(outcome.command === "time-status"
+                    ? { timezone: "Etc/UTC", canNtp: true, ntpEnabled: false, synchronized: true }
+                    : { canNtp: true, synchronized: false }), "Exact observation retained across collector reuse");
             } else {
                 const expected = root.scenario === "typed-error" ? "permission-denied"
                     : root.scenario === "timeout" ? "timeout"
                     : ["failed-start", "missing-helper"].indexOf(root.scenario) >= 0 ? "missing-provider" : "malformed";
-                root.check(outcome.error.code === expected && outcome.choices.length === 0 && outcome.preview === null,
+                root.check(outcome.error.code === expected && outcome.choices.length === 0 && outcome.preview === null
+                    && outcome.observation === null,
                     "Failed result withholds provisional data and preserves error");
             }
         }

--- a/tests/qml/SystemRegionalPreflightOwner.qml
+++ b/tests/qml/SystemRegionalPreflightOwner.qml
@@ -86,7 +86,7 @@ ShellRoot {
             : scenario === "timeout" ? 2 : 1), "No duplicate or missing completion");
         if (["stdout-overflow", "stderr-overflow"].indexOf(scenario) >= 0)
             check(Date.now() - startedAt < 2500, "Output flood is killed without a TERM grace period");
-        if (["success", "typed-error", "wrong-exit", "protocol-exit-127"].indexOf(scenario) >= 0 || replaces)
+        if (["success", "typed-error", "unsupported-error", "wrong-exit", "protocol-exit-127"].indexOf(scenario) >= 0 || replaces)
             check(provisional, "Complete bytes were observed before process exit without a result");
         const retained = model.result;
         model.consume(new Uint8Array([0]).buffer);
@@ -143,6 +143,7 @@ ShellRoot {
                     : { canNtp: true, synchronized: false }), "Exact observation retained across collector reuse");
             } else {
                 const expected = root.scenario === "typed-error" ? "permission-denied"
+                    : root.scenario === "unsupported-error" ? "unsupported"
                     : root.scenario === "timeout" ? "timeout"
                     : ["failed-start", "missing-helper"].indexOf(root.scenario) >= 0 ? "missing-provider" : "malformed";
                 root.check(outcome.error.code === expected && outcome.choices.length === 0 && outcome.preview === null

--- a/tests/qml/SystemRegionalPreflightParser.qml
+++ b/tests/qml/SystemRegionalPreflightParser.qml
@@ -72,12 +72,12 @@ ShellRoot {
             for (const code of [1, 2, -1])
                 root.check(!root.parse(command, "", "", good, code), "observation exit mismatch");
             root.check(!root.parse(command, "", "", good, 0, false), "crashed observation");
-            for (const code of ["missing-provider", "permission-denied", "timeout", "malformed", "interrupted", "internal"]) {
+            for (const code of ["missing-provider", "permission-denied", "unsupported", "timeout", "malformed", "internal"]) {
                 const failed = header + error.replace("internal", code) + complete;
                 root.check(root.parse(command, "", "", failed, 1), "typed observation error");
                 root.check(!root.parse(command, "", "", failed, 0), "observation error cannot succeed");
             }
-            for (const code of ["network", "unsupported", "canceled", "unknown"])
+            for (const code of ["network", "interrupted", "canceled", "unknown"])
                 root.check(!root.parse(command, "", "", header + error.replace("internal", code) + complete, 1), "closed observation error codes");
             root.check(!root.parse(command, "", "", header + error.replace(command, "regional") + complete, 1), "observation error owner");
             root.check(!root.parse(command, "", "", header + error + error + complete, 1), "duplicate observation error");

--- a/tests/qml/SystemRegionalPreflightParser.qml
+++ b/tests/qml/SystemRegionalPreflightParser.qml
@@ -37,6 +37,62 @@ ShellRoot {
         root.check(JSON.stringify(parser.choices) === JSON.stringify(values), kind + " exact catalog identities and order");
     }
     function unitTests() {
+        for (const command of ["time-status", "ntp-sample"]) {
+            const time = command === "time-status";
+            const header = command + "-protocol\t1\t0\n";
+            const complete = "complete\t" + command + "\n";
+            const row = time ? "time\tEtc/UTC\tyes\tno\tyes\n" : "sample\tyes\tno\n";
+            const good = header + row + complete;
+            const all = root.bytes(good);
+            for (let split = 0; split <= all.byteLength; split++) {
+                const parser = Protocol.create(command, "", "");
+                root.check(Protocol.consume(parser, all.slice(0, split)) && Protocol.consume(parser, all)
+                    && Protocol.finish(parser, 0, true), "every observation split: " + command + " " + split);
+                root.check(JSON.stringify(parser.observation) === JSON.stringify(time
+                    ? { timezone: "Etc/UTC", canNtp: true, ntpEnabled: false, synchronized: true }
+                    : { canNtp: true, synchronized: false }), "exact observation");
+            }
+            for (let bits = 0; bits < (time ? 8 : 4); bits++) {
+                const values = Array.from({length: time ? 3 : 2}, (_, i) => bits & (1 << i) ? "yes" : "no");
+                root.check(root.parse(command, "", "", header + (time ? "time\tEtc/UTC\t" : "sample\t")
+                    + values.join("\t") + "\n" + complete, 0), "every boolean combination");
+            }
+            const error = "error\t" + command + "\tinternal\tNot available\n";
+            for (const bad of [good.slice(0, -1), good + "\n", good + complete,
+                    good.replace("\t1\t0", "\t1\t1"), good.replace("\t1\t0", "\t2\t0"),
+                    header + complete, header + row + row + complete,
+                    header + row + error + complete, header + error + row + complete,
+                    good.replace("yes", "true"), good.replace("no", "0"),
+                    good.replace(row, row.slice(0, -1) + "\textra\n"),
+                    good.replace(row, "choice\tEtc/UTC\n"),
+                    good.replace(row, "preview\tntp-set\tenabled\t" + root.generation + "\tdisabled\tenabled\tdetail\n"),
+                    good.replace(row, time ? "sample\tyes\tno\n" : "time\tEtc/UTC\tyes\tno\tyes\n"),
+                    good.replace(complete, "complete\tregional-preview\n")])
+                root.check(!root.parse(command, "", "", bad, 0), "invalid observation");
+            for (const code of [1, 2, -1])
+                root.check(!root.parse(command, "", "", good, code), "observation exit mismatch");
+            root.check(!root.parse(command, "", "", good, 0, false), "crashed observation");
+            for (const code of ["missing-provider", "permission-denied", "timeout", "malformed", "interrupted", "internal"]) {
+                const failed = header + error.replace("internal", code) + complete;
+                root.check(root.parse(command, "", "", failed, 1), "typed observation error");
+                root.check(!root.parse(command, "", "", failed, 0), "observation error cannot succeed");
+            }
+            for (const code of ["network", "unsupported", "canceled", "unknown"])
+                root.check(!root.parse(command, "", "", header + error.replace("internal", code) + complete, 1), "closed observation error codes");
+            root.check(!root.parse(command, "", "", header + error.replace(command, "regional") + complete, 1), "observation error owner");
+            root.check(!root.parse(command, "", "", header + error + error + complete, 1), "duplicate observation error");
+            for (const value of ["x".repeat(513), "\u20ac".repeat(171), "bad\u202e"])
+                root.check(!root.parse(command, "", "", header + error.replace("Not available", value) + complete, 1), "bounded canonical observation detail");
+            root.check(root.parse(command, "", "", header + error.replace("Not available", "\u20ac".repeat(170) + "ab") + complete, 1), "512-byte observation detail");
+            for (const request of [[command, "timezone", ""], [command, "", "extra"], [command, null, ""], [command, "", null]])
+                root.check(!!Protocol.create(...request).failure, "no observation arguments");
+            const bounded = Protocol.create(command, "", "");
+            root.check(bounded.limit === 1024 && !Protocol.consume(bounded, new ArrayBuffer(1025)), "observation stream limit");
+            if (time) {
+                for (const value of ["", "../UTC", "Etc//UTC", "x".repeat(256), "\u00e9"])
+                    root.check(!root.parse(command, "", "", good.replace("Etc/UTC", value), 0), "invalid observed timezone");
+            }
+        }
         for (const kind of ["timezone", "locale"]) {
             const values = kind === "timezone" ? ["America/Chicago", "Etc/UTC"] : ["C", "en_US.utf8"];
             const good = root.choices(kind, values);

--- a/tests/test-quickshell-system-management-xvfb.sh
+++ b/tests/test-quickshell-system-management-xvfb.sh
@@ -600,40 +600,45 @@ preflight_helper="$work/preflight-data/dwm-titus/scripts/dwm-system-management"
 cp "$repo/tests/fixtures/system-regional-preflight-provider.py" "$preflight_helper"
 chmod +x "$preflight_helper"
 preflight_quickshell=$(command -v quickshell)
-for preflight_scenario in success typed-error wrong-exit protocol-exit-127 malformed truncated stdout-overflow stderr-overflow \
-	close kill-close close-stdout-overflow close-stderr-overflow timeout cancel-queued cancel-claim close-result failed-start missing-helper; do
-	preflight_directory="$work/preflight-$preflight_scenario"
-	mkdir -p "$preflight_directory"
-	preflight_path=$PATH
-	preflight_data="$work/preflight-data"
-	[ "$preflight_scenario" != failed-start ] || preflight_path="$work/preflight-empty-path"
-	if [ "$preflight_scenario" = missing-helper ]; then
-		preflight_path="$work/preflight-shell-path"
-		preflight_data="$work/preflight-missing-data"
-	fi
-	timeout --foreground --kill-after=2s 45s env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
-		XDG_DATA_HOME="$preflight_data" XDG_RUNTIME_DIR="$runtime" QT_QPA_PLATFORMTHEME= PATH="$preflight_path" \
-		DWM_PREFLIGHT_DIRECTORY="$preflight_directory" DWM_PREFLIGHT_SCENARIO="$preflight_scenario" \
-		"$preflight_quickshell" --no-duplicate --path "$work/regional-preflight-owner/shell.qml" \
-		>"$preflight_directory/output.log" 2>&1 &
-	quickshell_pid=$!
-	preflight_status=0
-	wait "$quickshell_pid" || preflight_status=$?
-	quickshell_pid=
-	case "$preflight_scenario" in
-	success) preflight_calls=6 ;;
-	close | kill-close | close-stdout-overflow | close-stderr-overflow | timeout | close-result) preflight_calls=2 ;;
-	failed-start | missing-helper) preflight_calls=0 ;;
-	*) preflight_calls=1 ;;
-	esac
-	preflight_actual=$(sed -n '1p' "$preflight_directory/calls" 2>/dev/null || true)
-	if [ "$preflight_status" -ne 0 ] || ! grep -F 'Regional preflight owner tests: PASS' "$preflight_directory/output.log" ||
-		grep -Fq 'Regional preflight owner FAILED:' "$preflight_directory/output.log" ||
-		[ "${preflight_actual:-0}" != "$preflight_calls" ] || [ -e "$preflight_directory/invalid-arguments" ] ||
-		[ -e "$preflight_directory/overlap" ] || pgrep -f "$preflight_helper" >/dev/null 2>&1; then
-		cat "$preflight_directory/output.log" >&2
-		exit 1
-	fi
+for preflight_mode in regional time-status ntp-sample; do
+	for preflight_scenario in success typed-error wrong-exit protocol-exit-127 malformed truncated stdout-overflow stderr-overflow \
+		close kill-close close-stdout-overflow close-stderr-overflow timeout cancel-queued cancel-claim close-result failed-start missing-helper; do
+		preflight_directory="$work/preflight-$preflight_mode-$preflight_scenario"
+		mkdir -p "$preflight_directory"
+		preflight_path=$PATH
+		preflight_data="$work/preflight-data"
+		[ "$preflight_scenario" != failed-start ] || preflight_path="$work/preflight-empty-path"
+		if [ "$preflight_scenario" = missing-helper ]; then
+			preflight_path="$work/preflight-shell-path"
+			preflight_data="$work/preflight-missing-data"
+		fi
+		timeout --foreground --kill-after=2s 45s env DISPLAY="$display" HOME="$home" XDG_CONFIG_HOME="$config_home" \
+			XDG_DATA_HOME="$preflight_data" XDG_RUNTIME_DIR="$runtime" QT_QPA_PLATFORMTHEME= PATH="$preflight_path" \
+			DWM_PREFLIGHT_DIRECTORY="$preflight_directory" DWM_PREFLIGHT_SCENARIO="$preflight_scenario" DWM_PREFLIGHT_MODE="$preflight_mode" \
+			"$preflight_quickshell" --no-duplicate --path "$work/regional-preflight-owner/shell.qml" \
+			>"$preflight_directory/output.log" 2>&1 &
+		quickshell_pid=$!
+		preflight_status=0
+		wait "$quickshell_pid" || preflight_status=$?
+		quickshell_pid=
+		case "$preflight_scenario" in
+		success)
+			preflight_calls=8
+			[ "$preflight_mode" = regional ] || preflight_calls=2
+			;;
+		close | kill-close | close-stdout-overflow | close-stderr-overflow | timeout | close-result) preflight_calls=2 ;;
+		failed-start | missing-helper) preflight_calls=0 ;;
+		*) preflight_calls=1 ;;
+		esac
+		preflight_actual=$(sed -n '1p' "$preflight_directory/calls" 2>/dev/null || true)
+		if [ "$preflight_status" -ne 0 ] || ! grep -F 'Regional preflight owner tests: PASS' "$preflight_directory/output.log" ||
+			grep -Fq 'Regional preflight owner FAILED:' "$preflight_directory/output.log" ||
+			[ "${preflight_actual:-0}" != "$preflight_calls" ] || [ -e "$preflight_directory/invalid-arguments" ] ||
+			[ -e "$preflight_directory/overlap" ] || pgrep -f "$preflight_helper" >/dev/null 2>&1; then
+			cat "$preflight_directory/output.log" >&2
+			exit 1
+		fi
+	done
 done
 
 mkdir -p "$work/operation-parser"

--- a/tests/test-quickshell-system-management-xvfb.sh
+++ b/tests/test-quickshell-system-management-xvfb.sh
@@ -601,7 +601,7 @@ cp "$repo/tests/fixtures/system-regional-preflight-provider.py" "$preflight_help
 chmod +x "$preflight_helper"
 preflight_quickshell=$(command -v quickshell)
 for preflight_mode in regional time-status ntp-sample; do
-	for preflight_scenario in success typed-error wrong-exit protocol-exit-127 malformed truncated stdout-overflow stderr-overflow \
+	for preflight_scenario in success typed-error unsupported-error wrong-exit protocol-exit-127 malformed truncated stdout-overflow stderr-overflow \
 		close kill-close close-stdout-overflow close-stderr-overflow timeout cancel-queued cancel-claim close-result failed-start missing-helper; do
 		preflight_directory="$work/preflight-$preflight_mode-$preflight_scenario"
 		mkdir -p "$preflight_directory"


### PR DESCRIPTION
## Summary
- Reuse the bounded regional QML reader for fixed no-argument `time-status` and `ntp-sample` observations.
- Enforce exact versioned records, boolean/timezone validation, closed command-owned error codes, and the 1024-byte stream cap. Publish only after complete bytes and a matching normal exit.
- Keep the existing single-reader ownership and reaping rules; scoped reads use a 12-second outer guard plus the existing three-second TERM-to-KILL grace.
- Extend parser coverage and run the lifecycle matrix for catalogs/previews and both scoped commands.

## Scope
Preparatory Phase 6 boundary only. No scheduling, Settings subscription changes, retained-confirmation policy changes, journal recovery changes, host settings changes, live Quickshell activation, or Phase 7 work. Owner-arrival reconciliation and the visible 30-second sampler remain separate integration work.

## Validation
- Focused managed parser/lifecycle run: 1,755 parser assertions and 57 lifecycle scenarios passed. Cases include collector reuse, malformed/truncated/wrong-exit output, typed errors, failed starts, output floods, actual timeout/kill grace, close/reopen, queued/reentrant cancellation, and closure during result publication.
- ShellCheck and shfmt across the required repository shell files; system-management source contract; diff whitespace check: passed.
- Configured Quickshell QML lint: passed with existing Qt/Quickshell metadata warnings.
- Documentation checks/build: passed, zero errors/warnings/hints, 11 pages.
- Independent CodeRabbit CLI reviews: completed, zero findings for the original nine-file boundary and the five-file error-code correction.
- `scripts/run-tests make clean all` and `scripts/run-tests`: passed. Full coverage includes 569 backend tests (247.328s), 57 reader lifecycle cases, 42 regional coordinator cases, 66 regional UI cases, and 48 delegated UI cases.
- Nested-X11 closed Settings CPU: 0.100%; closed large surfaces: 0.00%. Power lifecycle CPU: 0.133% before, 0.100% after (0.033-point delta).
- Required post-suite Codex reviews: both completed after their respective full gates, with no actionable defects.

## Review correction
Hosted Codex identified that the helper's six observation error codes include `unsupported`, not `interrupted`. The parser now matches the actual producer contract. Parser rejection/acceptance tests and all three reader modes cover the correction, increasing the lifecycle matrix to 57 cases. The complete local gate was rerun after the fix.

## Runtime and limitations
Fedora 44, Qt 6.11.2, the supported Fedora Quickshell 0.2.1 snapshot. Focused reader tests use private helper fixtures; the full suite also passed the actual nested-X11 lifecycle and UI gates. Managed test workspaces were removed after completion. A fresh read-only nested-X11 smoke test also verified both commands through the QML reader against the actual Fedora time service after the correction, with no host settings or live shell changes. There are no visible changes requiring screenshots at this boundary. The new reader is not activated by production Settings yet; no installed graphical authorization or combined Phase 6 completion is claimed.