### PR TITLE
feat(settings): add bounded hardware information reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ versions from `config.mk`.
 
 ### Changed
 
+- Add internal hostname1 hardware vendor/model reads with one bounded deadline,
+  independent property failures, and late-reply suppression. This preparation
+  does not activate a new protocol minor or Settings control.
+
 - Add internal bounded OS, kernel, CPU, memory, swap, and uptime readers with
   per-field failure isolation and checked byte counters. This preparatory
   boundary does not activate a new protocol minor, Settings UI, or polling loop.

--- a/TASKS.md
+++ b/TASKS.md
@@ -497,7 +497,11 @@ allowlisted fields, UTF-8 text, exact kB conversion, and unsigned 64-bit counter
 are validated without subprocesses, services, journals, or mutations. Twelve
 focused tests and a read-only Fedora 44 probe passed. This preparatory boundary
 adds no CLI command, protocol minor, Settings surface, or polling loop.
-Hostname1, filesystem/security sources, protocol integration, visible controls,
+The internal hostname1 reader also returns independent hardware vendor/model
+observations under one ten-second deadline, preserving a validated peer when
+the other property fails or times out. Twelve focused tests, including four
+real private-bus deadlines and late replies, and a read-only Fedora 44 probe
+passed. Filesystem/security sources, protocol integration, visible controls,
 and combined installed qualification remain pending.
 
 - [ ] Add event-driven or bounded system information and storage overview state

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -950,8 +950,19 @@ UTF-8 within 512 bytes; counters use exact unsigned 64-bit decimal values, and
 the first CPU model field is authoritative. Read denial is scoped `restricted`
 state, absent files are `unsupported`, other I/O failures are `unavailable`, and
 malformed data is `partial`; failed values are always `unknown`. It starts no
-service, subprocess, journal access, or polling loop. Hardware, filesystem,
-security, protocol, and Settings integration remain separate boundaries.
+service, subprocess, journal access, or polling loop.
+
+The internal hostname1 reader separately implements the two fixed hardware
+properties through the shared asynchronous service-reader lifetime. It accepts
+only bounded `(v)` replies containing printable UTF-8 strings of at most 512
+bytes, isolates missing, denied, or malformed properties, and preserves a
+validated peer when the aggregate deadline expires. Cancellation discards late
+replies without closing the shared bus. Private-bus tests exercise both property
+timeouts before and after the peer can be validated, including four real
+ten-second deadlines and successful reuse of the shared connection. These
+readers add no CLI command, protocol minor, Settings control, journal operation,
+or polling loop. Filesystem, security, protocol, and Settings integration remain
+separate boundaries.
 
 ### Security Status
 

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -37,6 +37,9 @@ INFORMATION_MEMORY_KEYS = {
     "MemTotal": "memory-total-bytes", "MemAvailable": "memory-available-bytes",
     "SwapTotal": "swap-total-bytes", "SwapFree": "swap-free-bytes",
 }
+HARDWARE_INFORMATION_FIELDS = {
+    "HardwareVendor": "hardware-vendor", "HardwareModel": "hardware-model",
+}
 MAX_LIST_RECORDS = 4096
 MAX_LIST_BYTES = 3 * 1024 * 1024
 READ_DEADLINE_SECONDS = 120
@@ -855,6 +858,83 @@ class ServiceRead:
         if self.failure:
             raise self.failure
         return self.value
+
+
+class HardwareRead(ServiceRead):
+    """Read two fixed hostname1 properties while preserving a validated peer."""
+
+    label = "Hardware information"
+
+    def __init__(self, Gio=None, GLib=None):
+        super().__init__(Gio, GLib)
+        self.values = {}
+        self.waiting = set(HARDWARE_INFORMATION_FIELDS)
+
+    def fail(self, failure):
+        if self.done:
+            return
+        for field in self.waiting:
+            self.values[HARDWARE_INFORMATION_FIELDS[field]] = information_unknown(failure)
+        self.waiting.clear()
+        self.finish(value=dict(self.values))
+
+    def record(self, field, state):
+        if not self.pending() or field not in self.waiting:
+            return
+        self.values[HARDWARE_INFORMATION_FIELDS[field]] = state
+        self.waiting.remove(field)
+        if not self.waiting:
+            self.finish(value=dict(self.values))
+
+    def property_failure(self, error):
+        if self.Gio.dbus_error_get_remote_error(error) == "org.freedesktop.DBus.Error.UnknownProperty":
+            return SnapshotFailure("unsupported", "Hardware information property is absent", "unsupported")
+        return self.bus_failure(error)
+
+    def connected(self, _source, result, _data):
+        if not self.pending():
+            return
+        try:
+            self.connection = self.Gio.bus_get_finish(result)
+            self.connection.set_exit_on_close(False)
+        except self.GLib.Error as error:
+            self.fail(self.bus_failure(error))
+            return
+        for field in HARDWARE_INFORMATION_FIELDS:
+            if not self.pending():
+                return
+            try:
+                self.connection.call("org.freedesktop.hostname1", "/org/freedesktop/hostname1",
+                    PROPERTIES_INTERFACE, "Get", self.GLib.Variant("(ss)", ("org.freedesktop.hostname1", field)),
+                    self.GLib.VariantType.new("(v)"), self.Gio.DBusCallFlags.NONE,
+                    max(1, int((self.deadline - time.monotonic()) * 1000)), self.cancellable, self.replied, field)
+            except self.GLib.Error as error:
+                self.record(field, information_unknown(self.property_failure(error)))
+
+    def replied(self, connection, result, field):
+        if not self.pending() or field not in self.waiting:
+            return
+        try:
+            reply = connection.call_finish(result)
+            if reply.get_type_string() != "(v)" or reply.get_size() > MAX_TEXT_BYTES + 32:
+                raise SnapshotFailure("malformed", "Invalid hardware information reply")
+            value = reply.get_child_value(0).get_variant()
+            if value.get_type_string() != "s" or value.get_size() > MAX_TEXT_BYTES + 1:
+                raise SnapshotFailure("malformed", "Invalid hardware information property")
+            state = information_text(value.unpack(), "Hardware identity reported by hostname1")
+        except self.GLib.Error as error:
+            state = information_unknown(self.property_failure(error))
+        except (SnapshotFailure, UnicodeError) as error:
+            state = information_unknown(error)
+        self.record(field, state)
+
+
+def read_hardware_information() -> dict[str, InformationState]:
+    """Keep missing service bindings scoped without swallowing interruption."""
+    try:
+        return run_interruptible_read(HardwareRead())
+    except SnapshotFailure as error:
+        return {identifier: information_unknown(error) for identifier in HARDWARE_INFORMATION_FIELDS.values()}
 
 
 @dataclass(frozen=True)

--- a/tests/fixtures/system-hardware-read-bus.py
+++ b/tests/fixtures/system-hardware-read-bus.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python3
+"""Qualify fixed hardware reads and aggregate deadlines on a private bus."""
+
+import os
+import runpy
+import sys
+import time
+
+os.environ["DBUS_SYSTEM_BUS_ADDRESS"] = os.environ["DBUS_SESSION_BUS_ADDRESS"]
+from gi.repository import Gio, GLib
+
+provider = runpy.run_path(sys.argv[1], run_name="hardware_read_fixture")
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+name = "org.freedesktop.hostname1"
+path = "/org/freedesktop/hostname1"
+fields = {"HardwareVendor": "hardware-vendor", "HardwareModel": "hardware-model"}
+mode = "normal"
+selected = "HardwareVendor"
+late_peer = False
+held = []
+calls = []
+properties = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.DBus.Properties">
+<method name="Get"><arg type="s" direction="in"/><arg type="s" direction="in"/><arg type="v" direction="out"/></method>
+</interface></node>""").interfaces[0]
+
+
+def name_call(method):
+    """Manage only the fixture's well-known name, never a host service."""
+    args = GLib.Variant("(su)", (name, 0)) if method == "RequestName" else GLib.Variant("(s)", (name,))
+    return bus.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+        method, args, GLib.VariantType.new("(u)"), Gio.DBusCallFlags.NONE, 3000, None).unpack()[0]
+
+
+def respond(invocation, field):
+    invocation.return_value(GLib.Variant("(v)", (GLib.Variant("s", field),)))
+
+
+def called(_bus, _sender, object_path, interface, method, args, invocation):
+    """Serve only two allowlisted read-only properties with typed replies."""
+    target, field = args.unpack()
+    assert (object_path, interface, method, target) == (path, "org.freedesktop.DBus.Properties", "Get", name)
+    assert field in fields
+    calls.append(field)
+    if mode == "stall" and (field == selected or late_peer):
+        held.append((invocation, field))
+    elif field == selected and mode in ("denied", "missing"):
+        error = "AccessDenied" if mode == "denied" else "UnknownProperty"
+        invocation.return_dbus_error("org.freedesktop.DBus.Error." + error, "Private fixture detail")
+    elif field == selected and mode in ("malformed", "oversized"):
+        value = GLib.Variant("b", True) if mode == "malformed" else GLib.Variant("s", "x" * 513)
+        invocation.return_value(GLib.Variant("(v)", (value,)))
+    else:
+        respond(invocation, field)
+
+
+def fresh_read():
+    start = len(calls)
+    read = provider["HardwareRead"]()
+    result = read.run()
+    assert sorted(calls[start:]) == sorted(fields), calls[start:]
+    assert read.done and read.cancellable.is_cancelled()
+    assert not bus.is_closed()
+    return read, result
+
+
+registration = 0
+try:
+    assert name_call("RequestName") == 1
+    registration = bus.register_object(path, properties, called, None, None)
+    _read, result = fresh_read()
+    assert all(state.status == "available" for state in result.values()), result
+    for selected in fields:
+        peer = next(field for field in fields if field != selected)
+        for mode, status, code in (("denied", "restricted", "permission-denied"),
+                ("missing", "unsupported", "unsupported"), ("malformed", "partial", "malformed"),
+                ("oversized", "partial", "malformed")):
+            _read, result = fresh_read()
+            failed = result[fields[selected]]
+            assert (failed.status, failed.value, failed.error_code) == (status, "unknown", code), result
+            assert result[fields[peer]].status == "available", result
+            assert "Private fixture detail" not in repr(result)
+        for late_peer in (False, True):
+            mode = "stall"
+            started = time.monotonic()
+            read, result = fresh_read()
+            assert 9.5 <= time.monotonic() - started < 15
+            failed = result[fields[selected]]
+            assert (failed.status, failed.value, failed.error_code) == ("unavailable", "unknown", "timeout"), result
+            assert result[fields[peer]].status == ("unavailable" if late_peer else "available"), result
+            assert len(held) == (2 if late_peer else 1)
+            saved = dict(result)
+            for invocation, field in held:
+                respond(invocation, field)
+            held.clear()
+            # A new read dispatches the old callbacks on the shared context too.
+            mode = "normal"
+            _next, current = fresh_read()
+            assert all(state.status == "available" for state in current.values()), current
+            assert read.value == saved, (read.value, saved)
+    assert name_call("ReleaseName") == 1
+    result = provider["HardwareRead"]().run()
+    assert all(state.status == "unavailable" and state.error_code == "missing-provider"
+               for state in result.values()), result
+    print("Private-bus hardware reads: PASS (fixed properties, isolation, four real deadlines, late replies, shared bus)")
+finally:
+    for invocation, _field in held:
+        invocation.return_dbus_error("org.freedesktop.DBus.Error.NoReply", "Fixture cleanup")
+    if registration:
+        bus.unregister_object(registration)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -3345,6 +3345,198 @@ class UnitEventMonitorTests(unittest.TestCase):
         self.assertEqual(result.stdout, "Private-bus unit events: PASS\n")
 
 
+class HardwareReadTests(unittest.TestCase):
+    def reader(self):
+        _regional, connection, gio, glib, variant = RegionalReadTests().reader()
+        return provider.HardwareRead(gio, glib), connection, gio, glib, variant
+
+    def reply(self, read, connection, variant, field, value="Fixture"):
+        connection.call_finish.return_value = variant.Variant("(v)", (variant.Variant("s", value),))
+        read.replied(connection, object(), field)
+
+    def test_fixed_gets_reply_orders_cleanup_and_single_use(self):
+        for order in (("HardwareVendor", "HardwareModel"), ("HardwareModel", "HardwareVendor")):
+            read, connection, gio, glib, variant = self.reader()
+            def run():
+                read.connected(None, object(), None)
+                for field in order:
+                    self.reply(read, connection, variant, field, field)
+            read.loop.run.side_effect = run
+            result = read.run()
+            self.assertEqual({key: state.value for key, state in result.items()},
+                {"hardware-vendor": "HardwareVendor", "hardware-model": "HardwareModel"})
+            self.assertTrue(all(state.status == "available" for state in result.values()))
+            calls = connection.call.call_args_list
+            self.assertEqual(len(calls), 2)
+            for call, field in zip(calls, ("HardwareVendor", "HardwareModel")):
+                self.assertEqual(call.args[:4], ("org.freedesktop.hostname1", "/org/freedesktop/hostname1",
+                    provider.PROPERTIES_INTERFACE, "Get"))
+                self.assertEqual(call.args[4].unpack(), ("org.freedesktop.hostname1", field))
+                self.assertEqual(call.args[5].dup_string(), "(v)")
+                self.assertEqual(call.args[6], gio.DBusCallFlags.NONE)
+                self.assertTrue(0 < call.args[7] <= 10000)
+                self.assertIs(call.args[8], read.cancellable)
+            glib.timeout_add.assert_called_once_with(10000, read.expire)
+            glib.source_remove.assert_called_once_with(17)
+            self.assertTrue(read.cancellable.cancel.called)
+            connection.close_sync.assert_not_called()
+            with self.assertRaises(RuntimeError):
+                read.run()
+
+    def test_property_errors_preserve_the_peer(self):
+        for field in provider.HARDWARE_INFORMATION_FIELDS:
+            peer = next(key for key in provider.HARDWARE_INFORMATION_FIELDS if key != field)
+            for remote, status, code in (("UnknownProperty", "unsupported", "unsupported"),
+                    ("AccessDenied", "restricted", "permission-denied"),
+                    ("NoReply", "unavailable", "timeout")):
+                read, connection, gio, _glib, variant = self.reader()
+                def run():
+                    read.connected(None, object(), None)
+                    gio.dbus_error_get_remote_error.return_value = "org.freedesktop.DBus.Error." + remote
+                    connection.call_finish.side_effect = variant.Error("private service detail")
+                    read.replied(connection, object(), field)
+                    connection.call_finish.side_effect = None
+                    self.reply(read, connection, variant, peer)
+                read.loop.run.side_effect = run
+                result = read.run()
+                failed = result[provider.HARDWARE_INFORMATION_FIELDS[field]]
+                self.assertEqual((failed.status, failed.value, failed.error_code), (status, "unknown", code))
+                self.assertEqual(result[provider.HARDWARE_INFORMATION_FIELDS[peer]].status, "available")
+                self.assertNotIn("private service detail", repr(result))
+
+    def test_malformed_envelope_type_text_and_byte_bound_are_scoped(self):
+        from gi.repository import GLib
+        cases = [(GLib.Variant("(s)", ("wrong",)), False),
+            (GLib.Variant("(v)", (GLib.Variant("b", True),)), False)]
+        for text, valid in (("", False), ("\n", False), ("x" * 512, True), ("x" * 513, False),
+                            ("\u00e9" * 256, True), ("\u00e9" * 257, False), ("x" * 4096, False)):
+            cases.append((GLib.Variant("(v)", (GLib.Variant("s", text),)), valid))
+        for reply, valid in cases:
+            read, connection, _gio, _glib, variant = self.reader()
+            def run():
+                read.connected(None, object(), None)
+                connection.call_finish.return_value = reply
+                read.replied(connection, object(), "HardwareVendor")
+                self.reply(read, connection, variant, "HardwareModel")
+            read.loop.run.side_effect = run
+            result = read.run()
+            self.assertEqual(result["hardware-vendor"].status, "available" if valid else "partial")
+            self.assertEqual(result["hardware-model"].value, "Fixture")
+
+    def test_oversized_reply_is_rejected_before_child_extraction(self):
+        read, connection, _gio, _glib, variant = self.reader()
+        reply = mock.Mock()
+        reply.get_type_string.return_value = "(v)"
+        reply.get_size.return_value = 1000000
+        def run():
+            read.connected(None, object(), None)
+            connection.call_finish.return_value = reply
+            read.replied(connection, object(), "HardwareVendor")
+            self.reply(read, connection, variant, "HardwareModel")
+        read.loop.run.side_effect = run
+        self.assertEqual(read.run()["hardware-vendor"].error_code, "malformed")
+        reply.get_child_value.assert_not_called()
+
+    def test_aggregate_timeout_preserves_a_valid_peer_and_discards_late_replies(self):
+        for field in provider.HARDWARE_INFORMATION_FIELDS:
+            peer = next(key for key in provider.HARDWARE_INFORMATION_FIELDS if key != field)
+            read, connection, _gio, glib, variant = self.reader()
+            def run():
+                read.connected(None, object(), None)
+                self.reply(read, connection, variant, peer)
+                read.expire()
+            read.loop.run.side_effect = run
+            result = read.run()
+            self.assertEqual(result[provider.HARDWARE_INFORMATION_FIELDS[peer]].status, "available")
+            failed = result[provider.HARDWARE_INFORMATION_FIELDS[field]]
+            self.assertEqual((failed.status, failed.value, failed.error_code), ("unavailable", "unknown", "timeout"))
+            connection.call_finish.reset_mock()
+            read.replied(connection, object(), field)
+            read.replied(connection, object(), peer)
+            connection.call_finish.assert_not_called()
+            glib.source_remove.assert_not_called()
+
+    def test_deadline_crossed_during_decode_cannot_publish_late_success(self):
+        read, connection, _gio, _glib, variant = self.reader()
+        original = provider.information_text
+        def decode(value, detail):
+            read.deadline = time.monotonic() - 1
+            return original(value, detail)
+        def run():
+            read.connected(None, object(), None)
+            self.reply(read, connection, variant, "HardwareModel")
+            with mock.patch.object(provider, "information_text", side_effect=decode):
+                self.reply(read, connection, variant, "HardwareVendor")
+        read.loop.run.side_effect = run
+        result = read.run()
+        self.assertEqual(result["hardware-model"].status, "available")
+        self.assertEqual(result["hardware-vendor"].error_code, "timeout")
+
+    def test_expired_connection_never_dispatches(self):
+        read, connection, gio, _glib, _variant = self.reader()
+        def run():
+            read.deadline = time.monotonic() - 1
+            read.connected(None, object(), None)
+        read.loop.run.side_effect = run
+        self.assertTrue(all(state.error_code == "timeout" for state in read.run().values()))
+        gio.bus_get_finish.assert_not_called()
+        connection.call.assert_not_called()
+
+    def test_duplicate_callback_cannot_replace_an_already_validated_property(self):
+        read, connection, _gio, _glib, variant = self.reader()
+        def run():
+            read.connected(None, object(), None)
+            self.reply(read, connection, variant, "HardwareVendor", "First")
+            self.reply(read, connection, variant, "HardwareVendor", "Duplicate")
+            self.reply(read, connection, variant, "HardwareModel")
+        read.loop.run.side_effect = run
+        self.assertEqual(read.run()["hardware-vendor"].value, "First")
+        self.assertEqual(connection.call_finish.call_count, 2)
+
+    def test_dispatch_failure_does_not_prevent_peer_dispatch(self):
+        read, connection, gio, _glib, variant = self.reader()
+        connection.call.side_effect = [variant.Error("denied"), None]
+        gio.dbus_error_get_remote_error.return_value = "org.freedesktop.DBus.Error.AccessDenied"
+        def run():
+            read.connected(None, object(), None)
+            self.reply(read, connection, variant, "HardwareModel")
+        read.loop.run.side_effect = run
+        result = read.run()
+        self.assertEqual(connection.call.call_count, 2)
+        self.assertEqual(result["hardware-vendor"].status, "restricted")
+        self.assertEqual(result["hardware-model"].status, "available")
+
+    def test_bus_failure_and_missing_bindings_are_scoped(self):
+        read, connection, gio, _glib, variant = self.reader()
+        gio.bus_get_finish.side_effect = variant.Error("private bus failure")
+        read.loop.run.side_effect = lambda: read.connected(None, object(), None)
+        result = read.run()
+        self.assertTrue(all(state.status == "unavailable" for state in result.values()))
+        self.assertNotIn("private bus failure", repr(result))
+        connection.call.assert_not_called()
+        failure = provider.SnapshotFailure("missing-provider", "Bindings unavailable", "unavailable")
+        with mock.patch.object(provider, "HardwareRead", side_effect=failure), \
+                mock.patch.object(provider, "open_journal_directory") as journal:
+            result = provider.read_hardware_information()
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all(state.error_code == "missing-provider" for state in result.values()))
+        journal.assert_not_called()
+
+    def test_wrapper_keeps_cooperative_interruption(self):
+        with mock.patch.object(provider, "HardwareRead") as reader, \
+                mock.patch.object(provider, "run_interruptible_read", side_effect=InterruptedError) as run:
+            with self.assertRaises(InterruptedError):
+                provider.read_hardware_information()
+            run.assert_called_once_with(reader.return_value)
+
+    def test_real_private_bus_property_isolation_and_aggregate_deadlines(self):
+        result = subprocess.run(["dbus-run-session", "--", "/usr/bin/python3",
+            str(REPO / "tests/fixtures/system-hardware-read-bus.py"), str(PROVIDER_PATH)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=70)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "Private-bus hardware reads: PASS (fixed properties, isolation, four real deadlines, late replies, shared bus)\n")
+
+
 class NtpReadTests(unittest.TestCase):
     def reader(self):
         _regional, connection, gio, glib, variant = RegionalReadTests().reader()


### PR DESCRIPTION
## Scope
Prepare fixed, read-only hostname1 HardwareVendor and HardwareModel observations without activating a CLI command, protocol minor, or Settings control.

- Reuse the shared asynchronous service lifetime with one ten-second aggregate deadline.
- Validate bounded variant envelopes and printable UTF-8 strings before publishing each property.
- Preserve already validated properties when peers fail, time out, or reply late; keep missing/denied/malformed errors scoped.
- Cancel local requests without closing the shared bus, and retain cooperative interruption.
- Add a private-bus fixture and twelve focused tests covering fixed calls, reply orders, byte limits, dispatch failures, four actual ten-second deadlines, and discarded late replies.

## Validation
- Focused HardwareReadTests: twelve passed in 40.227s.
- Read-only Fedora 44 x86_64 hostname1 probe: both hardware observations available; actual identity strings were not recorded in logs.
- Docs check/build passed (15 Astro files, zero errors/warnings/hints; eleven pages built).
- Independent CodeRabbit CLI review: zero findings across all six changed files.
- Full local gate: `scripts/run-tests make clean all && scripts/run-tests` passed, including 593 backend tests in 288.301s, nested-X11 lifecycle, staged installation, repeated-install preservation, and managed-workspace cleanup.
- Closed Settings CPU 0.067%; closed large surfaces 0.00%; Power baseline 0.133%, after 0.067%, delta 0.066 points.
- Post-full-gate Codex review: no actionable findings on the unchanged six-file diff.
- Exact uncommitted/staged diff SHA-256: bf739998bd80bc6be52e56331d300b2267151c8e414e651e06fdff89ae60704e.

## Limits
Internal preparation only. Filesystem/security sources, cumulative protocol integration, visible controls, and installed qualification remain pending. No host settings mutation, journal operation, polling, live shell synchronization, logout, or restart.