### PR TITLE
feat(system): add bounded security status readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ versions from `config.mk`.
 
 ### Changed
 
+- Add internal bounded SELinux, Secure Boot, and firewalld status readers with
+  source-specific unknown and denied states. These read-only preparations do
+  not add system configuration actions, public protocol records, or controls.
+
 - Add an internal fixed-command filesystem inventory with capped JSON, stable
   mount identities, exact byte counts, partial-result handling, and bounded
   owned-process cleanup. Public protocol and Settings integration remain pending.

--- a/TASKS.md
+++ b/TASKS.md
@@ -506,9 +506,13 @@ three-second monotonic deadline, bounded process-group cleanup, a shared 2 MiB
 stdout/stderr budget, and at most 256 mount-ID-keyed rows. Seventeen focused
 tests cover malformed and partial inventories, exact byte counts, truncation,
 timeouts, simulated wall-clock reversal, and interruption cleanup. A read-only
-Fedora 44 probe returned eight validated rows. Security sources, protocol
-integration, visible controls, and combined installed qualification remain
-pending.
+Fedora 44 probe returned eight validated rows. Internal SELinux, Secure Boot,
+and firewalld status readers now use only fixed capped files or a bounded
+read-only systemd query. Fifteen focused tests, including a real firewalld
+deadline and discarded late reply, passed; a read-only Fedora 44 probe returned
+available states for all three sources. Root encryption, shared screen-lock
+status, protocol integration, visible controls, and combined installed
+qualification remain pending.
 
 - [ ] Add event-driven or bounded system information and storage overview state
   without a new idle poller.

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -1041,6 +1041,21 @@ The individual mappings are:
 - Update state reuses the PackageKit snapshot from this provider. It never
   starts a refresh merely to populate the security summary.
 
+The internal security-reader boundary implements SELinux, Secure Boot, and
+firewalld status without activating cumulative minor 2. File reads use their
+fixed byte limit plus one detection byte, close before parsing, and never
+enumerate EFI variables. SELinux fallback accepts only the allowlisted key and
+never treats denied or malformed runtime evidence as disabled. The fixed
+systemd `ListUnitsByNames(["firewalld.service"])` query supplies its `ActiveState`
+field under one ten-second connection-to-decoding deadline, with no service
+activation or interactive authorization. Call failures remain unavailable,
+malformed replies remain partial, and late replies cannot publish state or
+close the shared bus. Fifteen focused tests include a private-bus deadline and
+connection reuse; real read-only Fedora 44 probes reported all three sources
+available. Root encryption and shared screen-lock integration remain pending.
+No new command, protocol record, Settings control, mutation, or polling loop is
+activated by this boundary.
+
 No status probe accepts a path, unit, property, command, device, or service name
 from QML.
 

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -43,6 +43,11 @@ HARDWARE_INFORMATION_FIELDS = {
 }
 FILESYSTEM_OUTPUT_BYTES = 2 * 1024 * 1024
 FILESYSTEM_RECORDS = 256
+SECURITY_FILES = {
+    "selinux-runtime": ("/sys/fs/selinux/enforce", 1),
+    "selinux-config": ("/etc/selinux/config", 64 * 1024),
+    "secure-boot": ("/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c", 5),
+}
 MAX_LIST_RECORDS = 4096
 MAX_LIST_BYTES = 3 * 1024 * 1024
 READ_DEADLINE_SECONDS = 120
@@ -423,6 +428,71 @@ def read_local_information() -> dict[str, InformationState]:
     except (OSError, SnapshotFailure) as error:
         result["uptime-seconds"] = information_unknown(error)
     return result
+
+
+def read_security_bytes(kind: str) -> bytes:
+    """Read one allowlisted source once, including an overflow-detection byte."""
+    if not isinstance(kind, str) or kind not in SECURITY_FILES:
+        raise SnapshotFailure("malformed", "Unknown security information source")
+    path, limit = SECURITY_FILES[kind]
+    with open(path, "rb") as source:
+        data = source.read(limit + 1)
+    if len(data) > limit:
+        raise SnapshotFailure("malformed", "Security information source exceeds its byte limit")
+    return data
+
+
+def read_selinux_status() -> InformationState:
+    """Use runtime enforcement; only an absent interface permits config fallback."""
+    try:
+        try:
+            runtime = read_security_bytes("selinux-runtime")
+        except OSError as error:
+            if error.errno not in (errno.ENOENT, errno.ENOTDIR):
+                raise
+        else:
+            if runtime not in (b"0", b"1"):
+                raise SnapshotFailure("malformed", "SELinux runtime state is malformed")
+            return InformationState("available", "enforcing" if runtime == b"1" else "permissive",
+                                    "SELinux kernel enforcement state")
+        data = read_security_bytes("selinux-config")
+        lines = []
+        for line in data.splitlines():
+            key, separator, value = line.partition(b"=")
+            lines.append(key.strip() + separator + value)
+
+        def decode(key, value):
+            fields = shlex.split(key + "=" + value.lstrip(), comments=True)
+            if len(fields) != 1 or not fields[0].startswith(key + "="):
+                raise SnapshotFailure("malformed", "SELinux configuration is malformed")
+            mode = fields[0][len(key) + 1:]
+            if mode != "disabled":
+                raise SnapshotFailure("malformed", "SELinux configuration does not establish disabled runtime state")
+            return InformationState("available", "disabled", "SELinux is configured disabled and its runtime interface is absent")
+
+        state = information_fields(b"\n".join(lines), {"SELINUX": "selinux"}, "=", decode)["selinux"]
+        return replace(state, status="unsupported") if state.error_code == "missing-provider" else state
+    except (OSError, SnapshotFailure) as error:
+        return information_unknown(error)
+
+
+def read_secure_boot_status() -> InformationState:
+    """Read only the fixed EFI variable; absence or denial never means disabled."""
+    try:
+        directory = os.stat("/sys/firmware/efi/efivars")
+        if not stat.S_ISDIR(directory.st_mode):
+            raise SnapshotFailure("malformed", "EFI variables source is not a directory")
+        try:
+            data = read_security_bytes("secure-boot")
+        except OSError as error:
+            if error.errno in (errno.ENOENT, errno.ENOTDIR):
+                raise SnapshotFailure("missing-provider", "Secure Boot variable is absent on EFI", "partial") from error
+            raise
+        if len(data) != 5 or data[4] not in (0, 1):
+            raise SnapshotFailure("malformed", "Secure Boot variable is malformed")
+        return InformationState("available", "enabled" if data[4] else "disabled", "EFI Secure Boot variable")
+    except (OSError, SnapshotFailure) as error:
+        return information_unknown(error)
 
 
 @dataclass(frozen=True)
@@ -1383,6 +1453,61 @@ class CupsRead(ServiceRead):
             self.unit_failed(unit, error)
         except SnapshotFailure as error:
             self.completed_unit(unit, failure=error)
+
+
+class FirewalldRead(ServiceRead):
+    """Read the ActiveState field of one fixed unit without activating it."""
+
+    label = "Firewalld status"
+
+    def connected(self, _source, result, _data):
+        if not self.pending():
+            return
+        try:
+            self.connection = self.Gio.bus_get_finish(result)
+            self.connection.set_exit_on_close(False)
+            if self.pending():
+                self.connection.call(SYSTEMD_NAME, SYSTEMD_PATH, SYSTEMD_MANAGER, "ListUnitsByNames",
+                    self.GLib.Variant("(as)", (["firewalld.service"],)), self.GLib.VariantType.new(UNIT_REPLY_TYPE),
+                    self.Gio.DBusCallFlags.NO_AUTO_START, max(1, int((self.deadline - time.monotonic()) * 1000)),
+                    self.cancellable, self.replied, None)
+        except self.GLib.Error as error:
+            self.fail(self.bus_failure(error))
+
+    def replied(self, connection, result, _data):
+        if not self.pending():
+            return
+        try:
+            unit = decode_unit_state(connection.call_finish(result))
+            if unit.load == "not-found":
+                if (unit.active, unit.sub) != ("inactive", "dead"):
+                    raise SnapshotFailure("malformed", "Firewalld absence state is inconsistent")
+                state = InformationState("unsupported", "unknown", "Firewalld unit is absent", "missing-provider")
+            elif unit.active in ("active", "inactive"):
+                state = InformationState("available", "enabled" if unit.active == "active" else "disabled",
+                    "Firewalld service only; other firewall rules and managers are not assessed")
+            else:
+                state = InformationState("partial", "unknown", "Firewalld service is failed or transitioning", "internal")
+            if self.pending():
+                self.finish(value=state)
+        except self.GLib.Error as error:
+            if self.pending():
+                if self.Gio.dbus_error_get_remote_error(error) == "org.freedesktop.systemd1.NoSuchUnit":
+                    self.fail(SnapshotFailure("missing-provider", "Firewalld unit is absent", "unsupported"))
+                else:
+                    self.fail(self.bus_failure(error))
+        except SnapshotFailure as error:
+            if self.pending():
+                self.fail(error)
+
+
+def read_firewalld_status() -> InformationState:
+    """Keep fixed service-call failures scoped while preserving interruption."""
+    try:
+        return run_interruptible_read(FirewalldRead())
+    except SnapshotFailure as error:
+        state = information_unknown(error)
+        return replace(state, status="unavailable") if state.status == "restricted" else state
 
 
 class RegionalRead(ServiceRead):

--- a/tests/fixtures/system-firewalld-read-bus.py
+++ b/tests/fixtures/system-firewalld-read-bus.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python3
+"""Qualify fixed firewalld status reads without contacting the host system bus."""
+
+import os
+import runpy
+import sys
+import time
+from unittest import mock
+
+os.environ["DBUS_SYSTEM_BUS_ADDRESS"] = os.environ["DBUS_SESSION_BUS_ADDRESS"]
+from gi.repository import Gio, GLib
+
+provider = runpy.run_path(sys.argv[1], run_name="firewalld_read_fixture")
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+name = "org.freedesktop.systemd1"
+path = "/org/freedesktop/systemd1"
+mode = "active"
+held = []
+calls = []
+manager = Gio.DBusNodeInfo.new_for_xml("""
+<node><interface name="org.freedesktop.systemd1.Manager">
+<method name="ListUnitsByNames"><arg type="as" direction="in"/><arg type="a(ssssssouso)" direction="out"/></method>
+</interface></node>""").interfaces[0]
+
+
+def reply(invocation, active="active"):
+    load = "not-found" if mode == "absent" else "loaded"
+    state = "inactive" if mode == "absent" else active
+    description = "x" * 70000 if mode == "oversized" else "Fixture firewall"
+    row = ("firewalld.service", description, load, state, "dead", "", path + "/unit/firewalld_2eservice", 0, "", "/")
+    invocation.return_value(GLib.Variant(provider["UNIT_REPLY_TYPE"], ([row],)))
+
+
+def called(_bus, _sender, object_path, interface, method, args, invocation):
+    assert (object_path, interface, method) == (path, name + ".Manager", "ListUnitsByNames")
+    assert args.unpack() == (["firewalld.service"],)
+    calls.append(args.unpack())
+    if mode == "stall":
+        held.append(invocation)
+    elif mode in ("denied", "missing"):
+        error = "org.freedesktop.DBus.Error.AccessDenied" if mode == "denied" else name + ".NoSuchUnit"
+        invocation.return_dbus_error(error, "Private fixture detail")
+    else:
+        reply(invocation, "bad\nstate" if mode == "malformed" else mode)
+
+
+def read_status():
+    start = len(calls)
+    reader = provider["FirewalldRead"]()
+    with mock.patch.dict(provider["read_firewalld_status"].__globals__, FirewalldRead=lambda: reader):
+        result = provider["read_firewalld_status"]()
+    assert len(calls) == start + 1
+    assert reader.done and reader.cancellable.is_cancelled()
+    assert not bus.is_closed()
+    assert "Private fixture detail" not in repr(result)
+    return reader, result
+
+
+registration = 0
+try:
+    answer = bus.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+        "RequestName", GLib.Variant("(su)", (name, 0)), GLib.VariantType.new("(u)"),
+        Gio.DBusCallFlags.NONE, 3000, None)
+    assert answer.unpack() == (1,)
+    registration = bus.register_object(path, manager, called, None, None)
+    for mode, status, value in (("active", "available", "enabled"), ("inactive", "available", "disabled"),
+            ("failed", "partial", "unknown"), ("activating", "partial", "unknown"),
+            ("absent", "unsupported", "unknown"), ("missing", "unsupported", "unknown"),
+            ("denied", "unavailable", "unknown"), ("malformed", "partial", "unknown"),
+            ("oversized", "partial", "unknown")):
+        _reader, result = read_status()
+        assert (result.status, result.value) == (status, value), (mode, result)
+    mode = "stall"
+    started = time.monotonic()
+    reader, result = read_status()
+    assert 9.5 <= time.monotonic() - started < 15
+    assert (result.status, result.value, result.error_code) == ("unavailable", "unknown", "timeout")
+    assert len(held) == 1
+    saved = reader.failure
+    mode = "active"
+    reply(held.pop())
+    _fresh, result = read_status()
+    assert result.value == "enabled"
+    assert reader.failure is saved and reader.value is None
+    print("Private-bus firewalld reads: PASS (fixed query, states, failures, deadline, late reply, shared bus)")
+finally:
+    for invocation in held:
+        invocation.return_dbus_error("org.freedesktop.DBus.Error.NoReply", "Fixture cleanup")
+    if registration:
+        bus.unregister_object(registration)

--- a/tests/test-fedora-platform.sh
+++ b/tests/test-fedora-platform.sh
@@ -125,8 +125,46 @@ if [[ -e $work/mutations.log ]] ||
 	exit 1
 fi
 
-if grep -ERq 'setenforce|/etc/selinux/config|(^|[[:space:]])(sudo[[:space:]]+)?chcon([[:space:]]|$)|semanage[[:space:]]+fcontext' \
-	"$repo/install.sh" "$repo/scripts"; then
+selinux_pattern='setenforce|/etc/selinux/config|(^|[[:space:]])(sudo[[:space:]]+)?chcon([[:space:]]|$)|semanage[[:space:]]+fcontext'
+# Allow only the fixed read-only source-map declaration, not the whole reader.
+# Every other path reference and all policy/context mutation commands still fail.
+selinux_read_source="$repo/scripts/dwm-system-management:    \"selinux-config\": (\"/etc/selinux/config\", 64 * 1024),"
+selinux_forbidden_matches() {
+	local line
+	while IFS= read -r line; do
+		if [[ $line != "$selinux_read_source" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+# Keep the exception exact, including its file and complete source line.
+if selinux_forbidden_matches <<<"$selinux_read_source"; then
+	printf 'SELinux read-only declaration was not recognized.\n' >&2
+	exit 1
+fi
+for statement in \
+	'open("/etc/selinux/config", "w")' \
+	'setenforce 0' \
+	'sudo chcon -t bin_t helper' \
+	'semanage fcontext -a -t bin_t helper'; do
+	grep -Eq "$selinux_pattern" <<<"$statement"
+	selinux_forbidden_matches <<<"$repo/scripts/dwm-system-management:$statement"
+done
+selinux_forbidden_matches <<<"$repo/install.sh:${selinux_read_source#*:}"
+selinux_forbidden_matches <<<"$selinux_read_source # changed"
+
+if grep -ERH "$selinux_pattern" "$repo/install.sh" "$repo/scripts" >"$work/selinux-matches"; then
+	:
+else
+	scan_status=$?
+	if [[ $scan_status -ne 1 ]]; then
+		printf 'SELinux policy scan failed with status %s.\n' "$scan_status" >&2
+		exit "$scan_status"
+	fi
+fi
+if selinux_forbidden_matches <"$work/selinux-matches"; then
 	printf 'Existing-system tools must not change host SELinux policy or assign file contexts.\n' >&2
 	exit 1
 fi

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -260,6 +260,224 @@ class LocalInformationTests(unittest.TestCase):
         self.assertEqual(self.read(uptime=OSError(errno.EIO, "clock unavailable"))["uptime-seconds"].status, "unavailable")
 
 
+class LocalSecurityTests(unittest.TestCase):
+    runtime_path = "/sys/fs/selinux/enforce"
+    config_path = "/etc/selinux/config"
+    variable_path = "/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"
+
+    def read(self, kind, *, runtime=b"1", config=b"SELINUX=disabled\n", variable=b"\x07\x00\x00\x00\x01", efi=None):
+        contents = {self.runtime_path: runtime, self.config_path: config, self.variable_path: variable}
+        limits = {self.runtime_path: 2, self.config_path: 65537, self.variable_path: 6}
+        opened, streams = [], []
+        class Source(io.BytesIO):
+            def read(inner, size=-1):
+                self.assertEqual(size, limits[inner.path])
+                return super().read(size)
+        def source(path, mode):
+            self.assertEqual(mode, "rb")
+            self.assertIn(path, contents)
+            opened.append(path)
+            value = contents[path]
+            if isinstance(value, Exception):
+                raise value
+            stream = Source(value)
+            stream.path = path
+            streams.append(stream)
+            return stream
+        efi = types.SimpleNamespace(st_mode=stat.S_IFDIR | 0o755) if efi is None else efi
+        stat_options = {"side_effect": efi} if isinstance(efi, Exception) else {"return_value": efi}
+        with mock.patch.object(provider, "open", source, create=True), \
+                mock.patch.object(provider.os, "stat", **stat_options) as source_stat, \
+                mock.patch.object(provider.os, "listdir", side_effect=AssertionError("Unexpected enumeration")), \
+                mock.patch.object(provider.os, "scandir", side_effect=AssertionError("Unexpected enumeration")), \
+                mock.patch.object(provider.subprocess, "Popen", side_effect=AssertionError("Unexpected subprocess")), \
+                mock.patch.object(provider, "open_journal_directory", side_effect=AssertionError("Unexpected journal")):
+            result = provider.read_selinux_status() if kind == "selinux" else provider.read_secure_boot_status()
+        self.assertTrue(all(stream.closed for stream in streams))
+        self.assertEqual(len(opened), len(set(opened)))
+        if kind == "selinux":
+            source_stat.assert_not_called()
+        else:
+            source_stat.assert_called_once_with("/sys/firmware/efi/efivars")
+        if result.status != "available":
+            self.assertEqual(result.value, "unknown")
+            self.assertNotEqual(result.error_code, "")
+        self.assertNotIn("private detail", repr(result))
+        return result, opened
+
+    def absent(self):
+        return OSError(errno.ENOENT, "private detail")
+
+    def test_selinux_runtime_is_authoritative_and_config_is_not_read(self):
+        for data, value in ((b"1", "enforcing"), (b"0", "permissive")):
+            result, opened = self.read("selinux", runtime=data, config=AssertionError("Unused config"))
+            self.assertEqual((result.status, result.value), ("available", value))
+            self.assertEqual(opened, [self.runtime_path])
+
+    def test_malformed_or_denied_runtime_never_falls_back_to_disabled(self):
+        for data in (b"", b"1\n", b"2", b"\x01", b"1" * 100):
+            result, opened = self.read("selinux", runtime=data)
+            self.assertEqual(result.status, "partial")
+            self.assertEqual(opened, [self.runtime_path])
+        for number, status in ((errno.EACCES, "restricted"), (errno.EPERM, "restricted"), (errno.EIO, "unavailable")):
+            result, opened = self.read("selinux", runtime=OSError(number, "private detail"))
+            self.assertEqual(result.status, status)
+            self.assertEqual(opened, [self.runtime_path])
+
+    def test_only_disabled_config_can_establish_state_without_runtime(self):
+        for text in (b"SELINUX=disabled", b' SELINUX = "disabled" # comment\nOTHER=\xff\n'):
+            result, opened = self.read("selinux", runtime=self.absent(), config=text)
+            self.assertEqual((result.status, result.value), ("available", "disabled"))
+            self.assertEqual(opened, [self.runtime_path, self.config_path])
+        for text in (b"SELINUX=enforcing", b"SELINUX=permissive", b"SELINUX=DISABLED", b"SELINUX=",
+                     b"SELINUX='unclosed", b"SELINUX=$(false)", b"SELINUX=\xff", b"SELINUX",
+                     b"SELINUX=disabled\nSELINUX=disabled\nSELINUX=disabled"):
+            result, _opened = self.read("selinux", runtime=self.absent(), config=text)
+            self.assertEqual(result.status, "partial")
+
+    def test_missing_config_or_key_is_unsupported_but_denial_is_restricted(self):
+        for config in (self.absent(), b"", b"# SELINUX=disabled\nUNRELATED=value"):
+            result, _opened = self.read("selinux", runtime=self.absent(), config=config)
+            self.assertEqual(result.status, "unsupported")
+        result, _opened = self.read("selinux", runtime=self.absent(), config=PermissionError(errno.EACCES, "private detail"))
+        self.assertEqual(result.status, "restricted")
+
+    def test_selinux_config_byte_limit_precedes_parsing(self):
+        base = b"SELINUX=disabled\n"
+        exact = base + b"#" * (65536 - len(base))
+        self.assertEqual(self.read("selinux", runtime=self.absent(), config=exact)[0].value, "disabled")
+        self.assertEqual(self.read("selinux", runtime=self.absent(), config=exact + b"x")[0].status, "partial")
+
+    def test_secure_boot_exact_binary_payload_and_attributes_prefix(self):
+        for value, state in ((0, "disabled"), (1, "enabled")):
+            result, opened = self.read("secure-boot", variable=b"\xff" * 4 + bytes([value]))
+            self.assertEqual((result.status, result.value), ("available", state))
+            self.assertEqual(opened, [self.variable_path])
+        for data in (b"", b"\x00" * 4, b"\x00" * 6, b"\x00" * 4 + b"1", b"\x00" * 4 + b"\x02"):
+            self.assertEqual(self.read("secure-boot", variable=data)[0].status, "partial")
+
+    def test_secure_boot_platform_absence_and_variable_absence_are_distinct(self):
+        result, opened = self.read("secure-boot", efi=self.absent())
+        self.assertEqual(result.status, "unsupported")
+        self.assertEqual(opened, [])
+        result, opened = self.read("secure-boot", variable=self.absent())
+        self.assertEqual(result.status, "partial")
+        self.assertEqual(opened, [self.variable_path])
+        result, opened = self.read("secure-boot", efi=types.SimpleNamespace(st_mode=stat.S_IFREG))
+        self.assertEqual(result.status, "partial")
+        self.assertEqual(opened, [])
+
+    def test_secure_boot_denial_and_io_failure_never_mean_disabled(self):
+        for source in ("efi", "variable"):
+            for number, status in ((errno.EACCES, "restricted"), (errno.EPERM, "restricted"), (errno.EIO, "unavailable")):
+                result, _opened = self.read("secure-boot", **{source: OSError(number, "private detail")})
+                self.assertEqual(result.status, status)
+
+    def test_source_selector_is_closed_before_open(self):
+        for kind in ("other", "/etc/passwd", [], None):
+            with mock.patch.object(provider, "open", create=True) as source, \
+                    self.assertRaises(provider.SnapshotFailure):
+                provider.read_security_bytes(kind)
+            source.assert_not_called()
+
+
+class FirewalldReadTests(unittest.TestCase):
+    def collect(self, state=None, *, remote=None, mode="normal"):
+        _unused, connection, gio, glib, variant = RegionalReadTests().reader()
+        read = provider.FirewalldRead(gio, glib)
+        gio.dbus_error_get_remote_error.return_value = remote
+        def run():
+            if mode == "connect-timeout":
+                read.expire()
+            read.connected(None, object(), None)
+            if mode == "timeout":
+                read.expire()
+            if remote:
+                connection.call_finish.side_effect = variant.Error("private detail")
+            else:
+                connection.call_finish.return_value = (variant.Variant("(s)", ("bad",)) if mode == "malformed"
+                    else CupsReadTests().reply(variant, state, **{"0": "firewalld.service"}))
+            if mode == "decode-timeout":
+                decode = provider.decode_unit_state
+                def delayed(reply):
+                    read.deadline = time.monotonic() - 1
+                    return decode(reply)
+                with mock.patch.object(provider, "decode_unit_state", side_effect=delayed):
+                    read.replied(connection, object(), None)
+            else:
+                read.replied(connection, object(), None)
+        read.loop.run.side_effect = run
+        with mock.patch.object(provider, "FirewalldRead", return_value=read), \
+                mock.patch.object(provider, "open_journal_directory") as journal:
+            result = provider.read_firewalld_status()
+        journal.assert_not_called()
+        connection.close_sync.assert_not_called()
+        self.assertTrue(read.cancellable.cancel.called)
+        self.assertNotIn("private detail", repr(result))
+        return result, read, connection, gio, glib
+
+    def test_fixed_unit_query_and_known_states(self):
+        for active, value in (("active", "enabled"), ("inactive", "disabled")):
+            result, _read, connection, gio, glib = self.collect(CupsReadTests().state(active=active))
+            self.assertEqual((result.status, result.value), ("available", value))
+            self.assertIn("other firewall", result.detail)
+            connection.call.assert_called_once()
+            args = connection.call.call_args.args
+            self.assertEqual(args[:4], (provider.SYSTEMD_NAME, provider.SYSTEMD_PATH, provider.SYSTEMD_MANAGER, "ListUnitsByNames"))
+            self.assertEqual(args[4].unpack(), (["firewalld.service"],))
+            self.assertEqual(args[6], gio.DBusCallFlags.NO_AUTO_START)
+            self.assertTrue(0 < args[7] <= 10000)
+            glib.source_remove.assert_called_once_with(17)
+
+    def test_absent_failed_transitional_and_malformed_states(self):
+        for active in ("failed", "activating", "deactivating", "reloading", "unknown"):
+            result, *_rest = self.collect(CupsReadTests().state(active=active))
+            self.assertEqual((result.status, result.value), ("partial", "unknown"))
+        result, *_rest = self.collect(CupsReadTests().state(load="not-found"))
+        self.assertEqual((result.status, result.value), ("unsupported", "unknown"))
+        for state in (CupsReadTests().state(load="not-found", active="active"), CupsReadTests().state(active="bad\nstate")):
+            self.assertEqual(self.collect(state)[0].error_code, "malformed")
+        self.assertEqual(self.collect(mode="malformed")[0].status, "partial")
+
+    def test_service_failures_and_late_replies_are_scoped(self):
+        for remote, status, code in (("org.freedesktop.systemd1.NoSuchUnit", "unsupported", "missing-provider"),
+                ("org.freedesktop.DBus.Error.AccessDenied", "unavailable", "permission-denied"),
+                ("org.freedesktop.DBus.Error.ServiceUnknown", "unavailable", "missing-provider")):
+            result, *_rest = self.collect(remote=remote)
+            self.assertEqual((result.status, result.value, result.error_code), (status, "unknown", code))
+        for mode in ("timeout", "connect-timeout"):
+            result, read, connection, _gio, _glib = self.collect(mode=mode)
+            self.assertEqual((result.status, result.error_code), ("unavailable", "timeout"))
+            connection.call_finish.reset_mock()
+            read.replied(connection, object(), None)
+            connection.call_finish.assert_not_called()
+            if mode == "connect-timeout":
+                connection.call.assert_not_called()
+
+    def test_missing_bindings_and_interruption(self):
+        with mock.patch.object(provider, "FirewalldRead", side_effect=provider.SnapshotFailure(
+                "missing-provider", "Bindings unavailable", "unavailable")):
+            self.assertEqual(provider.read_firewalld_status().status, "unavailable")
+        with mock.patch.object(provider, "FirewalldRead"), \
+                mock.patch.object(provider, "run_interruptible_read", side_effect=InterruptedError):
+            with self.assertRaises(InterruptedError):
+                provider.read_firewalld_status()
+
+    def test_decode_deadline_and_completed_callback_cannot_publish_late_state(self):
+        self.assertEqual(self.collect(mode="decode-timeout")[0].error_code, "timeout")
+        _result, read, connection, _gio, _glib = self.collect()
+        connection.call_finish.reset_mock()
+        read.replied(connection, object(), None)
+        connection.call_finish.assert_not_called()
+
+    def test_actual_private_bus_state_deadline_and_shared_connection(self):
+        result = subprocess.run(["dbus-run-session", "--", "/usr/bin/python3",
+            str(REPO / "tests/fixtures/system-firewalld-read-bus.py"), str(PROVIDER_PATH)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "Private-bus firewalld reads: PASS (fixed query, states, failures, deadline, late reply, shared bus)\n")
+
+
 class FilesystemInformationTests(unittest.TestCase):
     def row(self, identifier=7, **changes):
         return dict({"id": identifier, "source": "/dev/fixture", "target": "/", "fstype": "ext4",


### PR DESCRIPTION
## Scope
Add internal read-only SELinux, Secure Boot, and firewalld status readers for Phase 6. This is one independently testable preparation boundary; it does not activate a command, protocol minor, UI control, journal operation, mutation, or idle poller.

- Fixed capped files distinguish absent, denied, malformed, and known states. SELinux only falls back to its allowlisted config key when the runtime interface is absent.
- Secure Boot reads only the fixed EFI variable, including its four-byte attributes prefix and exact binary payload; no directory enumeration.
- One fixed systemd ListUnitsByNames query reads firewalld ActiveState under a ten-second aggregate deadline. It never starts firewalld or claims other firewall rules are absent; late replies cannot publish state or close the shared bus.
- Keep the Fedora platform guard's mutation regex and scan-error handling. Exempt only the exact reviewed read-only source-map declaration, with synthetic regression checks for direct writes, context changes, wrong files, and modified declarations.

## Validation
- Focused managed security tests: 15 passed in 10.198s, including a real private-bus ten-second timeout, discarded late reply, and shared connection reuse.
- Managed Fedora platform test: passed. ShellCheck and shfmt across install.sh, scripts/*.sh, and tests/*.sh passed.
- Read-only Fedora 44 probes: SELinux, Secure Boot, and firewalld sources each returned available; no host setting was changed.
- Documentation check/build passed (15 Astro files, zero diagnostics; 11 pages).
- Full clean build and managed suite passed: 625 backend tests in 313.166s; nested-X11 system-management lifecycle, staged/repeated installation, and release-archive validation passed. Closed Settings CPU 0.033%, large surfaces 0.00%; power lifecycle 0.167% before / 0.033% after. Managed workspaces cleaned.
- Post-full Codex review: no actionable findings; independently confirmed the shell guard's assertion semantics.
- CodeRabbit CLI reviewed all seven files; one shell-control-flow allegation was reproduced and rejected as non-actionable. Standalone helper return 0 continues to the repository scan; return 1 terminates under set -euo pipefail. Both behaviors were verified directly, and the platform gate reaches its final PASS marker. No code defect was found in the six reader/test/doc files.

## Limits and follow-up
Root encryption, shared screen-lock status, cumulative minor-2 integration, visible controls, and combined installed-session qualification remain pending. No live Quickshell configuration was activated, no logout/reboot was requested, and no host security setting was changed. Phase 6 remains active; Phase 7 is out of scope.
