### PR TITLE
feat(system): assemble bounded information provider records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ versions from `config.mk`.
 
 ### Changed
 
+- Assemble internal system information, filesystem, security, and diagnostics
+  records with isolated failures and complete filesystem-list bounds. Public
+  protocol activation and visible-pane integration remain pending.
+
 - Show unknown automatic-lock status in Power Settings and Control Center when
   live evidence is partial or unavailable, instead of displaying saved fallback
   values as enabled or disabled.

--- a/TASKS.md
+++ b/TASKS.md
@@ -491,6 +491,12 @@ Acceptance:
 
 ### INFO-RECOVERY-001: Information, Diagnostics, and Recovery
 
+The internal information formatter now assembles all nineteen information,
+storage, and security states, four fixed providers, and in-process health
+navigation. Reader failures remain owner-scoped, filesystem lists are buffered
+against their complete encoded budget, and diagnostics do not depend on journal
+admission. Public minor 2 and visible-pane lifecycle integration remain pending.
+
 The shared power helper now provides a fixed read-only `power-lock-snapshot`
 using the same formatter and existing power status owner as `power-snapshot`.
 The internal system-information reader validates its versioned lock record,

--- a/docs/P6-SYSTEM-MANAGEMENT.md
+++ b/docs/P6-SYSTEM-MANAGEMENT.md
@@ -899,6 +899,14 @@ This reader adds no command, mutation, Settings control, or protocol minor.
 
 ### System Information and Filesystems
 
+The internal record assembler combines the fixed readers into the complete
+information, storage, security, and diagnostics record set. It preserves exact
+decimal counters, emits missing observations explicitly, isolates source
+failures, and discards an entire filesystem list if its encoded reservation is
+exceeded. Health navigation requires no journal admission. This formatter is
+not called by startup recovery and does not yet activate snapshot minor 2;
+visible-pane monitor readiness remains the integrating caller's responsibility.
+
 The information snapshot uses only these fixed sources:
 
 - `/etc/os-release` is capped at 64 KiB and contributes only `PRETTY_NAME` and

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -569,8 +569,7 @@ def parse_filesystem_information(data: bytes) -> FilesystemInformation:
             partial = True
             continue
         if len(seen) >= FILESYSTEM_RECORDS:
-            partial = True
-            continue
+            raise SnapshotFailure("malformed", "Filesystem inventory exceeds its record limit")
         seen.add(identifier)
         display = []
         try:
@@ -6280,6 +6279,8 @@ def build_information_snapshot(sources: InformationSnapshotSources) -> list[str]
             (sources.hardware, tuple(HARDWARE_INFORMATION_FIELDS.values()))):
         try:
             values = read()
+        except InterruptedError:
+            raise
         except (OSError, SnapshotFailure) as failure:
             values = dict.fromkeys(identifiers, information_unknown(failure))
         for identifier in identifiers:
@@ -6289,6 +6290,8 @@ def build_information_snapshot(sources: InformationSnapshotSources) -> list[str]
     for identifier in INFORMATION_SECURITY_IDS:
         try:
             value = sources.security(identifier)
+        except InterruptedError:
+            raise
         except (OSError, SnapshotFailure) as failure:
             value = information_unknown(failure)
         state("security", identifier, value)
@@ -6312,6 +6315,8 @@ def build_information_snapshot(sources: InformationSnapshotSources) -> list[str]
             if size > 384 * 1024:
                 raise SnapshotFailure("malformed", "Filesystem inventory exceeds its byte limit")
             filesystem_lines.append(line)
+    except InterruptedError:
+        raise
     except (OSError, SnapshotFailure) as failure:
         filesystems = FilesystemInformation(information_unknown(failure))
         filesystem_lines = []

--- a/scripts/dwm-system-management
+++ b/scripts/dwm-system-management
@@ -6232,6 +6232,118 @@ def read_recovery_snapshot(backend: PackageKitBackend) -> RecoverySnapshot:
         return RecoverySnapshot(prior_restart=prior_restart, failures=tuple(failures + [failure]))
 
 
+INFORMATION_LOCAL_IDS = (
+    "os-name", "os-version", "kernel-release", "architecture", "cpu-model",
+    "logical-cpus", "memory-total-bytes", "memory-available-bytes",
+    "swap-total-bytes", "swap-free-bytes", "uptime-seconds",
+)
+INFORMATION_SECURITY_IDS = ("selinux", "secure-boot", "firewalld", "root-encryption", "screen-lock")
+
+
+class InformationSnapshotSources:
+    """Fixed readers, invoked only when an information snapshot is requested."""
+
+    def local(self):
+        return read_local_information()
+
+    def hardware(self):
+        return read_hardware_information()
+
+    def filesystems(self):
+        return read_filesystem_information()
+
+    def security(self, identifier):
+        readers = {"selinux": read_selinux_status, "secure-boot": read_secure_boot_status,
+            "firewalld": read_firewalld_status, "root-encryption": read_root_encryption,
+            "screen-lock": read_screen_lock}
+        return readers[identifier]()
+
+
+def build_information_snapshot(sources: InformationSnapshotSources) -> list[str]:
+    """Assemble the closed information records without journal or action admission.
+
+    This internal formatter deliberately does not activate a snapshot minor or
+    initiate reads from startup recovery. The caller owns visible-pane readiness.
+    """
+    groups = {owner: {"states": [], "errors": [], "statuses": []}
+              for owner in ("information", "storage", "security")}
+
+    def state(owner, identifier, value):
+        group = groups[owner]
+        group["statuses"].append(value.status)
+        group["states"].append("\t".join(("state", identifier, value.status,
+            clean_text(value.value, truncate=False), clean_text(value.detail))))
+        if value.error_code:
+            group["errors"].append("\t".join(("error", owner, value.error_code, clean_text(value.detail))))
+
+    for read, identifiers in ((sources.local, INFORMATION_LOCAL_IDS),
+            (sources.hardware, tuple(HARDWARE_INFORMATION_FIELDS.values()))):
+        try:
+            values = read()
+        except (OSError, SnapshotFailure) as failure:
+            values = dict.fromkeys(identifiers, information_unknown(failure))
+        for identifier in identifiers:
+            state("information", identifier, values.get(identifier, information_unknown(
+                SnapshotFailure("malformed", "Information reader omitted a required state"))))
+
+    for identifier in INFORMATION_SECURITY_IDS:
+        try:
+            value = sources.security(identifier)
+        except (OSError, SnapshotFailure) as failure:
+            value = information_unknown(failure)
+        state("security", identifier, value)
+
+    filesystem_lines = []
+    try:
+        filesystems = sources.filesystems()
+        # Buffer the complete encoded list before publishing its summary. This
+        # budget includes record prefixes, separators, and terminating newlines.
+        if len(filesystems.rows) > FILESYSTEM_RECORDS:
+            raise SnapshotFailure("malformed", "Filesystem inventory exceeds its record limit")
+        seen, size = set(), 0
+        for row in filesystems.rows:
+            if row.mount_id in seen:
+                raise SnapshotFailure("malformed", "Filesystem inventory repeats a mount identity")
+            seen.add(row.mount_id)
+            fields = ("filesystem", row.mount_id, row.status, row.source, row.target,
+                row.fstype, row.size_bytes, row.used_bytes, row.available_bytes, row.detail)
+            line = "\t".join(clean_text(field, truncate=False) for field in fields)
+            size += len(line.encode("utf-8")) + 1
+            if size > 384 * 1024:
+                raise SnapshotFailure("malformed", "Filesystem inventory exceeds its byte limit")
+            filesystem_lines.append(line)
+    except (OSError, SnapshotFailure) as failure:
+        filesystems = FilesystemInformation(information_unknown(failure))
+        filesystem_lines = []
+    state("storage", "filesystem-summary", filesystems.summary)
+
+    lines = []
+    for owner, group in groups.items():
+        statuses = group["statuses"]
+        if all(value == "available" for value in statuses) and not group["errors"]:
+            status = "available"
+        elif any(value in {"available", "partial"} for value in statuses):
+            status = "partial"
+        elif all(value == "unsupported" for value in statuses):
+            status = "unsupported"
+        elif all(value == "restricted" for value in statuses):
+            status = "restricted"
+        else:
+            status = "unavailable"
+        lines.append("\t".join(("provider", owner, status, "read-only",
+            "dwm-system-management", "Bounded read-only observations; inspect individual state details")))
+        lines.extend(group["states"])
+        if owner == "storage":
+            lines.extend(filesystem_lines)
+        lines.extend(dict.fromkeys(group["errors"]))
+    lines.extend((
+        "provider\tdiagnostics\tavailable\tuser-session\tdwm-system-health\tExisting health scan, diagnostics, and fixed repair workflow",
+        "action\thealth-open\tavailable\tuser-session\tdiagnostics\tOpen system health\tOpen the existing health view and read-only scan; repairs require separate confirmation",
+    ))
+    validate_snapshot_size(lines)
+    return lines
+
+
 class NativeSnapshotSources:
     """Fixed read-only sources; construction neither reads state nor starts tools."""
 

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -80,6 +80,28 @@ class InformationSnapshotTests(unittest.TestCase):
         self.assertEqual(rows(result, "action")[0][2], "available")
         self.assertEqual(len([row for row in rows(result, "error") if row[1] == "information"]), 1)
 
+    def test_interruption_stops_all_following_sources(self):
+        for reader in ("local", "hardware", "security", "filesystems"):
+            with self.subTest(reader=reader):
+                source = self.sources()
+                getattr(source, reader).side_effect = InterruptedError("Canceled")
+                with self.assertRaises(InterruptedError):
+                    provider.build_information_snapshot(source)
+                if reader in ("local", "hardware", "security"):
+                    source.filesystems.assert_not_called()
+                if reader in ("local", "hardware"):
+                    source.security.assert_not_called()
+
+    def test_real_parser_overflow_discards_complete_inventory(self):
+        source = self.sources()
+        data = json.dumps({"filesystems": [{"id": index, "source": "/dev/test", "target": "/mnt/test",
+            "fstype": "ext4", "size": 10, "used": 2, "avail": 8} for index in range(257)]}).encode()
+        source.filesystems.side_effect = lambda: provider.parse_filesystem_information(data)
+        result = provider.build_information_snapshot(source)
+        self.assertEqual(rows(result, "filesystem"), [])
+        self.assertTrue(any(row[1:3] == ["storage", "malformed"] for row in rows(result, "error")))
+        self.assertEqual(len(rows(result, "state")), 19)
+
     def test_missing_state_is_explicit_and_owner_scoped(self):
         source = self.sources()
         del source.local.return_value["cpu-model"]
@@ -616,10 +638,8 @@ class FilesystemInformationTests(unittest.TestCase):
         self.assertEqual(result.summary.status, "partial")
         result = self.parse([self.row(index) for index in range(256)])
         self.assertEqual((result.summary.status, result.summary.value), ("available", "256"))
-        result = self.parse([self.row(index) for index in range(257)] + [self.row(0)])
-        self.assertEqual(result.summary.status, "partial")
-        self.assertEqual(len(result.rows), 255)
-        self.assertNotIn("0", [row.mount_id for row in result.rows])
+        with self.assertRaisesRegex(provider.SnapshotFailure, "record limit"):
+            self.parse([self.row(index) for index in range(257)] + [self.row(0)])
 
     def test_invalid_json_shape_duplicate_keys_numbers_and_utf8(self):
         for data in (b"", b"[]", b"{}", b'{"filesystems":null}', b'{"filesystems": [], "filesystems": []}',

--- a/tests/test-system-management.py
+++ b/tests/test-system-management.py
@@ -42,6 +42,90 @@ sys.modules[SPEC.name] = provider
 SPEC.loader.exec_module(provider)
 
 
+class InformationSnapshotTests(unittest.TestCase):
+    def sources(self):
+        source = mock.Mock(spec=provider.InformationSnapshotSources)
+        source.local.return_value = {identifier: provider.InformationState("available", "1", "Local")
+            for identifier in provider.INFORMATION_LOCAL_IDS}
+        source.hardware.return_value = {identifier: provider.InformationState("available", "Hardware", "Host")
+            for identifier in provider.HARDWARE_INFORMATION_FIELDS.values()}
+        source.security.side_effect = lambda identifier: provider.InformationState("available",
+            {"selinux": "enforcing", "root-encryption": "encrypted"}.get(identifier, "enabled"), "Security")
+        source.filesystems.return_value = provider.FilesystemInformation(
+            provider.information_number(1, "Filesystems"), (provider.FilesystemRow(
+                "12", "available", "/dev/test", "/", "ext4", "18446744073709551615", "2", "3", "Bytes"),))
+        return source
+
+    def test_complete_records_and_exact_counters_without_admission(self):
+        with mock.patch.object(provider, "open_journal_directory", side_effect=AssertionError("Journal opened")):
+            result = provider.build_information_snapshot(self.sources())
+        self.assertEqual(len(rows(result, "provider")), 4)
+        self.assertEqual(len(rows(result, "state")), 19)
+        self.assertEqual([row[1] for row in rows(result, "action")], ["health-open"])
+        self.assertEqual(rows(result, "filesystem")[0][6], "18446744073709551615")
+        self.assertTrue(all(row[2] == "available" for row in rows(result, "provider")))
+        self.assertFalse(rows(result, "system-management-protocol"))
+
+    def test_source_failures_preserve_other_states_and_navigation(self):
+        source = self.sources()
+        source.hardware.side_effect = provider.SnapshotFailure("timeout", "Hardware timed out", "unavailable")
+        source.security.side_effect = lambda identifier: (provider.InformationState("restricted", "unknown", "Denied", "permission-denied")
+            if identifier == "selinux" else provider.InformationState("available", "enabled", "Security"))
+        result = provider.build_information_snapshot(source)
+        states = {row[1]: row for row in rows(result, "state")}
+        self.assertEqual(states["hardware-model"][2:4], ["unavailable", "unknown"])
+        self.assertEqual(states["os-name"][2], "available")
+        self.assertEqual(states["selinux"][2:4], ["restricted", "unknown"])
+        self.assertEqual(states["firewalld"][2], "available")
+        self.assertEqual(rows(result, "action")[0][2], "available")
+        self.assertEqual(len([row for row in rows(result, "error") if row[1] == "information"]), 1)
+
+    def test_missing_state_is_explicit_and_owner_scoped(self):
+        source = self.sources()
+        del source.local.return_value["cpu-model"]
+        result = provider.build_information_snapshot(source)
+        state = next(row for row in rows(result, "state") if row[1] == "cpu-model")
+        self.assertEqual(state[2:4], ["partial", "unknown"])
+        self.assertEqual(len(rows(result, "state")), 19)
+
+    def test_partial_filesystem_subset_retains_unknown_summary(self):
+        source = self.sources()
+        source.filesystems.return_value = replace(source.filesystems.return_value,
+            summary=provider.InformationState("partial", "unknown", "Incomplete", "malformed"))
+        result = provider.build_information_snapshot(source)
+        self.assertEqual(len(rows(result, "filesystem")), 1)
+        self.assertIn("state\tfilesystem-summary\tpartial\tunknown\tIncomplete", result)
+
+    def test_invalid_filesystem_list_is_discarded_atomically(self):
+        for kind in ("duplicate", "records", "bytes"):
+            with self.subTest(kind=kind):
+                source = self.sources()
+                row = source.filesystems.return_value.rows[0]
+                if kind == "duplicate":
+                    inventory = (row, row)
+                else:
+                    inventory = tuple(replace(row, mount_id=str(index),
+                        source="a" * 512, target="b" * 512, fstype="c" * 512, detail="d" * 512)
+                        for index in range(257 if kind == "records" else 256))
+                source.filesystems.return_value = replace(source.filesystems.return_value, rows=inventory)
+                result = provider.build_information_snapshot(source)
+                self.assertEqual(rows(result, "filesystem"), [])
+                self.assertTrue(any(row[1:4] == ["filesystem-summary", "partial", "unknown"] for row in rows(result, "state")))
+                self.assertTrue(any(row[1:3] == ["storage", "malformed"] for row in rows(result, "error")))
+                self.assertEqual(len(rows(result, "state")), 19)
+
+    def test_all_unavailable_statuses_aggregate_without_hiding_peers(self):
+        for status in ("restricted", "unsupported", "unavailable", "partial"):
+            with self.subTest(status=status):
+                source = self.sources()
+                source.security.side_effect = lambda _identifier: provider.InformationState(status, "unknown", "Absent", "missing-provider")
+                result = provider.build_information_snapshot(source)
+                providers = {row[1]: row for row in rows(result, "provider")}
+                self.assertEqual(providers["security"][2], status)
+                self.assertEqual(providers["information"][2], "available")
+                self.assertEqual(providers["diagnostics"][2], "available")
+
+
 class FixtureBackend:
     def __init__(
         self,


### PR DESCRIPTION
Assemble the existing bounded information readers into a complete internal record set: nineteen states, four fixed providers, filesystem rows, and the read-only health navigation offer. Source failures remain isolated, exact 64-bit counters stay strings, and an oversized or duplicate filesystem list is discarded atomically. Diagnostics availability is independent of journal admission.

Based on main after #282. This boundary does not activate a public protocol minor or launch new reads from startup recovery; the following integration PR owns pane readiness and cumulative consumer activation.

Validation:
- Complete `scripts/run-tests` passed: 659 backend tests, native QML and nested-X11 workflows, build, shell/format, staged and repeated install, and release archive checks.
- Thirty focused assembly/local/hardware tests passed; the six assembly regressions also passed after clarifying the health navigation detail.
- All 25 affected assembly/filesystem tests pass after preserving interruption through every assembler boundary and rejecting real parser overflow; both regressions failed before the fix.
- Documentation build and independent Codex review passed with no actionable findings.
