### PR TITLE
Stabilize Picom Appearance controls and add opacity settings

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -42,7 +42,7 @@ jobs:
           dnf install -y --setopt=install_weak_deps=False \
             "${required_packages[@]}" "${qml_packages[@]}" \
             "${system_management_packages[@]}" "${image_packages[@]}" \
-            diffutils dbus-daemon inotify-tools jq \
+            diffutils dbus-daemon inotify-tools jq picom \
             pkgconf-pkg-config ShellCheck shfmt pykickstart \
             xorg-x11-server-Xvfb
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ versions from `config.mk`.
 
 ### Fixed
 
+- Preserve per-screen Picom isolation, apply modern opacity defaults to dialogs,
+  retain ten recovery backups, and recover cleanly from concurrent config removal
+  and transient Appearance errors. Keep native relative shader and nested include
+  lookup behavior during edits.
+
 - Make Settings fullscreen like System Health (#302), stop Appearance overscroll
   bounce (#303), refresh running X11 clients when changing cursor themes (#304),
   and hide the redundant Blueman tray icon (#305).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ versions from `config.mk`.
 
 ### Changed
 
+- Replace unstable Picom Appearance checks with global opacity sliders,
+  configuration watching, and automatic GPU-aware backend selection with manual
+  overrides. Startup and restart now share the same display-scoped policy (#309).
+
 - Add Self-Heal to Quick Actions for launching a configured workstation repair
   script in a terminal with visible progress and authorization prompts (#306).
 - Simplify the Power dropdown to Reboot, Logout, Lock, Suspend, and Shutdown

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ INSTALL_COMMANDS = \
 	scripts/dwm-settings-input \
 	scripts/dwm-settings-appearance \
 	scripts/dwm-settings-font \
+	scripts/dwm-settings-picom \
 	scripts/dwm-settings-personalization \
 	scripts/dwm-settings-wallpaper \
 	scripts/dwm-settings-theme \
@@ -618,7 +619,13 @@ release-check: all
 		grep -Fqx 'Exec=${PREFIX}/bin/dwm'; \
 	echo "==> Release archive validated."
 
-check:
+check-picom:
+	$(call run_managed_test,python3 tests/test-picom.py)
+
+check-picom-xvfb:
+	$(call run_managed_test,python3 tests/test-picom-xvfb.py)
+
+check: check-picom check-picom-xvfb
 	$(MAKE) clean
 	$(MAKE) all
 	$(MAKE) check-shell
@@ -679,7 +686,7 @@ check:
 	$(MAKE) check-lightdm-config
 	$(MAKE) release-check
 
-.PHONY: clean all check check-accessibility check-appearance check-phase5-optional-components check-build-config check-build-deps check-default-apps check-xdg-autostart check-dev-sync-install \
+.PHONY: clean all check check-picom check-picom-xvfb check-accessibility check-appearance check-phase5-optional-components check-build-config check-build-deps check-default-apps check-xdg-autostart check-dev-sync-install \
 	check-cursor-reload \
 	check-test-runner \
 	check-display-profile check-display-setup check-fedora-iso-builder check-fedora-packages check-fedora-platform check-format check-install \

--- a/SPEC.md
+++ b/SPEC.md
@@ -539,6 +539,38 @@ Advanced partitioning, unrestricted service control, firewall policy editing,
 and similarly high-risk administration remain delegated unless a later
 specification defines a narrow safe interface.
 
+### 5.10.1 Picom Appearance
+
+Appearance provides a stable Compositor section backed by Picom configuration,
+independent of process polling. Active and inactive window opacity are global
+0-100 percent settings, saved on slider release (keyboard edits debounce for
+250 ms). Theme application reapplies current values without storing them in
+individual themes or overwriting them during theme rollback. Custom window
+rules retain precedence over managed defaults.
+
+The unprivileged `dwm-settings-picom` JSON protocol version 1 supplies `status`,
+`watch`, `set-opacity ACTIVE INACTIVE REVISION`, `set-backend BACKEND REVISION`,
+and `copy-config REVISION`. Mutations require the displayed source revision,
+validate before publication, preserve unrelated libconfig source and include
+files, back up changed files, and roll back failed activation. Missing Picom
+remains optional. Missing configuration shows 100 percent defaults and is
+created only on edit. Read-only system configurations require an explicit user
+copy, including referenced configuration files.
+
+`start`, `restart`, `reload`, `stop`, and `toggle` share user-and-display-scoped
+session handling. Valid syntax outside the editor's supported subset remains
+usable for session actions, with configuration parsing and backend policy
+delegated to Picom while explicit session overrides remain respected.
+Explicit `DWM_PICOM_CONFIG` and existing session `--config`
+paths precede standard Picom XDG discovery. `PICOM_BACKEND` overrides an
+explicit config backend; absent both, Automatic uses active-renderer diagnostics
+(GLX for accelerated Intel/AMD, XRender for NVIDIA, software, or unknown), with
+one XRender retry if automatic GLX startup fails. EGL is an explicit experimental
+choice. PCI passthrough devices do not determine the active renderer. NVIDIA
+synchronization defaults respect explicit configuration. Stopped Picom stays
+stopped during opacity edits or theme application. File watches end when
+Settings closes; no recurring compositor-state poll is required.
+
 ### 5.11 Fedora Image Contract
 
 Released Fedora images must be based on the Fedora Server Network Install ISO,

--- a/config/quickshell/appearance/AppearanceModel.qml
+++ b/config/quickshell/appearance/AppearanceModel.qml
@@ -38,7 +38,8 @@ Scope {
     property bool inventoryWatchSawEvent: false
     property bool inventoryWatchFailed: false
     property bool inventoryWatchRestartPending: false
-    property bool compositorWatchReady: false
+    readonly property alias picom: picomModel
+    PicomModel { id: picomModel; active: root.settingsVisible }
     property string wallpaperState: "idle"
     property string wallpaperPath: ""
     property string wallpaperFit: "fill"
@@ -462,12 +463,9 @@ Scope {
         root.inventoryWatchSawEvent = false;
         root.inventoryWatchFailed = true;
         root.inventoryWatchRestartPending = false;
-        root.compositorWatchReady = false;
         inventoryWatchExitSettleTimer.stop();
         inventoryWatchRestartTimer.stop();
         inventoryWatchProcess.running = false;
-        compositorWatchRestartTimer.stop();
-        compositorWatchProcess.running = false;
     }
 
     function parseInventory(text) {
@@ -532,19 +530,13 @@ Scope {
         }
         root.inventorySelections = selections;
         root.inventoryCandidates = candidates;
-        root.compositorWatchReady = selections.compositor.value === "picom";
         if (root.settingsVisible && !root.inventoryWatchFailed && watch.state === "available")
             root.startInventoryWatcher();
         if (watch.state !== "available") {
             inventoryWatchRestartTimer.stop();
             inventoryWatchProcess.running = false;
         }
-        if (root.settingsVisible && root.compositorWatchReady && !compositorWatchProcess.running)
-            compositorWatchProcess.running = true;
-        if (!root.compositorWatchReady) {
-            compositorWatchRestartTimer.stop();
-            compositorWatchProcess.running = false;
-        }
+
     }
 
     function parseSnapshot(text) {
@@ -855,6 +847,7 @@ Scope {
     }
 
     function refreshAll(forcePreviewStatus) {
+        picomModel.refresh();
         root.refreshSnapshot();
         root.refreshInventory();
         root.refreshPreviewStatus(forcePreviewStatus === true);
@@ -922,9 +915,6 @@ Scope {
         inventoryWatchProcess.running = false;
         root.inventoryWatchReady = false;
         root.inventoryWatchSawEvent = false;
-        compositorWatchSettleTimer.stop();
-        compositorWatchRestartTimer.stop();
-        compositorWatchProcess.running = false;
         xsettingsWatchProcess.running = false;
         root.xsettingsWatchReady = false;
         root.xsettingsWatchProtocolSeen = false;
@@ -1930,17 +1920,6 @@ Scope {
     }
 
     Process {
-        id: compositorWatchProcess
-        command: Commands.settingsAppearanceCommand("watch-compositor", [])
-        running: false
-        stdout: SplitParser { onRead: compositorWatchSettleTimer.restart() }
-        onRunningChanged: {
-            if (!running && root.settingsVisible && root.compositorWatchReady)
-                compositorWatchRestartTimer.restart();
-        }
-    }
-
-    Process {
         id: xsettingsWatchProcess
         command: Commands.settingsXsettingsCommand("watch", [])
         running: false
@@ -2196,23 +2175,6 @@ Scope {
             if (root.settingsVisible && (root.inventoryWatchState === "available"
                     || root.inventoryWatchState === "idle")
                     && !root.inventoryWatchFailed) root.startInventoryWatcher();
-        }
-    }
-
-    Timer {
-        id: compositorWatchSettleTimer
-        interval: 100
-        repeat: false
-        onTriggered: root.refreshInventory(true)
-    }
-
-    Timer {
-        id: compositorWatchRestartTimer
-        interval: 3000
-        repeat: false
-        onTriggered: {
-            if (root.settingsVisible && root.compositorWatchReady
-                    && !compositorWatchProcess.running) compositorWatchProcess.running = true;
         }
     }
 

--- a/config/quickshell/appearance/PicomModel.qml
+++ b/config/quickshell/appearance/PicomModel.qml
@@ -1,0 +1,120 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.core
+
+pragma ComponentBehavior: Bound
+
+Scope {
+    id: root
+    property bool active: false
+    property bool pending: false
+    property bool busy: false
+    property string message: ""
+    property string failure: ""
+    property var snapshot: ({ protocol: 1, editable: false, installed: false,
+        active: 100, inactive: 100, policy: "auto", effective: "", override: "",
+        revision: "", path: "", detail: "Loading Picom configuration", copyable: false })
+    property var actionArguments: []
+    property string action: "status"
+    readonly property bool editable: root.snapshot.editable && !root.busy
+
+    function accept(text) {
+        const value = JSON.parse(text);
+        if (value.protocol !== 1 || typeof value.editable !== "boolean"
+                || typeof value.revision !== "string" || typeof value.detail !== "string"
+                || typeof value.path !== "string" || typeof value.override !== "string"
+                || !Number.isFinite(value.active) || !Number.isFinite(value.inactive)
+                || value.active < 0 || value.active > 100 || value.inactive < 0 || value.inactive > 100
+                || ["auto", "xrender", "glx", "egl"].indexOf(value.policy) < 0)
+            throw new Error("Invalid Picom settings response");
+        root.snapshot = value;
+    }
+
+    function refresh() {
+        if (!root.active) return;
+        if (root.busy || statusProcess.running) {
+            root.pending = true;
+            return;
+        }
+        root.pending = false;
+        statusProcess.running = true;
+    }
+
+    function mutate(action, args) {
+        if (!root.editable && action !== "copy-config") return;
+        if (root.busy) return;
+        root.action = action;
+        root.actionArguments = args.concat([root.snapshot.revision]);
+        root.busy = true;
+        root.message = "";
+        root.failure = "";
+        actionProcess.running = true;
+    }
+
+    function setOpacity(active, inactive) {
+        root.mutate("set-opacity", [String(active), String(inactive)]);
+    }
+
+    onActiveChanged: {
+        if (active) root.refresh();
+        else {
+            statusProcess.running = false;
+            root.pending = false;
+            settle.stop();
+        }
+    }
+
+    Process {
+        id: statusProcess
+        command: Commands.helperCommand("dwm-settings-picom", "status", [], true)
+        stdout: StdioCollector { id: statusOutput }
+        stderr: StdioCollector { id: statusError }
+        onExited: (exitCode, exitStatus) => {
+            if (!root.active) return;
+            if (!root.busy) {
+                try {
+                    if (exitCode !== 0 || exitStatus !== 0) throw new Error(statusError.text || "Picom status failed");
+                    root.accept(statusOutput.text);
+                } catch (error) { root.failure = String(error); }
+            } else root.pending = true;
+            if (root.pending && !root.busy) settle.restart();
+        }
+    }
+
+    Process {
+        id: actionProcess
+        command: Commands.helperCommand("dwm-settings-picom", root.action, root.actionArguments, true)
+        stdout: StdioCollector { id: actionOutput }
+        stderr: StdioCollector { id: actionError }
+        onExited: (exitCode, exitStatus) => {
+            try {
+                if (exitCode !== 0 || exitStatus !== 0) throw new Error(actionError.text || "Picom change failed");
+                root.accept(actionOutput.text);
+                root.message = root.snapshot.message || "Picom configuration saved";
+            } catch (error) { root.failure = String(error); }
+            root.busy = false;
+            root.refresh();
+        }
+    }
+
+    Process {
+        id: watcher
+        command: Commands.helperCommand("dwm-settings-picom", "watch", [], true)
+        running: root.active
+        stdout: SplitParser {
+            onRead: data => { if (data === "changed" || data === "ready") settle.restart(); }
+        }
+        stderr: StdioCollector { id: watchError }
+        onExited: (exitCode, exitStatus) => {
+            if (root.active && (exitCode !== 0 || exitStatus !== 0))
+                root.failure = watchError.text || "Live Picom updates unavailable; use Refresh";
+        }
+    }
+
+    Timer {
+        id: settle
+        interval: 150
+        onTriggered: root.refresh()
+    }
+}

--- a/config/quickshell/appearance/PicomModel.qml
+++ b/config/quickshell/appearance/PicomModel.qml
@@ -11,7 +11,10 @@ Scope {
     property bool pending: false
     property bool busy: false
     property string message: ""
-    property string failure: ""
+    property string statusFailure: ""
+    property string watchFailure: ""
+    property string actionFailure: ""
+    readonly property string failure: actionFailure || statusFailure || watchFailure
     property var snapshot: ({ protocol: 1, editable: false, installed: false,
         active: 100, inactive: 100, policy: "auto", effective: "", override: "",
         revision: "", path: "", detail: "Loading Picom configuration", copyable: false })
@@ -48,7 +51,7 @@ Scope {
         root.actionArguments = args.concat([root.snapshot.revision]);
         root.busy = true;
         root.message = "";
-        root.failure = "";
+        root.actionFailure = "";
         actionProcess.running = true;
     }
 
@@ -76,7 +79,8 @@ Scope {
                 try {
                     if (exitCode !== 0 || exitStatus !== 0) throw new Error(statusError.text || "Picom status failed");
                     root.accept(statusOutput.text);
-                } catch (error) { root.failure = String(error); }
+                    root.statusFailure = "";
+                } catch (error) { root.statusFailure = String(error); }
             } else root.pending = true;
             if (root.pending && !root.busy) settle.restart();
         }
@@ -92,7 +96,7 @@ Scope {
                 if (exitCode !== 0 || exitStatus !== 0) throw new Error(actionError.text || "Picom change failed");
                 root.accept(actionOutput.text);
                 root.message = root.snapshot.message || "Picom configuration saved";
-            } catch (error) { root.failure = String(error); }
+            } catch (error) { root.actionFailure = String(error); }
             root.busy = false;
             root.refresh();
         }
@@ -103,12 +107,15 @@ Scope {
         command: Commands.helperCommand("dwm-settings-picom", "watch", [], true)
         running: root.active
         stdout: SplitParser {
-            onRead: data => { if (data === "changed" || data === "ready") settle.restart(); }
+            onRead: data => {
+                if (data === "ready") root.watchFailure = "";
+                if (data === "changed" || data === "ready") settle.restart();
+            }
         }
         stderr: StdioCollector { id: watchError }
         onExited: (exitCode, exitStatus) => {
             if (root.active && (exitCode !== 0 || exitStatus !== 0))
-                root.failure = watchError.text || "Live Picom updates unavailable; use Refresh";
+                root.watchFailure = watchError.text || "Live Picom updates unavailable; use Refresh";
         }
     }
 

--- a/config/quickshell/settings/AppearanceSettingsPane.qml
+++ b/config/quickshell/settings/AppearanceSettingsPane.qml
@@ -1388,6 +1388,8 @@ Flickable {
             }
         }
 
+        PicomSettingsPane { model: root.appearanceModel.picom }
+
         SectionLabel { label: "Application status" }
 
         Repeater {

--- a/config/quickshell/settings/PicomSettingsPane.qml
+++ b/config/quickshell/settings/PicomSettingsPane.qml
@@ -15,14 +15,22 @@ ColumnLayout {
     spacing: 10
 
     function synchronize() {
-        if (foreground.pressed || background.pressed || root.changed) return;
+        if (!root.model.snapshot.editable) {
+            keyboardDelay.stop();
+            root.changed = false;
+        } else if (foreground.pressed || background.pressed || root.changed) return;
         root.activeOpacity = root.model.snapshot.active;
         root.inactiveOpacity = root.model.snapshot.inactive;
     }
 
     function applyOpacity() {
         keyboardDelay.stop();
-        if (!root.changed || !root.model.editable) return;
+        if (!root.changed) return;
+        if (!root.model.snapshot.editable) {
+            root.synchronize();
+            return;
+        }
+        if (root.model.busy) return;
         root.changed = false;
         root.model.setOpacity(root.activeOpacity, root.inactiveOpacity);
     }

--- a/config/quickshell/settings/PicomSettingsPane.qml
+++ b/config/quickshell/settings/PicomSettingsPane.qml
@@ -1,0 +1,138 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls as Controls
+import qs.core
+
+pragma ComponentBehavior: Bound
+
+ColumnLayout {
+    id: root
+    required property var model
+    property real activeOpacity: 100
+    property real inactiveOpacity: 100
+    property bool changed: false
+    Layout.fillWidth: true
+    spacing: 10
+
+    function synchronize() {
+        if (foreground.pressed || background.pressed || root.changed) return;
+        root.activeOpacity = root.model.snapshot.active;
+        root.inactiveOpacity = root.model.snapshot.inactive;
+    }
+
+    function applyOpacity() {
+        keyboardDelay.stop();
+        if (!root.changed || !root.model.editable) return;
+        root.changed = false;
+        root.model.setOpacity(root.activeOpacity, root.inactiveOpacity);
+    }
+
+    Component.onCompleted: root.synchronize()
+    Connections {
+        target: root.model
+        function onSnapshotChanged() { root.synchronize(); }
+        function onBusyChanged() {
+            if (!root.model.busy) {
+                if (root.changed) keyboardDelay.restart();
+                else root.synchronize();
+            }
+        }
+    }
+
+    SectionLabel { label: "Compositor" }
+    UiText {
+        Layout.fillWidth: true
+        text: root.model.snapshot.detail
+        color: Theme.menuMutedText
+        wrapMode: Text.WordWrap
+    }
+    UiText {
+        Layout.fillWidth: true
+        text: root.model.snapshot.path
+        color: Theme.menuMutedText
+        wrapMode: Text.WrapAnywhere
+    }
+    UiText {
+        text: "Foreground (active): " + Math.round(root.activeOpacity) + "%"
+        color: Theme.menuText
+    }
+    Controls.Slider {
+        id: foreground
+        objectName: "picomActiveOpacity"
+        Accessible.name: "Foreground window opacity"
+        palette.highlight: Theme.accent
+        palette.button: Theme.controlNormalFill
+        Layout.fillWidth: true
+        from: 0; to: 100; stepSize: 1
+        value: root.activeOpacity
+        enabled: root.model.editable
+        onMoved: {
+            root.activeOpacity = value;
+            root.changed = true;
+            if (!pressed) keyboardDelay.restart();
+        }
+        onPressedChanged: { if (!pressed) root.applyOpacity(); }
+    }
+    UiText {
+        text: "Background (inactive): " + Math.round(root.inactiveOpacity) + "%"
+        color: Theme.menuText
+    }
+    Controls.Slider {
+        id: background
+        objectName: "picomInactiveOpacity"
+        Accessible.name: "Background window opacity"
+        palette.highlight: Theme.accent
+        palette.button: Theme.controlNormalFill
+        Layout.fillWidth: true
+        from: 0; to: 100; stepSize: 1
+        value: root.inactiveOpacity
+        enabled: root.model.editable
+        onMoved: {
+            root.inactiveOpacity = value;
+            root.changed = true;
+            if (!pressed) keyboardDelay.restart();
+        }
+        onPressedChanged: { if (!pressed) root.applyOpacity(); }
+    }
+    UiText {
+        text: "Backend" + (root.model.snapshot.effective ? " (current: " + root.model.snapshot.effective + ")" : "")
+        color: Theme.menuText
+    }
+    Controls.ComboBox {
+        objectName: "picomBackend"
+        Accessible.name: "Picom backend"
+        implicitHeight: Theme.controlHeight
+        font.family: Theme.fontFamily
+        font.pixelSize: Theme.inputFontSize
+        palette.button: Theme.controlNormalFill
+        palette.buttonText: Theme.controlNormalText
+        palette.base: Theme.popupBackground
+        palette.window: Theme.popupBackground
+        palette.text: Theme.popupText
+        palette.highlight: Theme.controlSelectedFill
+        palette.highlightedText: Theme.controlSelectedText
+        Layout.fillWidth: true
+        model: ["Automatic", "XRender", "GLX", "EGL (experimental)"]
+        currentIndex: ["auto", "xrender", "glx", "egl"].indexOf(root.model.snapshot.policy)
+        enabled: root.model.editable && !root.model.snapshot.override
+        onActivated: index => root.model.mutate("set-backend", [["auto", "xrender", "glx", "egl"][index]])
+    }
+    ShellButton {
+        visible: root.model.snapshot.copyable
+        enabled: !root.model.busy
+        label: "Create user configuration"
+        onActivated: root.model.mutate("copy-config", [])
+    }
+    UiText {
+        Layout.fillWidth: true
+        visible: text.length > 0
+        text: root.model.failure || root.model.message
+        color: root.model.failure ? Theme.danger : Theme.menuMutedText
+        wrapMode: Text.WordWrap
+    }
+    Timer {
+        id: keyboardDelay
+        interval: 250
+        onTriggered: root.applyOpacity()
+    }
+}

--- a/docs/src/content/configuration.md
+++ b/docs/src/content/configuration.md
@@ -43,7 +43,7 @@ The controls read the active Picom configuration, normally `~/.config/picom.conf
 or `~/.config/picom/picom.conf`, and observe external edits. With no configuration,
 they show 100% and create a minimal file on the first edit. A system configuration
 can be copied with **Create user configuration**. Comments, unrelated settings,
-and included files are preserved; each edit retains a recovery backup. Invalid
+and included files are preserved; the ten most recent edits retain recovery backups. Invalid
 or read-only configurations show an explanation rather than disappearing controls.
 Edits made while Picom is stopped take effect the next time it starts.
 Valid configurations using syntax the editor cannot rewrite, such as nested

--- a/docs/src/content/configuration.md
+++ b/docs/src/content/configuration.md
@@ -32,6 +32,43 @@ there so the tray host starts before tray clients. Use
 
 ---
 
+## Picom opacity and backend
+
+Open **Settings > Appearance > Compositor** to change foreground (active) and
+background (inactive) window opacity. Sliders save when released; keyboard edits
+save after a short pause. Values stay the same when switching themes. Custom
+Picom rules can override these defaults for individual windows.
+
+The controls read the active Picom configuration, normally `~/.config/picom.conf`
+or `~/.config/picom/picom.conf`, and observe external edits. With no configuration,
+they show 100% and create a minimal file on the first edit. A system configuration
+can be copied with **Create user configuration**. Comments, unrelated settings,
+and included files are preserved; each edit retains a recovery backup. Invalid
+or read-only configurations show an explanation rather than disappearing controls.
+Edits made while Picom is stopped take effect the next time it starts.
+Valid configurations using syntax the editor cannot rewrite, such as nested
+includes, still support startup, restart, and reload through Picom itself.
+
+**Automatic** chooses GLX for an accelerated Intel/AMD renderer and XRender for
+NVIDIA, software rendering, or unknown hardware. Failed automatic GLX startup
+retries XRender once. An existing explicit backend is preserved; choose Automatic
+to remove it. XRender, GLX, and experimental EGL remain selectable. The active
+renderer matters, not an unused or passthrough GPU installed in the machine.
+
+`PICOM_BACKEND` remains a session override. Unset it before selecting a different
+backend in Settings. `DWM_PICOM_CONFIG=/absolute/path/picom.conf` can select a
+custom configuration; an existing Picom `--config` argument is also respected.
+Command-line opacity overrides must be removed before editing opacity in Settings.
+
+```bash
+dwm-settings-picom status
+dwm-settings-picom restart
+```
+
+Restart and toggle affect only your compositor on the current display. Failed
+configuration activation restores the prior files and attempts to recover the
+previous compositor; the error identifies the backup and session log.
+
 ## config.h Essentials
 
 `config.h` is your personal copy of `config.def.h`. It is created automatically by `make` if it doesn't exist.

--- a/docs/src/content/troubleshooting.md
+++ b/docs/src/content/troubleshooting.md
@@ -148,11 +148,19 @@ Alacritty. The default `Super`+`X` binding remains plain Alacritty.
 
 Restart picom via the Control Center (**Quick Actions → Restart Picom**) or:
 ```bash
-pkill picom; setsid -f picom --backend xrender
+dwm-settings-picom restart
 ```
 
-If artifacts persist, set a different backend in `~/.config/picom.conf` or run with
-`PICOM_BACKEND=glx` or `PICOM_BACKEND=egl`.
+If artifacts persist, choose XRender or GLX in **Settings > Appearance >
+Compositor**. EGL is experimental. Automatic selection uses the active renderer
+and retries XRender if automatic GLX startup fails. Existing configuration choices
+and `PICOM_BACKEND=glx` or `PICOM_BACKEND=egl` session overrides remain respected.
+
+Run `dwm-settings-picom status` to see the configuration path and effective
+backend. The controls remain available while Picom is stopped. Configuration
+errors and concurrent edits are reported without silently replacing your choices;
+activation errors identify a recovery backup and session log.
+
 
 ---
 

--- a/dwm-fedora-nvidia.ks
+++ b/dwm-fedora-nvidia.ks
@@ -91,6 +91,7 @@ flatpak
 quickshell
 PackageKit
 PackageKit-glib
+python3
 python3-gobject
 python3-rpm
 accountsservice

--- a/dwm-fedora.ks
+++ b/dwm-fedora.ks
@@ -90,6 +90,7 @@ flatpak
 quickshell
 PackageKit
 PackageKit-glib
+python3
 python3-gobject
 python3-rpm
 accountsservice

--- a/scripts/autostart.sh
+++ b/scripts/autostart.sh
@@ -330,7 +330,6 @@ resume_theme_preview() {
 	fi
 }
 
-PICOM_BACKEND=${PICOM_BACKEND:-xrender}
 WM_GRAPHICAL_SESSION=wm-graphical-session.service
 
 # ── Phase 1: Blocking ──────────────────────────────────────────────────────────
@@ -508,7 +507,10 @@ if command -v feh >/dev/null 2>&1; then
 fi
 
 # Compositor
-start_detached_once picom picom --backend "$PICOM_BACKEND"
+if command -v picom >/dev/null 2>&1; then
+	picom_helper=$(command -v dwm-settings-picom 2>/dev/null || printf '%s' "${0%/*}/dwm-settings-picom")
+	"$picom_helper" start >/dev/null 2>&1 &
+fi
 
 # dwm root-window status publisher for Quickshell's event-driven panel.
 start_detached_display_command_once dwm-status

--- a/scripts/dwm-packages.sh
+++ b/scripts/dwm-packages.sh
@@ -38,7 +38,7 @@ dwm_packages() {
 		# fedora/updates repositories. It is required and belongs in the strict
 		# desktop transaction; the Fedora package-map check proves availability.
 		printf '%s\n' \
-			quickshell picom feh dex-autostart mate-polkit xsettingsd \
+			quickshell picom python3 feh dex-autostart mate-polkit xsettingsd \
 			alsa-utils brightnessctl dbus-tools inotify-tools jq pulseaudio-utils pipewire pavucontrol \
 			pipewire-pulseaudio wireplumber libnotify light-locker xorg-x11-drv-libinput \
 			bluez blueman playerctl upower power-profiles-daemon flatpak xdg-desktop-portal-gtk

--- a/scripts/dwm-quickshell-controlcenter
+++ b/scripts/dwm-quickshell-controlcenter
@@ -1549,15 +1549,14 @@ keybinds() {
 	' "$(config_file hotkeys.toml)"
 }
 
+picom_action() {
+	picom_helper=$(command -v dwm-settings-picom 2>/dev/null || printf '%s' "$repo_dir/scripts/dwm-settings-picom")
+	"$picom_helper" "$1" >/dev/null
+}
+
 restart_picom() {
-	pkill -x picom 2>/dev/null || true
-	if command -v picom >/dev/null 2>&1; then
-		launch_background picom
-		notify "Picom restarted"
-	else
-		printf 'picom is not installed\n' >&2
-		return 1
-	fi
+	picom_action restart || return 1
+	notify "Picom restarted"
 }
 
 restart_quickshell() {
@@ -1632,12 +1631,7 @@ reload_wallpaper() {
 }
 
 toggle_compositor() {
-	if pgrep -x picom >/dev/null 2>&1; then
-		pkill -x picom
-		notify "Compositor stopped"
-	else
-		restart_picom
-	fi
+	picom_action toggle
 }
 
 restart_networkmanager() {

--- a/scripts/dwm-settings-appearance
+++ b/scripts/dwm-settings-appearance
@@ -71,7 +71,7 @@ readonly -a required_colors=(
 )
 
 usage() {
-	printf 'usage: %s {snapshot|inventory|watch-inventory|watch-compositor}\n' "$0" >&2
+	printf 'usage: %s {snapshot|inventory|watch-inventory}\n' "$0" >&2
 }
 
 clean_field() {
@@ -1155,34 +1155,11 @@ normalize_x11_display() {
 	printf '%s\n' "$display"
 }
 
-picom_running_for_display() {
-	local current_display=${DISPLAY:-} proc_root=${DWM_APPEARANCE_PROC_ROOT:-/proc}
-	local pid environment_entry process_display
-	[[ -n $current_display ]] || return 1
-	current_display=$(normalize_x11_display "$current_display")
-	command -v pgrep >/dev/null 2>&1 || return 1
-	command -v id >/dev/null 2>&1 || return 1
-	command -v tr >/dev/null 2>&1 || return 1
-	while IFS= read -r pid; do
-		[[ $pid =~ ^[1-9][0-9]*$ && -r $proc_root/$pid/environ ]] || continue
-		while IFS= read -r environment_entry; do
-			[[ $environment_entry == DISPLAY=* ]] || continue
-			process_display=$(normalize_x11_display "${environment_entry#DISPLAY=}")
-			[[ $process_display == "$current_display" ]] && return 0
-		done < <(tr '\0' '\n' <"$proc_root/$pid/environ" 2>/dev/null)
-	done < <(pgrep -u "$(id -u)" -x picom 2>/dev/null || true)
-	return 1
-}
-
 emit_compositor_inventory() {
-	if ! command -v picom >/dev/null 2>&1; then
-		emit_inventory_selection compositor unavailable '' missing \
-			'Picom is optional and not installed'
-	elif picom_running_for_display; then
-		emit_inventory_selection compositor available picom running 'Picom is running'
+	if command -v picom >/dev/null 2>&1; then
+		emit_inventory_selection compositor available picom configuration 'Picom controls use its configuration file'
 	else
-		emit_inventory_selection compositor partial picom stopped \
-			'Picom is installed but not running on this display'
+		emit_inventory_selection compositor unavailable '' missing 'Picom is optional and not installed'
 	fi
 }
 
@@ -1491,41 +1468,6 @@ watch_inventory() {
 			((status != 0)) || status=1
 			return "$status"
 		fi
-	done
-}
-
-compositor_watch_cleanup() {
-	trap - EXIT HUP INT TERM
-	stop_parent_exit_watch
-	if [[ -n ${compositor_watch_work:-} ]]; then
-		rm -f -- "$compositor_watch_work/wait"
-		rmdir -- "$compositor_watch_work" 2>/dev/null || true
-	fi
-}
-
-watch_compositor() {
-	local state previous='' wait_fd
-	command -v pgrep >/dev/null 2>&1 || {
-		printf 'dwm-settings-appearance: pgrep is required for compositor watching\n' >&2
-		return 1
-	}
-	arm_parent_exit_watch
-	compositor_watch_work=$(mktemp -d "${TMPDIR:-/tmp}/dwm-appearance-compositor.XXXXXX")
-	mkfifo -- "$compositor_watch_work/wait"
-	exec {wait_fd}<>"$compositor_watch_work/wait"
-	trap compositor_watch_cleanup EXIT
-	trap 'exit 143' HUP INT TERM
-	while :; do
-		if picom_running_for_display; then
-			state=running
-		else
-			state=stopped
-		fi
-		if [[ $state != "$previous" ]]; then
-			printf 'compositor\t%s\n' "$state"
-			previous=$state
-		fi
-		read -r -t 1 -u "$wait_fd" _ || true
 	done
 }
 
@@ -2102,8 +2044,7 @@ emit_integrations() {
 	done
 
 	if command -v picom >/dev/null 2>&1; then
-		printf 'integration\tcompositor\tpartial\tpicom\tPicom is available but has no shared theme mutation contract\n'
-		add_error compositor unsupported 'Picom theme mutation is not implemented'
+		printf 'integration\tcompositor\tavailable\tpicom\tGlobal opacity is configured in the Compositor section\n'
 	else
 		printf 'integration\tcompositor\tunavailable\tmissing\tPicom is optional and not installed\n'
 	fi
@@ -2172,13 +2113,7 @@ watch-inventory)
 	}
 	watch_inventory
 	;;
-watch-compositor)
-	[[ $# -eq 1 ]] || {
-		usage
-		exit 2
-	}
-	watch_compositor
-	;;
+
 -h | --help | help)
 	usage
 	;;

--- a/scripts/dwm-settings-picom
+++ b/scripts/dwm-settings-picom
@@ -60,7 +60,7 @@ def run(argv, timeout=8):
 
 
 def display_name(value):
-    return re.sub(r"\.\d+$", "", value).replace("unix:", ":")
+    return re.sub(r"\.0$", "", value).replace("unix:", ":")
 
 
 def processes():
@@ -133,6 +133,7 @@ def resolve_include(path, name):
     include = Path(name)
     if include.is_absolute():
         return include
+    # Picom keeps the root configuration directory throughout nested includes.
     roots = [path.resolve().parent, config_home() / "picom/include"]
     roots += [
         Path(p) / "picom/include"
@@ -200,6 +201,7 @@ class Document:
         self.index = 0
         self.entries = {}
         self.includes = []
+        self.shaders = []
         self.group(None, True)
 
     def peek(self):
@@ -214,7 +216,7 @@ class Document:
         self.index += 1
         return value
 
-    def group(self, closing, top=False):
+    def group(self, closing, top=False, shader=False):
         names = set()
         while self.peek() and self.peek() != closing:
             if self.peek() == "@include":
@@ -238,7 +240,12 @@ class Document:
                     raise Error(f"Missing assignment for {key[0]}")
                 self.take()
                 start = self.index
-                self.value()
+                self.value(
+                    shader=key[0]
+                    in ("shader", "window-shader-fg", "root-pixmap-shader")
+                    or (shader and key[0] == "path"),
+                    shader_rules=key[0] == "window-shader-fg-rule",
+                )
                 last = self.tokens[self.index - 1][2]
                 if self.peek() in (";", ","):
                     last = self.take()[2]
@@ -265,22 +272,28 @@ class Document:
         if closing:
             self.take(closing)
 
-    def value(self):
+    def value(self, shader=False, shader_rules=False):
         value = self.peek()
         if value == "{":
             self.take()
-            self.group("}")
+            self.group("}", shader=shader)
         elif value in ("(", "["):
             self.take()
             end = ")" if value == "(" else "]"
             while self.peek() and self.peek() != end:
-                self.value()
+                self.value(shader=shader, shader_rules=shader_rules)
                 if self.peek() != end:
                     self.take(",")
             self.take(end)
         elif value.startswith('"'):
+            start = self.tokens[self.index][1]
+            parts = []
             while self.peek().startswith('"'):
-                self.take()
+                token = self.take()
+                if shader or shader_rules:
+                    parts.append(json.loads(token[0]))
+            if shader or shader_rules:
+                self.shaders.append(("".join(parts), start, token[2], shader_rules))
         elif value in ("true", "false") or re.fullmatch(
             r"[+-]?(?:0[xX][0-9a-fA-F]+|(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)[Ll]{0,2}",
             value,
@@ -363,7 +376,7 @@ class Configuration:
         for name, _ in doc.includes:
             if any(c in name for c in "*?["):
                 raise Error("Wildcard Picom includes require manual editing")
-            include = resolve_include(path, name)
+            include = resolve_include(self.path, name)
             self.load(include, [*ancestors, path.resolve()])
 
     def revision(self):
@@ -442,9 +455,9 @@ class Configuration:
         comma = "," if tokens(tail) else ""
         text = (
             f"\n{BEGIN}\n"
-            "{ match = \"window_type = 'normal' && (focused || group_focused)\"; "
+            '{ match = "focused || group_focused"; '
             f"opacity = {active}; }},\n"
-            "{ match = \"window_type = 'normal' && !(focused || group_focused)\"; "
+            '{ match = "!(focused || group_focused)"; '
             f"opacity = {inactive}; }}{comma}\n{END}\n"
         )
         return {doc.path: doc.text[:start] + text + doc.text[end:]}
@@ -639,7 +652,7 @@ def launch(config, original=None, previous=None):
     log_path = private_dir() / "session.log"
     safe_target(log_path)
     for index, command in enumerate(attempts):
-        with open(log_path, "w") as log:
+        with open(log_path, "w" if index == 0 else "a") as log:
             child = subprocess.Popen(
                 command,
                 stdin=subprocess.DEVNULL,
@@ -813,13 +826,23 @@ def validate_candidate(config, changes, candidate_path):
         prefix="validate-", dir=private_dir()
     ) as directory:
         mapping = {p: Path(directory) / str(i) for i, p in enumerate(candidate.docs)}
-        for path, doc in candidate.docs.items():
-            edits = []
-            for name, token in doc.includes:
-                include = resolve_include(path, name)
-                edits.append((token[1], token[2], json.dumps(str(mapping[include]))))
-            mapping[path].write_text(splice(doc.text, edits))
-        diagnostics(mapping[candidate_path])
+        # Picom also resolves shaders relative to the root configuration. Stage
+        # that file beside its final target, while includes remain private.
+        parent = candidate_path.resolve().parent
+        staging_parent = parent if parent.is_dir() else Path(directory)
+        with tempfile.NamedTemporaryFile(
+            prefix=".dwm-picom-validate-", dir=staging_parent
+        ) as root_file:
+            mapping[candidate_path] = Path(root_file.name)
+            for path, doc in candidate.docs.items():
+                edits = []
+                for name, token in doc.includes:
+                    include = resolve_include(candidate.path, name)
+                    edits.append(
+                        (token[1], token[2], json.dumps(str(mapping[include])))
+                    )
+                mapping[path].write_text(splice(doc.text, edits))
+            diagnostics(mapping[candidate_path])
 
 
 def mutate(action, args, revision):
@@ -877,10 +900,28 @@ def mutate(action, args, revision):
             for path, doc in config.docs.items():
                 replacements = []
                 for name, token in doc.includes:
-                    p = resolve_include(path, name)
+                    p = resolve_include(config.path, name)
                     replacements.append(
                         (token[1], token[2], json.dumps(str(mapping[p])))
                     )
+                for value, start, end, legacy_rule in doc.shaders:
+                    name, separator, condition = (
+                        value.partition(":") if legacy_rule else (value, "", "")
+                    )
+                    name = name.strip()
+                    if not name or name == "default" or Path(name).is_absolute():
+                        continue
+                    resource = config.path.resolve().parent / name
+                    if resource.is_file():
+                        # Keep vendor resources at their original absolute paths;
+                        # only the configuration graph becomes user-owned.
+                        replacements.append(
+                            (
+                                start,
+                                end,
+                                json.dumps(str(resource) + separator + condition),
+                            )
+                        )
                 changes[mapping[path]] = splice(doc.text, replacements)
 
         changes = {
@@ -895,6 +936,18 @@ def mutate(action, args, revision):
         if not changes:
             return "Configuration already matches"
         previous = {p: read_config(p) if p.exists() else None for p in changes}
+        # Bound recovery history under the mutation lock, including failed edits.
+        backups = sorted(
+            (
+                p
+                for p in private_dir().glob("backup-*")
+                if p.is_dir() and not p.is_symlink()
+            ),
+            key=lambda p: p.stat().st_mtime_ns,
+            reverse=True,
+        )
+        for stale in backups[9:]:
+            shutil.rmtree(stale)
         backup = Path(tempfile.mkdtemp(prefix="backup-", dir=private_dir()))
         for index, (path, text) in enumerate(previous.items()):
             if text is not None:
@@ -932,13 +985,17 @@ def mutate(action, args, revision):
         except (Error, OSError) as exc:
             conflicts = []
             for path in reversed(published):
-                if read_config(path) != changes[path]:
+                try:
+                    if read_config(path) != changes[path]:
+                        conflicts.append(str(path))
+                        continue
+                    if previous[path] is None:
+                        safe_target(path).unlink()
+                    else:
+                        publish(path, previous[path])
+                except (OSError, Error):
+                    # Preserve concurrent removals and keep restoring other files.
                     conflicts.append(str(path))
-                    continue
-                if previous[path] is None:
-                    safe_target(path).unlink()
-                else:
-                    publish(path, previous[path])
             if conflicts:
                 raise Error(
                     f"{exc}; newer edits preserved in {', '.join(conflicts)}; backup: {backup}"

--- a/scripts/dwm-settings-picom
+++ b/scripts/dwm-settings-picom
@@ -1,0 +1,1064 @@
+#!/usr/bin/env python3
+"""Configuration-backed Picom settings and display-scoped session control.
+
+The JSON protocol is version 1. No configuration is evaluated as Python or shell.
+Edits preserve source spans, including comments and unrelated libconfig values.
+"""
+
+import argparse
+import contextlib
+import ctypes
+import ctypes.util
+import fcntl
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+PROTOCOL = 1
+MAX_SIZE = 1024 * 1024
+BACKENDS = ("auto", "xrender", "glx", "egl")
+BEGIN = "# dwm-titus opacity defaults begin"
+END = "# dwm-titus opacity defaults end"
+
+
+class Error(Exception):
+    pass
+
+
+def read_config(path):
+    with open(path, encoding="utf-8", newline="") as stream:
+        return stream.read()
+
+
+def config_home():
+    value = os.environ.get("XDG_CONFIG_HOME", "")
+    return Path(value) if value.startswith("/") else Path.home() / ".config"
+
+
+def run(argv, timeout=8):
+    try:
+        return subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            env={**os.environ, "LC_ALL": "C"},
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise Error(f"{argv[0]}: {exc}") from exc
+
+
+def display_name(value):
+    return re.sub(r"\.\d+$", "", value).replace("unix:", ":")
+
+
+def processes():
+    """Only processes owned by this uid on this X server; never dump environ."""
+    display = display_name(os.environ.get("DISPLAY", ""))
+    if not display:
+        return []
+    result = []
+    for directory in Path("/proc").glob("[0-9]*"):
+        try:
+            if directory.stat().st_uid != os.getuid():
+                continue
+            if (directory / "comm").read_text().strip() != "picom":
+                continue
+            env = (directory / "environ").read_bytes().split(b"\0")
+            value = next((v[8:].decode() for v in env if v.startswith(b"DISPLAY=")), "")
+            if display_name(value) != display:
+                continue
+            args = [
+                os.fsdecode(v)
+                for v in (directory / "cmdline").read_bytes().split(b"\0")
+                if v
+            ]
+            # Diagnostic probes use the same comm and DISPLAY as the compositor,
+            # but never own its selection and must not affect session discovery.
+            if any(
+                arg in ("--diagnostics", "--help", "--version", "-h") for arg in args
+            ):
+                continue
+            identity = (directory / "stat").read_text().rsplit(")", 1)[1].split()[19]
+            result.append(
+                {"pid": int(directory.name), "args": args, "identity": identity}
+            )
+        except (OSError, UnicodeError, IndexError):
+            continue
+    return result
+
+
+def option(args, names):
+    for index, arg in enumerate(args):
+        for name in names:
+            if arg == name and index + 1 < len(args):
+                return args[index + 1]
+            if arg.startswith(name + "="):
+                return arg[len(name) + 1 :]
+            if len(name) == 2 and arg.startswith(name) and len(arg) > 2:
+                return arg[2:]
+            if name == "-i" and re.fullmatch(r"-[bcfS]+i.*", arg):
+                value = arg[arg.index("i") + 1 :]
+                if value:
+                    return value
+                if index + 1 < len(args):
+                    return args[index + 1]
+    return ""
+
+
+def candidates():
+    roots = [config_home()]
+    roots += [
+        Path(p)
+        for p in os.environ.get("XDG_CONFIG_DIRS", "/etc/xdg").split(":")
+        if p.startswith("/")
+    ]
+    return [
+        p for root in roots for p in (root / "picom.conf", root / "picom/picom.conf")
+    ]
+
+
+def resolve_include(path, name):
+    include = Path(name)
+    if include.is_absolute():
+        return include
+    roots = [path.resolve().parent, config_home() / "picom/include"]
+    roots += [
+        Path(p) / "picom/include"
+        for p in os.environ.get("XDG_CONFIG_DIRS", "/etc/xdg").split(":")
+        if p.startswith("/")
+    ]
+    for root in roots:
+        candidate = root / include
+        if candidate.exists() or candidate.is_symlink():
+            return candidate
+    raise Error(f"Picom include was not found in its XDG search paths: {name}")
+
+
+def source_path():
+    explicit = os.environ.get("DWM_PICOM_CONFIG", "")
+    running = processes()
+    if len(running) > 1:
+        raise Error(
+            "Multiple Picom processes use this display; stop the duplicate before editing"
+        )
+    if not explicit and running:
+        explicit = option(running[0]["args"], ("--config",))
+        if explicit and not explicit.startswith("/"):
+            explicit = str(Path(f"/proc/{running[0]['pid']}/cwd").resolve() / explicit)
+    if explicit:
+        if not explicit.startswith("/") or explicit == "/dev/null":
+            raise Error(
+                "The explicit Picom configuration must be a regular absolute file"
+            )
+        return Path(explicit)
+    return next(
+        (p for p in candidates() if p.exists() or p.is_symlink()),
+        config_home() / "picom.conf",
+    )
+
+
+# Keep token offsets to edit scalar values without serializing unrelated content.
+TOKEN = re.compile(
+    r'\s+|\#[^\n]*|//[^\n]*|/\*.*?\*/|"(?:\\.|[^"\\])*"|'
+    r"@include|[A-Za-z_*][A-Za-z0-9_*.-]*|"
+    r"[+-]?(?:0[xX][0-9a-fA-F]+|(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)[Ll]{0,2}|"
+    r"[{}()\[\]=:;,]",
+    re.DOTALL,
+)
+
+
+def tokens(text):
+    result = []
+    pos = 0
+    while pos < len(text):
+        match = TOKEN.match(text, pos)
+        if not match:
+            raise Error(f"Unsupported or malformed Picom syntax at character {pos}")
+        value = match.group()
+        if not (value.isspace() or value.startswith(("#", "//", "/*"))):
+            result.append((value, pos, match.end()))
+        pos = match.end()
+    return result
+
+
+class Document:
+    def __init__(self, path, text):
+        self.path, self.text = path, text
+        self.tokens = tokens(text)
+        self.index = 0
+        self.entries = {}
+        self.includes = []
+        self.group(None, True)
+
+    def peek(self):
+        return self.tokens[self.index][0] if self.index < len(self.tokens) else ""
+
+    def take(self, expected=None):
+        if not self.peek() or (expected is not None and self.peek() != expected):
+            raise Error(
+                f"Malformed Picom configuration: expected {expected or 'value'} in {self.path}"
+            )
+        value = self.tokens[self.index]
+        self.index += 1
+        return value
+
+    def group(self, closing, top=False):
+        names = set()
+        while self.peek() and self.peek() != closing:
+            if self.peek() == "@include":
+                if not top:
+                    raise Error(
+                        "Includes inside groups are not editable; move the include to top level"
+                    )
+                self.take()
+                token = self.take()
+                if not token[0].startswith('"'):
+                    raise Error("Picom include must be a quoted path")
+                self.includes.append((json.loads(token[0]), token))
+            else:
+                key = self.take()
+                if not re.fullmatch(r"[A-Za-z_*][A-Za-z0-9_*.-]*", key[0]):
+                    raise Error("Invalid Picom setting name")
+                if key[0] in names:
+                    raise Error(f"Duplicate Picom setting: {key[0]}")
+                names.add(key[0])
+                if self.peek() not in ("=", ":"):
+                    raise Error(f"Missing assignment for {key[0]}")
+                self.take()
+                start = self.index
+                self.value()
+                last = self.tokens[self.index - 1][2]
+                if self.peek() in (";", ","):
+                    last = self.take()[2]
+                if top:
+                    self.entries[key[0]] = (
+                        self.tokens[start][1],
+                        self.tokens[self.index - 1][2],
+                        key[1],
+                        last,
+                        self.tokens[start][0],
+                    )
+                    # Value end excludes the optional assignment terminator.
+                    end_index = self.index - 1
+                    if self.tokens[end_index][0] in (";", ","):
+                        end_index -= 1
+                    entry = self.entries[key[0]]
+                    self.entries[key[0]] = (
+                        entry[0],
+                        self.tokens[end_index][2],
+                        *entry[2:],
+                    )
+            if self.peek() in (";", ","):
+                self.take()
+        if closing:
+            self.take(closing)
+
+    def value(self):
+        value = self.peek()
+        if value == "{":
+            self.take()
+            self.group("}")
+        elif value in ("(", "["):
+            self.take()
+            end = ")" if value == "(" else "]"
+            while self.peek() and self.peek() != end:
+                self.value()
+                if self.peek() != end:
+                    self.take(",")
+            self.take(end)
+        elif value.startswith('"'):
+            while self.peek().startswith('"'):
+                self.take()
+        elif value in ("true", "false") or re.fullmatch(
+            r"[+-]?(?:0[xX][0-9a-fA-F]+|(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)[Ll]{0,2}",
+            value,
+        ):
+            self.take()
+        else:
+            raise Error(f"Invalid Picom value: {value}")
+
+
+def safe_target(path):
+    """Resolve owned dotfile symlinks; reject writable-by-others paths."""
+    current = path
+    for _ in range(16):
+        for parent in [current, *current.parents]:
+            if not parent.exists() and not parent.is_symlink():
+                continue
+            meta = parent.lstat()
+            if parent.is_symlink():
+                if meta.st_uid != os.getuid():
+                    raise Error(f"Untrusted symlink: {parent}")
+                continue
+            if meta.st_mode & 0o022:
+                # /tmp is a permitted ancestor, never the publication parent.
+                if (
+                    parent != path.parent
+                    and meta.st_uid == 0
+                    and meta.st_mode & stat.S_ISVTX
+                ):
+                    continue
+                raise Error(f"Path is writable by another user: {parent}")
+        resolved = current.resolve()
+        if resolved == current:
+            break
+        current = resolved
+    else:
+        raise Error("Too many Picom configuration symlinks")
+    if current.exists():
+        meta = current.stat()
+        if (
+            not stat.S_ISREG(meta.st_mode)
+            or meta.st_uid != os.getuid()
+            or not meta.st_mode & 0o200
+        ):
+            raise Error(f"Configuration is read-only: {current}")
+    parent = current.parent
+    while not parent.exists():
+        parent = parent.parent
+    if parent.stat().st_uid != os.getuid() or not os.access(parent, os.W_OK):
+        raise Error(f"Configuration directory is read-only: {parent}")
+    return current
+
+
+class Configuration:
+    def __init__(self, path=None, overrides=None):
+        self.path = path or source_path()
+        self.docs = {}
+        self.entries = {}
+        self.overrides = overrides or {}
+        self.load(self.path, [])
+
+    def load(self, path, ancestors):
+        if len(self.docs) >= 32 or path.resolve() in ancestors:
+            raise Error("Picom includes are cyclic or exceed 32 files")
+        if path in self.overrides:
+            text = self.overrides[path]
+        elif not path.exists() and not ancestors and not path.is_symlink():
+            text = self.overrides.get(path, "")
+        else:
+            if not path.is_file() or path.stat().st_size > MAX_SIZE:
+                raise Error(
+                    f"Picom configuration must be a regular file under 1 MiB: {path}"
+                )
+            text = self.overrides.get(path, read_config(path))
+        doc = Document(path, text)
+        self.docs[path] = doc
+        for key, entry in doc.entries.items():
+            if key in self.entries:
+                raise Error(f"Ambiguous setting across Picom includes: {key}")
+            self.entries[key] = (doc, entry)
+        for name, _ in doc.includes:
+            if any(c in name for c in "*?["):
+                raise Error("Wildcard Picom includes require manual editing")
+            include = resolve_include(path, name)
+            self.load(include, [*ancestors, path.resolve()])
+
+    def revision(self):
+        data = [
+            (str(p), str(p.resolve()), d.text, p.stat().st_mode if p.exists() else None)
+            for p, d in self.docs.items()
+        ]
+        return hashlib.sha256(json.dumps(data).encode()).hexdigest()
+
+    def scalar(self, name, default):
+        if name not in self.entries:
+            return default
+        doc, entry = self.entries[name]
+        raw = doc.text[entry[0] : entry[1]]
+        try:
+            return json.loads(raw)
+        except (ValueError, TypeError):
+            try:
+                return float(raw)
+            except ValueError as exc:
+                raise Error(f"{name} must be a scalar") from exc
+
+    def opacity(self):
+        if "rules" in self.entries:
+            doc, _ = self.entries["rules"]
+            block = managed_block(doc.text)
+            if not block:
+                return (1.0, 1.0)
+            values = re.findall(r"opacity\s*=\s*([0-9.]+)", block[2])
+            if len(values) != 2:
+                raise Error("Malformed managed Picom opacity rules")
+            result = tuple(float(v) for v in values)
+        else:
+            result = (
+                self.scalar("active-opacity", 1.0),
+                self.scalar("inactive-opacity", 1.0),
+            )
+        if any(
+            isinstance(v, bool)
+            or not isinstance(v, (int, float))
+            or not math.isfinite(v)
+            or not 0 <= v <= 1
+            for v in result
+        ):
+            raise Error("Picom opacity must be between 0 and 1")
+        return result
+
+    def changes(self, values):
+        edits = {}
+        for key, value in values.items():
+            if key in self.entries:
+                doc, entry = self.entries[key]
+                start, end = (entry[2], entry[3]) if value is None else entry[:2]
+                edits.setdefault(doc.path, []).append(
+                    (start, end, "" if value is None else json.dumps(value))
+                )
+            elif value is not None:
+                text = self.docs[self.path].text
+                edits.setdefault(self.path, []).append(
+                    (len(text), len(text), f"\n{key} = {json.dumps(value)};\n")
+                )
+        return {p: splice(self.docs[p].text, changes) for p, changes in edits.items()}
+
+    def opacity_changes(self, active, inactive):
+        if "rules" not in self.entries:
+            return self.changes(
+                {"active-opacity": active, "inactive-opacity": inactive}
+            )
+        doc, entry = self.entries["rules"]
+        block = managed_block(doc.text)
+        if block and not (entry[0] < block[0] < block[1] < entry[1]):
+            raise Error("Managed opacity markers must be inside the rules list")
+        start = block[0] if block else entry[0] + 1
+        end = block[1] if block else start
+        tail = doc.text[end : entry[1] - 1]
+        comma = "," if tokens(tail) else ""
+        text = (
+            f"\n{BEGIN}\n"
+            "{ match = \"window_type = 'normal' && (focused || group_focused)\"; "
+            f"opacity = {active}; }},\n"
+            "{ match = \"window_type = 'normal' && !(focused || group_focused)\"; "
+            f"opacity = {inactive}; }}{comma}\n{END}\n"
+        )
+        return {doc.path: doc.text[:start] + text + doc.text[end:]}
+
+
+def managed_block(text):
+    if BEGIN not in text and END not in text:
+        return None
+    if (
+        text.count(BEGIN) != 1
+        or text.count(END) != 1
+        or text.index(END) < text.index(BEGIN)
+    ):
+        raise Error("Malformed managed Picom opacity markers")
+    start, end = text.index(BEGIN), text.index(END) + len(END)
+    return start, end, text[start:end]
+
+
+def splice(text, edits):
+    for start, end, value in sorted(edits, reverse=True):
+        text = text[:start] + value + text[end:]
+    return text
+
+
+def diagnostics(path):
+    if not os.environ.get("DISPLAY"):
+        return ""
+    result = run(
+        ["picom", "--config", str(path), "--backend", "xrender", "--diagnostics"]
+    )
+    if result.returncode:
+        raise Error(
+            "Picom rejected the configuration: " + result.stderr[-1000:].strip()
+        )
+    return result.stdout
+
+
+def renderer(config):
+    # Diagnostics queries the current X server. PCI inventory is deliberately unused.
+    try:
+        text = diagnostics(config.path if config.path.exists() else Path("/dev/null"))
+    except Error:
+        return "unknown"
+    gl = re.search(r"\* GL renderer:\s*(.+)", text)
+    vendor = re.search(r"\* GL:\s*(.+)", text)
+    name = (
+        (vendor.group(1) if vendor else "") + " " + (gl.group(1) if gl else "")
+    ).lower()
+    if "nvidia" in name:
+        return "nvidia"
+    if any(v in name for v in ("llvmpipe", "softpipe", "software")):
+        return "software"
+    if re.search(r"\* Accelerated:\s*1", text):
+        if "intel" in name:
+            return "intel"
+        if any(v in name for v in ("amd", "radeon", "ati ")):
+            return "amd"
+    return "unknown"
+
+
+def backend(config, detect=True):
+    selected = config.scalar("backend", "auto")
+    override = os.environ.get("PICOM_BACKEND", "")
+    if selected not in BACKENDS or (override and override not in BACKENDS[1:]):
+        raise Error("Unsupported Picom backend; use auto, xrender, glx, or egl")
+    gpu = renderer(config) if detect else "unknown"
+    effective = override or selected
+    if effective == "auto":
+        effective = "glx" if gpu in ("intel", "amd") else "xrender"
+    return selected, effective, override, gpu
+
+
+def owner():
+    if not os.environ.get("DISPLAY"):
+        return 0
+    lib = ctypes.CDLL(ctypes.util.find_library("X11") or "libX11.so.6")
+    lib.XOpenDisplay.argtypes = [ctypes.c_char_p]
+    lib.XOpenDisplay.restype = ctypes.c_void_p
+    lib.XDefaultScreen.argtypes = [ctypes.c_void_p]
+    lib.XInternAtom.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
+    lib.XInternAtom.restype = ctypes.c_ulong
+    lib.XGetSelectionOwner.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+    lib.XGetSelectionOwner.restype = ctypes.c_ulong
+    lib.XCloseDisplay.argtypes = [ctypes.c_void_p]
+    connection = lib.XOpenDisplay(None)
+    if not connection:
+        raise Error("Cannot open the current X display")
+    try:
+        atom = lib.XInternAtom(
+            connection, f"_NET_WM_CM_S{lib.XDefaultScreen(connection)}".encode(), 0
+        )
+        return lib.XGetSelectionOwner(connection, atom)
+    finally:
+        lib.XCloseDisplay(connection)
+
+
+def stop(running):
+    for proc in running:
+        current = next(
+            (
+                p
+                for p in processes()
+                if p["pid"] == proc["pid"] and p["identity"] == proc["identity"]
+            ),
+            None,
+        )
+        if current:
+            os.kill(proc["pid"], signal.SIGTERM)
+    deadline = time.monotonic() + 4
+    while any(p["pid"] in {r["pid"] for r in running} for p in processes()):
+        if time.monotonic() >= deadline:
+            raise Error("Picom did not stop; no replacement was started")
+        time.sleep(0.05)
+
+
+def private_dir():
+    base = os.environ.get("XDG_STATE_HOME", "")
+    root = Path(base) if base.startswith("/") else Path.home() / ".local/state"
+    path = root / "dwm-titus/picom"
+    safe_target(path / "probe")
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return path
+
+
+@contextlib.contextmanager
+def locked():
+    path = private_dir() / "mutation.lock"
+    safe_target(path)
+    fd = os.open(path, os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        os.close(fd)
+
+
+class NativeConfiguration:
+    """Let Picom read valid configuration syntax outside the editor's subset."""
+
+    def __init__(self, path):
+        self.path = path
+
+
+def session_configuration():
+    path = source_path()
+    try:
+        return Configuration(path)
+    except Error:
+        return NativeConfiguration(path)
+
+
+def launch(config, original=None, previous=None):
+    if owner():
+        raise Error("Another compositor owns this display; it was not stopped")
+    previous = previous or []
+    if isinstance(config, NativeConfiguration):
+        override = os.environ.get("PICOM_BACKEND", "")
+        if override and override not in BACKENDS[1:]:
+            raise Error("Unsupported Picom backend; use xrender, glx, or egl")
+        policy, gpu = "native", "unknown"
+        effective = override or option(previous, ("--backend",))
+    else:
+        policy, effective, override, gpu = backend(config)
+    # Preserve unrelated session flags. Normal XDG discovery stays implicit so a
+    # future first edit or user copy can become the source without a stale --config.
+    extras = []
+    index = 1
+    while index < len(previous):
+        arg = previous[index]
+        if arg in ("--config", "--backend"):
+            index += 2
+            continue
+        if not arg.startswith(("--config=", "--backend=")):
+            extras.append(arg)
+        index += 1
+    explicit = os.environ.get("DWM_PICOM_CONFIG") or option(previous, ("--config",))
+    config_args = ["--config", str(config.path)] if explicit else []
+    backend_args = ["--backend", effective] if effective else []
+    args = original or ["picom", *config_args, *extras, *backend_args]
+    if (
+        not original
+        and gpu == "nvidia"
+        and "xrender-sync-fence" not in config.entries
+        and "--xrender-sync-fence" not in args
+    ):
+        args += ["--xrender-sync-fence"]
+    attempts = [args]
+    if not original and policy == "auto" and not override and effective == "glx":
+        fallback = args.copy()
+        fallback[fallback.index("--backend") + 1] = "xrender"
+        attempts.append(fallback)
+    log_path = private_dir() / "session.log"
+    safe_target(log_path)
+    for index, command in enumerate(attempts):
+        with open(log_path, "w") as log:
+            child = subprocess.Popen(
+                command,
+                stdin=subprocess.DEVNULL,
+                stdout=log,
+                stderr=log,
+                start_new_session=True,
+            )
+        deadline = time.monotonic() + 2
+        ready_since = None
+        while time.monotonic() < deadline:
+            code = child.poll()
+            if code not in (None, 0):
+                break
+            # --daemon and daemon=true fork; the successful parent may already
+            # have exited. Verify an owned process and X selection, not its parent.
+            if owner() and processes():
+                ready_since = ready_since or time.monotonic()
+                if time.monotonic() - ready_since >= 0.3:
+                    return "XRender fallback active" if index else "Picom active"
+            time.sleep(0.05)
+        if child.poll() is None:
+            child.terminate()
+            try:
+                child.wait(timeout=3)
+            except subprocess.TimeoutExpired as exc:
+                raise Error("Picom startup timed out and did not stop") from exc
+        remaining = processes()
+        if remaining:
+            stop(remaining)
+    raise Error(f"Picom failed to start; see {log_path}")
+
+
+def activate(config, action):
+    running = processes()
+    if len(running) > 1:
+        raise Error(
+            "Multiple Picom processes use this display; resolve duplicates first"
+        )
+    if action == "stop" or (action == "toggle" and running):
+        stop(running)
+        return "Picom stopped"
+    if action == "reload" and not running:
+        return "Saved; Picom is stopped"
+    if action == "start" and running:
+        return "Picom already running"
+    if not os.environ.get("DISPLAY"):
+        raise Error(
+            "DISPLAY is unavailable; configuration is saved for the next session"
+        )
+    if not isinstance(config, NativeConfiguration):
+        backend(config, detect=False)
+    elif os.environ.get("PICOM_BACKEND", "") not in ("", *BACKENDS[1:]):
+        raise Error("Unsupported Picom backend; use xrender, glx, or egl")
+    diagnostics(config.path if config.path.exists() else Path("/dev/null"))
+    if action == "reload":
+        os.kill(running[0]["pid"], signal.SIGUSR1)
+        time.sleep(0.15)
+        if not processes() or not owner():
+            raise Error("Picom did not remain active after reloading its configuration")
+        return "Picom configuration reloaded"
+    stop(running)
+    try:
+        return launch(config, previous=running[0]["args"] if running else [])
+    except Error as exc:
+        if running:
+            try:
+                launch(config, running[0]["args"])
+            except Error as recovery:
+                raise Error(
+                    f"{exc}; previous compositor recovery failed: {recovery}"
+                ) from exc
+        raise
+
+
+def status(detect=True):
+    result = {
+        "protocol": PROTOCOL,
+        "installed": bool(shutil.which("picom")),
+        "editable": False,
+        "active": 100,
+        "inactive": 100,
+        "policy": "auto",
+        "effective": "",
+        "override": "",
+        "revision": "",
+        "path": "",
+        "detail": "",
+        "copyable": False,
+        "running": bool(processes()),
+    }
+    try:
+        config = Configuration()
+        result["path"] = str(config.path)
+        result["revision"] = config.revision()
+        active, inactive = config.opacity()
+        result.update(active=active * 100, inactive=inactive * 100)
+        policy, effective, override, gpu = backend(
+            config, detect and result["installed"]
+        )
+        running = processes()
+        actual = option(running[0]["args"], ("--backend",)) if running else ""
+        result.update(
+            policy=policy,
+            effective=actual or effective,
+            override=override,
+            renderer=gpu,
+        )
+        details = ["Global opacity; custom window rules may override these defaults."]
+        if not config.path.exists():
+            details.append("No configuration yet; the first edit creates it.")
+        if not result["running"]:
+            details.append("Picom is stopped; edits apply the next time it starts.")
+        if override:
+            details.append(
+                f"PICOM_BACKEND={override} overrides the backend for this session."
+            )
+        if not result["installed"]:
+            details.append("Picom is optional and not installed.")
+        result["detail"] = " ".join(details)
+        try:
+            for path in config.docs:
+                safe_target(path)
+            result["editable"] = result["installed"]
+            if any(
+                option(p["args"], ("--active-opacity", "--inactive-opacity", "-i"))
+                for p in running
+            ):
+                result["editable"] = False
+                result["detail"] += (
+                    " Remove command-line opacity overrides before editing."
+                )
+        except Error as exc:
+            result["detail"] += " " + str(exc)
+            result["copyable"] = (
+                config.path
+                not in (
+                    config_home() / "picom.conf",
+                    config_home() / "picom/picom.conf",
+                )
+                and not os.environ.get("DWM_PICOM_CONFIG")
+                and not option(running[0]["args"] if running else [], ("--config",))
+            )
+    except (Error, OSError, ValueError) as exc:
+        result["detail"] = str(exc)
+    return result
+
+
+def publish(path, text):
+    target = safe_target(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, name = tempfile.mkstemp(prefix=".dwm-picom-", dir=target.parent)
+    try:
+        mode = stat.S_IMODE(target.stat().st_mode) if target.exists() else 0o600
+        with os.fdopen(fd, "w") as stream:
+            os.fchmod(stream.fileno(), mode)
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(name, target)
+    finally:
+        if os.path.exists(name):
+            os.unlink(name)
+
+
+def validate_candidate(config, changes, candidate_path):
+    candidate = Configuration(candidate_path, changes)
+    candidate.opacity()
+    if not os.environ.get("DISPLAY"):
+        return
+    with tempfile.TemporaryDirectory(
+        prefix="validate-", dir=private_dir()
+    ) as directory:
+        mapping = {p: Path(directory) / str(i) for i, p in enumerate(candidate.docs)}
+        for path, doc in candidate.docs.items():
+            edits = []
+            for name, token in doc.includes:
+                include = resolve_include(path, name)
+                edits.append((token[1], token[2], json.dumps(str(mapping[include]))))
+            mapping[path].write_text(splice(doc.text, edits))
+        diagnostics(mapping[candidate_path])
+
+
+def mutate(action, args, revision):
+    with locked():
+        config = Configuration()
+        if config.revision() != revision:
+            raise Error("Picom configuration changed; refresh before editing")
+        if not shutil.which("picom"):
+            raise Error("Picom is not installed")
+        if any(
+            option(p["args"], ("--active-opacity", "--inactive-opacity", "-i"))
+            for p in processes()
+        ):
+            raise Error("Remove command-line opacity overrides before editing")
+        if action == "set-opacity":
+            if any(not math.isfinite(v) or not 0 <= v <= 100 for v in args):
+                raise Error("Opacity must be between 0 and 100 percent")
+            changes = config.opacity_changes(*(v / 100 for v in args))
+        elif action == "set-backend":
+            if os.environ.get("PICOM_BACKEND"):
+                raise Error(
+                    "PICOM_BACKEND overrides the session; unset it before selecting a backend"
+                )
+            changes = config.changes(
+                {"backend": None if args[0] == "auto" else args[0]}
+            )
+        else:
+            destination = config_home() / "picom.conf"
+            if (
+                destination.exists()
+                or destination.is_symlink()
+                or config.path == destination
+            ):
+                raise Error("A user Picom configuration already exists")
+            if os.environ.get("DWM_PICOM_CONFIG") or option(
+                processes()[0]["args"] if processes() else [], ("--config",)
+            ):
+                raise Error(
+                    "An explicit --config path is active; edit that configuration instead"
+                )
+            mapping = {
+                p: (
+                    destination
+                    if p == config.path
+                    else config_home()
+                    / "picom/include/dwm-titus-import"
+                    / (
+                        hashlib.sha256((str(p) + doc.text).encode()).hexdigest()
+                        + ".conf"
+                    )
+                )
+                for p, doc in config.docs.items()
+            }
+            changes = {}
+            for path, doc in config.docs.items():
+                replacements = []
+                for name, token in doc.includes:
+                    p = resolve_include(path, name)
+                    replacements.append(
+                        (token[1], token[2], json.dumps(str(mapping[p])))
+                    )
+                changes[mapping[path]] = splice(doc.text, replacements)
+
+        changes = {
+            p: t for p, t in changes.items() if not p.exists() or read_config(p) != t
+        }
+        for path in changes:
+            safe_target(path)
+        candidate_path = (
+            config_home() / "picom.conf" if action == "copy-config" else config.path
+        )
+        validate_candidate(config, changes, candidate_path)
+        if not changes:
+            return "Configuration already matches"
+        previous = {p: read_config(p) if p.exists() else None for p in changes}
+        backup = Path(tempfile.mkdtemp(prefix="backup-", dir=private_dir()))
+        for index, (path, text) in enumerate(previous.items()):
+            if text is not None:
+                (backup / str(index)).write_text(text)
+        (backup / "manifest.json").write_text(
+            json.dumps(
+                {
+                    str(p): i if t is not None else None
+                    for i, (p, t) in enumerate(previous.items())
+                }
+            )
+        )
+        if Configuration().revision() != revision:
+            raise Error(
+                "Picom configuration changed during validation; no edits published"
+            )
+        running = processes()
+        published = []
+        try:
+            for path, text in changes.items():
+                current = read_config(path) if path.exists() else None
+                if current != previous[path]:
+                    raise Error("Concurrent Picom edit detected")
+                publish(path, text)
+                published.append(path)
+            current = Configuration(candidate_path)
+            diagnostics(candidate_path)
+            # Configuration writes are rolled back before restoring the old process.
+            if running:
+                stop(running)
+                message = launch(current, previous=running[0]["args"])
+            else:
+                message = "Saved; Picom is stopped"
+            return message + f". Backup: {backup}"
+        except (Error, OSError) as exc:
+            conflicts = []
+            for path in reversed(published):
+                if read_config(path) != changes[path]:
+                    conflicts.append(str(path))
+                    continue
+                if previous[path] is None:
+                    safe_target(path).unlink()
+                else:
+                    publish(path, previous[path])
+            if conflicts:
+                raise Error(
+                    f"{exc}; newer edits preserved in {', '.join(conflicts)}; backup: {backup}"
+                ) from exc
+            if running and not processes():
+                try:
+                    launch(Configuration(config.path), running[0]["args"])
+                except Error as recovery:
+                    raise Error(
+                        f"{exc}; recovery failed: {recovery}; backup: {backup}"
+                    ) from exc
+            raise Error(
+                f"{exc}; previous configuration restored. Backup: {backup}"
+            ) from exc
+
+
+def watch():
+    """Inotify watches are active only while Settings is open; no process polling."""
+    if not shutil.which("inotifywait"):
+        raise Error("Install inotify-tools for live Picom configuration updates")
+    child = None
+    parent = os.getppid()
+    libc = ctypes.CDLL(None)
+    libc.prctl(1, signal.SIGTERM, 0, 0, 0)
+
+    def finish(_sig, _frame):
+        if child is not None:
+            child.terminate()
+        raise SystemExit(0)
+
+    signal.signal(signal.SIGTERM, finish)
+    signal.signal(signal.SIGINT, finish)
+    if os.getppid() != parent:
+        return
+    while True:
+        paths = candidates()
+        try:
+            config = Configuration()
+            paths += list(config.docs)
+        except (Error, OSError, ValueError):
+            pass
+        parents = set()
+        for path in paths:
+            parent = path.parent
+            while not parent.exists():
+                parent = parent.parent
+            parents.add(str(parent))
+            if path.is_symlink():
+                parents.add(str(path.resolve().parent))
+        child = subprocess.Popen(
+            [
+                "inotifywait",
+                "-q",
+                "-e",
+                "close_write,create,delete,moved_to,moved_from,delete_self,move_self",
+                *sorted(parents),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            preexec_fn=lambda: libc.prctl(1, signal.SIGTERM, 0, 0, 0),  # noqa: PLW1509 - this CLI has no threads
+        )
+        try:
+            print("ready", flush=True)
+            code = child.wait()
+        finally:
+            if child.poll() is None:
+                child.terminate()
+                child.wait()
+        if code:
+            raise Error("Picom configuration watch failed; use Refresh")
+        print("changed", flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    subs = parser.add_subparsers(dest="action", required=True)
+    for action in ("status", "watch", "start", "restart", "reload", "stop", "toggle"):
+        subs.add_parser(action)
+    opacity = subs.add_parser("set-opacity")
+    opacity.add_argument("active", type=float)
+    opacity.add_argument("inactive", type=float)
+    opacity.add_argument("revision")
+    selector = subs.add_parser("set-backend")
+    selector.add_argument("backend", choices=BACKENDS)
+    selector.add_argument("revision")
+    copy = subs.add_parser("copy-config")
+    copy.add_argument("revision")
+    args = parser.parse_args()
+    if args.action == "status":
+        print(json.dumps(status()))
+    elif args.action == "watch":
+        watch()
+    elif args.action in ("set-opacity", "set-backend", "copy-config"):
+        values = (
+            [args.active, args.inactive]
+            if args.action == "set-opacity"
+            else [args.backend]
+            if args.action == "set-backend"
+            else []
+        )
+        detail = mutate(args.action, values, args.revision)
+        print(json.dumps({**status(), "message": detail}))
+    else:
+        # Stopping must work even when an external editor broke the config.
+        if args.action == "reload" and not processes():
+            detail = "Picom is stopped"
+        else:
+            with locked():
+                running = processes()
+                if args.action == "stop" or (args.action == "toggle" and running):
+                    stop(running)
+                    detail = "Picom stopped"
+                else:
+                    detail = activate(session_configuration(), args.action)
+        print(json.dumps({"protocol": PROTOCOL, "message": detail}))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (Error, OSError, ValueError) as error:
+        print(str(error), file=sys.stderr)
+        sys.exit(1)

--- a/scripts/theme-apply.sh
+++ b/scripts/theme-apply.sh
@@ -1229,4 +1229,14 @@ if [[ $RUNTIME_ONLY == 0 && $TRANSACTIONAL_APPLY == 0 ]] &&
 		XCURSOR_SIZE="$CURSOR_SIZE" 2>/dev/null || true
 fi
 
+# Opacity is global. Reapply the current configuration without writing it into
+# theme transactions or their rollback archives. A stopped compositor stays stopped.
+if [[ $TRANSACTIONAL_APPLY == 0 && -n ${DISPLAY:-} ]] && command -v picom &>/dev/null; then
+	PICOM_HELPER=${DWM_APPEARANCE_PICOM_HELPER:-$script_dir/dwm-settings-picom}
+	if [[ -x $PICOM_HELPER ]]; then
+		"$PICOM_HELPER" reload >/dev/null ||
+			echo 'theme-apply: Picom reload failed; see Appearance > Compositor' >&2
+	fi
+fi
+
 echo "theme-apply: applied theme '$THEME_NAME'"

--- a/tests/test-autostart.sh
+++ b/tests/test-autostart.sh
@@ -224,6 +224,13 @@ for name in feh picom dwm-status dwm-lock-watch light-locker dex dex-autostart; 
 	make_mock_command "$name"
 done
 
+cat >"$work/bin/dwm-settings-picom" <<'EOF'
+#!/bin/sh
+[ "$1" = start ] || exit 1
+[ -f "${TEST_STATE:?}/picom.running" ] || picom
+EOF
+chmod +x "$work/bin/dwm-settings-picom"
+
 # The production status publisher is a Bash script, so its comm is "bash"
 # rather than "dwm-status". Keep a real shebang process alive to exercise the
 # /proc command-path and DISPLAY guard instead of the old pgrep-name mock.

--- a/tests/test-dwm-settings-appearance-inventory.sh
+++ b/tests/test-dwm-settings-appearance-inventory.sh
@@ -431,14 +431,14 @@ grep -Fqx $'candidate\tgtk\tavailable\tAdwaita-dark\tAdwaita-dark\tBuilt-in GTK 
 grep -Fqx $'candidate\tgtk\tpartial\tLegacy\tLegacy\tTheme is missing GTK 3 or GTK 4 assets' \
 	<<<"$inventory"
 grep -Fqx $'selection\tqt\tavailable\tqt6ct\t\tCurrent Qt platform theme backend' <<<"$inventory"
-grep -Fqx $'selection\tcompositor\tavailable\tpicom\trunning\tPicom is running' <<<"$inventory"
+grep -Fqx $'selection\tcompositor\tavailable\tpicom\tconfiguration\tPicom controls use its configuration file' <<<"$inventory"
 
 printf 'DISPLAY=:99\0' >"$proc_root/4242/environ"
 other_display=$(HOME=$home PATH=$bin_dir XDG_CONFIG_HOME=$config_home \
 	XDG_DATA_HOME=$data_root DWM_APPEARANCE_DATA_DIRS=$data_root \
 	DWM_APPEARANCE_WALLPAPER_DIR=$wallpaper_dir QT_QPA_PLATFORMTHEME=qt6ct \
 	"$helper" inventory)
-grep -Fqx $'selection\tcompositor\tpartial\tpicom\tstopped\tPicom is installed but not running on this display' \
+grep -Fqx $'selection\tcompositor\tavailable\tpicom\tconfiguration\tPicom controls use its configuration file' \
 	<<<"$other_display"
 printf 'DISPLAY=:55\0' >"$proc_root/4242/environ"
 
@@ -447,7 +447,7 @@ equivalent_display=$(HOME=$home PATH=$bin_dir XDG_CONFIG_HOME=$config_home \
 	XDG_DATA_HOME=$data_root DWM_APPEARANCE_DATA_DIRS=$data_root \
 	DWM_APPEARANCE_WALLPAPER_DIR=$wallpaper_dir QT_QPA_PLATFORMTHEME=qt6ct \
 	"$helper" inventory)
-grep -Fqx $'selection\tcompositor\tavailable\tpicom\trunning\tPicom is running' \
+grep -Fqx $'selection\tcompositor\tavailable\tpicom\tconfiguration\tPicom controls use its configuration file' \
 	<<<"$equivalent_display"
 export DISPLAY=:55
 
@@ -870,52 +870,8 @@ bounded_inventory=$(HOME=$home PATH=$bounded_inventory_bin XDG_CONFIG_HOME=$conf
 grep -Fqx $'selection\twallpaper\tpartial\t\tfill\tWallpaper candidate discovery did not complete' \
 	<<<"$bounded_inventory"
 
-compositor_owner_helper_pid_file=$work/compositor-owner-helper.pid
-HOME=$home PATH=$bin_dir TMPDIR=$work XDG_CONFIG_HOME=$config_home \
-	XDG_DATA_HOME=$data_root \
-	bash -c '"$1" watch-compositor >"$2" & helper_pid=$!; printf "%s\n" "$helper_pid" >"$3"; wait "$helper_pid"' \
-	bash "$helper" "$work/compositor-owner.out" "$compositor_owner_helper_pid_file" &
-compositor_owner_pid=$!
-for _ in $(seq 1 300); do
-	[[ -s $compositor_owner_helper_pid_file && -s $work/compositor-owner.out ]] && break
-	sleep 0.02
-done
-compositor_owner_helper_pid=$(<"$compositor_owner_helper_pid_file")
-compositor_owner_helper_parent_pid=$(awk '/^PPid:/ { print $2 }' \
-	"/proc/$compositor_owner_helper_pid/status")
-[[ $compositor_owner_helper_parent_pid == "$compositor_owner_pid" ]]
-kill -KILL "$compositor_owner_pid"
-wait "$compositor_owner_pid" 2>/dev/null || true
-for _ in $(seq 1 300); do
-	process_running "$compositor_owner_helper_pid" || break
-	sleep 0.02
-done
-if process_running "$compositor_owner_helper_pid"; then
-	printf 'Compositor watcher survived its owner process (helper %s)\n' \
-		"$compositor_owner_helper_pid" >&2
-	exit 1
-fi
-
-picom_state=$work/picom.state
-printf 'running\n' >"$picom_state"
-coproc COMPOSITOR_WATCH {
-	exec env HOME="$home" PATH="$bin_dir" TMPDIR="$work" XDG_CONFIG_HOME="$config_home" \
-		XDG_DATA_HOME="$data_root" DWM_TEST_PICOM_STATE="$picom_state" \
-		"$helper" watch-compositor
-}
-# shellcheck disable=SC2153 # Named coprocesses expose NAME_PID dynamically.
-compositor_watch_pid=$COMPOSITOR_WATCH_PID
-read -r -t 3 compositor_running <&"${COMPOSITOR_WATCH[0]}"
-[[ $compositor_running == $'compositor\trunning' ]]
-printf 'stopped\n' >"$picom_state"
-read -r -t 3 compositor_stopped <&"${COMPOSITOR_WATCH[0]}"
-[[ $compositor_stopped == $'compositor\tstopped' ]]
-kill "$compositor_watch_pid"
-wait "$compositor_watch_pid" 2>/dev/null || true
-if find "$work" -maxdepth 1 -type d -name 'dwm-appearance-compositor.*' -print -quit | grep -q .; then
-	printf 'Compositor watcher left its wait directory behind\n' >&2
-	exit 1
-fi
+# Picom process state no longer gates Appearance inventory. File watching is
+# covered by test-picom.py and the dedicated nested Picom runtime test.
 
 blocking_scan_bin=$work/blocking-scan-bin
 blocking_scan_pid_file=$work/blocking-scan-child.pid

--- a/tests/test-dwm-settings-appearance.sh
+++ b/tests/test-dwm-settings-appearance.sh
@@ -218,8 +218,8 @@ grep -Fqx $'integration\tqt\tavailable\tqt6ct\tQt applications use the supported
 grep -Fqx $'integration\tcursor\tavailable\tCapitaine-Cursors-White\tManaged cursor theme is installed and applied' <<<"$output"
 grep -Fqx $'integration\talacritty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' <<<"$output"
 grep -Fqx $'integration\tkitty\tavailable\tactive-theme\tGenerated terminal theme matches the resolved palette' <<<"$output"
-grep -Fqx $'integration\tcompositor\tpartial\tpicom\tPicom is available but has no shared theme mutation contract' <<<"$output"
-grep -Fqx $'error\tcompositor\tunsupported\tPicom theme mutation is not implemented' <<<"$output"
+grep -Fqx $'integration\tcompositor\tavailable\tpicom\tGlobal opacity is configured in the Compositor section' <<<"$output"
+if grep -Fq 'Picom theme mutation is not implemented' <<<"$output"; then exit 1; fi
 
 no_picom_bin=$work/no-picom-bin
 cp -a "$bin_dir" "$no_picom_bin"

--- a/tests/test-dwm-settings-theme.sh
+++ b/tests/test-dwm-settings-theme.sh
@@ -138,6 +138,7 @@ SH
 chmod +x "$xsettings_stub"
 export DWM_APPEARANCE_XSETTINGS_HELPER=$xsettings_stub
 export DWM_APPEARANCE_CURSOR_HELPER=/usr/bin/true
+export DWM_APPEARANCE_PICOM_HELPER=/usr/bin/true
 export DWM_TEST_XSETTINGS_LOG=$work/xsettings.log
 
 run_theme() {

--- a/tests/test-picom-xvfb.py
+++ b/tests/test-picom-xvfb.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Exercise real Picom, configuration watching and Appearance on an isolated X server."""
+
+import ctypes
+import ctypes.util
+import importlib.machinery
+import importlib.util
+import json
+import os
+import select
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from PIL import ImageGrab
+
+repo = Path(__file__).resolve().parents[1]
+loader = importlib.machinery.SourceFileLoader(
+    "picom_runtime", str(repo / "scripts/dwm-settings-picom")
+)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+picom = importlib.util.module_from_spec(spec)
+sys.dont_write_bytecode = True
+loader.exec_module(picom)
+
+
+def wait_until(callback, description, seconds=10):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if callback():
+            return
+        time.sleep(0.05)
+    raise AssertionError(description() if callable(description) else description)
+
+
+def main():
+    for command in ("Xvfb", "picom", "quickshell", "dbus-run-session", "inotifywait"):
+        if not shutil.which(command):
+            raise RuntimeError(f"{command} is required")
+    primary = picom.processes()
+    xvfb = shell = connection = None
+    with tempfile.TemporaryDirectory(dir=os.environ.get("TMPDIR")) as directory:
+        work = Path(directory)
+        home, config, data, runtime = [
+            work / p for p in ("home", "config", "data", "runtime")
+        ]
+        for path in (home, config, data, runtime):
+            path.mkdir(mode=0o700)
+        env = {
+            **os.environ,
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(config),
+            "XDG_CONFIG_DIRS": str(work / "vendor"),
+            "XDG_DATA_HOME": str(data),
+            "XDG_STATE_HOME": str(work / "state"),
+            "XDG_RUNTIME_DIR": str(runtime),
+            "DWM_PICOM_CONFIG": "",
+            "PICOM_BACKEND": "",
+            "QT_QUICK_BACKEND": "software",
+            "QSG_RHI_BACKEND": "software",
+            "QT_QPA_PLATFORMTHEME": "",
+        }
+        read_fd, write_fd = os.pipe()
+        try:
+            with open(work / "xvfb.log", "w") as log:
+                xvfb = subprocess.Popen(
+                    [
+                        "Xvfb",
+                        "-displayfd",
+                        str(write_fd),
+                        "-screen",
+                        "0",
+                        "1024x768x24",
+                        "-nolisten",
+                        "tcp",
+                    ],
+                    pass_fds=(write_fd,),
+                    stdout=log,
+                    stderr=log,
+                )
+            os.close(write_fd)
+            if not select.select([read_fd], [], [], 10)[0]:
+                raise AssertionError("Xvfb startup timed out")
+            display = ":" + os.read(read_fd, 32).decode().strip()
+            os.close(read_fd)
+            env["DISPLAY"] = display
+
+            def helper(*args, success=True):
+                result = subprocess.run(
+                    [str(repo / "scripts/dwm-settings-picom"), *args],
+                    env=env,
+                    text=True,
+                    capture_output=True,
+                    timeout=25,
+                    check=False,
+                )
+                if success and result.returncode:
+                    raise AssertionError(result.stderr)
+                return json.loads(result.stdout) if success else result
+
+            conf = config / "picom.conf"
+            helper("start")
+            fresh = helper("status")
+            assert fresh["editable"] and not conf.exists()
+            helper("set-opacity", "100", "100", fresh["revision"])
+            assert conf.exists()
+            helper("stop")
+            print("PASS: first edit after startup without configuration", flush=True)
+            conf.write_text(
+                'backend="xrender";\nactive-opacity=1.0;\ninactive-opacity=1.0;\nfading=false;\nshadow=false;\nuse-ewmh-active-win=true;\n'
+            )
+            helper("start")
+            before = helper("status")
+            assert before["running"] and before["effective"] == "xrender"
+            with ThreadPoolExecutor(max_workers=4) as pool:
+                snapshots = list(pool.map(lambda _: helper("status"), range(8)))
+            assert all(s["editable"] and s["running"] for s in snapshots)
+            print(
+                "PASS: diagnostic probes never appear as duplicate compositors",
+                flush=True,
+            )
+            helper("set-opacity", "90", "50", before["revision"])
+            assert helper("status")["inactive"] == 50
+
+            lib = ctypes.CDLL(ctypes.util.find_library("X11"))
+            lib.XOpenDisplay.argtypes = [ctypes.c_char_p]
+            lib.XOpenDisplay.restype = ctypes.c_void_p
+            lib.XDefaultRootWindow.argtypes = [ctypes.c_void_p]
+            lib.XDefaultRootWindow.restype = ctypes.c_ulong
+            lib.XCreateSimpleWindow.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_ulong,
+                ctypes.c_int,
+                ctypes.c_int,
+                ctypes.c_uint,
+                ctypes.c_uint,
+                ctypes.c_uint,
+                ctypes.c_ulong,
+                ctypes.c_ulong,
+            ]
+            lib.XCreateSimpleWindow.restype = ctypes.c_ulong
+            lib.XMapWindow.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+            lib.XSetInputFocus.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_ulong,
+                ctypes.c_int,
+                ctypes.c_ulong,
+            ]
+            lib.XSync.argtypes = [ctypes.c_void_p, ctypes.c_int]
+            lib.XCloseDisplay.argtypes = [ctypes.c_void_p]
+            connection = lib.XOpenDisplay(display.encode())
+            root = lib.XDefaultRootWindow(connection)
+            first = lib.XCreateSimpleWindow(
+                connection, root, 20, 20, 180, 180, 0, 0, 0xFF0000
+            )
+            second = lib.XCreateSimpleWindow(
+                connection, root, 240, 20, 180, 180, 0, 0, 0xFF0000
+            )
+            lib.XInternAtom.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
+            lib.XInternAtom.restype = ctypes.c_ulong
+            lib.XChangeProperty.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_ulong,
+                ctypes.c_ulong,
+                ctypes.c_ulong,
+                ctypes.c_int,
+                ctypes.c_int,
+                ctypes.c_void_p,
+                ctypes.c_int,
+            ]
+            wm_state = lib.XInternAtom(connection, b"WM_STATE", 0)
+            normal_state = (ctypes.c_ulong * 2)(1, 0)
+            type_atom = lib.XInternAtom(connection, b"_NET_WM_WINDOW_TYPE", 0)
+            normal_type = ctypes.c_ulong(
+                lib.XInternAtom(connection, b"_NET_WM_WINDOW_TYPE_NORMAL", 0)
+            )
+            for window in (first, second):
+                lib.XChangeProperty(
+                    connection, window, wm_state, wm_state, 32, 0, normal_state, 2
+                )
+                lib.XChangeProperty(
+                    connection,
+                    window,
+                    type_atom,
+                    4,
+                    32,
+                    0,
+                    ctypes.byref(normal_type),
+                    1,
+                )
+                lib.XMapWindow(connection, window)
+            lib.XSync(connection, 0)
+            lib.XSetInputFocus(connection, first, 1, 0)
+            active_atom = lib.XInternAtom(connection, b"_NET_ACTIVE_WINDOW", 0)
+            window_atom = lib.XInternAtom(connection, b"WINDOW", 0)
+            value = ctypes.c_ulong(first)
+            lib.XChangeProperty(
+                connection,
+                root,
+                active_atom,
+                window_atom,
+                32,
+                0,
+                ctypes.byref(value),
+                1,
+            )
+            lib.XSync(connection, 0)
+            # Let Picom import the synthetic clients before delivering a focus
+            # transition, as a window manager would after managing MapRequest.
+            time.sleep(0.3)
+            lib.XSetInputFocus(connection, second, 1, 0)
+            lib.XSync(connection, 0)
+            time.sleep(0.1)
+            lib.XSetInputFocus(connection, first, 1, 0)
+            lib.XSync(connection, 0)
+            lib.XChangeProperty(
+                connection,
+                root,
+                active_atom,
+                window_atom,
+                32,
+                0,
+                ctypes.byref(value),
+                1,
+            )
+            lib.XSync(connection, 0)
+            samples = []
+
+            def opacity_visible():
+                image = ImageGrab.grab(xdisplay=display)
+                a, b = image.getpixel((80, 80))[0], image.getpixel((280, 80))[0]
+                samples.append((a, b))
+                return abs(a - 230) < 12 and abs(b - 128) < 12
+
+            wait_until(
+                opacity_visible,
+                lambda: (
+                    f"Active/inactive opacity must change actual rendered pixels: {samples[-5:]}"
+                ),
+            )
+            print("PASS: real XRender focus-dependent opacity", flush=True)
+
+            # Modern rules use the same global controls while preserving custom rules.
+            conf.write_text(
+                'backend="xrender";\nrules=({match="window_type = \'dock\'"; opacity=1.0;});\n'
+            )
+            helper("set-opacity", "85", "65", helper("status")["revision"])
+            assert helper("status")["active"] == 85
+            assert "window_type = 'dock'" in conf.read_text()
+            helper("restart")
+            helper("set-backend", "auto", helper("status")["revision"])
+            assert helper("status")["policy"] == "auto"
+            assert (
+                helper("status")["effective"] == "xrender"
+            )  # Xvfb is software-rendered.
+            print(
+                "PASS: modern rules, restart, and software-renderer selection",
+                flush=True,
+            )
+
+            # Use the actual managed-path QML model and controls, with IPC for assertions.
+            qml = config / "quickshell"
+            shutil.copytree(repo / "config/quickshell", qml)
+            scripts = data / "dwm-titus/scripts"
+            scripts.mkdir(parents=True)
+            shutil.copy2(repo / "scripts/dwm-settings-picom", scripts)
+            (qml / "shell.qml").write_text("""import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Io
+import "appearance"
+import "settings"
+import qs.core
+ShellRoot {
+    PicomModel { id: provider; active: true }
+    FloatingWindow {
+        visible: true
+        color: Theme.bg
+        implicitWidth: 700
+        implicitHeight: 600
+        ColumnLayout { anchors.fill: parent; anchors.margins: 20; PicomSettingsPane { model: provider } }
+    }
+    IpcHandler {
+        target: "picomTest"
+        function state(): string { return JSON.stringify(provider.snapshot); }
+        function error(): string { return provider.failure; }
+        function opacity(a: int, b: int): void { provider.setOpacity(a, b); }
+        function enabled(value: bool): void { provider.active = value; }
+    }
+}
+""")
+            with open(work / "qml.log", "w") as log:
+                shell = subprocess.Popen(
+                    [
+                        "dbus-run-session",
+                        "--",
+                        "quickshell",
+                        "--no-duplicate",
+                        "--path",
+                        str(qml / "shell.qml"),
+                    ],
+                    env=env,
+                    stdout=log,
+                    stderr=log,
+                    start_new_session=True,
+                )
+
+            def ipc(method, *args):
+                return subprocess.run(
+                    [
+                        "quickshell",
+                        "ipc",
+                        "--path",
+                        str(qml / "shell.qml"),
+                        "call",
+                        "picomTest",
+                        method,
+                        *args,
+                    ],
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                    timeout=8,
+                    check=False,
+                )
+
+            def ui_matches(key, expected):
+                result = ipc("state")
+                if result.returncode:
+                    return False
+                return json.loads(result.stdout).get(key) == expected
+
+            wait_until(lambda: ui_matches("active", 85), "QML did not load Picom state")
+            if os.environ.get("DWM_TEST_PICOM_CAPTURE"):
+                ImageGrab.grab(xdisplay=display).save(
+                    os.environ["DWM_TEST_PICOM_CAPTURE"]
+                )
+            assert ipc("opacity", "80", "60").returncode == 0
+            wait_until(
+                lambda: ui_matches("active", 80), "QML mutation did not converge"
+            )
+            final_state = helper("status")
+            assert final_state["inactive"] == 60, (
+                final_state,
+                ipc("state").stdout,
+                ipc("error").stdout,
+                conf.read_text(),
+            )
+            conf.write_text(
+                conf.read_text().replace("opacity = 0.8;", "opacity = 0.7;")
+            )
+            wait_until(
+                lambda: ui_matches("active", 70),
+                "External configuration edit was not observed",
+            )
+            helper("stop")
+            assert ui_matches("active", 70)
+            assert ipc("enabled", "false").returncode == 0
+            assert ipc("enabled", "true").returncode == 0
+            wait_until(
+                lambda: ui_matches("running", False),
+                "Stopped compositor state did not load",
+            )
+            assert ui_matches("editable", True)
+            assert ipc("error").stdout.strip() == ""
+            conf.write_text(
+                'backend="xrender"; daemon=true; active-opacity=.8; inactive-opacity=.6;'
+            )
+            helper("start")
+            helper("set-opacity", "75", "55", helper("status")["revision"])
+            assert helper("status")["running"]
+            conf.write_text("malformed configuration")
+            helper("stop")
+            nested = work / "nested-wintypes.conf"
+            nested.write_text("tooltip = { opacity = 0.8; };")
+            native_text = (
+                'backend="xrender"; wintypes = {\n@include "' + str(nested) + '"\n};'
+            )
+            conf.write_text(native_text)
+            helper("start")
+            assert helper("status")["running"]
+            assert not helper("status")["editable"]
+            helper("reload")
+            helper("restart")
+            assert helper("status")["running"]
+            assert conf.read_text() == native_text
+            helper("stop")
+            print(
+                "PASS: daemonized Picom, malformed-config stop, and native nested-include sessions",
+                flush=True,
+            )
+            log_text = (work / "qml.log").read_text()
+            assert not any(
+                text in log_text
+                for text in (
+                    "ReferenceError:",
+                    "TypeError:",
+                    "Failed to load configuration",
+                )
+            )
+            print(
+                "PASS: real QML controls, mutations, file watch, and stable stopped-compositor controls",
+                flush=True,
+            )
+        except Exception:
+            for path in (
+                work / "xvfb.log",
+                work / "qml.log",
+                work / "state/dwm-titus/picom/session.log",
+            ):
+                if path.exists():
+                    print(path.name + ":\n" + path.read_text()[-6000:])
+            raise
+        finally:
+            if shell:
+                os.killpg(shell.pid, 15)
+                shell.wait(timeout=8)
+            if "display" in locals():
+                subprocess.run(
+                    [str(repo / "scripts/dwm-settings-picom"), "stop"],
+                    env=env,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=10,
+                    check=False,
+                )
+            if connection:
+                lib.XCloseDisplay(connection)
+            if xvfb:
+                xvfb.terminate()
+                xvfb.wait(timeout=8)
+        assert picom.processes() == primary, (
+            "The primary display compositor was changed"
+        )
+        print("PASS: primary display compositor unchanged", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test-picom-xvfb.py
+++ b/tests/test-picom-xvfb.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Exercise real Picom, configuration watching and Appearance on an isolated X server."""
 
+import contextlib
 import ctypes
 import ctypes.util
 import importlib.machinery
@@ -252,6 +253,31 @@ def main():
             assert helper("status")["active"] == 85
             assert "window_type = 'dock'" in conf.read_text()
             helper("restart")
+            dialog_type = ctypes.c_ulong(
+                lib.XInternAtom(connection, b"_NET_WM_WINDOW_TYPE_DIALOG", 0)
+            )
+            for window in (first, second):
+                lib.XChangeProperty(
+                    connection,
+                    window,
+                    type_atom,
+                    4,
+                    32,
+                    0,
+                    ctypes.byref(dialog_type),
+                    1,
+                )
+            lib.XSync(connection, 0)
+
+            def dialog_opacity_visible():
+                image = ImageGrab.grab(xdisplay=display)
+                a, b = image.getpixel((80, 80))[0], image.getpixel((280, 80))[0]
+                return abs(a - 217) < 12 and abs(b - 166) < 12
+
+            wait_until(
+                dialog_opacity_visible, "Modern rules must apply opacity to dialogs"
+            )
+            print("PASS: modern rules apply opacity to dialogs", flush=True)
             helper("set-backend", "auto", helper("status")["revision"])
             assert helper("status")["policy"] == "auto"
             assert (
@@ -259,6 +285,55 @@ def main():
             )  # Xvfb is software-rendered.
             print(
                 "PASS: modern rules, restart, and software-renderer selection",
+                flush=True,
+            )
+
+            # Native Picom resolves resources and nested includes at the root.
+            modern_text = conf.read_text()
+            shader = config / "custom.frag"
+            shader.write_text(
+                "vec4 window_shader() { return default_post_processing(window_color()); }\n"
+            )
+            sub = config / "sub"
+            sub.mkdir()
+            (sub / "child.conf").write_text('@include "values.conf"')
+            (config / "values.conf").write_text(
+                "active-opacity=.9; inactive-opacity=.7;"
+            )
+            (sub / "values.conf").write_text("active-opacity=.1;")
+            conf.write_text(
+                'backend="xrender"; window-shader-fg="custom.frag";\n@include "sub/child.conf"'
+            )
+            helper("set-opacity", "82", "62", helper("status")["revision"])
+            assert helper("status")["active"] == 82
+            assert (sub / "values.conf").read_text() == "active-opacity=.1;"
+            assert 'window-shader-fg="custom.frag"' in conf.read_text()
+            assert not list(config.glob(".dwm-picom-validate-*"))
+            conf.write_text(modern_text)
+            helper("restart")
+            print(
+                "PASS: native relative shader and root-relative nested include edits",
+                flush=True,
+            )
+            helper("stop")
+            vendor = work / "vendor"
+            vendor.mkdir()
+            vendor_shader = vendor / "vendor.frag"
+            vendor_shader.write_text(shader.read_text())
+            vendor_config = vendor / "picom.conf"
+            vendor_config.write_text(
+                'backend="xrender"; window-shader-fg="vendor.frag";'
+            )
+            conf.unlink()
+            helper("copy-config", helper("status")["revision"])
+            assert str(vendor_shader) in conf.read_text()
+            helper("start")
+            assert helper("status")["running"]
+            helper("stop")
+            conf.write_text(modern_text)
+            helper("start")
+            print(
+                "PASS: vendor shader references survive user configuration copy and startup",
                 flush=True,
             )
 
@@ -282,7 +357,7 @@ ShellRoot {
         color: Theme.bg
         implicitWidth: 700
         implicitHeight: 600
-        ColumnLayout { anchors.fill: parent; anchors.margins: 20; PicomSettingsPane { model: provider } }
+        ColumnLayout { anchors.fill: parent; anchors.margins: 20; PicomSettingsPane { id: pane; model: provider } }
     }
     IpcHandler {
         target: "picomTest"
@@ -290,6 +365,19 @@ ShellRoot {
         function error(): string { return provider.failure; }
         function opacity(a: int, b: int): void { provider.setOpacity(a, b); }
         function enabled(value: bool): void { provider.active = value; }
+        function refresh(): void { provider.refresh(); }
+        function injectFailures(): void {
+            provider.statusFailure = "status failed";
+            provider.actionFailure = "mutation failed";
+        }
+        function statusError(): string { return provider.statusFailure; }
+        function clearActionError(): void { provider.actionFailure = ""; }
+        function pendingReadonly(): string {
+            pane.activeOpacity = 42;
+            pane.changed = true;
+            provider.snapshot = Object.assign({}, provider.snapshot, {editable: false, active: 81});
+            return JSON.stringify({changed: pane.changed, active: pane.activeOpacity});
+        }
     }
 }
 """)
@@ -335,10 +423,24 @@ ShellRoot {
                 return json.loads(result.stdout).get(key) == expected
 
             wait_until(lambda: ui_matches("active", 85), "QML did not load Picom state")
-            if os.environ.get("DWM_TEST_PICOM_CAPTURE"):
-                ImageGrab.grab(xdisplay=display).save(
-                    os.environ["DWM_TEST_PICOM_CAPTURE"]
-                )
+            assert ipc("injectFailures").returncode == 0
+            assert ipc("refresh").returncode == 0
+            wait_until(
+                lambda: ipc("statusError").stdout.strip() == "",
+                "Recovered status error remains",
+            )
+            assert ipc("error").stdout.strip() == "mutation failed"
+            assert ipc("clearActionError").returncode == 0
+            pending = json.loads(ipc("pendingReadonly").stdout)
+            assert pending == {"changed": False, "active": 81}
+            assert ipc("refresh").returncode == 0
+            wait_until(
+                lambda: ui_matches("active", 85), "QML did not restore refreshed state"
+            )
+            print(
+                "PASS: QML status recovery preserves mutation failures; readonly state cancels pending edits",
+                flush=True,
+            )
             assert ipc("opacity", "80", "60").returncode == 0
             wait_until(
                 lambda: ui_matches("active", 80), "QML mutation did not converge"
@@ -367,6 +469,10 @@ ShellRoot {
             )
             assert ui_matches("editable", True)
             assert ipc("error").stdout.strip() == ""
+            if os.environ.get("DWM_TEST_PICOM_CAPTURE"):
+                ImageGrab.grab(xdisplay=display).save(
+                    os.environ["DWM_TEST_PICOM_CAPTURE"]
+                )
             conf.write_text(
                 'backend="xrender"; daemon=true; active-opacity=.8; inactive-opacity=.6;'
             )
@@ -417,17 +523,25 @@ ShellRoot {
             raise
         finally:
             if shell:
-                os.killpg(shell.pid, 15)
-                shell.wait(timeout=8)
+                with contextlib.suppress(ProcessLookupError):
+                    os.killpg(shell.pid, 15)
+                try:
+                    shell.wait(timeout=8)
+                except subprocess.TimeoutExpired:
+                    with contextlib.suppress(ProcessLookupError):
+                        os.killpg(shell.pid, 9)
+                    with contextlib.suppress(subprocess.TimeoutExpired):
+                        shell.wait(timeout=8)
             if "display" in locals():
-                subprocess.run(
-                    [str(repo / "scripts/dwm-settings-picom"), "stop"],
-                    env=env,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    timeout=10,
-                    check=False,
-                )
+                with contextlib.suppress(OSError, subprocess.TimeoutExpired):
+                    subprocess.run(
+                        [str(repo / "scripts/dwm-settings-picom"), "stop"],
+                        env=env,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        timeout=10,
+                        check=False,
+                    )
             if connection:
                 lib.XCloseDisplay(connection)
             if xvfb:

--- a/tests/test-picom.py
+++ b/tests/test-picom.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Configuration preservation, transaction, GPU-policy and session isolation tests."""
+
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+loader = importlib.machinery.SourceFileLoader(
+    "picom_settings",
+    str(Path(__file__).resolve().parents[1] / "scripts/dwm-settings-picom"),
+)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+picom = importlib.util.module_from_spec(spec)
+sys.dont_write_bytecode = True
+loader.exec_module(picom)
+
+
+class PicomTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(dir=os.environ.get("TMPDIR"))
+        self.addCleanup(self.tmp.cleanup)
+        self.home = Path(self.tmp.name)
+        self.config = self.home / "config"
+        self.config.mkdir(mode=0o700)
+        self.path = self.config / "picom.conf"
+        self.env = patch.dict(
+            os.environ,
+            {
+                "HOME": str(self.home),
+                "XDG_CONFIG_HOME": str(self.config),
+                "XDG_CONFIG_DIRS": str(self.home / "vendor"),
+                "XDG_STATE_HOME": str(self.home / "state"),
+                "DISPLAY": "",
+                "DWM_PICOM_CONFIG": "",
+                "PICOM_BACKEND": "",
+            },
+        )
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.running = patch.object(picom, "processes", return_value=[])
+        self.running.start()
+        self.addCleanup(self.running.stop)
+        self.which = patch.object(picom.shutil, "which", return_value="/usr/bin/picom")
+        self.which.start()
+        self.addCleanup(self.which.stop)
+
+    def write(self, text):
+        self.path.write_text(text)
+        return picom.Configuration()
+
+    def apply(self, config, active=90, inactive=75):
+        return picom.mutate("set-opacity", [active, inactive], config.revision())
+
+    def test_missing_creates_only_on_edit(self):
+        state = picom.status(False)
+        self.assertFalse(self.path.exists())
+        self.assertTrue(state["editable"])
+        self.assertEqual(state["active"], 100)
+        self.apply(picom.Configuration())
+        self.assertEqual(picom.Configuration().opacity(), (0.9, 0.75))
+        self.assertEqual(self.path.stat().st_mode & 0o777, 0o600)
+
+    def test_preserves_comments_nested_keys_and_format(self):
+        text = '# active-opacity = .1;\nactive-opacity=.98; // active\ninactive-opacity = 0.8\nbackend="glx";\nwintypes: { tooltip = { opacity = 0.5; }; };\n'
+        config = self.write(text)
+        self.apply(config)
+        expected = text.replace("active-opacity=.98", "active-opacity=0.9").replace(
+            "inactive-opacity = 0.8", "inactive-opacity = 0.75"
+        )
+        self.assertEqual(self.path.read_text(), expected)
+        self.assertTrue(list((self.home / "state/dwm-titus/picom").glob("backup-*")))
+
+    def test_includes_preserved_and_changed_at_source(self):
+        child = self.config / "opacity.conf"
+        child.write_text("active-opacity = .7; inactive-opacity = .6;\n")
+        config = self.write('@include "opacity.conf"\nbackend = "glx";\n')
+        self.apply(config)
+        self.assertEqual(
+            self.path.read_text(), '@include "opacity.conf"\nbackend = "glx";\n'
+        )
+        self.assertEqual(picom.Configuration().opacity(), (0.9, 0.75))
+
+    def test_include_cycle_and_duplicates(self):
+        self.path.write_text('@include "picom.conf"')
+        with self.assertRaises(picom.Error):
+            picom.Configuration()
+        with self.assertRaises(picom.Error):
+            self.write("active-opacity=1; active-opacity=.5;")
+
+    def test_session_delegates_unsupported_editor_syntax(self):
+        self.path.write_text('backend="xrender"; wintypes={\n@include "types.conf"\n};')
+        config = picom.session_configuration()
+        self.assertIsInstance(config, picom.NativeConfiguration)
+        self.assertEqual(config.path, self.path)
+        self.assertFalse(picom.status(False)["editable"])
+        with self.assertRaises(picom.Error):
+            picom.Configuration()
+
+    def test_modern_rules_preserve_custom_exceptions(self):
+        custom = "{ match=\"class_g = 'Alacritty'\"; opacity=.8; shadow=false; }"
+        config = self.write("rules = (" + custom + ');\nbackend="glx";\n')
+        self.apply(config)
+        self.assertIn(custom, self.path.read_text())
+        self.assertEqual(picom.Configuration().opacity(), (0.9, 0.75))
+        self.assertLess(
+            self.path.read_text().index(picom.END), self.path.read_text().index(custom)
+        )
+        self.apply(picom.Configuration(), 88, 66)
+        self.assertEqual(self.path.read_text().count(picom.BEGIN), 1)
+        self.assertEqual(picom.Configuration().opacity(), (0.88, 0.66))
+
+    def test_empty_modern_rules(self):
+        self.apply(self.write("rules=();"))
+        self.apply(picom.Configuration(), 100, 100)
+        self.assertEqual(picom.Configuration().opacity(), (1, 1))
+
+    def test_stale_revision_no_overwrite(self):
+        config = self.write("active-opacity=.8;")
+        self.path.write_text("active-opacity=.6;")
+        with self.assertRaisesRegex(picom.Error, "changed"):
+            self.apply(config)
+        self.assertEqual(self.path.read_text(), "active-opacity=.6;")
+
+    def test_invalid_range_and_syntax(self):
+        config = self.write("active-opacity=.8;")
+        for value in (-1, 101, float("nan"), float("inf")):
+            with self.assertRaises(picom.Error):
+                self.apply(config, value)
+        for text in (
+            "active-opacity=oops;",
+            "rules=({foo=1;",
+            'active-opacity="oops";',
+        ):
+            with self.assertRaises(picom.Error):
+                self.write(text).opacity()
+
+    def test_owned_symlink_preserved(self):
+        target = self.home / "dotfiles.conf"
+        target.write_text("active-opacity=.8;")
+        self.path.symlink_to(target)
+        self.apply(picom.Configuration())
+        self.assertTrue(self.path.is_symlink())
+        self.assertIn("0.9", target.read_text())
+
+    def test_readonly_or_shared_path_rejected(self):
+        self.write("active-opacity=.8;")
+        self.path.chmod(0o444)
+        self.assertFalse(picom.status(False)["editable"])
+        with self.assertRaises(picom.Error):
+            self.apply(picom.Configuration())
+        self.path.chmod(0o666)
+        with self.assertRaises(picom.Error):
+            self.apply(picom.Configuration())
+
+    def test_failed_activation_restores_bytes(self):
+        original = "active-opacity=.8; # my choice\n"
+        config = self.write(original)
+        process = {"pid": 123, "identity": "1", "args": ["picom"]}
+        with (
+            patch.object(picom, "processes", return_value=[process]),
+            patch.object(picom, "stop"),
+            patch.object(picom, "launch", side_effect=picom.Error("failed")),
+            self.assertRaisesRegex(picom.Error, "restored"),
+        ):
+            self.apply(config)
+        self.assertEqual(self.path.read_text(), original)
+
+    def test_candidate_validation_precedes_publication(self):
+        config = self.write("active-opacity=.8;")
+        with (
+            patch.object(
+                picom, "validate_candidate", side_effect=picom.Error("bad syntax")
+            ),
+            self.assertRaises(picom.Error),
+        ):
+            self.apply(config)
+        self.assertEqual(self.path.read_text(), "active-opacity=.8;")
+
+    def test_validation_stages_relative_includes(self):
+        child = self.config / "child.conf"
+        child.write_text("active-opacity=.8;")
+        config = self.write('@include "child.conf"')
+
+        def validate(path):
+            staged = picom.Configuration(path)
+            self.assertEqual(staged.opacity(), (0.9, 0.75))
+            return ""
+
+        with (
+            patch.dict(os.environ, DISPLAY=":99"),
+            patch.object(picom, "diagnostics", side_effect=validate),
+        ):
+            picom.validate_candidate(
+                config, config.opacity_changes(0.9, 0.75), self.path
+            )
+        self.assertEqual(child.read_text(), "active-opacity=.8;")
+
+    def test_backend_precedence_and_auto(self):
+        config = self.write('backend="glx"; # preserve\n')
+        with patch.object(picom, "renderer", return_value="nvidia"):
+            self.assertEqual(picom.backend(config)[1], "glx")
+        picom.mutate("set-backend", ["auto"], config.revision())
+        self.assertIn("# preserve", self.path.read_text())
+        self.assertNotIn("backend=", self.path.read_text())
+        for gpu, expected in [
+            ("intel", "glx"),
+            ("amd", "glx"),
+            ("nvidia", "xrender"),
+            ("unknown", "xrender"),
+            ("software", "xrender"),
+        ]:
+            with patch.object(picom, "renderer", return_value=gpu):
+                self.assertEqual(picom.backend(picom.Configuration())[1], expected)
+        with patch.dict(os.environ, PICOM_BACKEND="egl"):
+            self.assertEqual(picom.backend(picom.Configuration())[1:3], ("egl", "egl"))
+            with self.assertRaises(picom.Error):
+                picom.mutate("set-backend", ["glx"], picom.Configuration().revision())
+
+    def test_active_renderer_not_pci_inventory(self):
+        for vendor, gl, accelerated, expected in [
+            ("Intel", "Mesa Intel Graphics", 1, "intel"),
+            ("NVIDIA Corporation", "RTX", 1, "nvidia"),
+            ("Mesa", "llvmpipe", 0, "software"),
+        ]:
+            text = (
+                f"* GL: {vendor}\n* GL renderer: {gl}\n* Accelerated: {accelerated}\n"
+            )
+            with patch.object(picom, "diagnostics", return_value=text):
+                self.assertEqual(picom.renderer(picom.Configuration()), expected)
+
+    def test_reload_does_not_start_stopped_compositor(self):
+        with patch.object(picom, "launch") as launch:
+            self.assertIn("stopped", picom.activate(picom.Configuration(), "reload"))
+            launch.assert_not_called()
+
+    def test_missing_picom_status(self):
+        with patch.object(picom.shutil, "which", return_value=None):
+            result = picom.status(False)
+            self.assertFalse(result["editable"])
+            self.assertIn("not installed", result["detail"])
+
+    def test_command_line_config_selection(self):
+        explicit = self.home / "other.conf"
+        explicit.write_text("active-opacity=.7;")
+        with patch.object(
+            picom,
+            "processes",
+            return_value=[{"args": ["picom", "--config", str(explicit)]}],
+        ):
+            self.assertEqual(picom.source_path(), explicit)
+
+    def test_copy_vendor_config_does_not_overwrite(self):
+        vendor = self.home / "vendor"
+        vendor.mkdir()
+        source = vendor / "picom.conf"
+        source.write_text('backend="glx";')
+        config = picom.Configuration()
+        picom.mutate("copy-config", [], config.revision())
+        self.assertEqual(self.path.read_text(), source.read_text())
+        with self.assertRaises(picom.Error):
+            picom.mutate("copy-config", [], picom.Configuration().revision())
+
+    def test_copy_vendor_include_graph_is_editable(self):
+        vendor = self.home / "vendor"
+        vendor.mkdir()
+        source = vendor / "picom.conf"
+        included = vendor / "opacity.conf"
+        included.write_text("active-opacity=.7; inactive-opacity=.6;")
+        included.chmod(0o444)
+        source.write_text('@include "opacity.conf"\nbackend="glx";')
+        source.chmod(0o444)
+        config = picom.Configuration()
+        picom.mutate("copy-config", [], config.revision())
+        self.assertTrue(picom.status(False)["editable"])
+        self.apply(picom.Configuration())
+        self.assertEqual(picom.Configuration().opacity(), (0.9, 0.75))
+        self.assertEqual(
+            included.read_text(), "active-opacity=.7; inactive-opacity=.6;"
+        )
+
+    def test_launch_implicit_discovery_and_daemon_readiness(self):
+        child = Mock()
+        child.poll.return_value = 0
+        with (
+            patch.object(picom, "owner", side_effect=[0, *([1] * 50)]),
+            patch.object(picom, "processes", return_value=[{"pid": 123}]),
+            patch.object(picom.subprocess, "Popen", return_value=child) as popen,
+        ):
+            picom.launch(
+                picom.Configuration(self.path),
+                previous=["picom", "--daemon", "--vsync"],
+            )
+        command = popen.call_args.args[0]
+        self.assertNotIn("--config", command)
+        self.assertNotIn("/dev/null", command)
+        self.assertIn("--daemon", command)
+        self.assertIn("--vsync", command)
+
+    def test_marker_outside_rules_is_rejected(self):
+        config = self.write(
+            "# dwm-titus opacity defaults begin\n# opacity = .1; opacity = .2;\n# dwm-titus opacity defaults end\nrules=();"
+        )
+        with self.assertRaises(picom.Error):
+            self.apply(config)
+
+    def test_crlf_is_preserved(self):
+        self.path.write_bytes(b"active-opacity=.8;\r\n# comment\r\n")
+        self.apply(picom.Configuration())
+        self.assertIn(b"# comment\r\n", self.path.read_bytes())
+
+    def test_system_xdg_include_search_order(self):
+        vendor = self.home / "vendor/picom/include"
+        vendor.mkdir(parents=True)
+        (vendor / "opacity.conf").write_text("active-opacity=.7; inactive-opacity=.6;")
+        config = self.write('@include "opacity.conf"')
+        self.assertEqual(config.opacity(), (0.7, 0.6))
+        self.apply(config)
+        self.assertEqual(picom.Configuration().opacity(), (0.9, 0.75))
+        (self.config / "opacity.conf").write_text("active-opacity=.4;")
+        self.assertEqual(picom.Configuration().opacity(), (0.4, 1.0))
+
+    def test_attached_short_opacity_override(self):
+        config = self.write('backend="xrender";')
+        for arguments in (
+            ["-i0.4"],
+            ["-i=.4"],
+            ["-bi0.4"],
+            ["-bi", "0.4"],
+            ["-bcfi", "0.4"],
+            ["-i", "0.4"],
+        ):
+            with patch.object(
+                picom, "processes", return_value=[{"args": ["picom", *arguments]}]
+            ):
+                self.assertFalse(picom.status(False)["editable"])
+                with self.assertRaisesRegex(picom.Error, "command-line opacity"):
+                    self.apply(config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test-picom.py
+++ b/tests/test-picom.py
@@ -56,6 +56,60 @@ class PicomTests(unittest.TestCase):
     def apply(self, config, active=90, inactive=75):
         return picom.mutate("set-opacity", [active, inactive], config.revision())
 
+    def test_display_screen_identity(self):
+        self.assertEqual(picom.display_name(":0.0"), picom.display_name("unix:0"))
+        self.assertNotEqual(picom.display_name(":0.1"), picom.display_name(":0"))
+        self.assertEqual(picom.display_name("host:2.1"), "host:2.1")
+
+    def test_backup_history_is_bounded(self):
+        self.write("active-opacity=.8;")
+        for value in range(70, 84):
+            self.apply(picom.Configuration(), value)
+        backups = list(picom.private_dir().glob("backup-*"))
+        self.assertEqual(len(backups), 10)
+        self.assertTrue(all((p / "manifest.json").exists() for p in backups))
+
+    def test_rollback_continues_after_concurrent_removal(self):
+        child = self.config / "inactive.conf"
+        child.write_text("inactive-opacity=.6;")
+        original = '@include "inactive.conf"\nactive-opacity=.8;'
+        config = self.write(original)
+        process = {"pid": 123, "identity": "1", "args": ["picom"]}
+
+        def fail_launch(*args, **kwargs):
+            child.unlink()
+            raise picom.Error("failed")
+
+        with (
+            patch.object(picom, "processes", return_value=[process]),
+            patch.object(picom, "stop"),
+            patch.object(picom, "launch", side_effect=fail_launch),
+            self.assertRaisesRegex(picom.Error, "newer edits preserved"),
+        ):
+            self.apply(config)
+        self.assertFalse(child.exists())
+        self.assertEqual(self.path.read_text(), original)
+
+    def test_failed_backend_retry_preserves_both_logs(self):
+        child = Mock()
+        child.poll.return_value = 1
+
+        def launch(command, **kwargs):
+            kwargs["stdout"].write(command[-1] + " failed\n")
+            return child
+
+        with (
+            patch.object(picom, "owner", return_value=0),
+            patch.object(picom, "renderer", return_value="intel"),
+            patch.object(picom.subprocess, "Popen", side_effect=launch),
+            self.assertRaises(picom.Error),
+        ):
+            picom.launch(picom.Configuration())
+        self.assertEqual(
+            (picom.private_dir() / "session.log").read_text(),
+            "glx failed\nxrender failed\n",
+        )
+
     def test_missing_creates_only_on_edit(self):
         state = picom.status(False)
         self.assertFalse(self.path.exists())
@@ -84,6 +138,20 @@ class PicomTests(unittest.TestCase):
             self.path.read_text(), '@include "opacity.conf"\nbackend = "glx";\n'
         )
         self.assertEqual(picom.Configuration().opacity(), (0.9, 0.75))
+
+    def test_nested_includes_use_root_directory(self):
+        sub = self.config / "sub"
+        sub.mkdir()
+        (sub / "child.conf").write_text('@include "values.conf"')
+        values = self.config / "values.conf"
+        values.write_text("active-opacity=.7; inactive-opacity=.6;")
+        decoy = sub / "values.conf"
+        decoy.write_text("active-opacity=.1;")
+        config = self.write('@include "sub/child.conf"')
+        self.assertEqual(config.opacity(), (0.7, 0.6))
+        self.apply(config)
+        self.assertEqual(picom.Configuration().opacity(), (0.9, 0.75))
+        self.assertEqual(decoy.read_text(), "active-opacity=.1;")
 
     def test_include_cycle_and_duplicates(self):
         self.path.write_text('@include "picom.conf"')
@@ -264,6 +332,23 @@ class PicomTests(unittest.TestCase):
         self.assertEqual(self.path.read_text(), source.read_text())
         with self.assertRaises(picom.Error):
             picom.mutate("copy-config", [], picom.Configuration().revision())
+
+    def test_copy_vendor_shader_references(self):
+        vendor = self.home / "vendor"
+        vendor.mkdir()
+        (vendor / "custom.frag").write_text("shader")
+        source = vendor / "picom.conf"
+        source.write_text(
+            'window-shader-fg="custom.frag"; root-pixmap-shader="custom.frag";'
+            "window-shader-fg-rule=[\"custom.frag:name = 'x'\", \"default:name = 'y'\"];"
+            'rules=({shader="custom.frag";}, {shader={path="custom.frag"; defines={COLOR="red";};};});'
+        )
+        picom.mutate("copy-config", [], picom.Configuration().revision())
+        copied = self.path.read_text()
+        self.assertEqual(copied.count(str(vendor / "custom.frag")), 5)
+        self.assertIn('COLOR="red"', copied)
+        self.assertIn("default:name = 'y'", copied)
+        self.assertIn('window-shader-fg="custom.frag"', source.read_text())
 
     def test_copy_vendor_include_graph_is_editable(self):
         vendor = self.home / "vendor"

--- a/tests/test-quickshell-appearance-model.sh
+++ b/tests/test-quickshell-appearance-model.sh
@@ -105,7 +105,7 @@ if grep -Fq 'Commands.checkedCommand(Commands.settingsAppearanceCommand("invento
 	exit 1
 fi
 grep -Fq 'Commands.settingsAppearanceCommand("watch-inventory", [])' "$model"
-grep -Fq 'Commands.settingsAppearanceCommand("watch-compositor", [])' "$model"
+grep -Fq 'PicomModel { id: picomModel; active: root.settingsVisible }' "$model"
 grep -Fq 'function startInventoryWatcher(restartIfRunning)' "$model"
 grep -Fq 'function finishInventoryWatcherExit()' "$model"
 sed -n '/function startInventoryWatcher(restartIfRunning)/,/^    }/p' "$model" |
@@ -132,10 +132,9 @@ grep -Fq 'root.refreshInventory(true)' "$model"
 grep -Fq 'root.inventoryWatchFailed = true' "$model"
 grep -Fq 'root.inventoryWatchState = "unavailable"' "$model"
 grep -Fq '&& !root.inventoryWatchFailed' "$model"
-grep -Fq 'onTriggered: root.refreshInventory(true)' "$model"
 grep -Fq 'if (!root.settingsVisible) return;' "$model"
 grep -Fq 'inventoryWatchProcess.running = false' "$model"
-grep -Fq 'compositorWatchProcess.running = false' "$model"
+if grep -Fq 'compositorWatchProcess' "$model"; then exit 1; fi
 grep -Fq 'root.inventoryCandidates = candidates' "$model"
 grep -Fq 'candidate.id === "wallpaper"' "$model"
 grep -Fq 'candidate.id === "font"' "$model"

--- a/tests/test-quickshell-controlcenter.sh
+++ b/tests/test-quickshell-controlcenter.sh
@@ -31,7 +31,7 @@ SH
 	chmod +x "$work/bin/$name"
 }
 
-for name in quickshell xprop dwm-quickshell-launcher dwm-quickshell-controlcenter dex picom feh maim notify-send pactl brightnessctl xset gsettings light-locker setsid dwm-terminal dwm-default-apps dwm-settings-wallpaper xdg-open nwg-look pkill pgrep dnf; do
+for name in quickshell xprop dwm-quickshell-launcher dwm-quickshell-controlcenter dex picom dwm-settings-picom feh maim notify-send pactl brightnessctl xset gsettings light-locker setsid dwm-terminal dwm-default-apps dwm-settings-wallpaper xdg-open nwg-look pkill pgrep dnf; do
 	stub_command "$name"
 done
 
@@ -419,8 +419,7 @@ grep -Fq 'quickshell --no-duplicate' "$work/actions.log"
 : >"$work/actions.log"
 run_helper action restart-picom >"$work/picom.out"
 grep -Fqx 'action	restart-picom' "$work/picom.out"
-grep -Fq 'pkill -x picom' "$work/actions.log"
-grep -Fqx 'picom ' "$work/actions.log"
+grep -Fqx 'dwm-settings-picom restart' "$work/actions.log"
 
 : >"$work/actions.log"
 run_helper action open-wallpapers >"$work/wallpapers.out"


### PR DESCRIPTION
## Summary

Appearance's compositor controls previously depended on unreliable process checks and could disappear. This change keeps them configuration-driven, adds global active/inactive opacity sliders, and shares scoped Picom session handling across autostart, Control Center, and theme reloads.

Opacity saves on release (250 ms keyboard debounce) and stays global across themes. Automatic backend policy uses the active renderer, supports explicit overrides, and retries XRender once after automatic GLX startup failure. Edits preserve unrelated source, root-relative includes and shader references, check revisions, validate candidates, retain the ten latest backups, and roll back failed activation without overwriting concurrent changes. Valid syntax outside the editor subset still supports native Picom startup/reload/restart.

## Type

- [x] Bug fix
- [x] Feature
- [x] Installer or Fedora packaging
- [x] Documentation

## Validation

Validated and independently reviewed head: `bfe227d3ad6ba94a406b42b9de0d7b5cbf63c3ab`, based on `origin/main` at `56ec27bf25e8a69665b05e48d5583bf0ec0122f5`.

On the local Fedora 44 x86_64 workstation, with `PATH=/usr/bin:/bin:$PATH` to use Fedora Python and its packaged Pillow:

- `scripts/run-tests make clean all`: passed.
- `scripts/run-tests make check-picom check-picom-xvfb`: passed, now 32 unit tests plus real Picom/Quickshell nested-X11 coverage. New cases verify normal/dialog rendered opacity, root-relative nested includes, relative shader edits, vendor shader copying and startup, bounded backups, rollback after concurrent removal, error recovery, pending-edit cancellation and retry logs.
- `scripts/run-tests`: every target through `check-system-management` passed, including 689 system-management unit tests, configured QML lint, Settings runtime/responsiveness, and a 0.067% closed-shell CPU sample. The user-requested live shell restart interrupted the isolated native system-management fixture, so this run exited 2 and is not claimed as an uninterrupted pass.
- The complete interrupted target and every remaining aggregate target passed in this resumed run:

```sh
scripts/run-tests make check-quickshell-system-management check-settings check-appearance check-quickshell-network check-quickshell-connectivity check-terminal check-gearlever-install check-herdr-install check-lock check-session-guards check-session-migration check-webapp-launch check-screenshot check-release-helper check-kickstart check-fedora-packages check-install check-install-preservation check-test-runner check-lightdm-config release-check
```

- `scripts/run-tests make check-xvfb-runtime`: passed.
- Disposable Fedora 44 container: `scripts/run-tests make clean all check-install check-install-preservation` and `scripts/run-tests make check-fedora-packages` passed (95 packages). Container tests used `DWM_TEST_TMP_ROOT=/var/tmp/dwm-titus-tests` so dropped-privilege fixtures could traverse the workspace.
- `npm --prefix docs ci` and `npm --prefix docs run build`: passed.
- Ruff lint/format on the Picom helper and tests, and `git diff --check`: passed.
- Independent `codex review` of the complete diff and working-tree fixes completed cleanly after three passes. The final pass reused unaffected aggregate coverage and verified the configuration-path corrections; focused unit/native tests were rerun after those changes.
- Local CodeRabbit review completed. Its remaining teardown finding was already fixed; published review threads are addressed by this commit.

Live installation was explicitly requested and synchronized with `scripts/dev-sync-install.sh`. Managed files match the checkout; the updated shell exposes both opacity sliders and tray IPC reports 7 items. The user can test the running controls. A later logout/login is still required to activate the updated dwm executable; no logout was forced.

Evidence, review logs and UI captures are retained on this workstation at `/home/titus/tmp/pr312-evidence/`. The primary compositor remained unchanged by isolated runtime tests. Existing configured QML lint warnings are recorded; native QML runtime passed. No new ISO boot/install or physical NVIDIA rendering qualification is claimed.

## User Impact and Risk

Existing explicit backends and session overrides remain respected. Settings use 100% defaults when no configuration exists and create it only on edit. Uneditable configurations show an explanation. Python 3 is now an explicit desktop dependency and is listed in both Kickstart variants.

Verified on Fedora 44 x86_64 with isolated Xvfb software rendering. Active-renderer diagnostics were inspected on studio-pc's Intel renderer; its NVIDIA device is passed through. Physical NVIDIA rendering qualification and a new ISO boot/install remain untested. The live workstation was updated at the user's request; merging remains a separate action.

## Related Issue

Closes #309

