### PR TITLE
feat(system): add bounded mount change monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ versions from `config.mk`.
   live evidence is partial or unavailable, instead of displaying saved fallback
   values as enabled or disabled.
 
+- Add a fixed read-only mount-event helper with acknowledged baseline readiness,
+  bounded event records, and owned-child cleanup. Settings storage monitoring
+  and cumulative protocol integration remain pending.
+
 - Reuse the power helper's automatic screen-lock evidence through a bounded
   internal information reader. Preserve unknown and unavailable states without
   adding a locking policy change or a second locker probe.

--- a/TASKS.md
+++ b/TASKS.md
@@ -491,6 +491,18 @@ Acceptance:
 
 ### INFO-RECOVERY-001: Information, Diagnostics, and Recovery
 
+Mount readiness also distinguishes the temporary initial parsing descriptor
+from the persistent polling descriptor. A delayed-open regression against the
+real Fedora findmnt reproduces the old early acknowledgment and passes with
+the corrected check.
+
+The fixed `watch-mounts` helper now waits for the live findmnt mountinfo
+baseline under a one-second deadline, then emits bounded allowlisted mount
+notifications. It uses descriptor isolation, owned-group cleanup, parent-death
+protection, and blocking event subscriptions after readiness. No journal,
+mutation, snapshot minor, or Settings surface is activated by this preparation;
+pane-generation ownership and storage refresh integration remain pending.
+
 The shared power helper now provides a fixed read-only `power-lock-snapshot`
 using the same formatter and existing power status owner as `power-snapshot`.
 The internal system-information reader validates its versioned lock record,

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -2616,7 +2616,9 @@ the service; that method is not used by the monitor.
 
   The fixed CLI helper is implemented as a preparatory boundary. It uses a pidfd
   and signal-wakeup pipe alongside child output, so no idle timer remains after
-  readiness. Lost output or failed cleanup exits unsuccessfully. The bounded
+  readiness. A read-interest watch on the output pipe catches reader closure
+  even with no mount events, without subscribing to continuously writable
+  events. Lost output or failed cleanup exits unsuccessfully. The bounded
   readiness probe retains early child output until the baseline is acknowledged.
   Root-model and pane integration described below remain pending; this command
   does not activate cumulative minor 2 or read a journal.

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -2624,10 +2624,13 @@ the service; that method is not used by the monitor.
 
   The fixed CLI helper is implemented as a preparatory boundary. It uses a pidfd
   and signal-wakeup pipe alongside child output, so no idle timer remains after
-  readiness. A closure-only epoll watch catches pipe/socket consumer loss
-  even with no mount events. Incoming socket data and a peer write-half-close
-  are not mistaken for loss, and neither readable nor writable readiness
-  creates an idle spin. Lost output or failed cleanup exits unsuccessfully. The bounded
+  readiness. The helper requires write-only pipe output, as supplied by
+  Quickshell. Its read-interest watch catches consumer loss even with no mount
+  events, without a writable idle spin. Other output types are rejected before
+  starting a child: sockets can half-close without an event, and read/write
+  FIFOs retain their own reader. For command-line inspection, use
+  `dwm-system-management watch-mounts | cat`. Shared operation writers retain
+  their separate output-type support. Lost output or failed cleanup exits unsuccessfully. The bounded
   readiness probe retains early child output until the baseline is acknowledged.
   Root-model and pane integration described below remain pending; this command
   does not activate cumulative minor 2 or read a journal.

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -2590,18 +2590,36 @@ the service; that method is not used by the monitor.
   minor-2 command accepts no arguments and is not an action or operation
   stream. Its supervisor starts exactly
   `findmnt --poll --raw --noheadings --output ACTION` in a dedicated process
-  group. The child marks every inherited nonstandard descriptor close-on-exec
-  before executing the fixed program. Before emitting anything, the supervisor
+  group. The child closes every inherited nonstandard descriptor before its
+  isolated Python startup, arms Linux parent-death SIGKILL, rechecks the original
+  parent identity, and replaces itself with the fixed program. Before emitting
+  anything, the supervisor
   waits under a one-second monotonic deadline until the live child's descriptor
   table contains the open `/proc/CHILD_PID/mountinfo` baseline. The readiness
   probe walks every numeric entry beneath that exact `/proc/CHILD_PID/fd`
   directory until it finds a symlink target equal to
-  `/proc/CHILD_PID/mountinfo`, the child exits, its proc identity changes, or
+  `/proc/CHILD_PID/mountinfo` with the persistent polling descriptor flags, the
+  child exits, its proc identity changes, or
   the deadline expires. It then emits the exact line
   `mount-monitor-ready`; subsequent bounded nonempty findmnt lines are emitted
   as `mount-change<TAB>ACTION`. Any other standard-output line, a line over 256
   bytes, a missed readiness deadline, or an unexpected supervisor or child exit
   marks storage `partial` with explicit-refresh guidance.
+
+  Fedora util-linux opens its initial parsing descriptor with `O_CLOEXEC` and
+  its persistent `poll_table` descriptor without that flag. The readiness probe
+  checks the exact descriptor's bounded `fdinfo` flags and rejects the initial
+  parsing open, which otherwise precedes the actual subscription. Unrecognized
+  descriptor behavior cannot certify readiness. A real Fedora findmnt regression
+  delays the initial parsing open and verifies that no acknowledgment escapes
+  before the persistent descriptor exists.
+
+  The fixed CLI helper is implemented as a preparatory boundary. It uses a pidfd
+  and signal-wakeup pipe alongside child output, so no idle timer remains after
+  readiness. Lost output or failed cleanup exits unsuccessfully. The bounded
+  readiness probe retains early child output until the baseline is acknowledged.
+  Root-model and pane integration described below remain pending; this command
+  does not activate cumulative minor 2 or read a journal.
 
   The root model starts the initial bounded JSON filesystem snapshot only after
   receiving `mount-monitor-ready`. The first snapshot is authoritative for the

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -2616,9 +2616,10 @@ the service; that method is not used by the monitor.
 
   The fixed CLI helper is implemented as a preparatory boundary. It uses a pidfd
   and signal-wakeup pipe alongside child output, so no idle timer remains after
-  readiness. A read-interest watch on the output pipe catches reader closure
-  even with no mount events, without subscribing to continuously writable
-  events. Lost output or failed cleanup exits unsuccessfully. The bounded
+  readiness. A closure-only epoll watch catches pipe/socket consumer loss
+  even with no mount events. Incoming socket data and a peer write-half-close
+  are not mistaken for loss, and neither readable nor writable readiness
+  creates an idle spin. Lost output or failed cleanup exits unsuccessfully. The bounded
   readiness probe retains early child output until the baseline is acknowledged.
   Root-model and pane integration described below remain pending; this command
   does not activate cumulative minor 2 or read a journal.

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -13,7 +13,6 @@ import io
 import json
 import os
 import re
-import select
 import selectors
 import shlex
 import shutil
@@ -9941,6 +9940,7 @@ def watch_mount_events() -> int:
     handlers = {}
     interrupted = 0
     code = 1
+    failure_detail = b"Mount monitoring is unavailable; reload storage status explicitly\n"
 
     def terminate(number, _frame):
         nonlocal interrupted
@@ -9948,6 +9948,15 @@ def watch_mount_events() -> int:
 
     try:
         with contextlib.ExitStack() as resources:
+            output_descriptor = sys.stdout.fileno()
+            output_mode = os.fstat(output_descriptor).st_mode
+            if (not stat.S_ISFIFO(output_mode)
+                    or fcntl.fcntl(output_descriptor, fcntl.F_GETFL) & os.O_ACCMODE != os.O_WRONLY):
+                # Only a write-only pipe gives this owner an idle reader-loss
+                # event. Sockets can half-close silently; O_RDWR FIFOs retain a
+                # reader themselves. Quickshell supplies the supported pipe.
+                failure_detail = b"Mount monitoring requires write-only pipe output; use a pipe consumer\n"
+                raise OSError("Unsupported mount monitor output")
             writer = control_output_writer(sys.stdout, resources)
             if writer is None:
                 raise OSError("Mount monitor requires a descriptor")
@@ -9976,17 +9985,10 @@ def watch_mount_events() -> int:
                 with selectors.DefaultSelector() as selector:
                     selector.register(wake_read, selectors.EVENT_READ)
                     selector.register(pidfd, selectors.EVENT_READ)
-                    output_descriptor = sys.stdout.fileno()
-                    output_mode = os.fstat(output_descriptor).st_mode
-                    output_events = None
-                    if stat.S_ISFIFO(output_mode) or stat.S_ISSOCK(output_mode):
-                        # HUP/ERR are reported even with no requested events.
-                        # A nested epoll descriptor lets the main selector watch
-                        # only closure, not writable readiness, incoming socket
-                        # data, or the peer shutting down its write direction.
-                        output_events = resources.enter_context(select.epoll())
-                        output_events.register(output_descriptor, 0)
-                        selector.register(output_events, selectors.EVENT_READ)
+                    if stat.S_ISFIFO(output_mode):
+                        # A write-end pipe reports EPOLLERR when its last reader
+                        # disappears. Read interest avoids a writable idle spin.
+                        selector.register(output_descriptor, selectors.EVENT_READ)
                     for stream in (process.stdout, process.stderr):
                         os.set_blocking(stream.fileno(), False)
                         selector.register(stream, selectors.EVENT_READ)
@@ -10011,7 +10013,7 @@ def watch_mount_events() -> int:
                                 continue
                             if key.fd == pidfd:
                                 raise OSError("Mount monitor exited unexpectedly")
-                            if key.fileobj is output_events:
+                            if key.fd == output_descriptor:
                                 raise OSError("Mount monitor consumer disappeared")
                             if not ready and key.fileobj is process.stdout:
                                 continue  # Retain early events until baseline acknowledgment.
@@ -10040,7 +10042,7 @@ def watch_mount_events() -> int:
         with contextlib.ExitStack() as resources:
             writer = control_output_writer(sys.stderr, resources)
             if writer is not None:
-                writer(b"Mount monitoring is unavailable; reload storage status explicitly\n")
+                writer(failure_detail)
     except (OSError, ValueError):
         pass
     return code

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -9770,6 +9770,151 @@ class UnitEventMonitor(AuthenticatedEventMonitor):
         return self.exit_code
 
 
+
+# This fresh, single-threaded child arms parent-death cleanup before replacing
+# itself with findmnt. Recheck the original parent to close the startup race.
+# Popen closes inherited nonstandard descriptors before the isolated interpreter.
+MOUNT_MONITOR_EXEC = """
+import ctypes, os, signal, sys
+libc = ctypes.CDLL(None, use_errno=True)
+if libc.prctl(1, signal.SIGKILL, 0, 0, 0) != 0:
+    sys.exit(1)
+if os.getppid() != int(sys.argv[1]):
+    sys.exit(1)
+os.execv('/usr/bin/findmnt', ['findmnt', '--poll', '--raw', '--noheadings', '--output', 'ACTION'])
+"""
+MOUNT_ACTIONS = frozenset((b"mount", b"umount", b"move", b"remount"))
+
+
+def mount_baseline_ready(process, identity) -> bool:
+    """Observe only the live, unreaped child's exact mountinfo descriptor."""
+    if locale_process_status(process) is not None:
+        raise OSError("Mount monitor exited before readiness")
+    directory = f"/proc/{process.pid}"
+    current = os.stat(directory)
+    if (current.st_dev, current.st_ino) != identity:
+        raise OSError("Mount monitor identity changed")
+    with os.scandir(directory + "/fd") as entries:
+        for entry in entries:
+            if not entry.name.isdecimal():
+                continue
+            try:
+                if os.readlink(entry.path) == directory + "/mountinfo":
+                    # Fedora util-linux opens its temporary parsing descriptor
+                    # with CLOEXEC, but poll_table's persistent fopen("r") does
+                    # not. Merely seeing mountinfo can race the first parse.
+                    with open(directory + "/fdinfo/" + entry.name, "r", encoding="ascii") as info:
+                        fields = info.read(4096).splitlines()
+                    flags = [line.split(":", 1)[1].strip() for line in fields if line.startswith("flags:")]
+                    if len(flags) == 1 and re.fullmatch(r"[0-7]+", flags[0]):
+                        if not int(flags[0], 8) & os.O_CLOEXEC:
+                            return True
+            except FileNotFoundError:
+                pass  # An unrelated startup descriptor may have just closed.
+    return False
+
+
+def watch_mount_events() -> int:
+    """Supervise one pane-owned fixed mount event stream without idle polling."""
+    if (threading.current_thread() is not threading.main_thread()
+            or signal.getsignal(signal.SIGCHLD) != signal.SIG_DFL):
+        return 1
+    process = None
+    handlers = {}
+    interrupted = 0
+    code = 1
+
+    def terminate(number, _frame):
+        nonlocal interrupted
+        interrupted = interrupted or number
+
+    try:
+        with contextlib.ExitStack() as resources:
+            writer = control_output_writer(sys.stdout, resources)
+            if writer is None:
+                raise OSError("Mount monitor requires a descriptor")
+
+            def emit(payload):
+                if writer(payload) != len(payload):
+                    raise OSError("Incomplete mount event output")
+
+            wake_read, wake_write = os.pipe2(os.O_NONBLOCK | os.O_CLOEXEC)
+            resources.callback(os.close, wake_read)
+            resources.callback(os.close, wake_write)
+            previous_wake = signal.set_wakeup_fd(wake_write)
+            resources.callback(signal.set_wakeup_fd, previous_wake)
+            for number in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+                handlers[number] = signal.signal(number, terminate)
+            try:
+                deadline = time.monotonic() + 1
+                process = subprocess.Popen(["/usr/bin/python3", "-I", "-c", MOUNT_MONITOR_EXEC,
+                    str(os.getpid())], stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE, start_new_session=True, close_fds=True,
+                    env={"PATH": "/usr/bin:/bin", "LANG": "C", "LC_ALL": "C"})
+                identity = os.stat(f"/proc/{process.pid}")
+                identity = (identity.st_dev, identity.st_ino)
+                pidfd = os.pidfd_open(process.pid)
+                resources.callback(os.close, pidfd)
+                with selectors.DefaultSelector() as selector:
+                    selector.register(wake_read, selectors.EVENT_READ)
+                    selector.register(pidfd, selectors.EVENT_READ)
+                    for stream in (process.stdout, process.stderr):
+                        os.set_blocking(stream.fileno(), False)
+                        selector.register(stream, selectors.EVENT_READ)
+                    ready = False
+                    pending = bytearray()
+                    while not interrupted:
+                        if not ready:
+                            observed = mount_baseline_ready(process, identity)
+                            if time.monotonic() >= deadline:
+                                raise OSError("Mount monitor readiness timed out")
+                            if observed:
+                                emit(b"mount-monitor-ready\n")
+                                ready = True
+                        # Readiness has one bounded startup probe. Once ready,
+                        # pipes, pidfd, and the signal wakeup are the only events.
+                        events = selector.select(None if ready else min(0.01, max(0, deadline - time.monotonic())))
+                        for key, _events in events:
+                            if interrupted:
+                                break
+                            if key.fd == wake_read:
+                                os.read(wake_read, 4096)
+                                continue
+                            if key.fd == pidfd:
+                                raise OSError("Mount monitor exited unexpectedly")
+                            if not ready and key.fileobj is process.stdout:
+                                continue  # Retain early events until baseline acknowledgment.
+                            chunk = os.read(key.fd, 4096)
+                            if not chunk or key.fileobj is process.stderr:
+                                raise OSError("Mount monitor output failed")
+                            pending.extend(chunk)
+                            while b"\n" in pending:
+                                line, _, pending = pending.partition(b"\n")
+                                if len(line) > 256 or bytes(line) not in MOUNT_ACTIONS:
+                                    raise OSError("Malformed mount event")
+                                emit(b"mount-change\t" + line + b"\n")
+                            if len(pending) > 256:
+                                raise OSError("Oversized mount event")
+            finally:
+                if process is not None:
+                    close_locale_process(process)
+    except (OSError, ValueError, SnapshotFailure):
+        pass
+    finally:
+        for number, handler in handlers.items():
+            signal.signal(number, handler)
+    if interrupted:
+        return 128 + interrupted
+    try:
+        with contextlib.ExitStack() as resources:
+            writer = control_output_writer(sys.stderr, resources)
+            if writer is not None:
+                writer(b"Mount monitoring is unavailable; reload storage status explicitly\n")
+    except (OSError, ValueError):
+        pass
+    return code
+
+
 def watch_service_events(service_kind=None) -> int:
     output_writer = None
 
@@ -9832,11 +9977,13 @@ def watch_account_events() -> int:
 
 
 def usage() -> int:
-    print(f"usage: {sys.argv[0]} snapshot | ntp-sample | time-status | watch-time | watch-updates | watch-regional time|locale | watch-accounts | watch-units printers|security | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE | timezone-set ZONE GENERATION | ntp-set enabled|disabled GENERATION | locale-set LANG=LOCALE GENERATION | accounts-open | password-open | printers-open | sources-open", file=sys.stderr)
+    print(f"usage: {sys.argv[0]} snapshot | ntp-sample | time-status | watch-mounts | watch-time | watch-updates | watch-regional time|locale | watch-accounts | watch-units printers|security | updates-refresh | updates-install-all GENERATION | watch-operation OPERATION_ID | ack-operation OPERATION_ID | updates-cancel OPERATION_ID | regional-choices timezone|locale | regional-preview ACTION VALUE | timezone-set ZONE GENERATION | ntp-set enabled|disabled GENERATION | locale-set LANG=LOCALE GENERATION | accounts-open | password-open | printers-open | sources-open", file=sys.stderr)
     return 2
 
 
 def main(argv: Sequence[str]) -> int:
+    if argv and argv[0] == "watch-mounts":
+        return watch_mount_events() if len(argv) == 1 else usage()
     if argv and argv[0] == "time-status":
         return finite_status_command(time_status_output) if len(argv) == 1 else usage()
     if argv and argv[0] == "watch-time":

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -13,6 +13,7 @@ import io
 import json
 import os
 import re
+import select
 import selectors
 import shlex
 import shutil
@@ -9860,11 +9861,15 @@ def watch_mount_events() -> int:
                     selector.register(pidfd, selectors.EVENT_READ)
                     output_descriptor = sys.stdout.fileno()
                     output_mode = os.fstat(output_descriptor).st_mode
+                    output_events = None
                     if stat.S_ISFIFO(output_mode) or stat.S_ISSOCK(output_mode):
-                        # A write-end pipe reports EPOLLERR when its last reader
-                        # disappears, even when no write or mount event occurs.
-                        # Requesting read events avoids a writable idle spin.
-                        selector.register(output_descriptor, selectors.EVENT_READ)
+                        # HUP/ERR are reported even with no requested events.
+                        # A nested epoll descriptor lets the main selector watch
+                        # only closure, not writable readiness, incoming socket
+                        # data, or the peer shutting down its write direction.
+                        output_events = resources.enter_context(select.epoll())
+                        output_events.register(output_descriptor, 0)
+                        selector.register(output_events, selectors.EVENT_READ)
                     for stream in (process.stdout, process.stderr):
                         os.set_blocking(stream.fileno(), False)
                         selector.register(stream, selectors.EVENT_READ)
@@ -9889,7 +9894,7 @@ def watch_mount_events() -> int:
                                 continue
                             if key.fd == pidfd:
                                 raise OSError("Mount monitor exited unexpectedly")
-                            if key.fd == output_descriptor:
+                            if key.fileobj is output_events:
                                 raise OSError("Mount monitor consumer disappeared")
                             if not ready and key.fileobj is process.stdout:
                                 continue  # Retain early events until baseline acknowledgment.

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -9858,6 +9858,13 @@ def watch_mount_events() -> int:
                 with selectors.DefaultSelector() as selector:
                     selector.register(wake_read, selectors.EVENT_READ)
                     selector.register(pidfd, selectors.EVENT_READ)
+                    output_descriptor = sys.stdout.fileno()
+                    output_mode = os.fstat(output_descriptor).st_mode
+                    if stat.S_ISFIFO(output_mode) or stat.S_ISSOCK(output_mode):
+                        # A write-end pipe reports EPOLLERR when its last reader
+                        # disappears, even when no write or mount event occurs.
+                        # Requesting read events avoids a writable idle spin.
+                        selector.register(output_descriptor, selectors.EVENT_READ)
                     for stream in (process.stdout, process.stderr):
                         os.set_blocking(stream.fileno(), False)
                         selector.register(stream, selectors.EVENT_READ)
@@ -9882,6 +9889,8 @@ def watch_mount_events() -> int:
                                 continue
                             if key.fd == pidfd:
                                 raise OSError("Mount monitor exited unexpectedly")
+                            if key.fd == output_descriptor:
+                                raise OSError("Mount monitor consumer disappeared")
                             if not ready and key.fileobj is process.stdout:
                                 continue  # Retain early events until baseline acknowledgment.
                             chunk = os.read(key.fd, 4096)

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -3500,7 +3500,7 @@ class DelegatedToolTests(unittest.TestCase):
 
 
 class MountMonitorTests(unittest.TestCase):
-    def start(self, body, *, delay=0, baseline=True, pass_fds=(), stdout=subprocess.PIPE):
+    def start(self, body, *, delay=0, baseline=True, pass_fds=()):
         directory = tempfile.TemporaryDirectory()
         self.addCleanup(directory.cleanup)
         path = pathlib.Path(directory.name) / "child"
@@ -3514,7 +3514,7 @@ class MountMonitorTests(unittest.TestCase):
         runner = (f"import runpy,sys\np=runpy.run_path({str(PROVIDER_PATH)!r})\n"
                   f"p['watch_mount_events'].__globals__['MOUNT_MONITOR_EXEC']={code!r}\n"
                   "sys.exit(p['watch_mount_events']())\n")
-        process = subprocess.Popen([sys.executable, "-c", runner], stdout=stdout,
+        process = subprocess.Popen([sys.executable, "-c", runner], stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE, pass_fds=pass_fds, bufsize=0)
         self.addCleanup(self.stop, process)
         deadline = time.monotonic() + 2
@@ -3533,8 +3533,7 @@ class MountMonitorTests(unittest.TestCase):
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait(timeout=2)
-        if process.stdout is not None:
-            process.stdout.close()
+        process.stdout.close()
         process.stderr.close()
 
     def row(self, process, timeout=2):
@@ -3668,27 +3667,49 @@ FILE *fopen64(const char *path, const char *mode) {
         self.assertEqual(process.wait(timeout=3), 1)
         self.gone(child)
 
-    def test_socket_data_and_half_close_preserve_monitor_until_consumer_closes(self):
-        sender, reader = socket.socketpair()
-        self.addCleanup(sender.close)
-        self.addCleanup(reader.close)
-        reader.settimeout(3)
-        process, child = self.start("time.sleep(0.6)\nos.write(1, b'mount\\n')", stdout=sender)
-        self.assertTrue(os.get_blocking(sender.fileno()), "Inherited socket flags changed")
-        sender.close()
-        self.assertEqual(reader.recv(4096), b"mount-monitor-ready\n")
-        reader.sendall(b"inbound data is not reader closure")
-        reader.shutdown(socket.SHUT_WR)
-        fields = pathlib.Path(f"/proc/{process.pid}/stat").read_text().rsplit(") ", 1)[1].split()
-        before = int(fields[11]) + int(fields[12])
-        time.sleep(0.2)
-        self.assertIsNone(process.poll(), "Live output consumer was mistaken for closure")
-        fields = pathlib.Path(f"/proc/{process.pid}/stat").read_text().rsplit(") ", 1)[1].split()
-        self.assertLessEqual(int(fields[11]) + int(fields[12]) - before, 1, "Unread socket data caused an idle spin")
-        self.assertEqual(reader.recv(4096), b"mount-change\tmount\n")
-        reader.close()
-        self.assertEqual(process.wait(timeout=3), 1)
-        self.gone(child)
+    def test_socket_outputs_are_rejected_before_starting_a_child(self):
+        for mode in ("plain", "input", "read-half", "write-half", "full-buffer"):
+            with self.subTest(mode=mode):
+                sender, reader = socket.socketpair()
+                with sender, reader, tempfile.TemporaryFile() as diagnostics, \
+                        os.fdopen(os.dup(sender.fileno()), "wb", buffering=0) as output:
+                    if mode == "input":
+                        reader.sendall(b"not a closure")
+                    elif mode == "read-half":
+                        reader.shutdown(socket.SHUT_RD)
+                    elif mode == "write-half":
+                        reader.shutdown(socket.SHUT_WR)
+                    elif mode == "full-buffer":
+                        sender.setblocking(False)
+                        try:
+                            while True:
+                                sender.send(b"x" * 4096)
+                        except BlockingIOError:
+                            pass
+                    blocking = os.get_blocking(sender.fileno())
+                    with mock.patch.object(provider.sys, "stdout", output), \
+                            mock.patch.object(provider.sys, "stderr", diagnostics), \
+                            mock.patch.object(provider.subprocess, "Popen", side_effect=AssertionError("Child started")) as spawn:
+                        self.assertEqual(provider.watch_mount_events(), 1)
+                    spawn.assert_not_called()
+                    self.assertEqual(os.get_blocking(sender.fileno()), blocking)
+                    diagnostics.seek(0)
+                    self.assertIn(b"requires write-only pipe output", diagnostics.read())
+
+    def test_regular_and_read_write_fifo_outputs_are_rejected_before_child(self):
+        with tempfile.TemporaryDirectory() as directory, tempfile.TemporaryFile() as regular:
+            fifo = pathlib.Path(directory) / "output"
+            os.mkfifo(fifo, 0o600)
+            with os.fdopen(os.open(fifo, os.O_RDWR | os.O_NONBLOCK), "wb", buffering=0) as retained_reader:
+                for output in (regular, retained_reader):
+                    with self.subTest(mode=os.fstat(output.fileno()).st_mode), tempfile.TemporaryFile() as diagnostics, \
+                            mock.patch.object(provider.sys, "stdout", output), \
+                            mock.patch.object(provider.sys, "stderr", diagnostics), \
+                            mock.patch.object(provider.subprocess, "Popen", side_effect=AssertionError("Child started")) as spawn:
+                        self.assertEqual(provider.watch_mount_events(), 1)
+                        spawn.assert_not_called()
+                        diagnostics.seek(0)
+                        self.assertIn(b"requires write-only pipe output", diagnostics.read())
 
     def test_idle_output_liveness_watch_does_not_spin(self):
         process, child = self.start("")

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -3563,6 +3563,25 @@ FILE *fopen64(const char *path, const char *mode) {
         self.assertEqual(process.wait(timeout=3), 1)
         self.gone(child)
 
+    def test_idle_output_liveness_watch_does_not_spin(self):
+        process, child = self.start("")
+        self.assertEqual(self.row(process), b"mount-monitor-ready\n")
+        def ticks():
+            fields = pathlib.Path(f"/proc/{process.pid}/stat").read_text().rsplit(") ", 1)[1].split()
+            return int(fields[11]) + int(fields[12])
+        before = ticks()
+        time.sleep(0.3)
+        self.assertLessEqual(ticks() - before, 1, "Idle mount supervisor consumed CPU ticks")
+        self.stop(process)
+        self.gone(child)
+
+    def test_idle_lost_output_consumer_stops_child_without_mount_events(self):
+        process, child = self.start("")
+        self.assertEqual(self.row(process), b"mount-monitor-ready\n")
+        process.stdout.close()
+        self.assertEqual(process.wait(timeout=3), 1)
+        self.gone(child)
+
     def test_proc_identity_change_and_exited_child_are_rejected(self):
         process = types.SimpleNamespace(pid=123)
         with mock.patch.object(provider, "locale_process_status", return_value=None), \

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -3396,7 +3396,7 @@ class DelegatedToolTests(unittest.TestCase):
 
 
 class MountMonitorTests(unittest.TestCase):
-    def start(self, body, *, delay=0, baseline=True, pass_fds=()):
+    def start(self, body, *, delay=0, baseline=True, pass_fds=(), stdout=subprocess.PIPE):
         directory = tempfile.TemporaryDirectory()
         self.addCleanup(directory.cleanup)
         path = pathlib.Path(directory.name) / "child"
@@ -3410,7 +3410,7 @@ class MountMonitorTests(unittest.TestCase):
         runner = (f"import runpy,sys\np=runpy.run_path({str(PROVIDER_PATH)!r})\n"
                   f"p['watch_mount_events'].__globals__['MOUNT_MONITOR_EXEC']={code!r}\n"
                   "sys.exit(p['watch_mount_events']())\n")
-        process = subprocess.Popen([sys.executable, "-c", runner], stdout=subprocess.PIPE,
+        process = subprocess.Popen([sys.executable, "-c", runner], stdout=stdout,
                                    stderr=subprocess.PIPE, pass_fds=pass_fds, bufsize=0)
         self.addCleanup(self.stop, process)
         deadline = time.monotonic() + 2
@@ -3429,7 +3429,8 @@ class MountMonitorTests(unittest.TestCase):
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait(timeout=2)
-        process.stdout.close()
+        if process.stdout is not None:
+            process.stdout.close()
         process.stderr.close()
 
     def row(self, process, timeout=2):
@@ -3560,6 +3561,28 @@ FILE *fopen64(const char *path, const char *mode) {
         process, child = self.start("time.sleep(0.15)\nos.write(1, b'mount\\n')")
         self.assertEqual(self.row(process), b"mount-monitor-ready\n")
         process.stdout.close()
+        self.assertEqual(process.wait(timeout=3), 1)
+        self.gone(child)
+
+    def test_socket_data_and_half_close_preserve_monitor_until_consumer_closes(self):
+        sender, reader = socket.socketpair()
+        self.addCleanup(sender.close)
+        self.addCleanup(reader.close)
+        reader.settimeout(3)
+        process, child = self.start("time.sleep(0.6)\nos.write(1, b'mount\\n')", stdout=sender)
+        self.assertTrue(os.get_blocking(sender.fileno()), "Inherited socket flags changed")
+        sender.close()
+        self.assertEqual(reader.recv(4096), b"mount-monitor-ready\n")
+        reader.sendall(b"inbound data is not reader closure")
+        reader.shutdown(socket.SHUT_WR)
+        fields = pathlib.Path(f"/proc/{process.pid}/stat").read_text().rsplit(") ", 1)[1].split()
+        before = int(fields[11]) + int(fields[12])
+        time.sleep(0.2)
+        self.assertIsNone(process.poll(), "Live output consumer was mistaken for closure")
+        fields = pathlib.Path(f"/proc/{process.pid}/stat").read_text().rsplit(") ", 1)[1].split()
+        self.assertLessEqual(int(fields[11]) + int(fields[12]) - before, 1, "Unread socket data caused an idle spin")
+        self.assertEqual(reader.recv(4096), b"mount-change\tmount\n")
+        reader.close()
         self.assertEqual(process.wait(timeout=3), 1)
         self.gone(child)
 

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -3395,6 +3395,190 @@ class DelegatedToolTests(unittest.TestCase):
             launch.assert_called_once()
 
 
+class MountMonitorTests(unittest.TestCase):
+    def start(self, body, *, delay=0, baseline=True, pass_fds=()):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        path = pathlib.Path(directory.name) / "child"
+        fixture = (f"import time\nopen({str(path)!r}, 'w').write(str(os.getpid()))\n"
+                   f"time.sleep({delay!r})\n"
+                   + ("baseline = open('/proc/self/mountinfo')\nos.set_inheritable(baseline.fileno(), True)\n" if baseline else "")
+                   + body + "\ntime.sleep(60)\n")
+        code = provider.MOUNT_MONITOR_EXEC.replace(
+            "os.execv('/usr/bin/findmnt', ['findmnt', '--poll', '--raw', '--noheadings', '--output', 'ACTION'])",
+            fixture)
+        runner = (f"import runpy,sys\np=runpy.run_path({str(PROVIDER_PATH)!r})\n"
+                  f"p['watch_mount_events'].__globals__['MOUNT_MONITOR_EXEC']={code!r}\n"
+                  "sys.exit(p['watch_mount_events']())\n")
+        process = subprocess.Popen([sys.executable, "-c", runner], stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE, pass_fds=pass_fds, bufsize=0)
+        self.addCleanup(self.stop, process)
+        deadline = time.monotonic() + 2
+        while not path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(path.exists())
+        child = int(path.read_text())
+        return process, child
+
+    @staticmethod
+    def stop(process):
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=2)
+        process.stdout.close()
+        process.stderr.close()
+
+    def row(self, process, timeout=2):
+        self.assertTrue(select.select([process.stdout], [], [], timeout)[0], "monitor output timed out")
+        return process.stdout.readline()
+
+    def gone(self, child):
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            try:
+                state = pathlib.Path(f"/proc/{child}/stat").read_text().rsplit(") ", 1)[1].split()[0]
+            except FileNotFoundError:
+                return
+            if state == "Z":  # An orphan awaits the host's reaper after parent KILL.
+                return
+            time.sleep(0.01)
+        self.fail("mount child remains running")
+
+    def test_readiness_precedes_queued_events_and_all_fixed_actions_are_preserved(self):
+        process, child = self.start("os.write(1, b'mount\\numount\\nmove\\nremount\\n')")
+        self.assertEqual(self.row(process), b"mount-monitor-ready\n")
+        for action in (b"mount", b"umount", b"move", b"remount"):
+            self.assertEqual(self.row(process), b"mount-change\t" + action + b"\n")
+        process.terminate()
+        self.assertEqual(process.wait(timeout=3), 143)
+        self.gone(child)
+
+    def test_delayed_baseline_emits_nothing_early(self):
+        process, child = self.start("", delay=0.3)
+        self.assertFalse(select.select([process.stdout], [], [], 0.1)[0])
+        self.assertEqual(self.row(process), b"mount-monitor-ready\n")
+        self.stop(process)
+        self.gone(child)
+
+    def test_real_findmnt_parsing_open_is_not_its_polling_baseline(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = pathlib.Path(directory)
+            source, library, marker = directory / "pause.c", directory / "pause.so", directory / "parsing"
+            source.write_text(r"""
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+FILE *fopen64(const char *path, const char *mode) {
+    FILE *(*original)(const char *, const char *) = dlsym(RTLD_NEXT, "fopen64");
+    FILE *result = original(path, mode);
+    if (result && strstr(path, "/mountinfo") && strchr(mode, 'e')) {
+        int fd = open(getenv("DWM_MOUNT_PARSE_MARKER"), O_WRONLY | O_CREAT, 0600);
+        if (fd >= 0) close(fd);
+        usleep(350000);
+    }
+    return result;
+}
+""")
+            subprocess.run(["cc", "-shared", "-fPIC", "-o", str(library), str(source), "-ldl"],
+                           check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            environment = {"PATH": "/usr/bin:/bin", "LC_ALL": "C", "LD_PRELOAD": str(library),
+                           "DWM_MOUNT_PARSE_MARKER": str(marker)}
+            process, child = self.start("os.execve('/usr/bin/findmnt', "
+                "['findmnt', '--poll', '--raw', '--noheadings', '--output', 'ACTION'], "
+                + repr(environment) + ")", baseline=False)
+            deadline = time.monotonic() + 1
+            while not marker.exists() and time.monotonic() < deadline:
+                time.sleep(0.005)
+            self.assertTrue(marker.exists(), "real findmnt did not reach its initial parsing open")
+            self.assertFalse(select.select([process.stdout], [], [], 0.15)[0])
+            self.assertEqual(self.row(process), b"mount-monitor-ready\n")
+            self.stop(process)
+            self.gone(child)
+
+    def test_temporary_parsing_descriptor_cannot_acknowledge_readiness(self):
+        process, child = self.start("baseline = open('/proc/self/mountinfo')\n"
+            "time.sleep(0.35)\nbaseline.close()\n"
+            "baseline = open('/proc/self/mountinfo')\nos.set_inheritable(baseline.fileno(), True)", baseline=False)
+        self.assertFalse(select.select([process.stdout], [], [], 0.2)[0])
+        self.assertEqual(self.row(process), b"mount-monitor-ready\n")
+        self.stop(process)
+        self.gone(child)
+
+    def test_missing_baseline_has_one_second_deadline_and_cleanup(self):
+        started = time.monotonic()
+        process, child = self.start("", baseline=False)
+        self.assertEqual(process.wait(timeout=3), 1)
+        self.assertLess(time.monotonic() - started, 2.8)
+        self.assertEqual(process.stdout.read(), b"")
+        self.assertIn(b"reload storage status explicitly", process.stderr.read())
+        self.gone(child)
+
+    def test_bad_output_and_unexpected_exit_fail_closed(self):
+        for body in ("os.write(1, b'unknown\\n')", "os.write(1, b'\\n')",
+                     "os.write(1, b'x' * 257)", "os.write(2, b'failure')",
+                     "sys.exit(0)"):
+            with self.subTest(body=body):
+                process, child = self.start(body)
+                self.assertEqual(process.wait(timeout=3), 1)
+                self.assertNotIn(b"mount-change", process.stdout.read())
+                self.gone(child)
+
+    def test_signal_cleanup_and_parent_death(self):
+        for number in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGKILL):
+            with self.subTest(number=number):
+                process, child = self.start("")
+                self.assertEqual(self.row(process), b"mount-monitor-ready\n")
+                process.send_signal(number)
+                expected = -number if number == signal.SIGKILL else 128 + number
+                self.assertEqual(process.wait(timeout=3), expected)
+                self.gone(child)
+
+    def test_nonstandard_descriptors_do_not_reach_child(self):
+        with tempfile.TemporaryFile() as inherited:
+            identity = os.fstat(inherited.fileno())
+            body = ("for name in os.listdir('/proc/self/fd'):\n"
+                    "    try: item = os.fstat(int(name))\n"
+                    "    except OSError: continue\n"
+                    f"    if (item.st_dev, item.st_ino) == {(identity.st_dev, identity.st_ino)!r}:\n"
+                    "        os.write(2, b'inherited descriptor')\n"
+                    "os.write(1, b'mount\\n')\n")
+            process, child = self.start(body, pass_fds=(inherited.fileno(),))
+            self.assertEqual(self.row(process), b"mount-monitor-ready\n")
+            self.assertEqual(self.row(process), b"mount-change\tmount\n")
+            self.stop(process)
+            self.gone(child)
+
+    def test_lost_output_consumer_stops_child(self):
+        process, child = self.start("time.sleep(0.15)\nos.write(1, b'mount\\n')")
+        self.assertEqual(self.row(process), b"mount-monitor-ready\n")
+        process.stdout.close()
+        self.assertEqual(process.wait(timeout=3), 1)
+        self.gone(child)
+
+    def test_proc_identity_change_and_exited_child_are_rejected(self):
+        process = types.SimpleNamespace(pid=123)
+        with mock.patch.object(provider, "locale_process_status", return_value=None), \
+                mock.patch.object(provider.os, "stat", return_value=types.SimpleNamespace(st_dev=1, st_ino=3)):
+            with self.assertRaises(OSError):
+                provider.mount_baseline_ready(process, (1, 2))
+        with mock.patch.object(provider, "locale_process_status", return_value=object()):
+            with self.assertRaises(OSError):
+                provider.mount_baseline_ready(process, (1, 2))
+
+    def test_fixed_command_rejects_arguments(self):
+        result = subprocess.run([str(PROVIDER_PATH), "watch-mounts", "other"], capture_output=True)
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(result.stdout, b"")
+
+
 class UpdateEventMonitorTests(unittest.TestCase):
     def monitor(self):
         class BusError(Exception):


### PR DESCRIPTION
Add a fixed read-only `watch-mounts` helper for the System Settings storage view. It acknowledges findmnt's persistent mount-table baseline before emitting bounded change records, and owns child cleanup across normal closure, signals, lost output and parent death. The initial temporary parsing descriptor cannot certify readiness.

The helper requires write-only pipe output, as supplied by Quickshell. Other output types are rejected before child creation because they cannot reliably expose idle consumer loss. Shared operation writers retain their separate output support. This PR adds no visible controls or cumulative protocol activation; #286 provides that integration.

Validation:
- Full managed gate passed through all repository, build, install and release checks; the earlier package-test SIGPIPE was fixed in merged #283 and the affected/remaining gates passed on the updated base.
- All 23 final mount/assembler tests pass: 15 mount-monitor cases and 8 information cases. They include real Fedora findmnt baseline timing, signal/parent-death cleanup, descriptor isolation, idle pipe closure/CPU, and pre-child rejection of sockets and self-retaining read/write FIFOs.
- A fresh private mount namespace produced real mount and unmount events, then verified idle pipe-consumer loss and bounded exit. No host mounts changed.
- Documentation build and final independent Codex review passed with no actionable findings.

Readiness depends on the verified Fedora util-linux descriptor behavior. Unsupported readiness remains an explicit failure.
