### PR TITLE
Fix post-merge Picom review findings from PR 312

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ versions from `config.mk`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve pending Picom edit revisions, import read-only includes from existing
+  user configurations, and recover include watches after invalid edits. Limit
+  failed-launch cleanup to its own processes and attempt compositor recovery
+  before reporting rollback conflicts, preserving relative configuration paths.
+
 ### Changed
 
 - Replace unstable Picom Appearance checks with global opacity sliders,

--- a/config/quickshell/appearance/PicomModel.qml
+++ b/config/quickshell/appearance/PicomModel.qml
@@ -44,19 +44,19 @@ Scope {
         statusProcess.running = true;
     }
 
-    function mutate(action, args) {
+    function mutate(action, args, revision) {
         if (!root.editable && action !== "copy-config") return;
         if (root.busy) return;
         root.action = action;
-        root.actionArguments = args.concat([root.snapshot.revision]);
+        root.actionArguments = args.concat([revision === undefined ? root.snapshot.revision : revision]);
         root.busy = true;
         root.message = "";
         root.actionFailure = "";
         actionProcess.running = true;
     }
 
-    function setOpacity(active, inactive) {
-        root.mutate("set-opacity", [String(active), String(inactive)]);
+    function setOpacity(active, inactive, revision) {
+        root.mutate("set-opacity", [String(active), String(inactive)], revision);
     }
 
     onActiveChanged: {

--- a/config/quickshell/settings/PicomSettingsPane.qml
+++ b/config/quickshell/settings/PicomSettingsPane.qml
@@ -11,6 +11,7 @@ ColumnLayout {
     property real activeOpacity: 100
     property real inactiveOpacity: 100
     property bool changed: false
+    property string editRevision: ""
     Layout.fillWidth: true
     spacing: 10
 
@@ -32,7 +33,7 @@ ColumnLayout {
         }
         if (root.model.busy) return;
         root.changed = false;
-        root.model.setOpacity(root.activeOpacity, root.inactiveOpacity);
+        root.model.setOpacity(root.activeOpacity, root.inactiveOpacity, root.editRevision);
     }
 
     Component.onCompleted: root.synchronize()
@@ -75,6 +76,7 @@ ColumnLayout {
         value: root.activeOpacity
         enabled: root.model.editable
         onMoved: {
+            if (!root.changed) root.editRevision = root.model.snapshot.revision;
             root.activeOpacity = value;
             root.changed = true;
             if (!pressed) keyboardDelay.restart();
@@ -96,6 +98,7 @@ ColumnLayout {
         value: root.inactiveOpacity
         enabled: root.model.editable
         onMoved: {
+            if (!root.changed) root.editRevision = root.model.snapshot.revision;
             root.inactiveOpacity = value;
             root.changed = true;
             if (!pressed) keyboardDelay.restart();

--- a/docs/src/content/configuration.md
+++ b/docs/src/content/configuration.md
@@ -42,7 +42,9 @@ Picom rules can override these defaults for individual windows.
 The controls read the active Picom configuration, normally `~/.config/picom.conf`
 or `~/.config/picom/picom.conf`, and observe external edits. With no configuration,
 they show 100% and create a minimal file on the first edit. A system configuration
-can be copied with **Create user configuration**. Comments, unrelated settings,
+can be copied with **Create user configuration**. The same action imports read-only
+includes referenced by an existing writable user configuration, backing up the
+root before updating its include paths. Comments, unrelated settings,
 and included files are preserved; the ten most recent edits retain recovery backups. Invalid
 or read-only configurations show an explanation rather than disappearing controls.
 Edits made while Picom is stopped take effect the next time it starts.

--- a/scripts/dwm-settings-picom
+++ b/scripts/dwm-settings-picom
@@ -22,6 +22,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import uuid
 from pathlib import Path
 
 PROTOCOL = 1
@@ -92,7 +93,19 @@ def processes():
                 continue
             identity = (directory / "stat").read_text().rsplit(")", 1)[1].split()[19]
             result.append(
-                {"pid": int(directory.name), "args": args, "identity": identity}
+                {
+                    "pid": int(directory.name),
+                    "args": args,
+                    "identity": identity,
+                    "launch_id": next(
+                        (
+                            os.fsdecode(v.split(b"=", 1)[1])
+                            for v in env
+                            if v.startswith(b"DWM_PICOM_LAUNCH_ID=")
+                        ),
+                        "",
+                    ),
+                }
             )
         except (OSError, UnicodeError, IndexError):
             continue
@@ -637,6 +650,20 @@ def launch(config, original=None, previous=None):
     config_args = ["--config", str(config.path)] if explicit else []
     backend_args = ["--backend", effective] if effective else []
     args = original or ["picom", *config_args, *extras, *backend_args]
+    if original and option(original, ("--config",)):
+        # source_path resolved the previous relative path before it was stopped.
+        args = []
+        index = 0
+        while index < len(original):
+            arg = original[index]
+            if arg == "--config":
+                args += [arg, str(config.path)]
+                index += 2
+                continue
+            args.append(
+                "--config=" + str(config.path) if arg.startswith("--config=") else arg
+            )
+            index += 1
     if (
         not original
         and gpu == "nvidia"
@@ -652,6 +679,7 @@ def launch(config, original=None, previous=None):
     log_path = private_dir() / "session.log"
     safe_target(log_path)
     for index, command in enumerate(attempts):
+        launch_id = uuid.uuid4().hex
         with open(log_path, "w" if index == 0 else "a") as log:
             child = subprocess.Popen(
                 command,
@@ -659,6 +687,7 @@ def launch(config, original=None, previous=None):
                 stdout=log,
                 stderr=log,
                 start_new_session=True,
+                env={**os.environ, "DWM_PICOM_LAUNCH_ID": launch_id},
             )
         deadline = time.monotonic() + 2
         ready_since = None
@@ -668,7 +697,7 @@ def launch(config, original=None, previous=None):
                 break
             # --daemon and daemon=true fork; the successful parent may already
             # have exited. Verify an owned process and X selection, not its parent.
-            if owner() and processes():
+            if owner() and any(p.get("launch_id") == launch_id for p in processes()):
                 ready_since = ready_since or time.monotonic()
                 if time.monotonic() - ready_since >= 0.3:
                     return "XRender fallback active" if index else "Picom active"
@@ -679,7 +708,7 @@ def launch(config, original=None, previous=None):
                 child.wait(timeout=3)
             except subprocess.TimeoutExpired as exc:
                 raise Error("Picom startup timed out and did not stop") from exc
-        remaining = processes()
+        remaining = [p for p in processes() if p.get("launch_id") == launch_id]
         if remaining:
             stop(remaining)
     raise Error(f"Picom failed to start; see {log_path}")
@@ -719,7 +748,7 @@ def activate(config, action):
     except Error as exc:
         if running:
             try:
-                launch(config, running[0]["args"])
+                launch(NativeConfiguration(config.path), running[0]["args"])
             except Error as recovery:
                 raise Error(
                     f"{exc}; previous compositor recovery failed: {recovery}"
@@ -786,18 +815,40 @@ def status(detect=True):
                 )
         except Error as exc:
             result["detail"] += " " + str(exc)
-            result["copyable"] = (
-                config.path
-                not in (
-                    config_home() / "picom.conf",
-                    config_home() / "picom/picom.conf",
-                )
-                and not os.environ.get("DWM_PICOM_CONFIG")
-                and not option(running[0]["args"] if running else [], ("--config",))
-            )
+            try:
+                copy_destination(config, running)
+                result["copyable"] = result["installed"]
+            except Error:
+                pass
+
     except (Error, OSError, ValueError) as exc:
         result["detail"] = str(exc)
     return result
+
+
+def copy_destination(config, running):
+    """Import vendor files, or relocate unsafe includes of a writable user root."""
+    if os.environ.get("DWM_PICOM_CONFIG") or option(
+        running[0]["args"] if running else [], ("--config",)
+    ):
+        raise Error(
+            "An explicit --config path is active; edit that configuration instead"
+        )
+    destination = config_home() / "picom.conf"
+    if config.path in (destination, config_home() / "picom/picom.conf"):
+        safe_target(config.path)
+        for path in config.docs:
+            if path == config.path:
+                continue
+            try:
+                safe_target(path)
+            except Error:
+                return config.path
+        raise Error("A user Picom configuration already exists and needs no import")
+    if destination.exists() or destination.is_symlink():
+        raise Error("A user Picom configuration already exists")
+    safe_target(destination)
+    return destination
 
 
 def publish(path, text):
@@ -870,19 +921,7 @@ def mutate(action, args, revision):
                 {"backend": None if args[0] == "auto" else args[0]}
             )
         else:
-            destination = config_home() / "picom.conf"
-            if (
-                destination.exists()
-                or destination.is_symlink()
-                or config.path == destination
-            ):
-                raise Error("A user Picom configuration already exists")
-            if os.environ.get("DWM_PICOM_CONFIG") or option(
-                processes()[0]["args"] if processes() else [], ("--config",)
-            ):
-                raise Error(
-                    "An explicit --config path is active; edit that configuration instead"
-                )
+            destination = copy_destination(config, processes())
             mapping = {
                 p: (
                     destination
@@ -896,6 +935,15 @@ def mutate(action, args, revision):
                 )
                 for p, doc in config.docs.items()
             }
+            if destination == config.path:
+                # Import unsafe documents without disconnecting writable files
+                # that the user still edits in place.
+                for path in config.docs:
+                    try:
+                        safe_target(path)
+                        mapping[path] = path
+                    except Error:
+                        pass
             changes = {}
             for path, doc in config.docs.items():
                 replacements = []
@@ -929,9 +977,7 @@ def mutate(action, args, revision):
         }
         for path in changes:
             safe_target(path)
-        candidate_path = (
-            config_home() / "picom.conf" if action == "copy-config" else config.path
-        )
+        candidate_path = destination if action == "copy-config" else config.path
         validate_candidate(config, changes, candidate_path)
         if not changes:
             return "Configuration already matches"
@@ -996,19 +1042,19 @@ def mutate(action, args, revision):
                 except (OSError, Error):
                     # Preserve concurrent removals and keep restoring other files.
                     conflicts.append(str(path))
-            if conflicts:
-                raise Error(
-                    f"{exc}; newer edits preserved in {', '.join(conflicts)}; backup: {backup}"
-                ) from exc
+            recovery_detail = ""
             if running and not processes():
                 try:
-                    launch(Configuration(config.path), running[0]["args"])
-                except Error as recovery:
-                    raise Error(
-                        f"{exc}; recovery failed: {recovery}; backup: {backup}"
-                    ) from exc
+                    launch(NativeConfiguration(config.path), running[0]["args"])
+                except (Error, OSError) as recovery:
+                    recovery_detail = f"; recovery failed: {recovery}"
+            restoration = (
+                f"newer edits preserved in {', '.join(conflicts)}"
+                if conflicts
+                else "previous configuration restored"
+            )
             raise Error(
-                f"{exc}; previous configuration restored. Backup: {backup}"
+                f"{exc}; {restoration}{recovery_detail}; backup: {backup}"
             ) from exc
 
 
@@ -1030,13 +1076,15 @@ def watch():
     signal.signal(signal.SIGINT, finish)
     if os.getppid() != parent:
         return
+    known_paths = []
     while True:
         paths = candidates()
         try:
             config = Configuration()
-            paths += list(config.docs)
+            known_paths = list(config.docs)
         except (Error, OSError, ValueError):
             pass
+        paths += known_paths
         parents = set()
         for path in paths:
             parent = path.parent

--- a/tests/test-picom-xvfb.py
+++ b/tests/test-picom-xvfb.py
@@ -372,6 +372,13 @@ ShellRoot {
         }
         function statusError(): string { return provider.statusFailure; }
         function clearActionError(): void { provider.actionFailure = ""; }
+        function staleEdit(newRevision: string): void {
+            pane.editRevision = provider.snapshot.revision;
+            pane.activeOpacity = 42;
+            pane.changed = true;
+            provider.snapshot = Object.assign({}, provider.snapshot, {revision: newRevision});
+            pane.applyOpacity();
+        }
         function pendingReadonly(): string {
             pane.activeOpacity = 42;
             pane.changed = true;
@@ -441,6 +448,23 @@ ShellRoot {
                 "PASS: QML status recovery preserves mutation failures; readonly state cancels pending edits",
                 flush=True,
             )
+            # The helper revision is changed on disk while the pane still has
+            # the old snapshot. A newer accepted snapshot must not rebase its edit.
+            assert ipc("enabled", "false").returncode == 0
+            conf.write_text(conf.read_text() + "\n# concurrent edit\n")
+            assert ipc("staleEdit", helper("status")["revision"]).returncode == 0
+            wait_until(
+                lambda: "changed" in ipc("error").stdout,
+                "Staged opacity failed to retain its original revision",
+            )
+            assert helper("status")["active"] == 85
+            assert ipc("clearActionError").returncode == 0
+            assert ipc("refresh").returncode == 0
+            assert ipc("enabled", "true").returncode == 0
+            wait_until(
+                lambda: ui_matches("revision", helper("status")["revision"]),
+                "Revision did not refresh after conflict",
+            )
             assert ipc("opacity", "80", "60").returncode == 0
             wait_until(
                 lambda: ui_matches("active", 80), "QML mutation did not converge"
@@ -473,6 +497,24 @@ ShellRoot {
                 ImageGrab.grab(xdisplay=display).save(
                     os.environ["DWM_TEST_PICOM_CAPTURE"]
                 )
+            watched = config / "picom/include/deep/opacity.conf"
+            watched.parent.mkdir(parents=True)
+            watched.write_text("active-opacity=.7;")
+            conf.write_text('@include "' + str(watched) + '"')
+            wait_until(lambda: ui_matches("active", 70), "Include did not load")
+            watched.write_text("malformed included configuration")
+            wait_until(
+                lambda: ui_matches("editable", False),
+                "Malformed include was not observed",
+            )
+            # Allow the watcher to rearm while parsing is broken.
+            time.sleep(0.3)
+            watched.write_text("active-opacity=.65;")
+            wait_until(
+                lambda: ui_matches("active", 65),
+                "Fixed nested include was not observed",
+            )
+            print("PASS: nested include watch recovers after parse failure", flush=True)
             conf.write_text(
                 'backend="xrender"; daemon=true; active-opacity=.8; inactive-opacity=.6;'
             )

--- a/tests/test-picom.py
+++ b/tests/test-picom.py
@@ -373,7 +373,10 @@ class PicomTests(unittest.TestCase):
         child.poll.return_value = 0
         with (
             patch.object(picom, "owner", side_effect=[0, *([1] * 50)]),
-            patch.object(picom, "processes", return_value=[{"pid": 123}]),
+            patch.object(picom.uuid, "uuid4", return_value=Mock(hex="attempt")),
+            patch.object(
+                picom, "processes", return_value=[{"pid": 123, "launch_id": "attempt"}]
+            ),
             patch.object(picom.subprocess, "Popen", return_value=child) as popen,
         ):
             picom.launch(
@@ -385,6 +388,96 @@ class PicomTests(unittest.TestCase):
         self.assertNotIn("/dev/null", command)
         self.assertIn("--daemon", command)
         self.assertIn("--vsync", command)
+
+    def test_failed_launch_only_stops_its_daemon(self):
+        own = {"pid": 123, "launch_id": "attempt"}
+        foreign = {"pid": 456, "launch_id": "other"}
+        child = Mock()
+        child.poll.return_value = 1
+        with (
+            patch.object(picom.uuid, "uuid4", return_value=Mock(hex="attempt")),
+            patch.object(picom, "owner", return_value=0),
+            patch.object(picom, "processes", return_value=[own, foreign]),
+            patch.object(picom.subprocess, "Popen", return_value=child),
+            patch.object(picom, "stop") as stop,
+            self.assertRaises(picom.Error),
+        ):
+            picom.launch(picom.Configuration(self.path))
+        stop.assert_called_once_with([own])
+
+    def test_recovery_rewrites_relative_config_argument(self):
+        child = Mock()
+        child.poll.return_value = 1
+        for args in (["--config", "relative.conf"], ["--config=relative.conf"]):
+            with (
+                patch.object(picom, "owner", return_value=0),
+                patch.object(picom.subprocess, "Popen", return_value=child) as popen,
+                self.assertRaises(picom.Error),
+            ):
+                picom.launch(
+                    picom.NativeConfiguration(self.path), ["picom", *args, "--vsync"]
+                )
+            command = popen.call_args.args[0]
+            self.assertEqual(picom.option(command, ("--config",)), str(self.path))
+            self.assertIn("--vsync", command)
+
+    def test_rollback_conflict_attempts_recovery_and_reports_both_errors(self):
+        config = self.write("active-opacity=.8;")
+        running = [{"pid": 123, "args": ["picom"]}]
+
+        def fail_launch(*args, **kwargs):
+            if running:
+                running.clear()
+                self.path.write_text("external edit")
+                raise picom.Error("replacement failed")
+            raise picom.Error("original failed")
+
+        with (
+            patch.object(picom, "processes", side_effect=lambda: list(running)),
+            patch.object(picom, "stop"),
+            patch.object(picom, "launch", side_effect=fail_launch) as launch,
+            self.assertRaisesRegex(
+                picom.Error, "newer edits preserved.*recovery failed: original failed"
+            ),
+        ):
+            self.apply(config)
+        self.assertEqual(launch.call_count, 2)
+        self.assertEqual(self.path.read_text(), "external edit")
+
+    def test_import_readonly_includes_of_existing_user_roots(self):
+        for relative in ("picom.conf", "picom/picom.conf"):
+            with self.subTest(relative=relative):
+                root = self.config / relative
+                root.parent.mkdir(exist_ok=True)
+                included = self.home / "readonly.conf"
+                included.write_text("active-opacity=.7;")
+                included.chmod(0o444)
+                original = '@include "' + str(included) + '"\n# preserved root'
+                root.write_text(original)
+                state = picom.status(False)
+                self.assertTrue(state["copyable"])
+                picom.mutate("copy-config", [], state["revision"])
+                self.assertTrue(picom.status(False)["editable"])
+                self.assertIn("# preserved root", root.read_text())
+                self.apply(picom.Configuration())
+                self.assertEqual(included.read_text(), "active-opacity=.7;")
+                root.unlink()
+                included.chmod(0o600)
+
+    def test_import_keeps_writable_includes_effective(self):
+        readonly = self.home / "vendor.conf"
+        readonly.write_text("active-opacity=.7;")
+        readonly.chmod(0o444)
+        writable = self.config / "mine.conf"
+        writable.write_text("inactive-opacity=.6;")
+        self.write('@include "' + str(readonly) + '"\n@include "mine.conf"')
+        picom.mutate("copy-config", [], picom.Configuration().revision())
+        self.assertIn(writable, picom.Configuration().docs)
+        self.apply(picom.Configuration())
+        self.assertEqual(writable.read_text(), "inactive-opacity=0.75;")
+        writable.write_text("inactive-opacity=.55;")
+        self.assertEqual(picom.Configuration().opacity(), (0.9, 0.55))
+        self.assertEqual(readonly.read_text(), "active-opacity=.7;")
 
     def test_marker_outside_rules_is_rejected(self):
         config = self.write(


### PR DESCRIPTION
Fix six review findings reported on merged PR #312:

- Keep the opacity edit's original revision through debounced snapshot updates, so concurrent edits produce a conflict instead of being overwritten.
- Offer explicit import of read-only includes from either standard writable user configuration path, with backups and preservation of the source include files.
- Keep watching known nested includes while their contents are invalid, so corrections refresh Settings.
- Identify each launch attempt and its daemon children, limiting readiness checks and failed-launch cleanup to that attempt.
- Replay a previous relative `--config` path using the resolved absolute path.
- Attempt compositor recovery before reporting rollback conflicts, preserving newer file contents and reporting any recovery failure too.

Regression coverage includes existing user-root imports, independent concurrent processes, both config argument forms, combined rollback/recovery failures, a native QML revision conflict, and native recovery of a malformed nested include watch. No dependencies, packaging, or defaults changed.

Validated and independently reviewed commit: `98ef9d488d78d99dd78832276395edf51dec96bb`, based on `origin/main` at `47b533f5fb74ada9e3c91c77de171a47477ecb83`.

On Fedora 44 x86_64, using `PATH=/usr/bin:/bin:$PATH` for managed tests:

- `scripts/run-tests make clean all`: passed.
- `scripts/run-tests`: passed the complete aggregate suite, including 689 system-management unit tests, full native Settings and system-management UI coverage, configured QML lint, shell checks, Fedora package mapping, staged installation, installer preservation and release validation.
- `scripts/run-tests make check-picom check-picom-xvfb check-xvfb-runtime`: passed, including the native pending-edit conflict and nested-include watch recovery regressions, daemonized Picom and the dwm Xvfb smoke test. Primary display compositor unchanged.
- After the final writable-include preservation correction, `scripts/run-tests make check-picom check-picom-xvfb`: passed, now 37 unit tests plus native Picom/QML. Unaffected aggregate and dwm evidence was reused; no base integration or other implementation changes followed.
- `npm --prefix docs ci` and `npm --prefix docs run build`: passed.
- Ruff lint and format checks for all changed Python files and `git diff --check`: passed.
- Independent local Codex review of the complete final diff: no actionable findings. Final local CodeRabbit review: zero findings.

Nested-X11 closed-shell CPU samples: Settings 0.033%, large surfaces 0.00%. Existing QML lint warnings remain; native runtime checks passed. No new image install/boot, physical NVIDIA qualification, or live workstation deployment was performed for this follow-up.

Evidence and review logs: `/home/titus/tmp/pr312-followup-evidence/` and `/home/titus/tmp/pr312-followup-*.log`.
