### PR TITLE
fix(install): avoid false runtime and package validation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -469,6 +469,12 @@ versions from `config.mk`.
 
 ### Fixed
 
+- Avoid a false dwm restart requirement after reinstalling an identical binary.
+  Live parity compares the running executable bytes even when its old inode
+  has been unlinked; changed or unreadable executables still require a restart.
+  Package-profile validation also drains matched output to avoid false SIGPIPE
+  failures under pipefail.
+
 - Keep visible floating windows above the tiled stack when focus changes while
   retaining focus-based ordering within the floating layer and the existing
   fullscreen and shell-surface priorities.

--- a/scripts/dev-sync-install.sh
+++ b/scripts/dev-sync-install.sh
@@ -388,12 +388,9 @@ runtime_verify() {
 	dwm_pid=$(pgrep -xo dwm 2>/dev/null || true)
 	dwm_restart_required=0
 	if [ -n "$dwm_pid" ]; then
-		running_executable=$(readlink "/proc/$dwm_pid/exe" 2>/dev/null || true)
-		case $running_executable in
-		*" (deleted)") dwm_restart_required=1 ;;
-		esac
-		if [ "$dwm_restart_required" -eq 0 ] &&
-			! cmp -s "/proc/$dwm_pid/exe" "$binary_target"; then
+		# Reinstallation can unlink the running executable without changing its
+		# bytes. Proc still exposes that inode; compare it even when deleted.
+		if ! cmp -s "/proc/$dwm_pid/exe" "$binary_target"; then
 			dwm_restart_required=1
 		fi
 	fi

--- a/tests/test-dev-sync-install.sh
+++ b/tests/test-dev-sync-install.sh
@@ -4,7 +4,16 @@ set -eu
 
 repo_dir=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
 work=$(mktemp -d)
-trap 'rm -rf "$work"' EXIT HUP INT TERM
+runtime_pid=
+cleanup() {
+	if [ -n "$runtime_pid" ]; then
+		kill "$runtime_pid" 2>/dev/null || true
+		wait "$runtime_pid" 2>/dev/null || true
+		runtime_pid=
+	fi
+	rm -rf "$work"
+}
+trap cleanup EXIT HUP INT TERM
 
 test_repo="$work/repo"
 test_home="$work/user home"
@@ -215,5 +224,66 @@ if "$test_repo/scripts/dev-sync-install.sh" --unknown >"$output" 2>&1; then
 	exit 1
 fi
 grep -Fq 'unknown option: --unknown' "$output"
+
+# An atomic reinstall unlinks the old executable even when its bytes match.
+# Exercise that kernel state with a private child, never the host window manager.
+runtime_bin="$work/runtime-bin"
+runtime_probe="$work/runtime-probe"
+mkdir "$runtime_bin"
+sed -n '/^runtime_verify() {$/,/^}$/p' "$test_repo/scripts/dev-sync-install.sh" >"$runtime_probe"
+cat >"$runtime_bin/pgrep" <<'EOF'
+#!/bin/sh
+case "$*" in
+'-xo dwm') printf '%s\n' "$DWM_TEST_DWM_PID" ;;
+'-xc quickshell') printf '1\n' ;;
+*) exit 2 ;;
+esac
+EOF
+printf '#!/bin/sh\nprintf "0\\n"\n' >"$runtime_bin/quickshell"
+printf '#!/bin/sh\nexit 0\n' >"$runtime_bin/systemctl"
+chmod +x "$runtime_bin/pgrep" "$runtime_bin/quickshell" "$runtime_bin/systemctl"
+cp /usr/bin/sleep "$work/runtime-dwm"
+cp "$work/runtime-dwm" "$prefix/bin/dwm"
+"$work/runtime-dwm" 60 &
+runtime_pid=$!
+runtime_try=0
+while [ "$(readlink "/proc/$runtime_pid/exe" 2>/dev/null || true)" != "$work/runtime-dwm" ]; do
+	runtime_try=$((runtime_try + 1))
+	[ "$runtime_try" -lt 50 ] || exit 1
+	sleep 0.02
+done
+rm "$work/runtime-dwm"
+case $(readlink "/proc/$runtime_pid/exe") in
+*" (deleted)") ;;
+*) exit 1 ;;
+esac
+runtime_check() {
+	DWM_TEST_DWM_PID="$runtime_pid" PATH="$runtime_bin:$PATH" DISPLAY=:fixture \
+		DWM_DEV_SYNC_SKIP_RUNTIME=0 sh -c '
+		set -eu
+		. "$1"
+		prefix=$2
+		binary_target=$prefix/bin/dwm
+		quickshell_dir=$3
+		runtime_verify 0
+	' sh "$runtime_probe" "$prefix" "$config_home/quickshell"
+}
+runtime_check >"$output" 2>&1
+grep -Fqx 'Running dwm matches the installed binary.' "$output"
+cp /usr/bin/true "$prefix/bin/dwm"
+if runtime_check >"$output" 2>&1; then
+	printf '%s\n' 'Different running executable unexpectedly passed.' >&2
+	exit 1
+fi
+grep -Fq 'running dwm does not match the installed binary' "$output"
+rm "$prefix/bin/dwm"
+if runtime_check >"$output" 2>&1; then
+	printf '%s\n' 'Missing installed executable unexpectedly passed.' >&2
+	exit 1
+fi
+grep -Fq 'running dwm does not match the installed binary' "$output"
+kill "$runtime_pid"
+wait "$runtime_pid" 2>/dev/null || true
+runtime_pid=
 
 printf '%s\n' 'Developer live-install synchronization: PASS'

--- a/tests/test-fedora-packages.sh
+++ b/tests/test-fedora-packages.sh
@@ -70,16 +70,17 @@ printf '%s\n' "$installed_provider_packages" | grep -Fxq upower
 printf '%s\n' "$installed_provider_packages" | grep -Fxq dbus-tools
 printf '%s\n' "$installed_provider_packages" | grep -Fxq inotify-tools
 printf '%s\n' "$installed_provider_packages" | grep -Fxq xsettingsd
+# Drain each producer under pipefail; grep -q can close a successful match early.
 for package in PackageKit PackageKit-glib python3-gobject python3-rpm accountsservice cups system-config-printer; do
-	dwm_packages fedora system-management | grep -Fxq "$package"
-	dwm_packages fedora recommended | grep -Fxq "$package"
+	dwm_packages fedora system-management | grep -Fx "$package" >/dev/null
+	dwm_packages fedora recommended | grep -Fx "$package" >/dev/null
 done
 for package in lxqt-admin dnfdragora; do
-	dwm_packages fedora system-management-optional | grep -Fxq "$package"
-	dwm_packages fedora optional | grep -Fxq "$package"
+	dwm_packages fedora system-management-optional | grep -Fx "$package" >/dev/null
+	dwm_packages fedora optional | grep -Fx "$package" >/dev/null
 done
 for package in xsettingsd xkbset; do
-	dwm_packages fedora source-update | grep -Fxq "$package"
+	dwm_packages fedora source-update | grep -Fx "$package" >/dev/null
 done
 [[ $("$repo/scripts/dwm-packages.sh" fedora source-update) == $'xsettingsd\nxkbset' ]]
 grep -Fq 'dwm_install_package_profile system-management' "$repo/install.sh"


### PR DESCRIPTION
A source reinstall can unlink dwm's running executable while installing identical bytes. The live check previously treated the deleted inode as a mandatory session restart. It now compares the retained executable directly, accepting identical bytes while still rejecting a changed or unreadable binary.

Fedora package validation also failed with SIGPIPE under pipefail when grep -q stopped reading a matching package list. The affected assertions now drain the producer without suppressing pipeline errors. Both fixes address false installation-validation failures found while qualifying main.

Validation on Fedora 44:
- A private-process regression reproduces a deleted running executable; identical bytes pass, changed and missing installed targets fail. It failed before the fix and passes after it.
- The original package pipeline reproduced exit 141 on the first attempt; the corrected form passed 100 repetitions.
- The full managed gate passed through check-kickstart, then exposed that package-test failure. After fixing it, check-fedora-packages, check-install, check-install-preservation, check-test-runner, check-lightdm-config, and release-check all passed. This supplies every remaining required gate, including 66 Fedora package entries, staged/repeated installation, and release archive validation.
- Final focused install validation, ShellCheck with sourced files, shfmt, diff checks, and documentation build passed.
- Actual running and installed dwm SHA-256 hashes matched on the live X11 desktop; the corrected runtime verifier passed with working Quickshell IPC. No session restart or user configuration reset was needed.
- Fresh independent built-in Codex review found no actionable regressions.
