### PR TITLE
feat(settings): add bounded filesystem information reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ versions from `config.mk`.
 
 ### Changed
 
+- Add an internal fixed-command filesystem inventory with capped JSON, stable
+  mount identities, exact byte counts, partial-result handling, and bounded
+  owned-process cleanup. Public protocol and Settings integration remain pending.
+
 - Add internal hostname1 hardware vendor/model reads with one bounded deadline,
   independent property failures, and late-reply suppression. This preparation
   does not activate a new protocol minor or Settings control.

--- a/TASKS.md
+++ b/TASKS.md
@@ -501,8 +501,14 @@ The internal hostname1 reader also returns independent hardware vendor/model
 observations under one ten-second deadline, preserving a validated peer when
 the other property fails or times out. Twelve focused tests, including four
 real private-bus deadlines and late replies, and a read-only Fedora 44 probe
-passed. Filesystem/security sources, protocol integration, visible controls,
-and combined installed qualification remain pending.
+passed. The internal filesystem reader now uses fixed `findmnt` JSON with a
+three-second monotonic deadline, bounded process-group cleanup, a shared 2 MiB
+stdout/stderr budget, and at most 256 mount-ID-keyed rows. Seventeen focused
+tests cover malformed and partial inventories, exact byte counts, truncation,
+timeouts, simulated wall-clock reversal, and interruption cleanup. A read-only
+Fedora 44 probe returned eight validated rows. Security sources, protocol
+integration, visible controls, and combined installed qualification remain
+pending.
 
 - [ ] Add event-driven or bounded system information and storage overview state
   without a new idle poller.

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -961,8 +961,22 @@ replies without closing the shared bus. Private-bus tests exercise both property
 timeouts before and after the peer can be validated, including four real
 ten-second deadlines and successful reuse of the shared connection. These
 readers add no CLI command, protocol minor, Settings control, journal operation,
-or polling loop. Filesystem, security, protocol, and Settings integration remain
-separate boundaries.
+or polling loop.
+
+The internal filesystem reader implements the fixed `findmnt` inventory without
+activating cumulative minor 2. Its independent timeout supervisor and collector
+use a three-second monotonic deadline; stdout and discarded stderr share one
+2 MiB budget. Cleanup retains the process-group identity until TERM/KILL and
+bounded reaping complete. Failed cleanup or nonzero exit cannot publish rows,
+and interruption remains terminal after cleanup and signal-handler restoration.
+Strict JSON rejects duplicate object keys and non-finite numbers. Missing or
+malformed rows leave a partial usable subset; duplicate mount IDs are removed,
+including duplicates encountered beyond the 256-record limit. Display paths
+are sanitized and bounded without merging distinct mount identities. Missing
+or invalid byte counts remain `unknown`, never zero. Private-process fixtures
+cover overflow, EOF without exit, TERM-resistant descendants, simulated wall
+clock reversal, and cleanup failure. Security, protocol, and Settings integration
+remain separate boundaries.
 
 ### Security Status
 

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -10,6 +10,7 @@ import errno
 import fcntl
 import hashlib
 import io
+import json
 import os
 import re
 import selectors
@@ -40,6 +41,8 @@ INFORMATION_MEMORY_KEYS = {
 HARDWARE_INFORMATION_FIELDS = {
     "HardwareVendor": "hardware-vendor", "HardwareModel": "hardware-model",
 }
+FILESYSTEM_OUTPUT_BYTES = 2 * 1024 * 1024
+FILESYSTEM_RECORDS = 256
 MAX_LIST_RECORDS = 4096
 MAX_LIST_BYTES = 3 * 1024 * 1024
 READ_DEADLINE_SECONDS = 120
@@ -420,6 +423,101 @@ def read_local_information() -> dict[str, InformationState]:
     except (OSError, SnapshotFailure) as error:
         result["uptime-seconds"] = information_unknown(error)
     return result
+
+
+@dataclass(frozen=True)
+class FilesystemRow:
+    """A mount-ID-keyed observation; paths are display text, never action input."""
+
+    mount_id: str
+    status: str
+    source: str
+    target: str
+    fstype: str
+    size_bytes: str
+    used_bytes: str
+    available_bytes: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class FilesystemInformation:
+    summary: InformationState
+    rows: tuple[FilesystemRow, ...] = ()
+
+
+def parse_filesystem_information(data: bytes) -> FilesystemInformation:
+    """Validate the fixed findmnt JSON inventory and retain only unambiguous rows."""
+    def pairs(items):
+        result = {}
+        for key, value in items:
+            if key in result:
+                raise ValueError("Duplicate JSON key")
+            result[key] = value
+        return result
+
+    def invalid_constant(_value):
+        raise ValueError("Invalid JSON number")
+
+    if len(data) > FILESYSTEM_OUTPUT_BYTES:
+        raise SnapshotFailure("malformed", "Filesystem output exceeds its byte limit")
+    try:
+        document = json.loads(data.decode("utf-8"), object_pairs_hook=pairs, parse_constant=invalid_constant)
+    except (ValueError, UnicodeError, RecursionError) as error:
+        raise SnapshotFailure("malformed", "Filesystem output is not valid bounded JSON") from error
+    if not isinstance(document, dict) or not isinstance(document.get("filesystems"), list):
+        raise SnapshotFailure("malformed", "Filesystem inventory is missing")
+    pending = list(reversed(document["filesystems"]))
+    seen, rows = set(), {}
+    partial = False
+    while pending:
+        item = pending.pop()
+        if not isinstance(item, dict):
+            partial = True
+            continue
+        children = item.get("children", [])
+        if isinstance(children, list):
+            pending.extend(reversed(children))
+        else:
+            partial = True
+        try:
+            identifier = information_number(item.get("id"), "Mount identity").value
+        except SnapshotFailure:
+            partial = True
+            continue
+        if identifier in seen:
+            rows.pop(identifier, None)
+            partial = True
+            continue
+        if len(seen) >= FILESYSTEM_RECORDS:
+            partial = True
+            continue
+        seen.add(identifier)
+        display = []
+        try:
+            for key in ("source", "target", "fstype"):
+                value = item.get(key)
+                if not isinstance(value, str) or not value:
+                    raise ValueError("Missing display field")
+                value.encode("utf-8")  # Reject escaped surrogates before sanitization.
+                display.append(clean_text("".join(char if char.isprintable() else " " for char in value)))
+        except (ValueError, UnicodeError):
+            partial = True
+            continue
+        counters = []
+        for key in ("size", "used", "avail"):
+            try:
+                counters.append(information_number(item.get(key), "Filesystem bytes").value)
+            except SnapshotFailure:
+                counters.append("unknown")
+        complete = "unknown" not in counters
+        partial = partial or not complete
+        rows[identifier] = FilesystemRow(identifier, "available" if complete else "partial", *display, *counters,
+            "Filesystem bytes at this read" if complete else "Some filesystem byte counts could not be read")
+    ordered = tuple(rows[key] for key in sorted(rows, key=int))
+    summary = (InformationState("partial", "unknown", "Filesystem inventory is incomplete", "malformed") if partial
+        else information_number(len(ordered), "Mounted real filesystems"))
+    return FilesystemInformation(summary, ordered)
 
 
 def validate_timezone_name(value: object) -> str:
@@ -2168,6 +2266,96 @@ def read_locale_choices() -> tuple[str, ...]:
             # otherwise callers could catch a read failure and keep running.
             if interrupted:
                 raise SystemExit(128 + interrupted)
+
+
+def read_filesystem_information() -> FilesystemInformation:
+    """Collect only the fixed findmnt inventory with bounded owned-group cleanup."""
+    if (threading.current_thread() is not threading.main_thread()
+            or signal.getsignal(signal.SIGCHLD) != signal.SIG_DFL):
+        return FilesystemInformation(information_unknown(
+            SnapshotFailure("internal", "Filesystem process ownership is unavailable", "unavailable")))
+    process = None
+    handlers = {}
+    interrupted = 0
+
+    def terminate(number, _frame):
+        nonlocal interrupted
+        interrupted = interrupted or number
+
+    def check_deadline():
+        if interrupted:
+            raise SystemExit(128 + interrupted)
+        if time.monotonic() >= deadline:
+            raise SnapshotFailure("timeout", "Filesystem enumeration timed out", "unavailable")
+
+    try:
+        try:
+            for number in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+                handlers[number] = signal.signal(number, terminate)
+            deadline = time.monotonic() + 3
+            check_deadline()
+            try:
+                process = subprocess.Popen(["/usr/bin/timeout", "--signal=TERM", "--kill-after=1", "3",
+                    "/usr/bin/findmnt", "--json", "--bytes", "--real", "--uniq", "--output",
+                    "ID,SOURCE,TARGET,FSTYPE,SIZE,USED,AVAIL"], stdin=subprocess.DEVNULL,
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True,
+                    env={"PATH": "/usr/bin:/bin", "LANG": "C", "LC_ALL": "C"})
+            except FileNotFoundError as error:
+                raise SnapshotFailure("missing-provider", "Filesystem command is unavailable", "unavailable") from error
+            output = bytearray()
+            received = 0
+            with selectors.DefaultSelector() as selector:
+                for stream in (process.stdout, process.stderr):
+                    os.set_blocking(stream.fileno(), False)
+                    selector.register(stream, selectors.EVENT_READ)
+                while True:
+                    check_deadline()
+                    status = locale_process_status(process)
+                    if status is not None and not selector.get_map():
+                        break
+                    for key, _events in selector.select(min(0.05, max(0, deadline - time.monotonic()))):
+                        check_deadline()
+                        try:
+                            chunk = os.read(key.fd, min(65536, FILESYSTEM_OUTPUT_BYTES - received + 1))
+                        except BlockingIOError:
+                            continue
+                        if not chunk:
+                            selector.unregister(key.fileobj)
+                            continue
+                        received += len(chunk)
+                        if received > FILESYSTEM_OUTPUT_BYTES:
+                            raise SnapshotFailure("malformed", "Filesystem output exceeds its byte limit")
+                        if key.fileobj is process.stdout:
+                            output.extend(chunk)
+            exit_code = status.si_status if status.si_code == os.CLD_EXITED else -status.si_status
+            if exit_code in (124, 137, -signal.SIGKILL):
+                raise SnapshotFailure("timeout", "Filesystem enumeration timed out", "unavailable")
+            if exit_code == 127:
+                raise SnapshotFailure("missing-provider", "Filesystem command is unavailable", "unavailable")
+            if exit_code != 0:
+                raise SnapshotFailure("internal", "Filesystem enumeration failed", "unavailable")
+            try:
+                result = parse_filesystem_information(bytes(output))
+            finally:
+                check_deadline()
+        finally:
+            try:
+                if process is not None:
+                    try:
+                        close_locale_process(process)
+                    except SnapshotFailure as error:
+                        raise SnapshotFailure(error.code, "Filesystem process cleanup could not be confirmed",
+                                              error.status) from error
+            finally:
+                for number, handler in handlers.items():
+                    signal.signal(number, handler)
+                if interrupted:
+                    raise SystemExit(128 + interrupted)
+    except SnapshotFailure as error:
+        return FilesystemInformation(information_unknown(error))
+    except OSError as error:
+        return FilesystemInformation(information_unknown(error))
+    return result
 
 
 def trusted_delegated_executable(path: str, basename: str) -> str:

--- a/tests/fixtures/system-filesystem-process.py
+++ b/tests/fixtures/system-filesystem-process.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+"""Finite filesystem JSON and hostile owned-process fixtures."""
+
+import json
+import os
+import pathlib
+import runpy
+import sys
+
+row = {"id": 7, "source": "/dev/fixture", "target": "/", "fstype": "ext4",
+       "size": 1048576, "used": 1024, "avail": 1047552}
+output = json.dumps({"filesystems": [row]}).encode()
+mode = sys.argv[1]
+if mode in ("success", "exact-budget", "exit"):
+    os.write(1, output)
+    if mode == "exact-budget":
+        sys.stderr.buffer.write(b"x" * (2 * 1024 * 1024 - len(output)))
+    elif mode == "exit":
+        os.write(2, b"private diagnostic must not reach the result\n")
+        sys.exit(int(sys.argv[2]))
+elif mode == "empty-json":
+    os.write(1, b'{"filesystems": []}')
+elif mode == "bad-json":
+    os.write(1, b'{"filesystems": [')
+elif mode == "invalid-utf8":
+    os.write(1, b'\xff')
+else:
+    # Share only the existing synthetic overflow and TERM-resistant child modes.
+    assert mode in {"stdout-overflow", "stderr-overflow", "combined-overflow", "closed-pipes", "descendant"}
+    runpy.run_path(str(pathlib.Path(__file__).with_name("system-locale-process.py")))

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -260,6 +260,224 @@ class LocalInformationTests(unittest.TestCase):
         self.assertEqual(self.read(uptime=OSError(errno.EIO, "clock unavailable"))["uptime-seconds"].status, "unavailable")
 
 
+class FilesystemInformationTests(unittest.TestCase):
+    def row(self, identifier=7, **changes):
+        return dict({"id": identifier, "source": "/dev/fixture", "target": "/", "fstype": "ext4",
+            "size": 1048576, "used": 1024, "avail": 1047552}, **changes)
+
+    def parse(self, rows):
+        return provider.parse_filesystem_information(provider.json.dumps({"filesystems": rows}).encode())
+
+    def test_complete_nested_inventory_is_keyed_and_sorted_by_mount_id(self):
+        result = self.parse([self.row(10, children=[self.row(2)])])
+        self.assertEqual((result.summary.status, result.summary.value), ("available", "2"))
+        self.assertEqual([row.mount_id for row in result.rows], ["2", "10"])
+        self.assertTrue(all(row.status == "available" and row.size_bytes == "1048576" for row in result.rows))
+        self.assertEqual(self.parse([]).summary.value, "0")
+
+    def test_display_sanitization_does_not_merge_distinct_mounts(self):
+        result = self.parse([self.row(1, target="/a\nb", source="/dev/\tfixture"),
+            self.row(2, target="/a b", fstype="x" * 600)])
+        self.assertEqual(result.summary.value, "2")
+        self.assertEqual([row.target for row in result.rows], ["/a b", "/a b"])
+        self.assertEqual(result.rows[0].source, "/dev/ fixture")
+        self.assertEqual(len(result.rows[1].fstype), 512)
+        result = self.parse([self.row(source="\u00e9" * 300)])
+        self.assertEqual(len(result.rows[0].source.encode()), 512)
+
+    def test_bad_rows_and_nested_shape_preserve_valid_peers(self):
+        for bad in (None, [], self.row(id="7"), self.row(id=True), self.row(id=-1),
+                    self.row(source=None), self.row(target=""), self.row(fstype="\ud800")):
+            result = self.parse([bad, self.row(8)])
+            self.assertEqual((result.summary.status, result.summary.value), ("partial", "unknown"))
+            self.assertEqual([row.mount_id for row in result.rows], ["8"])
+        result = self.parse([self.row(children="wrong")])
+        self.assertEqual(result.summary.status, "partial")
+        self.assertEqual(len(result.rows), 1)
+
+    def test_counters_remain_exact_and_failed_values_are_unknown(self):
+        for value in (None, True, False, -1, 1.0, "1", 1 << 64):
+            result = self.parse([self.row(size=value)])
+            self.assertEqual(result.summary.status, "partial")
+            row = result.rows[0]
+            self.assertEqual((row.status, row.size_bytes, row.used_bytes), ("partial", "unknown", "1024"))
+        result = self.parse([self.row(size=(1 << 64) - 1, used=0, avail=0)])
+        self.assertEqual(result.rows[0].size_bytes, str((1 << 64) - 1))
+        self.assertEqual(result.summary.status, "available")
+        result = self.parse([self.row(size=None, used=None, avail=None)])
+        self.assertEqual((result.rows[0].size_bytes, result.rows[0].used_bytes, result.rows[0].available_bytes),
+                         ("unknown", "unknown", "unknown"))
+
+    def test_duplicate_mount_ids_are_removed_even_after_record_limit(self):
+        result = self.parse([self.row(1), self.row(1), self.row(1), self.row(2)])
+        self.assertEqual([row.mount_id for row in result.rows], ["2"])
+        self.assertEqual(result.summary.status, "partial")
+        result = self.parse([self.row(index) for index in range(256)])
+        self.assertEqual((result.summary.status, result.summary.value), ("available", "256"))
+        result = self.parse([self.row(index) for index in range(257)] + [self.row(0)])
+        self.assertEqual(result.summary.status, "partial")
+        self.assertEqual(len(result.rows), 255)
+        self.assertNotIn("0", [row.mount_id for row in result.rows])
+
+    def test_invalid_json_shape_duplicate_keys_numbers_and_utf8(self):
+        for data in (b"", b"[]", b"{}", b'{"filesystems":null}', b'{"filesystems": [], "filesystems": []}',
+                     b'{"filesystems":[{"id":1,"id":2}]}', b'{"filesystems":[],"extra":NaN}',
+                     b'{"filesystems":[],"extra":Infinity}', b'\xff', b"[" * 2000 + b"]" * 2000):
+            with self.subTest(data=data[:50]), self.assertRaises(provider.SnapshotFailure) as caught:
+                provider.parse_filesystem_information(data)
+            self.assertEqual(caught.exception.code, "malformed")
+
+    def test_parser_byte_limit_is_checked_before_decoding(self):
+        data = b'{"filesystems":[]}'
+        exact = data + b" " * (provider.FILESYSTEM_OUTPUT_BYTES - len(data))
+        self.assertEqual(provider.parse_filesystem_information(exact).summary.value, "0")
+        with self.assertRaises(provider.SnapshotFailure):
+            provider.parse_filesystem_information(exact + b" ")
+
+
+class FilesystemProcessTests(unittest.TestCase):
+    @contextlib.contextmanager
+    def source(self, mode="success", *arguments, signal_number=None, expect_cleanup=True):
+        popen, processes = subprocess.Popen, []
+        def launch(command, **options):
+            self.assertEqual(command, ["/usr/bin/timeout", "--signal=TERM", "--kill-after=1", "3",
+                "/usr/bin/findmnt", "--json", "--bytes", "--real", "--uniq", "--output",
+                "ID,SOURCE,TARGET,FSTYPE,SIZE,USED,AVAIL"])
+            self.assertEqual(options["env"], {"PATH": "/usr/bin:/bin", "LANG": "C", "LC_ALL": "C"})
+            self.assertEqual(options["stdin"], subprocess.DEVNULL)
+            self.assertTrue(options["start_new_session"])
+            self.assertNotIn("preexec_fn", options)
+            process = popen(command[:4] + ["/usr/bin/python3",
+                str(REPO / "tests/fixtures/system-filesystem-process.py"), mode, *arguments], **options)
+            processes.append(process)
+            if signal_number is not None:
+                signal.raise_signal(signal_number)
+            return process
+        try:
+            with mock.patch.object(provider.subprocess, "Popen", side_effect=launch):
+                yield processes
+            if expect_cleanup:
+                self.assertTrue(all(p.returncode is not None and p.stdout.closed and p.stderr.closed for p in processes))
+        finally:
+            for process in processes:
+                if process.returncode is None:
+                    with contextlib.suppress(ProcessLookupError):
+                        os.killpg(process.pid, signal.SIGKILL)
+                    process.wait(timeout=2)
+                for stream in (process.stdout, process.stderr):
+                    if stream:
+                        stream.close()
+
+    def test_fixed_fresh_command_and_exact_combined_budget(self):
+        with self.source() as processes, mock.patch.dict(os.environ, {"LC_ALL": "invalid"}), \
+                mock.patch.object(provider, "open_journal_directory") as journal:
+            for _ in range(2):
+                result = provider.read_filesystem_information()
+                self.assertEqual((result.summary.status, result.summary.value), ("available", "1"))
+            self.assertEqual(len(processes), 2)
+            journal.assert_not_called()
+        with self.source("exact-budget"):
+            self.assertEqual(provider.read_filesystem_information().summary.status, "available")
+        with self.source("empty-json"):
+            self.assertEqual(provider.read_filesystem_information().summary.value, "0")
+
+    def test_bad_output_is_scoped_and_never_publishes_rows(self):
+        for mode in ("bad-json", "invalid-utf8", "stdout-overflow", "stderr-overflow", "combined-overflow"):
+            with self.subTest(mode=mode), self.source(mode):
+                result = provider.read_filesystem_information()
+                self.assertEqual((result.summary.status, result.summary.value, result.summary.error_code),
+                                 ("partial", "unknown", "malformed"))
+                self.assertEqual(result.rows, ())
+
+    def test_exit_status_is_required_and_stderr_is_not_disclosed(self):
+        for status, code in ((1, "internal"), (125, "internal"), (126, "internal"),
+                             (127, "missing-provider"), (124, "timeout"), (137, "timeout")):
+            with self.subTest(status=status), self.source("exit", str(status)):
+                result = provider.read_filesystem_information()
+                self.assertEqual((result.summary.status, result.summary.error_code), ("unavailable", code))
+                self.assertEqual(result.rows, ())
+                self.assertNotIn("private diagnostic", repr(result))
+
+    def test_missing_command_and_permission_denial_restore_handlers(self):
+        handlers = {n: signal.getsignal(n) for n in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)}
+        for error, status, code in ((FileNotFoundError(), "unavailable", "missing-provider"),
+                (PermissionError(errno.EACCES, "private"), "restricted", "permission-denied")):
+            with mock.patch.object(provider.subprocess, "Popen", side_effect=error):
+                result = provider.read_filesystem_information()
+            self.assertEqual((result.summary.status, result.summary.error_code), (status, code))
+            self.assertEqual(result.rows, ())
+        self.assertEqual(handlers, {n: signal.getsignal(n) for n in handlers})
+
+    def test_wall_clock_changes_do_not_extend_timeout_or_preserve_descendants(self):
+        with tempfile.TemporaryDirectory() as directory:
+            pid_file = str(pathlib.Path(directory) / "child-pid")
+            started = time.monotonic()
+            with self.source("descendant", pid_file), mock.patch.object(provider.time, "time", side_effect=[9999, -9999]):
+                result = provider.read_filesystem_information()
+            self.assertEqual((result.summary.status, result.summary.error_code), ("unavailable", "timeout"))
+            self.assertLess(time.monotonic() - started, 5.5)
+            LocaleEnumerationTests().assert_process_stopped(int(pathlib.Path(pid_file).read_text()))
+
+    def test_eof_without_exit_still_times_out(self):
+        with self.source("closed-pipes"):
+            self.assertEqual(provider.read_filesystem_information().summary.error_code, "timeout")
+
+    def test_decoding_after_deadline_never_publishes_success_or_malformed(self):
+        monotonic = time.monotonic
+        for malformed in (False, True):
+            offset = [0]
+            def decode(_data):
+                offset[0] = 4
+                if malformed:
+                    raise provider.SnapshotFailure("malformed", "Late failure")
+                return provider.FilesystemInformation(provider.InformationState("available", "0", "Fixture"))
+            with self.source(), mock.patch.object(provider.time, "monotonic", side_effect=lambda: monotonic() + offset[0]), \
+                    mock.patch.object(provider, "parse_filesystem_information", side_effect=decode):
+                result = provider.read_filesystem_information()
+            self.assertEqual(result.summary.error_code, "timeout")
+            self.assertEqual(result.rows, ())
+
+    def test_interruption_cleans_owned_children_before_exit(self):
+        for number in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            previous = signal.getsignal(number)
+            with self.source("closed-pipes", signal_number=number):
+                with self.assertRaises(SystemExit) as caught:
+                    provider.read_filesystem_information()
+                self.assertEqual(caught.exception.code, 128 + number)
+            self.assertIs(signal.getsignal(number), previous)
+
+    def test_cleanup_failure_never_publishes_success_or_hides_interruption(self):
+        for number in (None, signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            def cleanup(_process):
+                if number is not None:
+                    signal.raise_signal(number)
+                raise provider.SnapshotFailure("timeout", "Private cleanup detail", "unavailable")
+            with self.source(expect_cleanup=False), mock.patch.object(provider, "close_locale_process", side_effect=cleanup):
+                if number is not None:
+                    with self.assertRaises(SystemExit) as caught:
+                        provider.read_filesystem_information()
+                    self.assertEqual(caught.exception.code, 128 + number)
+                else:
+                    result = provider.read_filesystem_information()
+                    self.assertEqual(result.summary.error_code, "timeout")
+                    self.assertEqual(result.rows, ())
+                    self.assertNotIn("Private cleanup detail", repr(result))
+
+    def test_unavailable_child_ownership_prevents_launch(self):
+        with mock.patch.object(provider.signal, "getsignal", return_value=signal.SIG_IGN), \
+                mock.patch.object(provider.subprocess, "Popen") as launch:
+            self.assertEqual(provider.read_filesystem_information().summary.status, "unavailable")
+            launch.assert_not_called()
+        results = []
+        with mock.patch.object(provider.subprocess, "Popen") as launch:
+            thread = threading.Thread(target=lambda: results.append(provider.read_filesystem_information()))
+            thread.start()
+            thread.join(timeout=2)
+            self.assertFalse(thread.is_alive())
+            self.assertEqual(results[0].summary.status, "unavailable")
+            launch.assert_not_called()
+
+
 class RegionalPreflightTests(unittest.TestCase):
     def time_state(self, **changes):
         return replace(provider.RegionalTimeState("UTC", True, False, True), **changes)


### PR DESCRIPTION
## Scope
Prepare a fixed read-only filesystem inventory without activating the public CLI, cumulative protocol minor, or Settings controls.

- Run only the fixed findmnt JSON/bytes/real/uniq command, under a three-second monotonic deadline and independent timeout supervisor.
- Cap combined stdout/stderr at 2 MiB; require normal successful exit and confirmed owned-process-group cleanup.
- Reject malformed/duplicate-key JSON, preserve partial usable rows, cap 256 mount identities, and remove ambiguous duplicate IDs even beyond that cap.
- Keep display paths sanitized and separate from stable mount identities; preserve exact unsigned byte counts and explicit unknowns.
- Add seventeen focused parser/process tests, including real TERM-resistant descendants, EOF-without-exit, simulated wall-clock reversal, and interruption/cleanup failures.

## Validation
- Focused filesystem tests: seventeen passed in 15.294s.
- Read-only Fedora 44 x86_64 probe: available inventory with eight validated rows; no paths recorded.
- Documentation check/build passed, with zero errors/warnings/hints and eleven built pages.
- Independent CodeRabbit CLI review: zero findings across all six changed files.
- Full local gate: `scripts/run-tests make clean all && scripts/run-tests` passed, including 610 backend tests in 304.363s, nested-X11 lifecycle, staged/repeated installation, and managed-workspace cleanup.
- Closed Settings CPU 0.067%; closed large surfaces 0.00%; Power baseline 0.167%, after 0.067%, delta 0.100 points.
- Post-full-gate Codex review: no actionable findings on the unchanged six-file diff.
- Exact uncommitted/staged diff SHA-256: 9fa345e69ab7a5caa5ff97ae5fba76cb7f7286ca419bd3742f6a21c5fa2b3ff5.

## Limits
Internal reader only: no Settings activation, mount monitor, protocol minor change, journal, arbitrary command/path input, mutation, live shell sync, logout, or restart. Security probes, protocol/UI integration, and combined installed qualification remain pending.