### PR TITLE
fix(kickstart): prevent gearlever failure from aborting post phase

### DIFF
--- a/dwm-fedora-nvidia.ks
+++ b/dwm-fedora-nvidia.ks
@@ -215,7 +215,7 @@ install -m 0440 /dev/null "$install_sudoers"
 printf '%s ALL=(ALL) NOPASSWD: ALL\n' "$target_user" > "$install_sudoers"
 
 su - "$target_user" -c 'cd "$HOME/.local/share/dwm-titus" && ./install.sh --non-interactive --profile core'
-su - "$target_user" -c 'cd "$HOME/.local/share/dwm-titus" && scripts/install-gearlever'
+su - "$target_user" -c 'cd "$HOME/.local/share/dwm-titus" && scripts/install-gearlever' || true
 
 if getent group gamemode >/dev/null 2>&1; then
 	usermod -aG gamemode "$target_user"

--- a/dwm-fedora.ks
+++ b/dwm-fedora.ks
@@ -206,7 +206,7 @@ install -m 0440 /dev/null "$install_sudoers"
 printf '%s ALL=(ALL) NOPASSWD: ALL\n' "$target_user" > "$install_sudoers"
 
 su - "$target_user" -c 'cd "$HOME/.local/share/dwm-titus" && ./install.sh --non-interactive --profile core'
-su - "$target_user" -c 'cd "$HOME/.local/share/dwm-titus" && scripts/install-gearlever'
+su - "$target_user" -c 'cd "$HOME/.local/share/dwm-titus" && scripts/install-gearlever' || true
 
 if getent group gamemode >/dev/null 2>&1; then
 	usermod -aG gamemode "$target_user"


### PR DESCRIPTION
## Summary
During Anaconda installations, `scripts/install-gearlever` executes `flatpak install --user`. Inside the Anaconda `%post` chroot environment, the target user's `systemd --user` session bus is inactive, causing the user-scoped flatpak installation to fail with:
`Error: Failed to install it.mijorus.gearlever: User 1000 does not exist`

Because `dwm-fedora.ks` and `dwm-fedora-nvidia.ks` enforce `%post --erroronfail` with `set -eu`, this uncaught failure causes Anaconda to crash into a `ScriptError: 8` exception, freezing the Anaconda UI indefinitely on "Running post-installation scripts".
This fix mirrors `install.sh` (which already wraps Gear Lever installation in `|| true` on line 410), allowing Anaconda to complete the post-installation phase and present the reboot screen cleanly.

## Key Changes
- `dwm-fedora.ks`: Append `|| true` to `scripts/install-gearlever`.
- `dwm-fedora-nvidia.ks`: Append `|| true` to `scripts/install-gearlever`.

## Validation
- [x] `tests/test-kickstart-variants.sh` passes.
- [x] Validated via QEMU UEFI installation from a rebuilt ISO: Anaconda completed `%post` and reached the reboot prompt cleanly.

## Screenshot
<img width="1234" height="498" alt="screenshot-2026-09-10_04-19-08" src="https://github.com/user-attachments/assets/9517fc48-0655-421a-9c09-8a4648c59681" />
