### PR TITLE
Install offline system images from Cloudflare downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ versions from `config.mk`.
 
 ## [Unreleased]
 
+### Changed
+
+- Use verified Cloudflare-hosted compressed ISOs for the primary download and
+  installation guides, with checksums, offline setup steps and hardware limits.
+
+### Fixed
+
+- Exclude `.env`, `.env.*` and `.envrc` at every depth from the ISO source
+  payload, independently of Git ignore rules.
+
+### Added
+
+- Add a compressed filesystem image build path with local Anaconda installation,
+  separate standard/NVIDIA manifests, offline user setup and build-time checks
+  for the desktop package contract, including maim and clipboard dependencies.
+
 ## [0.7.0] - 2026-09-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -48,17 +48,39 @@ For complete requirements and installation details, see the
 
 ### Fedora ISO
 
-Download the latest image:
+Download the **v0.7.0 offline images (2026-09-11)** for Fedora 44 x86_64:
 
-| Image | Download |
-| --- | --- |
-| Standard | [`dwm-titus.iso`](https://github.com/ChrisTitusTech/dwm-titus/releases/latest/download/dwm-titus.iso) |
-| NVIDIA | [`dwm-titus-nvidia.iso`](https://github.com/ChrisTitusTech/dwm-titus/releases/latest/download/dwm-titus-nvidia.iso) |
-| Checksums and release notes | [Latest release](https://github.com/ChrisTitusTech/dwm-titus/releases/latest) |
+| Image | Size | Download |
+| --- | --- | --- |
+| Standard | 3.39 GiB | [Standard ISO](https://downloads.christitus.com/iso/2026-09-11/dwm-titus-fedora44-x86_64-20260911.iso) |
+| NVIDIA | 3.96 GiB | [NVIDIA ISO](https://downloads.christitus.com/iso/2026-09-11/dwm-titus-fedora44-x86_64-20260911-nvidia.iso) |
+| Verification | | [SHA256SUMS](https://downloads.christitus.com/iso/2026-09-11/SHA256SUMS) and [release notes](https://github.com/ChrisTitusTech/dwm-titus/releases/tag/v0.7.0) |
 
-Use the NVIDIA image only for systems that need the dedicated NVIDIA
-installation path. Write the selected ISO to a USB drive, boot it, complete the
-Fedora installer, and reboot into the `dwm` session.
+Download the checksum file into the same directory as your selected ISO, then run:
+
+```sh
+sha256sum --ignore-missing -c SHA256SUMS
+```
+
+Confirm your ISO reports `OK`. Write it as a disk image to an 8 GB or larger USB
+drive, boot it, choose your disk, locale and administrator account in Anaconda,
+then install and reboot into the `dwm` session. Writing the USB erases its contents;
+review Anaconda's disk changes before starting installation.
+
+Packages are already included in the compressed system image. Installation needs
+no Internet connection or software selection. The images include Quickshell,
+Gear Lever, `maim`, region capture and clipboard tools. Internet access is needed
+later for updates and additional software.
+
+Standard offline installation passed UEFI and BIOS VM tests. The NVIDIA image
+passed UEFI installation and desktop tests with virtual graphics; **physical
+NVIDIA acceleration remains untested**. Secure Boot was off during qualification.
+See the [installation guide](https://dwm.christitus.com/install.html#fedora-iso-recommended-for-a-new-installation)
+and [build qualification](https://downloads.christitus.com/iso/2026-09-11/BUILD-NOTES.md).
+
+The older GitHub-hosted `dwm-titus.iso` and `dwm-titus-nvidia.iso` assets are
+network installers. Use the Cloudflare links above for offline installation.
+For building images, see [compressed-image builds](docs/COMPRESSED-IMAGES.md).
 
 ### Existing System
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -417,6 +417,17 @@ Deliver a repeatable Fedora-only desktop installation and upgrade experience.
 - Unsupported or untested Fedora hardware paths are stated precisely in
   release notes.
 
+## Compressed System Image Installation
+
+Status: VM qualification completed 2026-09-11; physical NVIDIA validation remains outstanding. See [compressed-image qualification](docs/COMPRESSED-QUALIFICATION.md).
+
+Replace end-user package downloads with a sanitized, prebuilt Fedora filesystem
+while retaining Anaconda disk and account choices. Standard and NVIDIA images
+remain separate. The factory must contain all shipped feature dependencies,
+including maim and clipboard capture tools. Acceptance requires a networkless
+installation and first-boot desktop validation, clean per-machine identities,
+recorded artifact size, and a repeatable build procedure.
+
 ## Future Evaluation
 
 After the Fedora phases are stable, evaluate additional accessibility work,

--- a/SPEC.md
+++ b/SPEC.md
@@ -8,13 +8,15 @@ window rules, a managed Quickshell shell and Settings layer, and supporting
 desktop services and helpers.
 
 The product is a cohesive Fedora desktop installed from the official Fedora
-Server Network Install ISO or onto an existing Fedora installation. Other
+Server installer environment with a prebuilt compressed system image, or onto an
+existing Fedora installation. Factory image builds resolve packages online;
+end-user compressed-image installation must work without network access. Other
 distributions are outside the supported product and validation contract.
 
 ## 2. Goals
 
 - Install a complete, daily-usable Fedora desktop from a minimal network
-  installer base.
+  installer base, with packages and desktop assets prepared at image-build time.
 - Provide one cohesive Settings experience for common display, input,
   connectivity, audio, power, appearance, default-application, update, and
   system-information workflows.
@@ -47,7 +49,8 @@ The primary release target is the Fedora desktop image:
 
 | Target | Current contract |
 | --- | --- |
-| Base media | Fedora 44 Server Network Install ISO |
+| Base media | Fedora 44 Server Network Install ISO as the Anaconda runtime |
+| Installation payload | Prebuilt compressed Fedora root filesystem, installed offline |
 | Session | Xorg with dwm and the managed Quickshell shell |
 | Variants | Standard and explicitly selected NVIDIA image |
 | Initial release architecture | x86_64 |
@@ -693,6 +696,11 @@ In a real or nested X11 session:
 - The ISO builder embeds the checkout and selected Kickstart without dropping
   the upstream boot behavior.
 - The documented Fedora Server Network Install source checksum is verified.
+- Compressed-image installation completes without Internet access or package
+  selection. Required desktop packages, screenshot/clipboard tools, fonts,
+  themes and Gear Lever runtimes are present in the captured filesystem.
+- Capture removes factory accounts, temporary authorization, machine identity
+  and storage state, and retains the boot files needed by both firmware paths.
 - At least the standard image completes Anaconda installation in a VM, reboots,
   reaches LightDM and a usable dwm session, and starts the managed Quickshell
   shell.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,23 +1,38 @@
 # Active Tasks
 
-No implementation phase is active. Phase 7 software and image qualification is
-complete with explicit limitations; no later phase was started.
+## Compressed system image installer
 
-## Phase 7 closeout
+Authorized 2026-09-11. Replace install-time repository resolution with a
+prebuilt Fedora root filesystem while retaining Anaconda disk, locale and
+account selection. Preserve standard/NVIDIA separation and existing-system
+installation. Phase 7 historical evidence remains in docs/P7-QUALIFICATION.md.
 
-Detailed procedures and evidence are in [docs/P7-QUALIFICATION.md](docs/P7-QUALIFICATION.md).
+- [x] Build a disposable factory system from the existing package contract.
+- [x] Exclude dotenv files recursively from the ISO payload and verify the
+      actual rsync filters against root and nested dummy credential files.
+- [x] Move required desktop assets into system-wide image storage; remove
+      factory accounts, credentials, identifiers, logs and machine-specific state.
+- [x] Capture and checksum a compressed filesystem and embed it in the Fedora
+      Server installer with a local liveimg Kickstart and offline user setup.
+- [x] Verify standard/NVIDIA identity, failure handling and output preservation.
+- [x] Require maim, clipboard/region-capture dependencies and all shipped-feature
+      commands; exercise screenshots and clipboard ownership after offline install.
+- [x] Install with networking disconnected; verify first boot, new user,
+      LightDM/dwm/Quickshell, fonts, Gear Lever and template identity cleanup.
+- [x] Measure artifact sizes, document the supported build/update workflow and
+      limitations, and complete applicable tests and independent local review.
 
-- P7-BASE: Fedora 44 signed source, architecture, firmware and hardware matrix recorded.
-- P7-IMAGE: standard/NVIDIA Kickstarts, 73-entry package map, builds and media checks passed.
-- P7-INSTALL: clean BIOS/UEFI image installation, normal reboot and managed desktop passed; existing Fedora core/recommended and repeat installs passed.
-- P7-UPGRADE: user configuration/ownership preservation, controlled interrupted-build retry and backup restoration passed with SELinux Enforcing.
-- P7-DESKTOP/UI-6: real and nested X11 focus, IPC, lifecycle, small displays and idle-resource checks passed. QEMU S3 resume failed and is unqualified; physical NVIDIA, displays, radios, audio and suspend were not tested.
-- P7-RELEASE: full repository gates, recovery documentation and independent local review passed. Source commit/push is authorized; final published-head verification is recorded in the task result.
+- [x] Upload verified ISOs and checksums to the configured Cloudflare R2 bucket;
+      verify uploaded objects by reading them back and comparing SHA-256.
 
-## Publication boundary
+R2 upload authorized 2026-09-11 only after offline installation and desktop
+verification. The user subsequently authorized updating the v0.7.0 release,
+then publishing the download/install guidance and merging this work into main.
 
-Merge, version selection, tagged artifacts and release publication remain
-separate actions requiring explicit authorization. They are not unfinished
-Phase 7 implementation tasks. Any release notes must retain the exact failed
-and untested paths in the qualification record. Do not claim universal hardware
-support from these VM results.
+- [x] Verify all public Cloudflare downloads and update the v0.7.0 release links.
+- [x] Update README and the installation guide for the offline Cloudflare ISOs.
+- [x] Build and inspect the documentation and complete independent review of
+      the compressed-image implementation and Cloudflare download guidance.
+
+The user authorized publication and merge into main; GitHub records the merge
+state and post-merge documentation deployment.

--- a/docs/COMPRESSED-IMAGES.md
+++ b/docs/COMPRESSED-IMAGES.md
@@ -1,0 +1,105 @@
+# Compressed system image builds
+
+The compressed-image path prepares the complete desktop once in a disposable
+Fedora 44 virtual machine. Anaconda installs its local filesystem archive,
+then creates configuration for the account selected by the user. Package
+selection and repository downloads happen at image-build time. Disk selection,
+partitioning, locale and account creation remain interactive.
+
+The [2026-09-11 qualification record](COMPRESSED-QUALIFICATION.md) covers offline
+installation and desktop tests for these compressed builds, with explicit hardware
+limits. Download the qualified images from the Cloudflare links in the
+[README](../README.md#fedora-iso). The original GitHub-attached v0.7.0 ISOs still
+use network installation.
+
+## Build
+
+Use a clean checkout and the signed, verified Fedora Server netinst base from
+[RELEASING.md](RELEASING.md#fedora-installer-isos). The factory builder checks its
+pinned SHA-256 before starting. It requires an x86_64 Fedora host with access to
+KVM, QEMU, OVMF, libguestfs/guestfish, xz, pykickstart and the existing ISO-build
+tools. Allow space for a 50 GiB virtual disk, an uncompressed filesystem archive
+and the final artifacts. Factory provisioning requires Internet access.
+
+```bash
+source scripts/dwm-packages.sh
+mapfile -t factory_packages < <(dwm_packages fedora image-factory)
+sudo dnf install "${factory_packages[@]}"
+
+mkdir -p "$HOME/tmp/dwm-compressed/staging" "$HOME/tmp/dwm-compressed/artifacts"
+export TMPDIR="$HOME/tmp/dwm-compressed/staging"
+export DWM_TEST_TMP_ROOT="$HOME/tmp/dwm-compressed"
+
+scripts/build-dwm-fedora-system-image.py \
+  --input "$HOME/tmp/dwm-compressed/Fedora-Server-netinst-x86_64-44-1.7.iso" \
+  --output "$HOME/tmp/dwm-compressed/artifacts/standard.tar.xz" \
+  --variant standard
+
+scripts/build-dwm-fedora-installer-iso.sh \
+  --input "$HOME/tmp/dwm-compressed/Fedora-Server-netinst-x86_64-44-1.7.iso" \
+  --system-image "$HOME/tmp/dwm-compressed/artifacts/standard.tar.xz" \
+  --output "$HOME/tmp/dwm-compressed/artifacts/dwm-titus.iso" \
+  --variant standard
+```
+
+Repeat both commands with `--variant nvidia` and distinct `nvidia.tar.xz` and
+`dwm-titus-nvidia.iso` outputs. Standard and NVIDIA archives are not
+interchangeable. Keep each archive's `.json` manifest beside it: the ISO builder
+checks the platform, variant, size and SHA-256 before embedding the payload.
+A checksum detects changed bytes; it does not authenticate an untrusted archive.
+
+The factory uses a fresh virtual disk and a locked temporary account. It never
+installs the desktop on the build host. Before capture it removes that account,
+its home, temporary sudo access, machine identifiers and storage configuration.
+The capture includes `/boot` and the EFI filesystem. The ISO supplies the offline account-setup helper, so installer fixes do not
+require downloading all factory packages again. The finished image contains
+system-wide fonts, themes and Gear Lever with its Flatpak runtimes, plus the
+RPM and Flatpak manifests under `/usr/share/dwm-titus-image/`.
+Offline account setup creates the standard XDG directories and seeds
+`Pictures/backgrounds` with the bundled default wallpaper. It does not need to
+download a wallpaper collection on the installed machine.
+
+## Desktop dependency gate
+
+Image capture fails if the shared full Fedora package contract is incomplete.
+It also checks the executables used by the shipped desktop. Screenshot support
+requires `maim`, its shared libraries (including region selection), `xclip`,
+`xdotool`, `xrandr`, `notify-send`, XDG helpers and `dwm-screenshot`. The gate
+also covers terminal, compositor, wallpaper, locking, audio, networking,
+Bluetooth, media, brightness, file management and managed shell helpers.
+Hardware-specific integrations such as the optional Looking Glass VM shortcut
+still require their separately configured client and virtual machine.
+
+After installation, test all three screenshot bindings in the actual X11
+session: Super+P saves the active monitor, Super+Shift+P saves a selected region,
+and Super+Ctrl+P copies a selected region as `image/png`. A package inventory
+alone does not prove a working capture or clipboard owner.
+
+## Qualification and updates
+
+Install onto a new VM disk with no Internet access. Verify Anaconda does not
+wait for repository metadata, then verify first boot, a newly created account,
+LightDM, dwm, Quickshell, screenshots, clipboard ownership, fonts and Gear Lever.
+Record firmware mode, architecture, variant, source checksum, artifact sizes
+and untested hardware. Test BIOS and UEFI separately. A virtual NVIDIA-variant
+install does not qualify physical NVIDIA acceleration.
+
+Installed machines remain ordinary mutable Fedora systems. Their package
+repositories are available for later online updates. Use the existing
+[source update and recovery procedure](src/content/install.md#source-updates-and-recovery)
+for desktop source updates. To refresh installation media, rebuild the factory
+image so the new ISO contains the updated packages and assets; changing the
+checkout beside an old archive does not update the archive's installed desktop.
+
+Measure finished files instead of estimating from package download totals:
+
+```sh
+stat -c '%n %s bytes' "$HOME/tmp/dwm-compressed/artifacts/"*.tar.xz \
+  "$HOME/tmp/dwm-compressed/artifacts/"*.iso
+sha256sum "$HOME/tmp/dwm-compressed/artifacts/"*.iso
+```
+
+Compressed images are larger than netinstall media. Check the release host's
+individual asset limit before publication; do not silently truncate or replace
+an oversized ISO. Factory logs are retained beside the archive in `.logs/`;
+disposable build disks and temporary archives are removed when the builder exits.

--- a/docs/COMPRESSED-QUALIFICATION.md
+++ b/docs/COMPRESSED-QUALIFICATION.md
@@ -1,0 +1,98 @@
+# DWM-Titus compressed installers - 2026-09-11
+
+These Fedora 44 x86_64 installers contain a preinstalled compressed desktop.
+Anaconda retains disk, partition, language, timezone, keyboard and account
+selection. Installation needs no package selection or Internet connection.
+The installed systems remain ordinary, updatable Fedora installations.
+
+| Image | Size | Verification |
+| --- | --- | --- |
+| dwm-titus-fedora44-x86_64-20260911.iso | 3.39 GiB | Offline UEFI and BIOS installation, LVM first boot, LightDM and desktop |
+| dwm-titus-fedora44-x86_64-20260911-nvidia.iso | 3.96 GiB | Offline UEFI installation and desktop using a virtual GPU; physical NVIDIA validation outstanding |
+
+Both variants reached dwm and Quickshell with a new administrator account,
+Meslo fonts, the default wallpaper and Gear Lever running offline. The standard
+image contains no proprietary NVIDIA driver; the NVIDIA image includes the
+610.57.04 driver and its built module for kernel 6.19.10-300.fc44.x86_64.
+
+All three screenshot shortcuts were exercised with the default compositor:
+
+- Super+P: monitor JPEG, verified at 1280x800.
+- Super+Shift+P: region JPEG, verified at 600x400.
+- Super+Ctrl+P: region PNG clipboard, read back and verified at 600x400.
+
+The six saved captures decoded successfully and contained nonblank image data.
+The three installed VMs had distinct machine identities. Factory account and
+temporary sudo access were removed, and shared system assets are root-owned.
+The captured filesystems and final ISO source payloads were checked for dotenv
+filenames. Credentials are not part of these images.
+
+## Verify downloads
+
+Place both ISOs beside SHA256SUMS and run:
+
+```sh
+sha256sum -c SHA256SUMS
+```
+
+The RPM and Flatpak inventories describe the bundled packages. BUILD-MANIFEST.json
+records the exact ISO and source filesystem checksums and the Fedora base checksum.
+These are compressed-image builds based on the v0.7.0 desktop, not replacements
+for the previously published GitHub v0.7.0 netinstall release assets.
+
+## Qualification limits and observed logs
+
+Tests used fresh 50 GiB virtual disks, QEMU/KVM, virtio graphics and no network
+adapter. Standard firmware coverage includes UEFI and BIOS; NVIDIA coverage is
+UEFI with a virtual GPU. Physical NVIDIA acceleration, Secure Boot, TPM-backed
+unlocking, physical devices and suspend/resume are not qualified by these tests.
+
+The standard installs reported no failed system services. Early boot logged TPM
+rule/account warnings, and the UEFI tests also logged a graphics connector cleanup
+warning. The installed root contains the tss account/group. First login logged a
+keyring control-file message. Desktop, compositor, fonts, Gear Lever and captures
+worked after those messages.
+
+The NVIDIA VM reported nvidia-persistenced.service failed because it has no
+NVIDIA device or /dev/nvidia nodes. This is not a successful NVIDIA hardware test;
+the NVIDIA image still needs validation on a real NVIDIA system. Its offline
+installation, generic desktop and screenshot tests passed.
+
+The full repository test suite passed. Independent local reviews found no
+remaining actionable code findings, including the final offline user-setup fix.
+
+## Exact artifacts and local gates
+
+- `dwm-titus-fedora44-x86_64-20260911.iso`: 3635675136 bytes; SHA-256 `fe8340bb9ce6a1731e21f88e39efe9ec72d3593d1e797817a96a4d316f8d7763`.
+- `dwm-titus-fedora44-x86_64-20260911-nvidia.iso`: 4252237824 bytes; SHA-256 `cedd84e952e2b96e713d211e95530fdc6960dd7a1a15d170231f3c8585f59e5e`.
+
+Fedora Server netinst base SHA-256: `ae20c06bea746913cadea7d80463e13f4bf55bee4df2918111c921c674b70283`.
+
+Validation commands: `scripts/run-tests` (complete suite, exit 0), `scripts/run-tests make check-kickstart check-fedora-packages` (92 package capabilities), ShellCheck and shfmt on image scripts, real factory captures, final ISO media checks, and independent local Codex reviews. The final user-setup change also passed its focused checks and review before new offline installations.
+
+Screenshots and full local logs are retained in the build evidence directory. All test VMs had no network adapter. No physical GPU was assigned or borrowed for these tests.
+
+## R2 upload verification
+
+Uploaded both ISOs, SHA256SUMS, build notes, build manifest, and the four RPM/Flatpak
+manifests to bucket `titusos` under `iso/2026-09-11/`. All nine objects passed a
+complete authenticated download and SHA-256 comparison against the qualified
+local artifacts. The upload receipt is retained as
+`/home/titus/tmp/dwm-compressed-20260911/evidence/upload-qualification.uploaded.json`.
+After the user connected `downloads.christitus.com`, all nine complete public
+downloads passed SHA-256 verification against the qualified artifacts. An ISO
+byte-range request returned HTTP 206 with the requested 1024 bytes. Evidence is
+retained as `public-download-verification.json` in the same directory.
+
+The existing GitHub `v0.7.0` release was updated with these public links,
+qualification limits, and build provenance on 2026-09-11. The published notes
+were read back and matched the prepared body; existing assets were preserved.
+The tag and source archives remain unchanged. Public downloads are under
+`https://downloads.christitus.com/iso/2026-09-11/`.
+
+The Cloudflare download/install documentation passed `npm --prefix docs ci`
+and `npm --prefix docs run build` (zero Astro errors/warnings, 11 pages). The
+rendered installation page was inspected in a browser; both installation and
+home-page download links matched the publicly verified artifacts. Final
+independent Codex review found no actionable defects in the complete change,
+reusing the unchanged installer and VM coverage above.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -47,6 +47,11 @@ of `config.h` and object files.
 
 ## Fedora installer ISOs
 
+For the compressed filesystem build and offline qualification workflow, see
+[COMPRESSED-IMAGES.md](COMPRESSED-IMAGES.md). The v0.7.0 release now links the verified Cloudflare-hosted offline images.
+The original GitHub-attached ISO assets use the network package installation
+path described below.
+
 Track Phase 7 procedures, evidence and qualification limits in
 [P7-QUALIFICATION.md](P7-QUALIFICATION.md). Build success alone does not qualify
 installation or first boot.

--- a/docs/src/content/install.md
+++ b/docs/src/content/install.md
@@ -10,7 +10,76 @@ eyebrow: Start here
 > **dwm-titus is Fedora-only.** Fedora Linux with Xorg is required for every
 > supported installation, package, test, and release path.
 
-## Quick Install (Recommended)
+## Fedora ISO (Recommended for a New Installation)
+
+The v0.7.0 offline images dated 2026-09-11 install a complete Fedora 44 x86_64
+desktop from a compressed system image. Packages are included, so installation
+works without an Internet connection or software selection.
+
+| Image | Size | Download |
+| --- | --- | --- |
+| Standard | 3.39 GiB | [Download standard ISO](https://downloads.christitus.com/iso/2026-09-11/dwm-titus-fedora44-x86_64-20260911.iso) |
+| NVIDIA | 3.96 GiB | [Download NVIDIA ISO](https://downloads.christitus.com/iso/2026-09-11/dwm-titus-fedora44-x86_64-20260911-nvidia.iso) |
+| Checksums | | [Download SHA256SUMS](https://downloads.christitus.com/iso/2026-09-11/SHA256SUMS) |
+
+Use the standard image unless you need the proprietary NVIDIA driver packages.
+Both include LightDM, dwm, Quickshell, fonts, Gear Lever, and `maim` with region
+capture and clipboard dependencies. Internet access is needed for later updates
+and additional software.
+
+### Verify the Download
+
+Save your selected ISO and `SHA256SUMS` in the same directory. On Linux, run:
+
+```sh
+sha256sum --ignore-missing -c SHA256SUMS
+```
+
+Your selected ISO must report `OK`; do not continue with a mismatch. For a
+resumable standard-image download from the command line:
+
+```sh
+curl --fail --location --continue-at - --remote-name \
+  https://downloads.christitus.com/iso/2026-09-11/dwm-titus-fedora44-x86_64-20260911.iso
+curl --fail --location --remote-name \
+  https://downloads.christitus.com/iso/2026-09-11/SHA256SUMS
+sha256sum --ignore-missing -c SHA256SUMS
+```
+
+For NVIDIA, use the NVIDIA ISO link from the table with the same checksum file.
+
+### Install from USB
+
+1. Write the ISO as a disk image to an **8 GB or larger USB drive** using a USB
+   image writer. This erases the USB drive; copying the ISO file onto it is not
+   the same as writing the image.
+2. Boot the USB and use the default media-test/install entry. Qualification used
+   Secure Boot disabled; Secure Boot support is not verified.
+3. Select your language and keyboard, time zone, installation disk and partition
+   layout. Create your user account and select administrator access.
+4. Review the proposed disk changes and choose **Begin Installation**. The
+   compressed image provides the package set; there is no installation-source
+   or software-selection step and no network connection is required.
+5. Once installation finishes, reboot and remove the USB. Log in through LightDM
+   using the **dwm** session. The desktop is already installed; you do not need to
+   run the existing-system installer below.
+
+`Super` is usually the Windows key. Open a terminal with `Super+X`, take a full
+screenshot with `Super+P`, select a region with `Super+Shift+P`, or copy a region
+to the clipboard with `Super+Ctrl+P`.
+
+Standard installation and first desktop login passed offline UEFI and BIOS VM
+checks. The NVIDIA image passed offline UEFI and desktop checks using virtual
+graphics. **Physical NVIDIA acceleration remains untested**; its persistence
+service cannot run in a VM without an NVIDIA device. See the
+[build notes and qualification limits](https://downloads.christitus.com/iso/2026-09-11/BUILD-NOTES.md),
+[package/build manifest](https://downloads.christitus.com/iso/2026-09-11/BUILD-MANIFEST.json), and
+[v0.7.0 release notes](https://github.com/ChrisTitusTech/dwm-titus/releases/tag/v0.7.0).
+The older ISO files attached directly to that GitHub release still require
+network package installation; use the Cloudflare downloads above for offline
+installation.
+
+## Existing Fedora System: Quick Install
 
 The easiest way is via [Linutil](https://christitus.com/linux):
 

--- a/dwm-fedora-image.ks
+++ b/dwm-fedora-image.ks
@@ -1,0 +1,20 @@
+# Offline compressed-system installation. Rendered by the ISO builder.
+# Disk, locale, keyboard, timezone and account selection remain interactive.
+firstboot --disable
+selinux --disabled
+liveimg --url="file:///run/install/repo/images/dwm-rootfs.tar.xz" --checksum="@IMAGE_SHA256@"
+bootloader --location=mbr @BOOT_ARGUMENTS@
+services --enabled=NetworkManager,lightdm
+
+# Keep the installer bootstrap with the ISO, allowing fixes without rebuilding
+# packages. The desktop itself still comes from the checksummed system image.
+%post --nochroot --interpreter=/bin/bash --erroronfail --log=/mnt/sysimage/root/dwm-titus-image-bootstrap.log
+set -euo pipefail
+[[ -f /mnt/sysimage/etc/dwm-titus-image ]]
+install -o 0 -g 0 -m 0755 /run/install/repo/dwm-titus/scripts/image/finish-install.sh /mnt/sysimage/usr/share/dwm-titus-image/scripts/image/finish-install.sh
+%end
+
+%post --interpreter=/bin/bash --erroronfail --log=/root/dwm-titus-image-install.log
+set -euo pipefail
+bash /usr/share/dwm-titus-image/scripts/image/finish-install.sh --installer-target
+%end

--- a/scripts/build-dwm-fedora-installer-iso.sh
+++ b/scripts/build-dwm-fedora-installer-iso.sh
@@ -3,10 +3,12 @@ set -euo pipefail
 
 usage() {
 	cat <<'EOF'
-Usage: scripts/build-dwm-fedora-installer-iso.sh --input ISO --output ISO [--variant standard|nvidia] [--version X.Y.Z]
+Usage: scripts/build-dwm-fedora-installer-iso.sh --input ISO --output ISO [--variant standard|nvidia] [--version X.Y.Z] [--system-image ROOTFS.tar.xz]
 
 Embed this checkout and a dwm-titus Kickstart into a Fedora installer ISO.
 The resulting ISO exposes the checkout at /run/install/repo/dwm-titus.
+--system-image selects offline installation from a factory-built root filesystem
+and its required .tar.xz.json manifest. The manifest must match --variant.
 EOF
 }
 
@@ -18,6 +20,7 @@ input_iso=
 output_iso=
 variant=standard
 version=
+system_image=
 
 while (($# > 0)); do
 	case "$1" in
@@ -56,6 +59,14 @@ while (($# > 0)); do
 	--variant=*)
 		variant=${1#*=}
 		shift
+		;;
+	--system-image)
+		(($# >= 2)) || {
+			err "--system-image requires a value"
+			exit 1
+		}
+		system_image=$2
+		shift 2
 		;;
 	--version)
 		if (($# < 2)) || [[ -z ${2:-} ]]; then
@@ -134,16 +145,59 @@ if [[ ! -f $ks_file ]]; then
 fi
 
 work_dir="$(mktemp -d)"
+tmp_output=
+trap 'rm -rf "$work_dir"; [[ -z $tmp_output ]] || rm -f "$tmp_output"' EXIT
 payload_dir="$work_dir/dwm-titus"
+system_image_args=()
+if [[ -n $system_image ]]; then
+	image_sha=$(
+		python3 - "$system_image" "$variant" <<'PYTHON'
+import hashlib
+import json
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+if not path.name.endswith('.tar.xz'):
+    sys.exit('System image must be a .tar.xz file')
+metadata = json.loads(Path(str(path) + '.json').read_text())
+if (metadata.get('protocol'), metadata.get('variant'), metadata.get('fedora'), metadata.get('architecture')) != (1, sys.argv[2], '44', 'x86_64'):
+    sys.exit('System-image manifest does not match Fedora 44, x86_64 and selected variant')
+with path.open('rb') as stream:
+    digest = hashlib.file_digest(stream, 'sha256').hexdigest()
+if digest != metadata.get('sha256') or path.stat().st_size != metadata.get('size'):
+    sys.exit('System-image checksum or size mismatch')
+print(digest)
+PYTHON
+	)
+	ks_file="$work_dir/image.ks"
+	boot_arguments=
+	if [[ -n $extra_linux_args ]]; then
+		boot_arguments="--append=\"$extra_linux_args\""
+	fi
+	sed -e "s/@IMAGE_SHA256@/$image_sha/" \
+		-e "s/@BOOT_ARGUMENTS@/$boot_arguments/" "$repo_dir/dwm-fedora-image.ks" >"$ks_file"
+	ksvalidator "$ks_file"
+	system_image_args=(-map "$system_image" /images/dwm-rootfs.tar.xz)
+fi
 output_dir="$(dirname "$output_iso")"
 output_base="$(basename "$output_iso")"
 tmp_output="$(mktemp "$output_dir/.$output_base.tmp.XXXXXX")"
 rm -f "$tmp_output"
-trap 'rm -rf "$work_dir"; rm -f "$tmp_output"' EXIT
 
+# These basename patterns apply at every depth, independently of Git ignores.
 rsync -a --delete \
+	--exclude='.env' \
+	--exclude='.env.*' \
+	--exclude='.envrc' \
 	--exclude='.git/' \
 	--exclude='.cache/' \
+	--exclude='node_modules/' \
+	--exclude='__pycache__/' \
+	--exclude='/docs/dist/' \
+	--exclude='/docs/.astro/' \
+	--exclude='/.ci-pykickstart/' \
+	--exclude='/.serena/' \
+	--exclude='/vicinae/' \
 	--exclude='release/' \
 	--exclude='config.h' \
 	--exclude='*.o' \
@@ -212,7 +266,8 @@ xorriso -indev "$input_iso" -outdev "$tmp_output" \
 	-map "$ks_file" /dwm-fedora.ks \
 	"${grub_xorriso_args[@]}" \
 	-map "$payload_dir" /dwm-titus \
-	"${extra_xorriso_args[@]}"
+	"${extra_xorriso_args[@]}" \
+	"${system_image_args[@]}"
 
 # Rewriting the ISO drops the upstream media checksum. The default Fedora
 # boot entry uses rd.live.check, so verify a fresh checksum before publishing

--- a/scripts/build-dwm-fedora-system-image.py
+++ b/scripts/build-dwm-fedora-system-image.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Build a sanitized root filesystem in a disposable KVM guest (never on host)."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+def run(*args, **kwargs):
+    return subprocess.run([str(a) for a in args], check=True, **kwargs)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--input', type=Path, required=True, help='Verified Fedora 44 Server netinst ISO')
+    parser.add_argument('--output', type=Path, required=True, help='New root filesystem .tar.xz')
+    parser.add_argument('--variant', choices=['standard', 'nvidia'], default='standard')
+    parser.add_argument('--timeout', type=int, default=7200)
+    args = parser.parse_args()
+    args.input = args.input.resolve(strict=True)
+    args.output = args.output.absolute()
+    # Pin the reviewed Fedora 44 Server base used by both firmware paths.
+    with args.input.open('rb') as stream:
+        source_sha256 = hashlib.file_digest(stream, 'sha256').hexdigest()
+    if source_sha256 != 'ae20c06bea746913cadea7d80463e13f4bf55bee4df2918111c921c674b70283':
+        parser.error('input checksum does not match Fedora 44 Server 1.7 x86_64')
+    if not args.output.name.endswith('.tar.xz') or args.output.exists():
+        parser.error('output must be a new .tar.xz file')
+    for tool in ['qemu-system-x86_64', 'qemu-img', 'xorriso', 'guestfish', 'xz', 'ksvalidator']:
+        if not shutil.which(tool):
+            parser.error(f'missing tool: {tool}')
+    repo = Path(__file__).resolve().parent.parent
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    test_root = Path(os.environ.get('DWM_TEST_TMP_ROOT', str(Path.home() / 'tmp')))
+    test_root.mkdir(parents=True, exist_ok=True)
+    evidence = args.output.with_name(args.output.name + '.logs')
+    evidence.mkdir(exist_ok=False)
+    with tempfile.TemporaryDirectory(prefix='dwm-factory.', dir=test_root) as temp:
+        work = Path(temp)
+        env = os.environ.copy()
+        env['TMPDIR'] = str(work)
+        env['LIBGUESTFS_BACKEND'] = 'direct'
+        with (evidence / 'build.log').open('w') as log:
+            run(repo / 'scripts/build-dwm-fedora-installer-iso.sh', '--input', args.input,
+                '--output', work / 'network.iso', '--variant', args.variant,
+                env=env, stdout=log, stderr=subprocess.STDOUT)
+            profile = repo / ('dwm-fedora-nvidia.ks' if args.variant == 'nvidia' else 'dwm-fedora.ks')
+            ks = ('text\nlang en_US.UTF-8\nkeyboard us\ntimezone UTC --utc\n'
+                  'rootpw --lock\nuser --name=imagebuilder --groups=wheel --lock\n'
+                  'ignoredisk --only-use=vda\nzerombr\nclearpart --all --initlabel --drives=vda\n'
+                  'autopart --type=plain --nohome\npoweroff\n' + profile.read_text())
+            ks = ks.replace('set -eu\n', 'set -eu\nexec > /dev/ttyS0 2>&1\n')
+            boot_packages = run('bash', repo / 'scripts/dwm-packages.sh', 'fedora',
+                                'image-boot', capture_output=True, text=True).stdout
+            ks = ks.replace('%packages\n', '%packages\n' + boot_packages, 1)
+            ks += ('\n%post --interpreter=/bin/bash --erroronfail\nset -euo pipefail\nexec > /dev/ttyS0 2>&1\n'
+                   f"printf '%s\\n' '{args.variant}' > /etc/dwm-titus-factory-target\n"
+                   'bash /home/imagebuilder/.local/share/dwm-titus/scripts/image/prepare-factory.sh --factory-target\n%end\n')
+            (work / 'factory.ks').write_text(ks)
+            run('ksvalidator', work / 'factory.ks', stdout=log, stderr=subprocess.STDOUT)
+            run('xorriso', '-indev', work / 'network.iso', '-outdev', work / 'factory.iso',
+                '-boot_image', 'any', 'replay', '-map', work / 'factory.ks', '/factory.ks',
+                stdout=log, stderr=subprocess.STDOUT)
+            for name in ['vmlinuz', 'initrd.img']:
+                run('xorriso', '-osirrox', 'on', '-indev', args.input, '-extract',
+                    '/images/pxeboot/' + name, work / name, stdout=log, stderr=subprocess.STDOUT)
+            run('qemu-img', 'create', '-f', 'qcow2', work / 'factory.qcow2', '50G', stdout=log)
+            shutil.copy2('/usr/share/edk2/ovmf/OVMF_VARS.fd', work / 'vars.fd')
+            command = ['qemu-system-x86_64', '-enable-kvm', '-machine', 'q35', '-cpu', 'host',
+                       '-smp', '4', '-m', '6144', '-display', 'none', '-serial', 'stdio', '-monitor', 'none',
+                       '-drive', 'if=pflash,format=raw,readonly=on,file=/usr/share/edk2/ovmf/OVMF_CODE.fd',
+                       '-drive', f'if=pflash,format=raw,file={work}/vars.fd',
+                       '-drive', f'file={work}/factory.qcow2,if=virtio,format=qcow2',
+                       '-cdrom', str(work / 'factory.iso'), '-nic', 'user,model=virtio-net-pci',
+                       '-kernel', str(work / 'vmlinuz'), '-initrd', str(work / 'initrd.img'),
+                       '-append', 'inst.stage2=hd:LABEL=Fedora-S-dvd-x86_64-44 inst.ks=hd:LABEL=Fedora-S-dvd-x86_64-44:/factory.ks inst.text console=ttyS0']
+            (evidence / 'qemu-command.json').write_text(json.dumps(command, indent=2) + '\n')
+            with (evidence / 'factory-console.log').open('w') as console:
+                run(*command, stdout=console, stderr=subprocess.STDOUT, timeout=args.timeout)
+            marker = run('guestfish', '--ro', '-a', work / 'factory.qcow2', '-i', 'cat',
+                         '/etc/dwm-titus-image', env=env, capture_output=True, text=True).stdout
+            if f'variant={args.variant}\n' not in marker:
+                raise RuntimeError('Factory did not finish preparation')
+            run('guestfish', '-a', work / 'factory.qcow2', '-i',
+                'upload', repo / 'scripts/image/check-root.sh', '/tmp/dwm-image-check.sh', ':',
+                'sh', 'bash /tmp/dwm-image-check.sh', ':', 'rm-f', '/tmp/dwm-image-check.sh', ':',
+                'tar-out', '/',
+                work / 'rootfs.tar', 'numericowner:true', 'xattrs:true', 'selinux:true', 'acls:true',
+                env=env, stdout=log, stderr=subprocess.STDOUT)
+            run('xz', '-T4', '-6', work / 'rootfs.tar', stdout=log, stderr=subprocess.STDOUT)
+            # Copy into an adjacent temporary file; publish only a completed capture.
+            with tempfile.NamedTemporaryFile(dir=args.output.parent, delete=False) as out:
+                staged = Path(out.name)
+            try:
+                shutil.copyfile(work / 'rootfs.tar.xz', staged)
+                with staged.open('rb') as stream:
+                    digest = hashlib.file_digest(stream, 'sha256').hexdigest()
+                staged.replace(args.output)
+            finally:
+                staged.unlink(missing_ok=True)
+            manifest = {'protocol': 1, 'variant': args.variant, 'fedora': '44', 'architecture': 'x86_64',
+                        'source_sha256': source_sha256, 'sha256': digest, 'size': args.output.stat().st_size}
+            args.output.with_name(args.output.name + '.json').write_text(json.dumps(manifest, indent=2) + '\n')
+            print(json.dumps(manifest))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/dwm-packages.sh
+++ b/scripts/dwm-packages.sh
@@ -15,6 +15,14 @@ dwm_packages() {
 	fedora:image-build)
 		printf '%s\n' xorriso rsync squashfs-tools-ng isomd5sum python3-pillow fontconfig google-noto-sans-fonts
 		;;
+	fedora:image-factory)
+		dwm_packages "$family" image-build
+		printf '%s\n' qemu-system-x86 qemu-img edk2-ovmf libguestfs pykickstart xz
+		;;
+	fedora:image-boot)
+		printf '%s\n' tar dracut-network grub2-pc grub2-pc-modules grub2-efi-x64 shim-x64 \
+			lvm2 cryptsetup btrfs-progs xfsprogs e2fsprogs mdadm dosfstools
+		;;
 	fedora:x11)
 		printf '%s\n' xorg-x11-server-Xorg xorg-x11-xinit xrandr xset xsetroot xinput setxkbmap xkbset
 		;;

--- a/scripts/image/check-root.sh
+++ b/scripts/image/check-root.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Sanitize the powered-off factory filesystem and validate before capture.
+set -euo pipefail
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+[[ -f /etc/dwm-titus-image && $(id -u) == 0 ]]
+[[ $(getent passwd imagebuilder | cut -d: -f6) == /home/imagebuilder ]]
+factory_uid=$(id -u imagebuilder)
+factory_gid=$(id -g imagebuilder)
+userdel --remove imagebuilder
+# Factory storage and identities must never be copied onto installed machines.
+: >/etc/fstab
+: >/etc/machine-id
+rm -f /var/lib/dbus/machine-id /var/lib/systemd/random-seed /etc/ssh/ssh_host_*
+rm -f /etc/sudoers.d/90-dwm-titus-install /etc/dwm-titus-factory-target
+rm -f /etc/adjtime /etc/kernel/cmdline /etc/kernel/entry-token
+rm -f /etc/passwd- /etc/shadow- /etc/group- /etc/gshadow-
+rm -f /var/lib/systemd/credential.secret
+rm -f /etc/pki/akmods/private/private_key.priv /etc/pki/akmods/certs/public_key.der
+rm -rf /var/lib/AccountsService/users/* /var/lib/AccountsService/icons/*
+rm -rf /etc/NetworkManager/system-connections/* /var/lib/NetworkManager/*
+rm -rf /boot/loader/entries/* /boot/grub2/grub.cfg /boot/grub2/grubenv /boot/efi/EFI/fedora/grub.cfg
+rm -rf /opt/dwm-titus
+rm -rf /root/* /root/.[!.]* /root/..?* /tmp/* /var/tmp/* /var/log/*
+rm -rf /var/cache/dnf /var/cache/libdnf5 /var/cache/akmods
+printf 'localhost\n' >/etc/hostname
+# The factory account owned these files before capture. Never give the first
+# installed account write access to system assets or the root-run finish helper.
+find /etc /usr /opt /var /boot \( -uid "$factory_uid" -o -gid "$factory_gid" \) -exec chown -h root:root {} +
+shared_assets=(/usr/share/dwm-titus-image /usr/local/share/fonts/dwm-titus
+	/usr/share/themes/Nordic /usr/share/icons/Capitaine-Cursors*)
+chown -R root:root "${shared_assets[@]}"
+chmod -R go-w "${shared_assets[@]}"
+[[ -z $(find /etc /usr /opt /var /boot \( -uid "$factory_uid" -o -gid "$factory_gid" \) -print -quit) ]]
+[[ -z $(find "${shared_assets[@]}" \( ! -user root -o ! -group root -o \( ! -type l -a -perm /022 \) \) -print -quit) ]]
+# Reuse the package contract instead of maintaining a second RPM list.
+# Loaded from the installed image, not the build host.
+# shellcheck disable=SC1091
+source /usr/share/dwm-titus-image/scripts/dwm-packages.sh
+mapfile -t packages < <({
+	dwm_packages fedora full
+	dwm_packages fedora terminal
+	dwm_packages fedora lightdm
+	dwm_packages fedora image-boot
+} | sort -u)
+rpm -q "${packages[@]}" >/dev/null
+[[ -z $(find /usr/share/dwm-titus-image \( -name '.env' -o -name '.env.*' -o -name '.envrc' \) -print -quit) ]]
+missing=0
+# maim uses libslop for region selection; RPM resolves its shared dependencies.
+for command in dwm quickshell alacritty maim xclip xdotool xrandr xset xinput \
+	setxkbmap xkbset notify-send xdg-open xdg-mime xdg-user-dir \
+	picom feh dex-autostart xsettingsd light-locker light-locker-command \
+	nmcli bluetoothctl wpctl pactl playerctl brightnessctl amixer protonrestart \
+	flatpak pavucontrol thunar file-roller dconf gsettings \
+	busctl systemctl loginctl pkexec jq python3 \
+	dwm-screenshot dwm-terminal dwm-default-apps dwm-lock dwm-diagnostics \
+	dwm-quickshell-launcher dwm-quickshell-controlcenter; do
+	if ! command -v "$command" >/dev/null; then
+		printf 'Missing shipped-feature command: %s\n' "$command" >&2
+		missing=1
+	fi
+done
+((missing == 0))
+for command in maim dwm; do
+	libraries=$(ldd "$(command -v "$command")")
+	if [[ $libraries == *'not found'* ]]; then
+		printf '%s\n' "$libraries" >&2
+		exit 1
+	fi
+done
+flatpak --system info it.mijorus.gearlever >/dev/null
+[[ $(fc-match -f '%{family}' 'MesloLGS Nerd Font Mono') == *Meslo* ]]
+[[ -n $(find /boot -maxdepth 1 -name 'vmlinuz-*' -print -quit) ]]
+[[ -x /usr/libexec/polkit-mate-authentication-agent-1 ]]
+[[ -d /usr/share/themes/Nordic && -f /usr/share/xsessions/dwm.desktop ]]
+[[ ! -s /etc/machine-id && ! -s /etc/fstab ]]
+[[ -z $(awk -F: '$3 >= 1000 && $3 < 60000 {print $1}' /etc/passwd) ]]
+[[ ! -e /etc/sudoers.d/90-dwm-titus-install ]]
+if compgen -G '/etc/ssh/ssh_host_*' >/dev/null; then exit 1; fi
+printf 'Offline image feature dependencies and factory identity: PASS\n'

--- a/scripts/image/finish-install.sh
+++ b/scripts/image/finish-install.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Offline Anaconda %post: system packages and assets are already in the image.
+set -euo pipefail
+[[ ${1:-} == --installer-target && -f /etc/dwm-titus-image ]]
+[[ $(id -u) == 0 ]]
+source_dir=/usr/share/dwm-titus-image
+mapfile -t users < <(awk -F: '$3 >= 1000 && $3 < 60000 && $6 ~ "^/home/" && $7 !~ /(nologin|false)$/ {print $1}' /etc/passwd)
+((${#users[@]} > 0)) || {
+	echo 'Create a regular user in Anaconda.' >&2
+	exit 1
+}
+for user in "${users[@]}"; do
+	home=$(getent passwd "$user" | cut -d: -f6)
+	[[ $home == /home/* && ! -L $home ]]
+	target="$home/.local/share/dwm-titus"
+	for directory in "$home/.local" "$home/.local/share"; do
+		[[ ! -L $directory && (! -e $directory || -d $directory) ]] || {
+			printf 'Unsafe user data directory: %s\n' "$directory" >&2
+			exit 1
+		}
+		if [[ ! -e $directory ]]; then
+			install -d -o "$user" -g "$(id -gn "$user")" "$directory"
+		fi
+	done
+	[[ ! -e $target && ! -L $target ]]
+	cp -a "$source_dir" "$target"
+	chown -R "$user:$(id -gn "$user")" "$target"
+	# Expanded under the real user, not the installer.
+	# shellcheck disable=SC2016
+	runuser -u "$user" -- env -i HOME="$home" USER="$user" LOGNAME="$user" \
+		PATH=/usr/local/bin:/usr/bin:/bin LANG=C.UTF-8 \
+		dbus-run-session -- bash -ec '
+export DBUS_SYSTEM_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS
+cd "$HOME/.local/share/dwm-titus"
+make install-user
+xdg-user-dirs-update
+mkdir -p "$HOME/Pictures/backgrounds"
+wallpaper="$HOME/Pictures/backgrounds/dwm-titus.jpg"
+if [[ ! -e $wallpaper && ! -L $wallpaper ]]; then
+	install -m 0644 lightdm/wallpaper.jpg "$wallpaper"
+fi
+scripts/install-gearlever
+'
+	if getent group gamemode >/dev/null; then usermod -aG gamemode "$user"; fi
+done
+systemctl enable NetworkManager lightdm
+systemctl set-default graphical.target

--- a/scripts/image/prepare-factory.sh
+++ b/scripts/image/prepare-factory.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Runs only inside the disposable factory installer target, never on the host.
+set -euo pipefail
+[[ ${1:-} == --factory-target && -f /etc/dwm-titus-factory-target ]]
+[[ $(id -u) == 0 && $(getent passwd imagebuilder | cut -d: -f6) == /home/imagebuilder ]]
+# shellcheck disable=SC1091
+source /etc/os-release
+[[ $ID == fedora && $VERSION_ID == 44 ]]
+variant=$(cat /etc/dwm-titus-factory-target)
+[[ $variant == standard || $variant == nvidia ]]
+source_dir=/home/imagebuilder/.local/share/dwm-titus
+install -d /usr/share/dwm-titus-image /usr/local/share/fonts/dwm-titus
+cp -a "$source_dir"/. /usr/share/dwm-titus-image/
+cp -a /home/imagebuilder/.local/share/fonts/. /usr/local/share/fonts/dwm-titus/
+# User configuration is generated offline for the real account at installation.
+# Install the Flatpak system-wide so it is not tied to the factory account.
+# Expanded by the private child shell.
+# shellcheck disable=SC2016
+if ! flatpak --system info it.mijorus.gearlever >/dev/null 2>&1; then
+	dbus-run-session -- sh -ec '
+export DBUS_SYSTEM_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS
+flatpak --system remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+flatpak --system install --noninteractive -y flathub it.mijorus.gearlever
+flatpak --system info it.mijorus.gearlever
+'
+fi
+fc-cache -f
+rpm -qa --qf '%{NAME}-%{EPOCHNUM}:%{VERSION}-%{RELEASE}.%{ARCH}\n' | sort >/usr/share/dwm-titus-image/rpm-manifest.txt
+flatpak --system list --columns=ref:full,active:full >/usr/share/dwm-titus-image/flatpak-manifest.txt
+printf 'protocol=1\nvariant=%s\nfedora=44\narchitecture=x86_64\n' "$variant" >/etc/dwm-titus-image
+[[ -x /usr/local/bin/dwm && -f /usr/share/xsessions/dwm.desktop ]]
+[[ -d /var/lib/flatpak/app/it.mijorus.gearlever ]]
+printf 'DWM_FACTORY_PREPARED\n'

--- a/tests/test-fedora-iso-builder.sh
+++ b/tests/test-fedora-iso-builder.sh
@@ -9,15 +9,27 @@ work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
 mkdir -p "$work/bin"
+export DWM_TEST_REAL_RSYNC
+DWM_TEST_REAL_RSYNC=$(command -v rsync)
+export DWM_TEST_PAYLOAD_FIXTURE="$work/payload fixture"
+mkdir -p "$DWM_TEST_PAYLOAD_FIXTURE/nested/deeper"
+printf 'payload\n' >"$DWM_TEST_PAYLOAD_FIXTURE/payload-marker"
+printf 'retained\n' >"$DWM_TEST_PAYLOAD_FIXTURE/nested/deeper/keep.txt"
+for directory in "$DWM_TEST_PAYLOAD_FIXTURE" "$DWM_TEST_PAYLOAD_FIXTURE/nested/deeper"; do
+	for name in .env .env.local .env.production .envrc; do
+		printf 'DUMMY_TOKEN=test-only\n' >"$directory/$name"
+	done
+done
 
 cat >"$work/bin/rsync" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 
 printf '%s\n' "$*" >>"$DWM_TEST_RSYNC_LOG"
-dest=${@: -1}
-mkdir -p "$dest"
-printf 'payload\n' >"$dest/payload-marker"
+# Exercise the production filters with real rsync, using only dummy files.
+args=("$@")
+args[$#-2]="$DWM_TEST_PAYLOAD_FIXTURE/"
+"$DWM_TEST_REAL_RSYNC" "${args[@]}"
 SH
 chmod +x "$work/bin/rsync"
 
@@ -47,6 +59,7 @@ grub_map=
 bios_grub_map=
 payload_map=
 product_map=
+rootfs_map=
 
 while (($# > 0)); do
 	case "$1" in
@@ -68,6 +81,7 @@ while (($# > 0)); do
 		/boot/grub2/grub.cfg) bios_grub_map=${2:-} ;;
 		/dwm-titus) payload_map=${2:-} ;;
 		/images/product.img) product_map=${2:-} ;;
+		/images/dwm-rootfs.tar.xz) rootfs_map=${2:-} ;;
 		esac
 		shift 3
 		;;
@@ -93,7 +107,16 @@ fi
 
 if [[ -n $outdev ]]; then
 	[[ -s $product_map ]]
+	[[ -s $payload_map/payload-marker && -s $payload_map/nested/deeper/keep.txt ]]
+	if [[ -n $(find "$payload_map" \( -name '.env' -o -name '.env.*' -o -name '.envrc' \) -print -quit) ]]; then
+		printf 'dotenv file reached ISO payload\n' >&2
+		exit 1
+	fi
 	{
+		if [[ -n $rootfs_map ]]; then
+			[[ -s $rootfs_map ]]
+			cat "$ks_map" >"$DWM_TEST_IMAGE_KS"
+		fi
 		printf 'ks=%s\n' "$ks_map"
 		printf 'grub=%s\n' "$grub_map"
 		printf 'payload=%s\n' "$payload_map"
@@ -174,6 +197,7 @@ run_builder() {
 	grep -F -- "--exclude=*.iso" "$DWM_TEST_RSYNC_LOG" >/dev/null
 }
 
+export DWM_TEST_IMAGE_KS="$work/image.ks"
 export DWM_TEST_XORRISO_LOG="$work/xorriso.log"
 export DWM_TEST_RSYNC_LOG="$work/rsync.log"
 export DWM_TEST_BRANDING="$repo/branding/anaconda"
@@ -259,5 +283,53 @@ if (cd "$work" && python3 "$repo/scripts/generate-sidebar-logo.py" --version 0.7
 fi
 grep -Fq -- '--out-dir requires --series' "$work/bad.err"
 [[ ! -e $work/ignored.png && ! -e $work/ignored && ! -e $work/branding && ! -e $work/sidebar-logo-v0.7.1.png ]]
+
+# Offline payloads must match the variant and verified bytes before ISO creation.
+image="$work/root filesystem.tar.xz"
+printf 'compressed fixture\n' >"$image"
+python3 - "$image" <<'PYTHON'
+import hashlib, json, pathlib, sys
+p = pathlib.Path(sys.argv[1])
+m = dict(protocol=1, variant='standard', fedora='44', architecture='x86_64',
+         size=p.stat().st_size, sha256=hashlib.sha256(p.read_bytes()).hexdigest())
+pathlib.Path(str(p) + '.json').write_text(json.dumps(m))
+PYTHON
+run_builder standard "$standard_iso" --system-image "$image"
+grep -Fq 'liveimg --url="file:///run/install/repo/images/dwm-rootfs.tar.xz" --checksum=' "$DWM_TEST_IMAGE_KS"
+if grep -Eq '^(url |repo |%packages)' "$DWM_TEST_IMAGE_KS"; then
+	echo 'Offline installer requests online package selection' >&2
+	exit 1
+fi
+python3 - "$image.json" <<'PYTHON'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1]); m = json.loads(p.read_text())
+m['variant'] = 'nvidia'; p.write_text(json.dumps(m))
+PYTHON
+run_builder nvidia "$nvidia_iso" --system-image "$image"
+grep -Fq 'bootloader --location=mbr --append="rd.driver.blacklist=nouveau modprobe.blacklist=nouveau nvidia-drm.modeset=1"' "$DWM_TEST_IMAGE_KS"
+python3 - "$image.json" <<'PYTHON'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1]); m = json.loads(p.read_text())
+m['variant'] = 'standard'; p.write_text(json.dumps(m))
+PYTHON
+mkdir "$work/invalid-temp"
+for failure in variant checksum manifest; do
+	selected=standard
+	case $failure in
+	variant) selected=nvidia ;;
+	checksum) printf 'tampered\n' >>"$image" ;;
+	manifest) rm "$image.json" ;;
+	esac
+	printf 'previous image\n' >"$standard_iso"
+	if TMPDIR="$work/invalid-temp" PATH="$work/bin:$PATH" \
+		"$repo/scripts/build-dwm-fedora-installer-iso.sh" --input "$input_iso" \
+		--output "$standard_iso" --variant "$selected" --system-image "$image" \
+		>"$work/failed.out" 2>"$work/failed.err"; then
+		echo "Accepted invalid system image: $failure" >&2
+		exit 1
+	fi
+	[[ $(cat "$standard_iso") == 'previous image' ]]
+	[[ -z $(find "$work/invalid-temp" -mindepth 1 -print -quit) ]]
+done
 
 printf 'Fedora ISO builder: PASS\n'

--- a/tests/test-fedora-packages.sh
+++ b/tests/test-fedora-packages.sh
@@ -27,7 +27,8 @@ fi
 mapfile -t packages < <(
 	{
 		dwm_packages fedora required
-		dwm_packages fedora image-build
+		dwm_packages fedora image-factory
+		dwm_packages fedora image-boot
 		dwm_packages fedora desktop
 		dwm_packages fedora system-management
 		dwm_packages fedora system-management-optional


### PR DESCRIPTION
Fedora's network installer could stall while resolving repositories and selecting software. This adds factory-built compressed system images so Anaconda installs the complete desktop offline, while retaining interactive disk, locale and user setup. README and the documentation home/install page now point to the verified Cloudflare downloads, with sizes, checksum verification and USB installation steps.

The image workflow includes separate standard/NVIDIA manifests, storage/boot dependencies, offline user configuration, system-wide fonts and Gear Lever, and required maim/region/clipboard tools. Factory identities are removed and dotenv files are excluded recursively from the ISO payload, with a real-rsync regression check.

### Validation

- Reviewed commit: `975174d` against `a04ea8a7b3aac52079f6444d30494fe214039f48`; no base divergence. Independent local Codex review of the complete diff finished with no actionable findings. Final changes after review only record completed validation in planning/evidence documents.
- Reused passing unchanged implementation coverage: `scripts/run-tests` (complete suite, exit 0), clean native build, `scripts/run-tests make check-kickstart check-fedora-packages` (92 capabilities), ShellCheck/shfmt, package/build/preservation checks, and previous independent review/fix cycles.
- New documentation: `npm --prefix docs ci` and `npm --prefix docs run build` pass, zero Astro errors/warnings, 11 pages. Browser inspection confirms the rendered download table and guide. Rendered home/install links match the verified public artifacts; README section anchor resolves. `git diff --check` passes.
- Exact final standard ISO installed with no network adapter under both UEFI and BIOS, using default LVM; LightDM, dwm, Quickshell, fonts, Gear Lever and screenshot/clipboard workflows pass. NVIDIA variant passes offline UEFI installation and desktop checks with virtio graphics. Final helper SHA matches the qualified build.
- Both full ISO downloads and all seven supporting files passed authenticated R2 and public HTTPS SHA-256 comparisons. HTTP byte-range resume returned 206. Public evidence: [build notes](https://downloads.christitus.com/iso/2026-09-11/BUILD-NOTES.md), [exact build manifest](https://downloads.christitus.com/iso/2026-09-11/BUILD-MANIFEST.json), [checksums](https://downloads.christitus.com/iso/2026-09-11/SHA256SUMS).
- Full logs, VM screenshots (including release-bios-desktop.png and release-nvidia-captures.png), runtime results and review logs are retained locally under `/home/titus/tmp/dwm-compressed-20260911/evidence`. Repository qualification: `docs/COMPRESSED-QUALIFICATION.md`.

### Limits

Physical NVIDIA acceleration remains untested; nvidia-persistenced fails in the NVIDIA VM because no NVIDIA device is attached. Secure Boot, physical peripherals and suspend/resume remain unqualified. These limits are explicit in the download/install guide and release notes. Existing GitHub v0.7.0 assets/tag are preserved; the release links the new R2-hosted builds and records their separate provenance.

The pre-existing local `.gitignore` edit is excluded from this commit. No credentials or generated ISO/root filesystem files are committed. The user explicitly authorized updating the download/install path and merging to main. Hosted checks run on main as the repository's post-merge safety net.
