### PR TITLE
Reduce Settings startup work and tighten local review loops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,10 @@ package or installation path.
   until clean before pushing. Reuse passing checks for unchanged code; rerun
   the full relevant gate after base integration or changes that invalidate it.
   Record the reviewed commit, commands, results, and manual evidence in the PR.
+- Give each review invocation a local evidence file with the base, reviewed
+  tree/commit, command results, log paths, and explicitly reused coverage. Use
+  the custom prompt in `CONTRIBUTING.md` when supplying this context. Reviewers
+  should repeat long tests only for invalidated evidence or a concrete concern.
 - After publishing, verify the remote head matches the locally validated
   content and inspect unresolved review threads. Resolve actionable feedback
   before merging. Hosted CI runs on `main` as a post-merge safety net, with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ versions from `config.mk`.
 
 ### Changed
 
+- Create Settings panes on first visit and retain them for subsequent navigation;
+  avoid repeating section discovery while typing a search for the same section.
+- Pass local validation evidence into review and add a focused native Settings
+  responsiveness gate to shorten fix/review iterations before Phase 7.
+
 - Replace raw System update logs and audit hashes with current-package progress,
   separate overall progress, and concise verified completion messages.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ submitting a pull request.
 | C or build configuration | `scripts/run-tests make clean all`, then `scripts/run-tests` |
 | Shell or installer | `scripts/run-tests make check-shell check-format` and focused tests |
 | X11 behavior | `scripts/run-tests make check-xvfb-runtime check-monitor-tags` |
+| Settings loading, search, and section navigation | `scripts/run-tests make check-quickshell-settings-responsiveness-xvfb` plus the full Settings runtime gate |
 | Quickshell QML | `scripts/run-tests make check-quickshell-qml` plus real or nested X11 runtime validation |
 | System update UI | `scripts/run-tests tests/test-quickshell-update-ui-xvfb.sh` for the focused native fixture, plus configured QML lint |
 | Documentation | `npm --prefix docs ci`, then `npm --prefix docs run build` |
@@ -92,6 +93,27 @@ validation before pushing so fixes do not require another hosted CI run:
 4. Record the final commit, exact passing commands, reused evidence, runtime
    environment, and any gaps in the PR. Push once the loop is clean, verify
    the remote head, and inspect unresolved review threads before merging.
+
+Give the reviewer the evidence before starting it. A short local evidence file
+should name the base and reviewed tree/commit, changed paths, exact commands,
+exit results, log paths, runtime environment, and any coverage reused from an
+unchanged base. Keep logs outside the checkout. Use a custom review prompt when
+passing evidence (the CLI does not combine a custom prompt with `--base` or
+`--uncommitted`):
+
+```sh
+codex review 'Review the complete diff against origin/main, including uncommitted
+and untracked changes. Read /absolute/path/to/local-evidence.md first. Reuse its
+passing evidence where the code and assumptions are unchanged. Run additional
+checks when a finding, changed behavior, or coverage gap requires them. Report
+findings directly; do not launch nested reviews.'
+```
+
+After a fix, update the evidence and review the affected diff and its integration
+with the original change. A repeated long native suite is necessary only when
+the fix invalidates its evidence. Do not substitute a focused test for unrun
+required coverage; the new responsiveness target accelerates iteration while
+the existing Settings suite still validates real providers and interactions.
 
 Local validation and independent Codex review are the normal merge gate.
 Automatic build/test and documentation workflows run after merges to `main`;

--- a/Makefile
+++ b/Makefile
@@ -456,6 +456,9 @@ check-quickshell-tray:
 check-quickshell-health-xvfb:
 	tests/test-quickshell-health-xvfb.sh
 
+check-quickshell-settings-responsiveness-xvfb:
+	tests/test-quickshell-settings-responsiveness-xvfb.sh
+
 check-quickshell-qml:
 	scripts/quickshell-qmllint --root config/quickshell
 
@@ -628,6 +631,7 @@ check:
 	$(MAKE) check-quickshell-defaults-model
 	$(MAKE) check-quickshell-appearance-model
 	$(MAKE) check-quickshell-settings-xvfb
+	$(MAKE) check-quickshell-settings-responsiveness-xvfb
 	$(MAKE) check-quickshell-design-system
 	$(MAKE) check-quickshell-large-surfaces
 	$(MAKE) check-quickshell-large-surfaces-xvfb
@@ -667,5 +671,5 @@ check:
 	check-display-profile check-display-setup check-fedora-iso-builder check-fedora-packages check-fedora-platform check-format check-install \
 	check-gearlever-install check-herdr-install check-install-manifest check-install-preservation check-kickstart check-lock \
 	check-session-guards check-session-migration check-screenshot check-release-helper check-shell check-webapp-launch check-diagnostics check-status check-system-health check-system-management check-quickshell-system-management check-settings \
-	check-quickshell-launcher check-quickshell-controls check-quickshell-audio check-quickshell-controlcenter check-quickshell-power check-quickshell-power-backend check-quickshell-power-model check-quickshell-session-actions check-quickshell-defaults-model check-quickshell-appearance-model check-quickshell-design-system check-quickshell-large-surfaces check-quickshell-large-surfaces-xvfb check-quickshell-panel-menus check-quickshell-panel-settings check-quickshell-command-menu check-quickshell-notifications check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-network check-quickshell-connectivity check-quickshell-qml check-lightdm-config check-terminal check-xvfb-runtime install install-system install-user \
+	check-quickshell-launcher check-quickshell-controls check-quickshell-audio check-quickshell-controlcenter check-quickshell-power check-quickshell-power-backend check-quickshell-power-model check-quickshell-session-actions check-quickshell-defaults-model check-quickshell-appearance-model check-quickshell-design-system check-quickshell-large-surfaces check-quickshell-large-surfaces-xvfb check-quickshell-panel-menus check-quickshell-panel-settings check-quickshell-command-menu check-quickshell-notifications check-quickshell-tray check-quickshell-health-xvfb check-quickshell-settings-xvfb check-quickshell-settings-responsiveness-xvfb check-quickshell-network check-quickshell-connectivity check-quickshell-qml check-lightdm-config check-terminal check-xvfb-runtime install install-system install-user \
 	install-cursors native release release-check uninstall

--- a/TASKS.md
+++ b/TASKS.md
@@ -2,6 +2,9 @@
 
 ## Phase 7: Fedora Image and Release Qualification
 
+Pre-Phase 7 responsiveness and local-review maintenance is recorded in
+`docs/PRE-P7-MAINTENANCE.md`. Phase 7 remains on hold until explicitly started.
+
 Phase 6 is complete. Its acceptance evidence and remaining hardware/service
 limitations are recorded in `docs/P6-QUALIFICATION.md`. Phase 7 is queued;
 implementation has not started. Keep each boundary independently reviewable and
@@ -71,7 +74,8 @@ limitation; unavailable hardware is not reported as tested.
   required for the selected release candidates.
 - [ ] Review release notes, upgrade commands, recovery documentation and the
   completed evidence matrix.
-- [ ] Complete independent review and exact-head hosted checks for each PR.
+- [ ] Complete independent local review and applicable local validation for each PR;
+  verify the published head matches the reviewed content.
 - [ ] Request release/publication authorization if it has not already been given.
 
 Acceptance: release artifacts and procedures are reproducible and review-ready,

--- a/config/quickshell/settings/DeferredSettingsPane.qml
+++ b/config/quickshell/settings/DeferredSettingsPane.qml
@@ -1,0 +1,23 @@
+import QtQuick
+
+Loader {
+    id: root
+
+    required property bool selected
+    required property bool windowVisible
+    property bool visited: false
+
+    // Keep visited items alive: switching sections must preserve local drafts,
+    // scroll positions and bindings to the independently owned operation models.
+    active: visited
+    asynchronous: true
+    visible: selected && status === Loader.Ready
+    focus: true
+
+    function loadIfSelected() {
+        if (windowVisible && selected) visited = true;
+    }
+    onSelectedChanged: loadIfSelected()
+    onWindowVisibleChanged: loadIfSelected()
+    Component.onCompleted: loadIfSelected()
+}

--- a/config/quickshell/settings/SettingsModel.qml
+++ b/config/quickshell/settings/SettingsModel.qml
@@ -661,11 +661,15 @@ Scope {
     }
 
     function setSearch(value) {
+        if (root.searchQuery === value) return;
         root.searchQuery = value;
         root.selectedIndex = 0;
         if (root.filteredSections.length > 0) {
-            root.selectedSectionId = root.filteredSections[0].id;
-            root.activateSection(root.selectedSectionId);
+            const id = root.filteredSections[0].id;
+            if (root.selectedSectionId !== id) {
+                root.selectedSectionId = id;
+                root.activateSection(id);
+            }
         }
     }
 
@@ -682,8 +686,10 @@ Scope {
         for (let index = 0; index < root.filteredSections.length; index++) {
             if (root.filteredSections[index].id === id) {
                 root.selectedIndex = index;
-                root.selectedSectionId = id;
-                root.activateSection(id);
+                if (root.selectedSectionId !== id) {
+                    root.selectedSectionId = id;
+                    root.activateSection(id);
+                }
                 return;
             }
         }
@@ -693,8 +699,11 @@ Scope {
         const sections = root.filteredSections;
         if (sections.length === 0) return;
         root.selectedIndex = (root.selectedIndex + delta + sections.length) % sections.length;
-        root.selectedSectionId = sections[root.selectedIndex].id;
-        root.activateSection(root.selectedSectionId);
+        const id = sections[root.selectedIndex].id;
+        if (root.selectedSectionId !== id) {
+            root.selectedSectionId = id;
+            root.activateSection(id);
+        }
     }
 
     function parseDiscovery(text) {
@@ -737,6 +746,8 @@ Scope {
     }
 
     function refresh() {
+        if (root.selectedSectionId === "displays") root.refreshDisplays();
+        if (root.selectedSectionId === "input") root.refreshInput();
         if (root.visible && root.selectedSectionId === "appearance" && root.accessibilityModel)
             root.accessibilityModel.refresh();
         if (root.visible && root.selectedSectionId === "appearance" && root.panelSettingsModel)
@@ -764,7 +775,7 @@ Scope {
         root.searchQuery = "";
         root.selectedIndex = 0;
         root.selectedSectionId = root.sections[0].id;
-        root.refresh();
+        root.refreshCapabilities();
         root.activateSection(root.selectedSectionId);
 		root.recoverDisplayPreview();
 		root.recoverInputPreview();

--- a/config/quickshell/settings/SettingsWindow.qml
+++ b/config/quickshell/settings/SettingsWindow.qml
@@ -328,82 +328,109 @@ FloatingWindow {
                                 color: Theme.popupBorder
                             }
 
-                            DisplaySettingsPane {
+                            DeferredSettingsPane {
                                 Layout.fillWidth: true
                                 Layout.fillHeight: true
-                                visible: root.settingsModel.selectedSectionId === "displays"
-                                settingsModel: root.settingsModel
+                                selected: root.settingsModel.selectedSectionId === "displays"
+                                windowVisible: root.visible
+                                sourceComponent: DisplaySettingsPane {
+                                    settingsModel: root.settingsModel
+                                }
                             }
 
-                            InputSettingsPane {
+                            DeferredSettingsPane {
                                 Layout.fillWidth: true
                                 Layout.fillHeight: true
-                                visible: root.settingsModel.selectedSectionId === "input"
-                                settingsModel: root.settingsModel
+                                selected: root.settingsModel.selectedSectionId === "input"
+                                windowVisible: root.visible
+                                sourceComponent: InputSettingsPane {
+                                    settingsModel: root.settingsModel
+                                }
                             }
 
-                            NetworkSettingsPane {
+                            DeferredSettingsPane {
                                 Layout.fillWidth: true
                                 Layout.fillHeight: true
-                                visible: root.settingsModel.selectedSectionId === "network"
-                                networkModel: root.networkModel
+                                selected: root.settingsModel.selectedSectionId === "network"
+                                windowVisible: root.visible
+                                sourceComponent: NetworkSettingsPane {
+                                    networkModel: root.networkModel
+                                }
                             }
 
-                            BluetoothSettingsPane {
+                            DeferredSettingsPane {
                                 Layout.fillWidth: true
                                 Layout.fillHeight: true
-                                visible: root.settingsModel.selectedSectionId === "bluetooth"
-                                bluetoothModel: root.bluetoothModel
+                                selected: root.settingsModel.selectedSectionId === "bluetooth"
+                                windowVisible: root.visible
+                                sourceComponent: BluetoothSettingsPane {
+                                    bluetoothModel: root.bluetoothModel
+                                }
                             }
 
-                            AudioSettingsPane {
+                            DeferredSettingsPane {
                                 Layout.fillWidth: true
                                 Layout.fillHeight: true
-                                visible: root.settingsModel.selectedSectionId === "audio"
-                                controlsModel: root.controlsModel
+                                selected: root.settingsModel.selectedSectionId === "audio"
+                                windowVisible: root.visible
+                                sourceComponent: AudioSettingsPane {
+                                    controlsModel: root.controlsModel
+                                }
                             }
 
-                            PowerSettingsPane {
+                            DeferredSettingsPane {
                                 Layout.fillWidth: true
                                 Layout.fillHeight: true
-                                visible: root.settingsModel.selectedSectionId === "power"
-                                powerModel: root.powerModel
-                                powerMenuModel: root.powerMenuModel
+                                selected: root.settingsModel.selectedSectionId === "power"
+                                windowVisible: root.visible
+                                sourceComponent: PowerSettingsPane {
+                                    powerModel: root.powerModel
+                                    powerMenuModel: root.powerMenuModel
+                                }
                             }
 
-                            DefaultsSettingsPane {
+                            DeferredSettingsPane {
                                 Layout.fillWidth: true
                                 Layout.fillHeight: true
-                                visible: root.settingsModel.selectedSectionId === "defaults"
-                                defaultsModel: root.defaultsModel
-                                autostartModel: root.autostartModel
+                                selected: root.settingsModel.selectedSectionId === "defaults"
+                                windowVisible: root.visible
+                                sourceComponent: DefaultsSettingsPane {
+                                    defaultsModel: root.defaultsModel
+                                    autostartModel: root.autostartModel
+                                }
                             }
 
-                            AppearanceSettingsPane {
+                            DeferredSettingsPane {
                                 Layout.fillWidth: true
                                 Layout.fillHeight: true
-                                visible: root.settingsModel.selectedSectionId === "appearance"
-                                appearanceModel: root.appearanceModel
-                                accessibilityModel: root.accessibilityModel
-                                notificationModel: root.notificationModel
-                                panelSettingsModel: root.panelSettingsModel
-                                textScaleCapability: root.settingsModel.capabilityById(
-                                    "accessibility-text-scale")
-                                notificationCapability: root.settingsModel.capabilityById(
-                                    "accessibility-notifications")
-                                capabilities: root.settingsModel.capabilitiesForSection("appearance")
-                                    .filter(function(capability) {
-                                        return capability.id !== "themes" && capability.id !== "wallpaper";
-                                    })
+                                selected: root.settingsModel.selectedSectionId === "appearance"
+                                windowVisible: root.visible
+                                sourceComponent: AppearanceSettingsPane {
+                                    appearanceModel: root.appearanceModel
+                                    accessibilityModel: root.accessibilityModel
+                                    notificationModel: root.notificationModel
+                                    panelSettingsModel: root.panelSettingsModel
+                                    textScaleCapability: root.settingsModel.capabilityById(
+                                        "accessibility-text-scale")
+                                    notificationCapability: root.settingsModel.capabilityById(
+                                        "accessibility-notifications")
+                                    capabilities: root.settingsModel.capabilitiesForSection("appearance")
+                                        .filter(function(capability) {
+                                            return capability.id !== "themes" && capability.id !== "wallpaper";
+                                        })
+                                }
                             }
 
-                            SystemSettingsPane {
-                                clockText: root.clock.settingsText
+                            DeferredSettingsPane {
                                 Layout.fillWidth: true
                                 Layout.fillHeight: true
-                                visible: root.settingsModel.selectedSectionId === "system"
-                                systemManagementModel: root.systemManagementModel
-                                capabilities: root.settingsModel.capabilitiesForSection("system")
+                                selected: root.settingsModel.selectedSectionId === "system"
+                                windowVisible: root.visible
+                                sourceComponent: SystemSettingsPane {
+                                    clockText: root.clock.settingsText
+                                    systemManagementModel: root.systemManagementModel
+                                    capabilities: root.settingsModel.capabilitiesForSection("system")
+                                }
                             }
 
                             ListView {

--- a/config/quickshell/settings/SystemRegionalControls.qml
+++ b/config/quickshell/settings/SystemRegionalControls.qml
@@ -102,8 +102,11 @@ ColumnLayout {
         else if (enableButton.activeFocus) root.revealRequested(focusTarget(ntpCard, enableButton));
         else if (disableButton.activeFocus) root.revealRequested(focusTarget(ntpCard, disableButton));
         else {
-            for (let index = 0; index < catalogRepeater.count; index++)
-                catalogRepeater.itemAt(index).revealFocus();
+            for (let index = 0; index < catalogRepeater.count; index++) {
+                const item = catalogRepeater.itemAt(index);
+                // An asynchronous pane can have a count before its delegates exist.
+                if (item !== null) item.revealFocus();
+            }
         }
     }
     function focusTarget(card, button) { return card.height > viewportHeight ? button : card; }

--- a/docs/PRE-P7-MAINTENANCE.md
+++ b/docs/PRE-P7-MAINTENANCE.md
@@ -1,0 +1,75 @@
+# Pre-Phase 7 maintenance
+
+Phase 6 is complete. This maintenance boundary improves Settings and local
+review iteration; it does not start Phase 7 image or release qualification.
+
+## Responsiveness
+
+Settings creates each pane asynchronously on its first visit. Visited panes
+stay alive, preserving local drafts and scroll state. Service discovery,
+preview rollback and system-operation ownership remain in the existing models.
+Repeated search or navigation within the same section no longer reactivates
+its providers; opening Settings and explicit refresh remain available.
+
+A nested Fedora 44 X11 fixture measured 1,235 visual items and nine panes while
+Settings was closed before the change, versus 63 items and zero panes afterward
+(95% fewer visual items in the Settings window). Its repeated search/navigation
+sequence went from six section activations to zero. These are structural
+measurements, not a claim of a 95% wall-clock or memory improvement. The fixture
+uses inert helpers to isolate UI behavior; provider behavior is covered by the
+existing Settings integration suite.
+
+## Local review loop
+
+PR #291 moved routine PR validation to local gates, retaining main-branch CI
+and manual dispatch. `CONTRIBUTING.md` now supplies an evidence-first review
+prompt so an independent reviewer can reuse passing coverage instead of
+repeating long native suites without a concrete reason. The focused
+`check-quickshell-settings-responsiveness-xvfb` target covers pane creation,
+geometry, retained identity/drafts and search activation in a few seconds.
+It is also included in the aggregate gate.
+
+## Remaining reports
+
+No Phase 6 implementation checkbox remains open. The following existing issue
+reports remain open; automated coverage does not establish that a reporter's
+hardware or old installation is fixed:
+
+| Issue | Disposition before Phase 7 |
+| --- | --- |
+| #192: Wi-Fi after reboot, wallpaper/font reports | Needs current installation diagnostics and reproduction; retain networking and session coverage. |
+| #187: AMD mixed-monitor/high-refresh artifacts | Requires physical display/GPU reproduction; include in hardware qualification where available. |
+| #130: Quickshell remains after an older startx session | Current session cleanup has regression coverage; the old-install report remains unverified. |
+| #108: Older installer/terminal failure | Installer and terminal fixtures pass; a real image installation remains Phase 7 work. |
+| #77: Fractional scaling request | Physical scaling qualification remains open; no new scaling guarantee. |
+| #68: Alt+Shift layout-toggle request | Separate feature request, outside this maintenance boundary. |
+
+No issues were closed on the strength of unrelated automated tests. Phase 7
+remains queued and its tasks remain unchecked. Existing unrelated worktrees
+are preserved; the primary checkout must be clean and synchronized with
+`origin/main` at handoff.
+
+## Validation
+
+Fedora 44 x86_64, Quickshell 0.2.1 Fedora snapshot (`dacfa9d`), Qt 6.11.2,
+nested Xvfb and isolated D-Bus sessions:
+
+- Clean build, configured QML lint and large-surface source contract passed.
+- The focused responsiveness fixture passed with all nine pane layouts,
+  retained pane identity and an unsaved profile name, deduplicated selection,
+  and explicit Display/Input refresh.
+- The complete Settings Xvfb lifecycle suite passed, with 0.100% sampled closed
+  CPU. The large-surface suite passed with 0.00% sampled closed CPU.
+- Settings provider/Input tests, 13 display-profile tests, staged install
+  manifest, repeated-install preservation, ShellCheck, shfmt and diff checks
+  passed.
+- Unchanged backend, system-operation, installer security, package, release
+  and documentation-build coverage is reused from merged PR #291. This change
+  does not modify those implementations or start image qualification.
+
+The first native run exposed the old test's reliance on same-section selection
+for a forced refresh; it now uses explicit Refresh. An initial Input shell test
+exited without identifying its assertion; both a command-traced rerun and the
+normal complete target passed without a backend change. No claim is made about
+unavailable physical hardware, real PackageKit operations, or a newly deployed
+live desktop. Exact reviewed content and local log paths are recorded in the PR.

--- a/tests/fixtures/settings-responsiveness.py
+++ b/tests/fixtures/settings-responsiveness.py
@@ -1,0 +1,37 @@
+"""Instrument an isolated production shell; never run installed desktop helpers."""
+from pathlib import Path
+import sys
+
+
+def replace_once(text, old, new):
+    if text.count(old) != 1:
+        raise SystemExit(f"Settings fixture injection point changed: {old}")
+    return text.replace(old, new, 1)
+
+
+qml = Path(sys.argv[1])
+model = qml / "settings/SettingsModel.qml"
+text = model.read_text()
+for method, counter in (
+    ("activateSection(id)", "testActivations"),
+    ("refreshDisplays()", "testDisplayReads"),
+    ("refreshInput()", "testInputReads"),
+):
+    signature = f"function {method} {{"
+    text = replace_once(
+        text, signature,
+        f"property int {counter}: 0\n    {signature}\n        {counter}++;",
+    )
+model.write_text(text)
+commands = qml / "core/Commands.qml"
+text = replace_once(
+    commands.read_text(), "const argv = args || [];",
+    'return ["true"];\n        const argv = args || [];',
+)
+commands.write_text(text)
+shell = qml / "shell.qml"
+text = shell.read_text()
+if not text.rstrip().endswith("}"):
+    raise SystemExit("Settings fixture shell root changed")
+end = text.rfind("}")
+shell.write_text(text[:end] + Path(sys.argv[2]).read_text() + text[end:])

--- a/tests/qml/SettingsResponsiveness.inc
+++ b/tests/qml/SettingsResponsiveness.inc
@@ -1,0 +1,87 @@
+    // Runs inside an isolated copy of the production ShellRoot.
+    property int responseStage: 0
+    property var responsePanes: []
+    property double responseStarted: Date.now()
+    property var responseFirstPane: null
+    function responseCheck(ok, detail) {
+        if (!ok) {
+            console.error("Responsiveness FAILED: " + detail);
+            Qt.quit();
+            throw new Error(detail);
+        }
+    }
+    function responseItems(item, predicate) {
+        let result = predicate(item) ? [item] : [];
+        for (const child of item.children || [])
+            result = result.concat(responseItems(child, predicate));
+        return result;
+    }
+    function responsePaneItems() {
+        return responseItems(settingsWindow.contentItem, item => /^(Display|Input|Network|Bluetooth|Audio|Power|Defaults|Appearance|System)SettingsPane_QML/.test(String(item)));
+    }
+    Timer {
+        interval: 50
+        running: true
+        repeat: true
+        onTriggered: {
+            if (root.responseStage === 0) {
+                console.info("Settings measurement: closed panes=" + root.responsePaneItems().length
+                    + " items=" + root.responseItems(settingsWindow.contentItem, () => true).length
+                    + " startup_ms=" + (Date.now() - root.responseStarted));
+                root.responseCheck(root.responsePaneItems().length === 0, "Closed startup creates no panes");
+                settingsModel.openWindow();
+                root.responseStarted = Date.now();
+                root.responseStage = 1;
+            } else if (root.responseStage === 1) {
+                const panes = root.responsePaneItems();
+                if (!panes.some(item => String(item).startsWith("DisplaySettingsPane"))) return;
+                console.info("Settings measurement: first pane ready_ms=" + (Date.now() - root.responseStarted));
+                const before = settingsModel.testActivations;
+                settingsModel.setSearch("dis");
+                settingsModel.setSearch("disp");
+                settingsModel.selectSection("displays");
+                settingsModel.selectRelative(1); // One matching section.
+                console.info("Settings measurement: redundant activations=" + (settingsModel.testActivations - before));
+                root.responseCheck(settingsModel.testActivations === before, "Same-section search/navigation does not rediscover");
+                settingsModel.setSearch("audio");
+                root.responseCheck(settingsModel.testActivations === before + 1 && settingsModel.selectedSectionId === "audio", "A changed search activates its section exactly once");
+                settingsModel.selectSection("displays");
+                root.responseCheck(settingsModel.testActivations === before + 2 && settingsModel.searchQuery === "", "Selecting outside the filter clears it without intermediate activation");
+                const reads = settingsModel.testDisplayReads;
+                settingsModel.refresh();
+                root.responseCheck(settingsModel.testDisplayReads === reads + 1, "Explicit Refresh reloads display state");
+                root.responseFirstPane = panes.find(item => String(item).startsWith("DisplaySettingsPane"));
+                root.responseFirstPane.profileName = "Unsaved display profile";
+                root.responseStage = 2;
+                settingsModel.setSearch("");
+            } else if (root.responseStage >= 2 && root.responseStage <= 10) {
+                const index = root.responseStage - 2;
+                const section = settingsModel.sections[index];
+                settingsModel.selectSection(section.id);
+                const expected = ["Display", "Input", "Network", "Bluetooth", "Audio", "Power", "Defaults", "Appearance", "System"][index];
+                const pane = root.responsePaneItems().find(item => String(item).startsWith(expected + "SettingsPane"));
+                if (!pane || !pane.visible || pane.width <= 0 || pane.height <= 0) return;
+                root.responseCheck(pane.width > 0 && pane.height > 0, "Loaded pane has layout geometry: " + section.id);
+                if (section.id === "input") {
+                    const reads = settingsModel.testInputReads;
+                    settingsModel.refresh();
+                    root.responseCheck(settingsModel.testInputReads === reads + 1, "Explicit Refresh reloads input state");
+                }
+                root.responsePanes.push(pane);
+                root.responseStage++;
+            } else if (root.responseStage === 11) {
+                settingsModel.close();
+                root.responseCheck(root.responsePaneItems().length === 9, "Closing retains visited panes");
+                settingsModel.openWindow();
+                root.responseStage++;
+            } else {
+                root.responseCheck(root.responsePaneItems().length === 9, "Reopening does not duplicate panes");
+                root.responseCheck(root.responsePaneItems().indexOf(root.responseFirstPane) >= 0, "First pane identity survives navigation and close");
+                root.responseCheck(root.responseFirstPane.profileName === "Unsaved display profile", "Unsaved profile name survives navigation and close");
+                root.responseCheck(root.responsePanes.every(item => root.responsePaneItems().indexOf(item) >= 0), "Every visited pane survives");
+                settingsModel.close();
+                console.info("Settings responsiveness: PASS");
+                Qt.quit();
+            }
+        }
+    }

--- a/tests/test-quickshell-settings-responsiveness-xvfb.sh
+++ b/tests/test-quickshell-settings-responsiveness-xvfb.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -eu
+
+repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+for command_name in Xvfb dbus-run-session quickshell timeout python3; do
+	if ! command -v "$command_name" >/dev/null 2>&1; then
+		printf 'SKIP: %s is unavailable\n' "$command_name"
+		exit 77
+	fi
+done
+if [ "${DWM_SETTINGS_RESPONSIVENESS_DBUS_SESSION:-0}" != 1 ]; then
+	exec env DWM_SETTINGS_RESPONSIVENESS_DBUS_SESSION=1 dbus-run-session -- "$0" "$@"
+fi
+
+work=$(mktemp -d)
+xvfb_pid=
+cleanup() {
+	if [ -n "$xvfb_pid" ]; then
+		kill "$xvfb_pid" 2>/dev/null || true
+		wait "$xvfb_pid" 2>/dev/null || true
+	fi
+	rm -rf "$work"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+mkdir -p "$work/qml" "$work/home/.config/dwm-titus" \
+	"$work/data/dwm-titus/scripts" "$work/runtime" "$work/state"
+chmod 700 "$work/runtime"
+cp -a "$repo/config/quickshell/." "$work/qml/"
+cp "$repo/config/"*.toml "$work/home/.config/dwm-titus/"
+python3 "$repo/tests/fixtures/settings-responsiveness.py" "$work/qml" "$repo/tests/qml/SettingsResponsiveness.inc"
+Xvfb -displayfd 3 -screen 0 1024x768x24 -nolisten tcp -extension GLX \
+	3>"$work/display" >"$work/xvfb.log" 2>&1 &
+xvfb_pid=$!
+i=0
+while [ ! -s "$work/display" ] && [ "$i" -lt 100 ]; do
+	i=$((i + 1))
+	sleep 0.05
+done
+display_number=$(sed -n '1p' "$work/display")
+case $display_number in
+'' | *[!0-9]*)
+	cat "$work/xvfb.log" >&2
+	exit 1
+	;;
+esac
+
+status=0
+timeout --foreground --kill-after=2s 45s env DISPLAY=":$display_number" HOME="$work/home" \
+	XDG_CONFIG_HOME="$work/home/.config" XDG_DATA_HOME="$work/data" XDG_RUNTIME_DIR="$work/runtime" \
+	QT_QPA_PLATFORMTHEME= QT_QUICK_BACKEND=software QSG_RHI_BACKEND=software \
+	quickshell --no-duplicate --path "$work/qml/shell.qml" >"$work/ui.log" 2>&1 || status=$?
+if [ "$status" -ne 0 ] || ! grep -F 'Settings responsiveness: PASS' "$work/ui.log" ||
+	grep -Eq 'Responsiveness FAILED:|ReferenceError:|TypeError:' "$work/ui.log"; then
+	cat "$work/ui.log" >&2
+	exit 1
+fi
+grep -F 'Settings measurement:' "$work/ui.log"

--- a/tests/test-quickshell-settings-xvfb.sh
+++ b/tests/test-quickshell-settings-xvfb.sh
@@ -1050,7 +1050,7 @@ done
 # Hold a pre-change discovery result across Keep. The model must queue the
 # resulting refresh instead of letting this stale snapshot win permanently.
 : >"$input_discovery_fixture.hold"
-settings_ipc_retry select input >/dev/null
+settings_ipc_retry refresh >/dev/null
 i=0
 while [ ! -f "$input_discovery_fixture.captured" ] && [ "$i" -lt 100 ]; do
 	i=$((i + 1))


### PR DESCRIPTION
## Summary

Settings previously constructed all nine panes while closed, and search updates/reselecting a section repeatedly activated discovery. Load panes asynchronously on first visit, keep visited panes alive for drafts and navigation, and activate providers only when selection changes. Explicit Refresh now reloads Display and Input state without double discovery on opening.

The native UI fixture measured closed Settings visual items dropping from 1,235 to 63, and its repeated search/navigation sequence from six activations to zero. This is a structural improvement, not a claim of 95% faster wall-clock performance. Guard regional focus restoration while asynchronous delegates are still being created.

Add a focused native responsiveness target and pass local validation evidence directly to independent reviews so unchanged long suites are reused. Align the remaining planning checklist with local gates, record unresolved reports accurately, and keep Phase 7 queued.

## Type

- [x] Bug fix
- [x] Refactor
- [x] Documentation

## Validation

Reviewed/published commit: `da8d2c012f208b4f15aeb433b7b433ed2079c732`; tree: `776813cd71c733818491c3ecf086784f2b1bfe1c`. Independent local Codex review verified the complete staged tree and reported no actionable defects (`/home/titus/tmp/pre-p7-review.log`). The remote branch matches the reviewed local commit.

Fedora 44 x86_64, Quickshell `0.2.1^git20260209.dacfa9d-5.fc44`, Qt 6.11.2, isolated Xvfb/D-Bus.

- `scripts/run-tests make clean all check-quickshell-qml check-quickshell-large-surfaces`: passed (`/home/titus/tmp/pre-p7-static.log`).
- `scripts/run-tests make check-quickshell-settings-responsiveness-xvfb`: passed, all nine layouts, retained pane identity and unsaved profile name, deduplicated search/selection, and explicit Display/Input refresh (`/home/titus/tmp/pre-p7-responsiveness-final.log`). The fixture intentionally uses inert helpers; the complete suite below validates provider interactions.
- `scripts/run-tests make check-quickshell-settings-xvfb`: passed on final production code, including lifecycle/recovery and 0.100% closed CPU (`/home/titus/tmp/pre-p7-settings-final.log`).
- `scripts/run-tests make check-quickshell-large-surfaces-xvfb`: passed, including keyboard navigation and 0.00% closed CPU (`/home/titus/tmp/pre-p7-surfaces.log`).
- `scripts/run-tests make check-settings check-install-manifest check-install-preservation check-quickshell-qml`: passed on final code, including 13 display-profile tests (`/home/titus/tmp/pre-p7-gates-final.log`).
- ShellCheck and `shfmt -d` on both changed shell tests, and `git diff --cached --check`: passed.

Reused unchanged coverage: merged #291's full aggregate evidence covers C/native dwm, system-operation backends and native suite, Fedora container installer/security, package/release gates and Astro docs build. Its merge is `d359a4f1de838fd28fc85487a3dd8a6edf3eb8f3`; all three post-merge hosted workflows also succeeded. These implementations are unchanged here. The complete reviewed evidence packet is `/home/titus/tmp/pre-p7-evidence.md`.

The first Settings run exposed a test relying on same-section selection to force a stale discovery; it now calls explicit Refresh and the complete rerun passes. An initial Input shell test exited without identifying its assertion; both a traced complete rerun and the normal target passed without backend edits. This transient is recorded rather than omitted.

## User Impact and Risk

No migration or configuration change. Visited panes remain resident; initial Settings construction is reduced. Models continue to own provider lifecycles, previews and recovery. Roll back this commit to restore eager panes and previous selection behavior. No live desktop deployment/restart, physical hardware qualification, real package mutation, or Phase 7 image work was performed.

Existing reports #192, #187, #130, #108, #77 and #68 remain open with limitations in `docs/PRE-P7-MAINTENANCE.md`; this PR does not claim to resolve unverified installations or hardware. Presentation styling is unchanged; native layout and interaction evidence is above.
