### PR TITLE
feat(settings): add bounded local information readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ versions from `config.mk`.
 
 ### Changed
 
+- Add internal bounded OS, kernel, CPU, memory, swap, and uptime readers with
+  per-field failure isolation and checked byte counters. This preparatory
+  boundary does not activate a new protocol minor, Settings UI, or polling loop.
+
 - Sample network-time synchronization every 30 seconds while System Settings
   is open and after a verified NTP result. Serialize reads with recovery,
   preserve matching prompts and keyboard focus, and retain the last reported

--- a/TASKS.md
+++ b/TASKS.md
@@ -491,6 +491,15 @@ Acceptance:
 
 ### INFO-RECOVERY-001: Information, Diagnostics, and Recovery
 
+The internal local-information reader now returns eleven independent OS, kernel,
+processor, memory, swap, and uptime observations. Fixed file reads are capped;
+allowlisted fields, UTF-8 text, exact kB conversion, and unsigned 64-bit counters
+are validated without subprocesses, services, journals, or mutations. Twelve
+focused tests and a read-only Fedora 44 probe passed. This preparatory boundary
+adds no CLI command, protocol minor, Settings surface, or polling loop.
+Hostname1, filesystem/security sources, protocol integration, visible controls,
+and combined installed qualification remain pending.
+
 - [ ] Add event-driven or bounded system information and storage overview state
   without a new idle poller.
 - [ ] Add privacy and security status, diagnostics, recovery actions, and reset

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -941,6 +941,18 @@ Each failed or malformed source degrades only the states or filesystem records
 it owns. A missing hostname1 property does not invalidate OS, kernel, processor,
 memory, or filesystem state.
 
+The internal local-reader boundary implements the eleven OS, kernel, CPU,
+memory, swap, and uptime states without activating cumulative minor 2. It reads
+each fixed file once with its byte limit plus one overflow-detection byte, closes
+the source before parsing, and retains valid peer fields when an allowlisted
+field is missing, duplicated, or malformed. Display fields must be printable
+UTF-8 within 512 bytes; counters use exact unsigned 64-bit decimal values, and
+the first CPU model field is authoritative. Read denial is scoped `restricted`
+state, absent files are `unsupported`, other I/O failures are `unavailable`, and
+malformed data is `partial`; failed values are always `unknown`. It starts no
+service, subprocess, journal access, or polling loop. Hardware, filesystem,
+security, protocol, and Settings integration remain separate boundaries.
+
 ### Security Status
 
 Each probe has a fixed source and emits its own state instead of making the

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -32,6 +32,11 @@ PROTOCOL_MAJOR = 1
 PROTOCOL_MINOR = 0
 SNAPSHOT_MINOR = 1
 MAX_TEXT_BYTES = 512
+INFORMATION_UINT_MAX = (1 << 64) - 1
+INFORMATION_MEMORY_KEYS = {
+    "MemTotal": "memory-total-bytes", "MemAvailable": "memory-available-bytes",
+    "SwapTotal": "swap-total-bytes", "SwapFree": "swap-free-bytes",
+}
 MAX_LIST_RECORDS = 4096
 MAX_LIST_BYTES = 3 * 1024 * 1024
 READ_DEADLINE_SECONDS = 120
@@ -266,6 +271,152 @@ class SnapshotFailure(Exception):
         self.code = code
         self.detail = clean_text(detail)
         self.status = status
+
+
+@dataclass(frozen=True)
+class InformationState:
+    """One independently readable information value, not yet a protocol row."""
+
+    status: str
+    value: str
+    detail: str
+    error_code: str = ""
+
+
+def information_unknown(error: Exception) -> InformationState:
+    """Normalize source failures without exposing source contents or exception text."""
+    if isinstance(error, SnapshotFailure):
+        return InformationState(error.status, "unknown", error.detail, error.code)
+    if isinstance(error, OSError):
+        if error.errno in (errno.EACCES, errno.EPERM):
+            return InformationState("restricted", "unknown", "Information source access denied", "permission-denied")
+        if error.errno in (errno.ENOENT, errno.ENOTDIR):
+            return InformationState("unsupported", "unknown", "Information source is absent", "missing-provider")
+        return InformationState("unavailable", "unknown", "Information source could not be read", "internal")
+    return InformationState("partial", "unknown", "Information source is malformed", "malformed")
+
+
+def information_text(value: object, detail: str) -> InformationState:
+    """Validate bounded printable display text without truncating a malformed field."""
+    if not isinstance(value, str) or not value.strip():
+        raise SnapshotFailure("malformed", "Information text is missing or invalid")
+    if len(value) > MAX_TEXT_BYTES or not value.isprintable() or len(value.encode("utf-8")) > MAX_TEXT_BYTES:
+        raise SnapshotFailure("malformed", "Information text is oversized or undisplayable")
+    return InformationState("available", value, detail)
+
+
+def information_number(value: object, detail: str) -> InformationState:
+    """Keep counters exact as canonical unsigned 64-bit decimal text."""
+    if type(value) is not int or not 0 <= value <= INFORMATION_UINT_MAX:
+        raise SnapshotFailure("malformed", "Information counter is invalid or overflowing")
+    return InformationState("available", str(value), detail)
+
+
+def information_fields(data: bytes, keys: Mapping[str, str], separator: str,
+                       decode: Callable[[str, str], InformationState]) -> dict[str, InformationState]:
+    """Isolate duplicate, missing, and malformed allowlisted fields from their peers."""
+    result = {}
+    seen = set()
+    encoded_keys = {key.encode("ascii"): key for key in keys}
+    for line in data.splitlines():
+        raw_key, found, value = line.partition(separator.encode("ascii"))
+        key = encoded_keys.get(raw_key)
+        if key is None:
+            continue
+        identifier = keys[key]
+        try:
+            if not found or key in seen:
+                raise SnapshotFailure("malformed", "Duplicate or malformed information field")
+            result[identifier] = decode(key, value.decode("utf-8"))
+        except (SnapshotFailure, UnicodeError, ValueError) as error:
+            result[identifier] = information_unknown(error)
+        seen.add(key)
+    for identifier in keys.values():
+        if identifier not in result:
+            result[identifier] = InformationState("partial", "unknown", "Information field was not reported", "missing-provider")
+    return result
+
+
+def parse_os_information(data: bytes) -> dict[str, InformationState]:
+    """Read only the two display keys; shell-like quoting never executes anything."""
+    def decode(key, value):
+        fields = shlex.split(key + "=" + value, comments=False)
+        if len(fields) != 1 or not fields[0].startswith(key + "="):
+            raise SnapshotFailure("malformed", "Malformed OS information field")
+        return information_text(fields[0][len(key) + 1:], "Operating system identity")
+
+    return information_fields(data, {"PRETTY_NAME": "os-name", "VERSION_ID": "os-version"}, "=", decode)
+
+
+def parse_memory_information(data: bytes) -> dict[str, InformationState]:
+    """Accept only decimal kernel kB values and check the exact 1024-byte conversion."""
+    def decode(_key, value):
+        match = re.fullmatch(r"[ \t]*([0-9]{1,20})[ \t]+kB[ \t]*", value)
+        if match is None:
+            raise SnapshotFailure("malformed", "Malformed memory information field")
+        return information_number(int(match[1]) * 1024, "Memory bytes at this read")
+
+    return information_fields(data, INFORMATION_MEMORY_KEYS, ":", decode)
+
+
+def parse_cpu_information(data: bytes) -> dict[str, InformationState]:
+    """Use the first x86_64 model-name field, never a later processor's fallback."""
+    for line in data.splitlines():
+        key, found, value = line.partition(b":")
+        if key.strip() == b"model name":
+            if not found:
+                raise SnapshotFailure("malformed", "Malformed processor model field")
+            return {"cpu-model": information_text(value.decode("utf-8").strip(), "Processor model")}
+    return {"cpu-model": InformationState("partial", "unknown", "Processor model was not reported", "missing-provider")}
+
+
+def read_local_information() -> dict[str, InformationState]:
+    """Read fixed local sources once; no service, subprocess, journal, or mutation."""
+    result = {}
+    sources = (
+        ("/etc/os-release", 64 * 1024, parse_os_information, ("os-name", "os-version")),
+        ("/proc/cpuinfo", 4 * 1024 * 1024, parse_cpu_information, ("cpu-model",)),
+        ("/proc/meminfo", 1024 * 1024, parse_memory_information, tuple(INFORMATION_MEMORY_KEYS.values())),
+    )
+    for path, limit, parse, identifiers in sources:
+        try:
+            with open(path, "rb") as source:
+                data = source.read(limit + 1)
+            if len(data) > limit:
+                raise SnapshotFailure("malformed", "Information source exceeds its byte limit")
+            result.update(parse(data))
+        except (OSError, UnicodeError, SnapshotFailure) as error:
+            result.update((identifier, information_unknown(error)) for identifier in identifiers)
+    try:
+        identity = os.uname()
+    except OSError as error:
+        result.update((identifier, information_unknown(error)) for identifier in ("kernel-release", "architecture"))
+    else:
+        for attribute, identifier in (("release", "kernel-release"), ("machine", "architecture")):
+            try:
+                result[identifier] = information_text(getattr(identity, attribute, None), "Kernel identity")
+            except (SnapshotFailure, UnicodeError) as error:
+                result[identifier] = information_unknown(error)
+    try:
+        count = os.cpu_count()
+        if count is None:
+            raise SnapshotFailure("missing-provider", "Logical processor count was not reported")
+        if type(count) is not int or count <= 0:
+            raise SnapshotFailure("malformed", "Logical processor count is invalid")
+        result["logical-cpus"] = information_number(count, "Logical processors")
+    except (OSError, SnapshotFailure) as error:
+        result["logical-cpus"] = information_unknown(error)
+    try:
+        clock = getattr(time, "CLOCK_BOOTTIME", None)
+        if clock is None:
+            raise SnapshotFailure("unsupported", "Boot-time clock is unavailable", "unsupported")
+        uptime = time.clock_gettime(clock)
+        if type(uptime) not in (int, float) or not 0 <= uptime < (1 << 64):
+            raise SnapshotFailure("malformed", "Boot-time clock returned an invalid counter")
+        result["uptime-seconds"] = information_number(int(uptime), "Whole seconds since boot, including suspend")
+    except (OSError, SnapshotFailure) as error:
+        result["uptime-seconds"] = information_unknown(error)
+    return result
 
 
 def validate_timezone_name(value: object) -> str:

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -88,6 +88,178 @@ def rows(lines, kind):
     return [line.split("\t") for line in lines if line.startswith(f"{kind}\t")]
 
 
+class LocalInformationTests(unittest.TestCase):
+    FILES = {
+        "/etc/os-release": b'NAME=ignored\nPRETTY_NAME="Fedora Linux 44 (Fixture)"\nVERSION_ID=44\n',
+        "/proc/cpuinfo": b"processor: 0\nmodel name\t: Fixture CPU\nmodel name: Later CPU\n",
+        "/proc/meminfo": b"MemTotal: 1024 kB\nMemAvailable: 768 kB\nSwapTotal: 256 kB\nSwapFree: 128 kB\n",
+    }
+
+    def read(self, files=None, *, identity=None, count=4, uptime=10.99):
+        """Exercise the fixed reader without files, services, subprocesses, or journals."""
+        contents = dict(self.FILES)
+        contents.update(files or {})
+        streams, reads, opened = [], [], []
+
+        class Source(io.BytesIO):
+            def read(self, size=-1):
+                reads.append(size)
+                return super().read(size)
+
+        def open_source(path, mode):
+            self.assertEqual(mode, "rb")
+            self.assertIn(path, self.FILES)
+            opened.append(path)
+            value = contents[path]
+            if isinstance(value, Exception):
+                raise value
+            stream = Source(value)
+            streams.append(stream)
+            return stream
+
+        identity = identity if identity is not None else types.SimpleNamespace(release="6.fixture", machine="x86_64")
+        def response(value):
+            return {"side_effect": value} if isinstance(value, Exception) else {"return_value": value}
+
+        output = io.StringIO()
+        with mock.patch.object(provider, "open", open_source, create=True), \
+                mock.patch.object(provider.os, "uname", **response(identity)), \
+                mock.patch.object(provider.os, "cpu_count", **response(count)), \
+                mock.patch.object(provider.time, "clock_gettime", **response(uptime)) as clock, \
+                mock.patch.object(provider.subprocess, "Popen", side_effect=AssertionError("Unexpected subprocess")), \
+                mock.patch.object(provider.os, "system", side_effect=AssertionError("Unexpected shell")), \
+                mock.patch.object(provider.ServiceRead, "run", side_effect=AssertionError("Unexpected service read")), \
+                mock.patch.object(provider, "open_journal_directory", side_effect=AssertionError("Unexpected journal")), \
+                contextlib.redirect_stdout(output):
+            result = provider.read_local_information()
+            if getattr(provider.time, "CLOCK_BOOTTIME", None) is not None:
+                clock.assert_called_once_with(provider.time.CLOCK_BOOTTIME)
+            else:
+                clock.assert_not_called()
+        self.assertEqual(output.getvalue(), "")
+        self.assertCountEqual(opened, self.FILES)
+        self.assertEqual(len(reads), len(streams))
+        self.assertTrue(all(stream.closed for stream in streams))
+        self.assertTrue(all(size in (65537, 4194305, 1048577) for size in reads))
+        self.assertEqual(len(result), 11)
+        for state in result.values():
+            if state.status != "available":
+                self.assertEqual(state.value, "unknown")
+                self.assertNotEqual(state.error_code, "")
+        return result
+
+    def test_complete_fixed_local_snapshot(self):
+        result = self.read()
+        self.assertTrue(all(state.status == "available" and state.error_code == "" for state in result.values()))
+        expected = {"os-name": "Fedora Linux 44 (Fixture)", "os-version": "44",
+            "kernel-release": "6.fixture", "architecture": "x86_64", "cpu-model": "Fixture CPU",
+            "logical-cpus": "4", "memory-total-bytes": "1048576", "memory-available-bytes": "786432",
+            "swap-total-bytes": "262144", "swap-free-bytes": "131072", "uptime-seconds": "10"}
+        self.assertEqual({key: state.value for key, state in result.items()}, expected)
+
+    def test_file_failures_remain_source_scoped_and_do_not_expose_exception_text(self):
+        for path, identifier in (("/etc/os-release", "os-name"), ("/proc/cpuinfo", "cpu-model"),
+                                 ("/proc/meminfo", "memory-total-bytes")):
+            for number, status, code in ((errno.ENOENT, "unsupported", "missing-provider"),
+                    (errno.ENOTDIR, "unsupported", "missing-provider"),
+                    (errno.EACCES, "restricted", "permission-denied"),
+                    (errno.EPERM, "restricted", "permission-denied"), (errno.EIO, "unavailable", "internal")):
+                with self.subTest(path=path, errno=number):
+                    result = self.read({path: OSError(number, "private source details")})
+                    self.assertEqual((result[identifier].status, result[identifier].error_code), (status, code))
+                    self.assertEqual(result["logical-cpus"].status, "available")
+                    self.assertEqual(result["kernel-release"].status, "available")
+                    self.assertNotIn("private source details", repr(result))
+
+    def test_each_file_is_capped_before_parsing_and_exact_limit_is_accepted(self):
+        for path, limit, identifier in (("/etc/os-release", 65536, "os-name"),
+                ("/proc/cpuinfo", 4194304, "cpu-model"), ("/proc/meminfo", 1048576, "memory-total-bytes")):
+            with self.subTest(path=path):
+                data = self.FILES[path] + b"#" * (limit - len(self.FILES[path]))
+                self.assertEqual(self.read({path: data})[identifier].status, "available")
+                result = self.read({path: data + b"x"})
+                self.assertEqual(result[identifier].error_code, "malformed")
+                self.assertEqual(result["uptime-seconds"].status, "available")
+
+    def test_os_keys_are_allowlisted_and_quoted_values_are_never_evaluated(self):
+        result = self.read({"/etc/os-release": b"PRETTY_NAME='$(false) literal'\nVERSION_ID=44\nTOKEN=do-not-disclose\nOTHER='unclosed\nUNRELATED=\xff\n"})
+        self.assertEqual(result["os-name"].value, "$(false) literal")
+        self.assertEqual(result["os-version"].value, "44")
+        self.assertNotIn("do-not-disclose", repr(result))
+
+    def test_malformed_os_field_does_not_hide_the_other_key(self):
+        for field in (b'PRETTY_NAME="unclosed', b"PRETTY_NAME=two words", b"PRETTY_NAME=",
+                      b"PRETTY_NAME", b"PRETTY_NAME=one\nPRETTY_NAME=two\nPRETTY_NAME=three"):
+            with self.subTest(field=field):
+                result = self.read({"/etc/os-release": field + b"\nVERSION_ID=44\n"})
+                self.assertEqual(result["os-name"].status, "partial")
+                self.assertEqual(result["os-version"].value, "44")
+
+    def test_missing_fields_and_invalid_utf8_are_scoped(self):
+        result = self.read({"/etc/os-release": b"", "/proc/cpuinfo": b"", "/proc/meminfo": b""})
+        self.assertEqual(sum(state.status == "available" for state in result.values()), 4)
+        for path, identifier, target in (("/etc/os-release", "os-name", b"Fedora Linux 44 (Fixture)"),
+                ("/proc/cpuinfo", "cpu-model", b"Fixture CPU"), ("/proc/meminfo", "memory-total-bytes", b"1024 kB")):
+            result = self.read({path: self.FILES[path].replace(target, b"\xff")})
+            self.assertEqual(result[identifier].error_code, "malformed")
+            self.assertEqual(result["architecture"].status, "available")
+            self.assertEqual(result["os-version"].value, "44")
+            self.assertEqual(result["memory-available-bytes"].value, "786432")
+
+    def test_first_cpu_model_and_utf8_field_bound(self):
+        for name, status in (("", "partial"), ("\x00CPU", "partial"), ("e" * 512, "available"),
+                             ("e" * 513, "partial"), ("\u00e9" * 256, "available"), ("\u00e9" * 257, "partial")):
+            with self.subTest(length=len(name), status=status):
+                result = self.read({"/proc/cpuinfo": ("model name: " + name + "\nmodel name: valid later\n").encode()})
+                self.assertEqual(result["cpu-model"].status, status)
+        result = self.read({"/proc/cpuinfo": b"model name: First\nmodel name: \xff\n"})
+        self.assertEqual(result["cpu-model"].value, "First")
+
+    def test_memory_units_numbers_duplicates_and_unknown_keys(self):
+        for value in ("1 KB", "1 MB", "-1 kB", "+1 kB", "1.5 kB", "1e3 kB", "\u0661 kB", "1 kB extra", "9" * 1000 + " kB"):
+            with self.subTest(value=value[:30]):
+                data = self.FILES["/proc/meminfo"].replace(b"768 kB", value.encode())
+                result = self.read({"/proc/meminfo": data})
+                self.assertEqual(result["memory-available-bytes"].status, "partial")
+                self.assertEqual(result["memory-total-bytes"].value, "1048576")
+        data = self.FILES["/proc/meminfo"] + b"MemAvailable: 1 kB\nMemAvailable: 2 kB\nUnknown: invalid\n"
+        self.assertEqual(self.read({"/proc/meminfo": data})["memory-available-bytes"].error_code, "malformed")
+
+    def test_memory_conversion_overflow_boundary_and_canonical_zeroes(self):
+        maximum = provider.INFORMATION_UINT_MAX // 1024
+        for value, expected in ((str(maximum), str(maximum * 1024)), (str(maximum + 1), "unknown"),
+                                ("00000000000000000001", "1024"), ("0", "0")):
+            result = self.read({"/proc/meminfo": self.FILES["/proc/meminfo"].replace(b"768 kB", (value + " kB").encode())})
+            self.assertEqual(result["memory-available-bytes"].value, expected)
+
+    def test_uname_failure_and_fields_are_independent(self):
+        result = self.read(identity=OSError(errno.EIO, "private uname detail"))
+        self.assertEqual(result["kernel-release"].status, "unavailable")
+        self.assertEqual(result["architecture"].status, "unavailable")
+        self.assertEqual(result["os-name"].status, "available")
+        result = self.read(identity=types.SimpleNamespace(release="bad\nrelease", machine="x86_64"))
+        self.assertEqual(result["kernel-release"].status, "partial")
+        self.assertEqual(result["architecture"].value, "x86_64")
+
+    def test_logical_processor_count_is_checked_without_hiding_other_cpu_data(self):
+        for value in (None, True, False, 0, -1, 1.5, "4", 1 << 64):
+            with self.subTest(value=value):
+                result = self.read(count=value)
+                self.assertEqual(result["logical-cpus"].status, "partial")
+                self.assertEqual(result["cpu-model"].status, "available")
+
+    def test_uptime_is_checked_floored_and_uses_only_boottime(self):
+        for value in (float("nan"), float("inf"), -float("inf"), -0.1, True, "10", 1 << 64, 1 << 10000):
+            result = self.read(uptime=value)
+            self.assertEqual(result["uptime-seconds"].status, "partial")
+            self.assertEqual(result["memory-total-bytes"].status, "available")
+        for value, expected in ((0, "0"), (0.99, "0"), (12.99, "12")):
+            self.assertEqual(self.read(uptime=value)["uptime-seconds"].value, expected)
+        with mock.patch.object(provider.time, "CLOCK_BOOTTIME", None):
+            self.assertEqual(self.read()["uptime-seconds"].status, "unsupported")
+        self.assertEqual(self.read(uptime=OSError(errno.EIO, "clock unavailable"))["uptime-seconds"].status, "unavailable")
+
+
 class RegionalPreflightTests(unittest.TestCase):
     def time_state(self, **changes):
         return replace(provider.RegionalTimeState("UTC", True, False, True), **changes)


### PR DESCRIPTION
## Scope
Prepare the internal Phase 6 local system-information reader without changing the CLI, cumulative protocol minor, or Settings UI.

- Read only fixed, capped OS, CPU, and memory files plus uname, logical CPU count, and CLOCK_BOOTTIME.
- Keep eleven observations independently typed; preserve valid peer fields when selected fields are missing, duplicated, malformed, or invalid UTF-8.
- Validate printable display strings and exact unsigned 64-bit counters. Normalize failures without exposing exception contents.
- Add twelve focused regression tests and keep hardware, filesystems, security, and integration explicitly pending.

## Validation
Focused local-information tests: 12 passed.
Read-only probe on Fedora 44 x86_64: all eleven local observations available and checked; no host settings changed.
Documentation: npm run check and npm run build passed.
Independent CodeRabbit CLI review: no actionable findings in the five-file diff.

Full local gate: `scripts/run-tests make clean all && scripts/run-tests` passed, including 581 backend tests (248.168 seconds), nested-X11 lifecycle, staged installation, and repeated-install preservation. Closed Settings CPU was 0.067%; closed large surfaces 0.00%. The managed test workspace was removed.
Post-full-gate Codex review: no actionable findings on the unchanged five-file diff.
Exact uncommitted/staged diff SHA-256: e729995546511458ec4b7a12a46432b8cbce9bc49df4d43483c17ae1d6bdc993.

## Limits
This is an internal preparatory boundary, not Phase 6 completion. No new public output, polling, service access, journal operation, mutation, installed configuration synchronization, or live shell activation.