### PR TITLE
Fix Settings persistence test race and record Phase 7 readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ versions from `config.mk`.
 
 ### Changed
 
+- Wait for acknowledged notification-policy persistence in the native restart
+  test, with delayed-write coverage to prevent timing-dependent CI failures.
+
 - Create Settings panes on first visit and retain them for subsequent navigation;
   avoid repeating section discovery while typing a search for the same section.
 - Pass local validation evidence into review and add a focused native Settings

--- a/TASKS.md
+++ b/TASKS.md
@@ -2,7 +2,8 @@
 
 ## Phase 7: Fedora Image and Release Qualification
 
-Pre-Phase 7 responsiveness and local-review maintenance is recorded in
+Pre-Phase 7 responsiveness, live maintenance and local validation are complete.
+Entry evidence and remaining qualification limits are recorded in
 `docs/PRE-P7-MAINTENANCE.md`. Phase 7 remains on hold until explicitly started.
 
 Phase 6 is complete. Its acceptance evidence and remaining hardware/service

--- a/docs/PRE-P7-MAINTENANCE.md
+++ b/docs/PRE-P7-MAINTENANCE.md
@@ -73,3 +73,52 @@ exited without identifying its assertion; both a command-traced rerun and the
 normal complete target passed without a backend change. No claim is made about
 unavailable physical hardware, real PackageKit operations, or a newly deployed
 live desktop. Exact reviewed content and local log paths are recorded in the PR.
+
+## Phase 7 entry handoff (2026-09-10)
+
+The merged Settings changes were synchronized to the developer's live Fedora
+44 desktop. Managed-file and running-dwm parity passed, one managed Quickshell
+instance answered IPC, and six tray items returned. Settings completed fresh
+discovery with no system-management error codes. This supplements the earlier
+nested-session evidence; it is not image, reboot, or hardware qualification.
+
+Workstation maintenance completed three disabled autostart overrides using
+vendor Exec metadata while preserving Hidden=true, restarted the failed document
+portal, and installed the optional account and software-source tools. A scoped
+DaVinci udev override corrected the missing-group error while preserving the
+original rule for rollback. All 103 installed udev rules validated, and no user
+or system services remained failed. The separate workstation self-healing script
+passed seven regression tests and an independent review; a repeated apply made
+no further content repairs and reported all remaining findings. It is a local
+maintenance tool, not a new installer feature.
+
+Remaining health findings are explicit qualification context:
+
+- Boot journal and kernel messages are retained evidence. A later check found
+  the document portal had exited with status 21 after its FUSE mount disappeared.
+  Restart restored the mount and its D-Bus API; the cause of that recurrence
+  remains unproven. One later generic virtqemud error had no accompanying failed
+  service, and libvirt still listed the running VM. These workstation observations
+  remain visible; no claim of permanently error-free host operation is made.
+- The running kernel's taint includes the out-of-tree, unsigned kvmfr module.
+  No module was unloaded, taint flag hidden, or reboot claimed.
+- Picom theme mutation remains unsupported, and high-risk administration remains
+  delegated as specified. Neither is an incomplete Phase 6 implementation task.
+
+The post-merge CI safety net for #294 exposed a notification-persistence test
+race: it restarted Quickshell after seeing an optimistic timeout value, before
+FileView acknowledged the atomic disk write. The test now waits for the saved
+state and verifies the exact JSON before restarting. Its copied model delays
+writes by 250 ms so the old race reproduces deterministically. The focused
+native regression reproduced the original 6000-ms result and passed with the
+expected 4000-ms result after the correction. Production notification behavior
+is unchanged. The complete Settings lifecycle suite and focused
+responsiveness gate then passed locally in a Fedora 44 container with the same
+Quickshell snapshot release (`dacfa9d-5.fc44`) and Qt 6.11.2 as the failed CI run.
+The notification contract check, clean build, ShellCheck, shfmt and diff checks
+also passed. This resolves the known post-merge failure through local evidence.
+
+Phase 7 remains queued. Beginning qualification does not mean the images,
+reboot paths, physical hardware, or release artifacts are already qualified.
+The next authorized phase begins with P7-BASE; the implementation and publication
+steps in TASKS.md remain unchecked until their own evidence exists.

--- a/tests/fixtures/delay-notification-policy.py
+++ b/tests/fixtures/delay-notification-policy.py
@@ -1,0 +1,24 @@
+"""Delay the copied model's write so restart tests must await persistence."""
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+start = text.index('    function savePolicy() {')
+end = text.index('    function setDoNotDisturb(', start)
+block = text[start:end]
+old = '        policyFile.setText(JSON.stringify({'
+ending = '        }) + "\\n");'
+if block.count(old) != 1 or block.count(ending) != 1:
+    raise SystemExit('Notification policy fixture injection point changed')
+block = block.replace(old, '        delayedPolicyWrite.text = JSON.stringify({')
+block = block.replace(ending, '        }) + "\\n";\n        delayedPolicyWrite.restart();')
+timer = '''    Timer {
+        id: delayedPolicyWrite
+        property string text: ""
+        interval: 250
+        onTriggered: policyFile.setText(text)
+    }
+
+'''
+path.write_text(text[:start] + timer + block + text[end:])

--- a/tests/test-quickshell-settings-xvfb.sh
+++ b/tests/test-quickshell-settings-xvfb.sh
@@ -7,7 +7,7 @@ expected_window_width=${DWM_SETTINGS_EXPECTED_WINDOW_WIDTH:-1180}
 expected_window_height=${DWM_SETTINGS_EXPECTED_WINDOW_HEIGHT:-760}
 
 for command_name in Xvfb dbus-monitor dbus-run-session glib-compile-schemas \
-	gsettings inotifywait quickshell xdotool xinput xkbset xprop pgrep getconf; do
+	gsettings inotifywait python3 quickshell xdotool xinput xkbset xprop pgrep getconf; do
 	if ! command -v "$command_name" >/dev/null 2>&1; then
 		printf 'SKIP: %s is unavailable\n' "$command_name"
 		exit 77
@@ -330,6 +330,9 @@ glib-compile-schemas "$schema_dir"
 export GSETTINGS_SCHEMA_DIR="$schema_dir"
 export GSETTINGS_BACKEND=keyfile
 cp -a "$repo/config/quickshell/." "$config_home/quickshell/"
+# Make an acknowledged disk write necessary before the persistence restart.
+python3 "$repo/tests/fixtures/delay-notification-policy.py" \
+	"$config_home/quickshell/notifications/NotificationModel.qml"
 cp "$repo/tests/fixtures/system-operation-provider.py" "$data_home/dwm-titus/scripts/dwm-system-management"
 chmod +x "$data_home/dwm-titus/scripts/dwm-system-management"
 cp "$repo/config/quickshell/assets/ctt_logo.png" "$home/Pictures/backgrounds/test-wallpaper.png"
@@ -1879,6 +1882,15 @@ while [ "$i" -lt 100 ]; do
 done
 [ "$(notification_ipc_retry policyState)" = available ]
 notification_ipc_retry setPopupTimeout 4000 >/dev/null
+# IPC exposes the optimistic value before FileView finishes its atomic write.
+notification_wait_available
+python3 - "$config_home/dwm-titus/notification-settings.json" <<'PYTHON'
+import json
+import sys
+with open(sys.argv[1]) as stream:
+    policy = json.load(stream)
+assert policy == {"version": 1, "doNotDisturb": True, "popupTimeoutMs": 4000}, policy
+PYTHON
 [ "$(notification_ipc_retry doNotDisturb)" = true ]
 [ "$(notification_ipc_retry popupTimeout)" = 4000 ]
 test_stage='validating notification policy after restart'


### PR DESCRIPTION
## Summary

The post-merge Settings test restarted Quickshell after observing an optimistic popup timeout, before FileView acknowledged its atomic write. On the CI runner the saved timeout therefore remained 6000 ms instead of the expected 4000 ms.

Wait for the acknowledged saved state and verify the exact policy JSON before restarting. Delay policy writes by 250 ms in the copied test model so this boundary is tested deterministically. The original test reproduces the exact CI failure with this fixture; the corrected focused test passes. Production notification behavior is unchanged.

Record the live desktop repairs and explicit historical/unsupported findings in the pre-Phase 7 handoff. Phase 7 remains queued, and no image or release work is started.

## Validation

- Focused native reproduction: failed before the fix with `available / true / 6000`, matching CI; passed after the fix, including persistence, reset, and malformed-policy recovery.
- `scripts/run-tests make clean all`: passed on the Fedora 44 host.
- `scripts/run-tests make check-quickshell-notifications`: passed.
- Complete local Fedora 44 container: `scripts/run-tests make clean all check-quickshell-settings-xvfb check-quickshell-settings-responsiveness-xvfb` passed with the CI versions (Quickshell dacfa9d-5.fc44, Qt 6.11.2); closed Settings CPU 0.033%.
- ShellCheck, shfmt, and `git diff --check`: passed.
- Live managed-file/runtime parity: passed; one Quickshell instance, six tray items, no failed user/system services, fresh System discovery with no error codes.
- Separate workstation maintenance: seven regression tests and clean independent review; idempotent repeat, all 103 udev rules valid. Historical boot/kernel warnings and explicitly unsupported features remain visible.

Unchanged application, backend, installer, package/release and documentation-build checks retain the passing evidence from #291/#294. The #294 post-merge failure was investigated, reproduced locally, and corrected here; it is not ignored as an optional hosted check. Logs are retained locally under `/home/titus/tmp/p7-*`.

## Impact and limits

This changes test synchronization and adds a regression fixture plus handoff documentation. No user configuration, runtime API, or deployment migration changes. The local self-healing tool is not added to the product installer. Physical hardware, reboot, image installation and release qualification remain Phase 7 work. No related issue is automatically closed.

The document portal recurred after its FUSE mount disappeared; restart restored its mount and D-Bus API, but the underlying cause remains unproven. A generic virtqemud error did not correspond to a failed service or unavailable libvirt connection. These are retained workstation follow-ups, not evidence of permanent host health.

## Independent local review

Reviewed commit `02eb7db2bb9a979f538d3a999abf40444e47dd8b`, tree `9a14d24578a4eee073e3a94a50dfc2e1b6041133`, base `080b39e758dfed257edbc6916afbf346b2f99696`. Independent Codex review passed with no actionable findings. The final documentation-only correction was independently reviewed, reusing unchanged passing coverage. Evidence: `/home/titus/tmp/p7-readiness-evidence.md`; reviews: `/home/titus/tmp/p7-readiness-review.log` and `/home/titus/tmp/p7-readiness-review-final.log`; full container log: `/home/titus/tmp/p7-container-current.log`. Final live parity passed after validation.
