### PR TITLE
Fix initial theme convergence and include icon themes in installer defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,6 +289,8 @@ install-user:
 			find "${CFG_DIR}/$$b" \( -name '*.sh' -o -name '*.py' \) -print0 2>/dev/null | xargs -0 -r chmod +x; \
 		fi; \
 	done
+	@echo "==> Applying initial theme convergence..."
+	HOME="${USER_HOME}" XDG_CONFIG_HOME="${XDG_CONFIG_HOME}" scripts/theme-apply.sh
 	@echo ""
 	@echo "  dwm installed successfully."
 	@echo "  Log out and select 'dwm', or start with: startx"

--- a/dwm-fedora-nvidia.ks
+++ b/dwm-fedora-nvidia.ks
@@ -127,6 +127,8 @@ libnotify
 light-locker
 xorg-x11-drv-libinput
 dconf
+adwaita-icon-theme
+papirus-icon-theme
 arc-theme
 adw-gtk3-theme
 numix-gtk-theme

--- a/dwm-fedora.ks
+++ b/dwm-fedora.ks
@@ -126,6 +126,8 @@ libnotify
 light-locker
 xorg-x11-drv-libinput
 dconf
+adwaita-icon-theme
+papirus-icon-theme
 arc-theme
 adw-gtk3-theme
 numix-gtk-theme

--- a/scripts/dwm-packages.sh
+++ b/scripts/dwm-packages.sh
@@ -70,7 +70,7 @@ dwm_packages() {
 		fi
 		;;
 	fedora:theme)
-		printf '%s\n' dconf
+		printf '%s\n' dconf adwaita-icon-theme papirus-icon-theme
 		;;
 	fedora:theme-gtk)
 		printf '%s\n' \

--- a/scripts/image/finish-install.sh
+++ b/scripts/image/finish-install.sh
@@ -44,6 +44,7 @@ if [[ ! -e $wallpaper && ! -L $wallpaper ]]; then
 	install -m 0644 lightdm/wallpaper.jpg "$wallpaper"
 fi
 scripts/install-gearlever
+bash scripts/theme-apply.sh
 '
 	if getent group gamemode >/dev/null; then usermod -aG gamemode "$user"; fi
 done

--- a/scripts/image/seed-terminal.sh
+++ b/scripts/image/seed-terminal.sh
@@ -3,18 +3,19 @@
 set -euo pipefail
 [[ $(id -u) != 0 ]]
 config_home=${XDG_CONFIG_HOME:-$HOME/.config}
+skel_dir=${SKEL_DIR:-/etc/skel}
 bashrc=$HOME/.bashrc
 if [[ -L $bashrc ]]; then
 	exit 0
 fi
-if [[ -e $bashrc ]] && ! cmp -s "$bashrc" /etc/skel/.bashrc; then
+if [[ -e $bashrc ]] && ! cmp -s "$bashrc" "$skel_dir/.bashrc"; then
 	printf 'Preserving existing Bash configuration: %s\n' "$bashrc"
 	exit 0
 fi
 # Fedora's stock .bashrc also sources user-owned .bashrc.d fragments. A stock
 # .bashrc alone does not establish that this account has an untouched prompt.
 for startup in .bash_profile .bash_login .profile; do
-	if [[ -L $HOME/$startup ]] || { [[ -e $HOME/$startup ]] && ! cmp -s "$HOME/$startup" "/etc/skel/$startup"; }; then
+	if [[ -L $HOME/$startup ]] || { [[ -e $HOME/$startup ]] && ! cmp -s "$HOME/$startup" "$skel_dir/$startup"; }; then
 		printf 'Preserving existing shell startup: %s\n' "$HOME/$startup"
 		exit 0
 	fi

--- a/tests/test-image-user-defaults.sh
+++ b/tests/test-image-user-defaults.sh
@@ -14,10 +14,28 @@ if [[ $(id -u) == 0 ]]; then
 	exit
 fi
 export HOME=$work/home XDG_CONFIG_HOME=$work/home/.config XDG_DATA_HOME=$work/home/.local/share
-mkdir -p "$XDG_CONFIG_HOME/starship" "$work/bin"
+export SKEL_DIR=$work/skel
+mkdir -p "$XDG_CONFIG_HOME/starship" "$work/bin" "$SKEL_DIR"
+cat >"$SKEL_DIR/.bashrc" <<'RC'
+# Stock Fedora .bashrc
+export PATH=$PATH:$HOME/.local/bin:$HOME/bin
+if [ -d ~/.bashrc.d ]; then
+	for rc in ~/.bashrc.d/*; do
+		if [ -f "$rc" ]; then
+			. "$rc"
+		fi
+	done
+fi
+unset rc
+RC
+cat >"$SKEL_DIR/.bash_profile" <<'RC'
+# Stock Fedora .bash_profile
+[ -f ~/.bashrc ] && . ~/.bashrc
+export PATH=$PATH:$HOME/.local/bin:$HOME/bin
+RC
 cp "$repo/config/starship/starship.toml" "$XDG_CONFIG_HOME/starship/"
-cp /etc/skel/.bashrc "$HOME/.bashrc"
-cp /etc/skel/.bash_profile "$HOME/.bash_profile"
+cp "$SKEL_DIR/.bashrc" "$HOME/.bashrc"
+cp "$SKEL_DIR/.bash_profile" "$HOME/.bash_profile"
 cat >"$work/bin/starship" <<'SH'
 #!/bin/sh
 printf 'init\n' >>"$HOME/invocations"
@@ -46,7 +64,7 @@ bash "$repo/scripts/image/seed-terminal.sh"
 cmp "$work/custom" "$HOME/.bashrc"
 # A stock .bashrc can still source a customized prompt from .bashrc.d.
 rm "$HOME/.bashrc"
-cp /etc/skel/.bashrc "$HOME/.bashrc"
+cp "$SKEL_DIR/.bashrc" "$HOME/.bashrc"
 cp "$HOME/.bashrc" "$work/stock"
 mkdir "$HOME/.bashrc.d"
 printf 'PS1="fragment> "\n' >"$HOME/.bashrc.d/prompt.sh"

--- a/tests/test-kickstart-variants.sh
+++ b/tests/test-kickstart-variants.sh
@@ -53,6 +53,8 @@ required_packages=(
 	gnome-keyring-pam
 	qt6ct
 	qt5ct
+	adwaita-icon-theme
+	papirus-icon-theme
 	arc-theme
 	adw-gtk3-theme
 	numix-gtk-theme


### PR DESCRIPTION
### Summary
Fixes missing desktop application icons on offline/fresh installations and ensures appearance configuration converges immediately upon first login.

### Root Causes
1. **Missing application icons on offline install:**
Modern GNOME/Adwaita v46+ removed legacy application icons from the base `adwaita-icon-theme` package. On offline installations (or before `dnf upgrade`), Quickshell application launcher displayed placeholder squares because neither full Freedesktop application icons nor alternative icon themes were present.
2. **Restricted personalization mutation state:**
On fresh installs, `theme-apply.sh` was never executed during the user provisioning stage. As a result, GTK, Qt, and theme environment baselines were uninitialized, causing `dwm-settings-personalization` to report `mutation: restricted` and disabling the "Apply icon theme" button in Settings.
3. **Test hermeticity:**
`tests/test-image-user-defaults.sh` relied directly on `/etc/skel/.bashrc` sourcing `.bashrc.d/*`, which caused test failures when executed on developer workstations running non-Fedora distributions.

### Changes
- **Icon theme packages:**
Added `adwaita-icon-theme` and `papirus-icon-theme` to `fedora:theme` in `scripts/dwm-packages.sh`, `dwm-fedora.ks`, and `dwm-fedora-nvidia.ks` to guarantee full Freedesktop icon coverage out of the box.
- **Initial theme convergence:**
Invoked `scripts/theme-apply.sh` in `scripts/image/finish-install.sh` and the `Makefile` `install-user` target so GTK 3/4, Qt, and environment configurations converge before first session launch.
- **Test hermeticity:**
Permitted overriding `SKEL_DIR` in `scripts/image/seed-terminal.sh` (defaulting to `/etc/skel`) and added an isolated mock fixture in `tests/test- image-user-defaults.sh`.
- **Test suite synchronization:**
Synchronized `required_packages` in `tests/test-kickstart-variants.sh`.

### Verification
- `tests/test-kickstart-variants.sh`: PASS
- `tests/test-image-user-defaults.sh`: PASS
- `tests/test-dwm-settings-personalization.sh`: PASS
- `make check-install-manifest`: PASS